### PR TITLE
OpenAPI Kotlin class equals & hashCode fix

### DIFF
--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinModel.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinModel.mustache
@@ -85,7 +85,17 @@ sealed interface {{classname}} {
   }
 {{/vendorExtensions.x-discriminator-values-check}}
 
+{{^hasVars}}
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (javaClass != other?.javaClass) return false
+    return true
+  }
 
+  override fun hashCode(): Int {
+    return javaClass.hashCode()
+  }
+{{/hasVars}}
 
   {{#allVars}}
       {{#isEnum}}


### PR DESCRIPTION
OpenAPI Generator Kotlin class without fields equals & hashCode contract missing fixed