### PR TITLE
OpenAPI generator updated

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ if (hasProperty('buildScan')) {
 
 allprojects {
     group = "ru.tinkoff.kora"
-    version = System.getenv().getOrDefault("KORA_VERSION", "1.1.0-SNAPSHOT")
+    version = System.getenv().getOrDefault("KORA_VERSION", "1.2.0-SNAPSHOT")
     repositories {
         mavenCentral()
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -167,7 +167,7 @@ glassfish-jaxb-javax = { module = "org.glassfish.jaxb:jaxb-runtime", version = "
 commons-codec = { module = "commons-codec:commons-codec", version = "1.16.1" }
 commons-io = { module = "commons-io:commons-io", version = "2.16.1" }
 
-openapi-generator = { module = "org.openapitools:openapi-generator", version = "7.16.0" }
+openapi-generator = { module = "org.openapitools:openapi-generator", version = "7.14.0" }
 translit-icu4j = { module = "com.ibm.icu:icu4j", version = "77.1" }
 swagger-core = { module = "io.swagger.core.v3:swagger-core", version.ref = "swagger" }
 swagger-models = { module = "io.swagger.core.v3:swagger-models", version.ref = "swagger" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -167,7 +167,7 @@ glassfish-jaxb-javax = { module = "org.glassfish.jaxb:jaxb-runtime", version = "
 commons-codec = { module = "commons-codec:commons-codec", version = "1.16.1" }
 commons-io = { module = "commons-io:commons-io", version = "2.16.1" }
 
-openapi-generator = { module = "org.openapitools:openapi-generator", version = "7.6.0" }
+openapi-generator = { module = "org.openapitools:openapi-generator", version = "7.16.0" }
 translit-icu4j = { module = "com.ibm.icu:icu4j", version = "77.1" }
 swagger-core = { module = "io.swagger.core.v3:swagger-core", version.ref = "swagger" }
 swagger-models = { module = "io.swagger.core.v3:swagger-models", version.ref = "swagger" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -167,7 +167,7 @@ glassfish-jaxb-javax = { module = "org.glassfish.jaxb:jaxb-runtime", version = "
 commons-codec = { module = "commons-codec:commons-codec", version = "1.16.1" }
 commons-io = { module = "commons-io:commons-io", version = "2.16.1" }
 
-openapi-generator = { module = "org.openapitools:openapi-generator", version = "7.4.0" }
+openapi-generator = { module = "org.openapitools:openapi-generator", version = "7.6.0" }
 translit-icu4j = { module = "com.ibm.icu:icu4j", version = "77.1" }
 swagger-core = { module = "io.swagger.core.v3:swagger-core", version.ref = "swagger" }
 swagger-models = { module = "io.swagger.core.v3:swagger-models", version.ref = "swagger" }

--- a/openapi/openapi-generator/src/main/java/ru/tinkoff/kora/openapi/generator/KoraCodegen.java
+++ b/openapi/openapi-generator/src/main/java/ru/tinkoff/kora/openapi/generator/KoraCodegen.java
@@ -43,6 +43,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.openapitools.codegen.utils.ModelUtils.getSchemaItems;
 import static org.openapitools.codegen.utils.StringUtils.*;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
@@ -1193,7 +1194,7 @@ public class KoraCodegen extends DefaultCodegen {
         var schema = ModelUtils.unaliasSchema(this.openAPI, p, importMapping);
         var target = ModelUtils.isGenerateAliasAsModel() ? p : schema;
         if (ModelUtils.isArraySchema(target)) {
-            var items = getSchemaItems((ArraySchema) schema);
+            var items = getSchemaItems(schema);
             return getSchemaType(target) + "<" + getTypeDeclaration(items) + ">";
         } else if (ModelUtils.isMapSchema(target)) {
             // Note: ModelUtils.isMapSchema(p) returns true when p is a composed schema that also defines
@@ -1293,7 +1294,7 @@ public class KoraCodegen extends DefaultCodegen {
                     : "java.util.List.<%s>of(";
             }
 
-            Schema<?> itemOriginal = getSchemaItems((ArraySchema) schema);
+            Schema<?> itemOriginal = getSchemaItems(schema);
             Schema itemSchema = ModelUtils.getReferencedSchema(this.openAPI, itemOriginal);
             String typeDeclaration = getTypeDeclaration(ModelUtils.unaliasSchema(this.openAPI, itemOriginal));
             Object java8obj = additionalProperties.get("java8");


### PR DESCRIPTION
OpenAPI generator updated to 7.16.0 (breaking change) (requires OpenAPI plugin update to `7.16.0`)