### PR TITLE
JDBC async signature fixes

### DIFF
--- a/annotation-processor-common/src/main/java/ru/tinkoff/kora/annotation/processor/common/TagUtils.java
+++ b/annotation-processor-common/src/main/java/ru/tinkoff/kora/annotation/processor/common/TagUtils.java
@@ -2,6 +2,7 @@ package ru.tinkoff.kora.annotation.processor.common;
 
 import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.CodeBlock;
+import com.squareup.javapoet.TypeName;
 
 import javax.lang.model.AnnotatedConstruct;
 import javax.lang.model.element.Element;
@@ -103,6 +104,21 @@ public final class TagUtils {
             }
         }
         return Set.of();
+    }
+
+    public static AnnotationSpec makeAnnotationSpecForTypes(TypeName ... tags) {
+        var annotation = AnnotationSpec.builder(CommonClassNames.tag);
+        var value = CodeBlock.builder();
+        value.add("{");
+        var tagsList = List.of(tags);
+        for (int i = 0; i < tagsList.size(); i++) {
+            if (i > 0) {
+                value.add(", ");
+            }
+            value.add("$T.class", tagsList.get(i));
+        }
+        value.add("}");
+        return annotation.addMember("value", value.build()).build();
     }
 
     public static AnnotationSpec makeAnnotationSpec(Set<String> tags) {

--- a/database/database-annotation-processor/src/main/java/ru/tinkoff/kora/database/annotation/processor/cassandra/CassandraRepositoryGenerator.java
+++ b/database/database-annotation-processor/src/main/java/ru/tinkoff/kora/database/annotation/processor/cassandra/CassandraRepositoryGenerator.java
@@ -91,6 +91,7 @@ public class CassandraRepositoryGenerator implements RepositoryGenerator {
         var returnType = methodType.getReturnType();
         var isFlux = CommonUtils.isFlux(returnType);
         var isMono = CommonUtils.isMono(returnType);
+        var isFuture = CommonUtils.isFuture(returnType);
         if (isMono || isFlux) {
             b.addCode("return ");
             b.beginControlFlow("$T.deferContextual(_reactorCtx ->", isFlux ? CommonClassNames.flux : CommonClassNames.mono);
@@ -103,7 +104,7 @@ public class CassandraRepositoryGenerator implements RepositoryGenerator {
                 b.beginControlFlow(".flatMapMany(_st ->");
             }
             b.addStatement("var _stmt = _st.boundStatementBuilder()");
-        } else if (CommonUtils.isFuture(returnType)) {
+        } else if (isFuture) {
             b.addStatement("var _telemetry = this._connectionFactory.telemetry().createContext($T.current(), _query)", CommonClassNames.context);
             b.addStatement("var _session = this._connectionFactory.currentSession()");
             b.addCode("return _session.prepareAsync(_query.sql()).thenCompose(_st -> {$>\n");
@@ -138,7 +139,7 @@ public class CassandraRepositoryGenerator implements RepositoryGenerator {
                   });
                 """);
             b.endControlFlow(")");// defer
-        } else if (CommonUtils.isFuture(returnType)) {
+        } else if (isFuture) {
             if (CommonUtils.isVoid(((DeclaredType) returnType).getTypeArguments().get(0))) {
                 b.addStatement("return _session.executeAsync(_s).thenApply(_rs -> (Void)null)");
             } else {

--- a/database/database-annotation-processor/src/main/java/ru/tinkoff/kora/database/annotation/processor/jdbc/JdbcRepositoryGenerator.java
+++ b/database/database-annotation-processor/src/main/java/ru/tinkoff/kora/database/annotation/processor/jdbc/JdbcRepositoryGenerator.java
@@ -78,7 +78,7 @@ public final class JdbcRepositoryGenerator implements RepositoryGenerator {
         var returnType = methodType.getReturnType();
         if (CommonUtils.isMono(returnType)) {
             returnType = Visitors.visitDeclaredType(returnType, dt -> dt.getTypeArguments().get(0));
-        } else if(CommonUtils.isFuture(returnType)) {
+        } else if (CommonUtils.isFuture(returnType)) {
             returnType = Visitors.visitDeclaredType(returnType, dt -> dt.getTypeArguments().get(0));
         }
 
@@ -281,7 +281,7 @@ public final class JdbcRepositoryGenerator implements RepositoryGenerator {
             constructorBuilder.addParameter(ParameterSpec.builder(TypeName.get(Executor.class), "_executor")
                 .addAnnotation(AnnotationSpec.builder(Tag.class).addMember("value", executorTag).build())
                 .build());
-        } else if(needThreadPool) {
+        } else if (needThreadPool) {
             builder.addField(TypeName.get(Executor.class), "_executor", Modifier.PRIVATE, Modifier.FINAL);
             constructorBuilder.addStatement("this._executor = _executor");
             constructorBuilder.addParameter(ParameterSpec.builder(TypeName.get(Executor.class), "_executor")

--- a/database/database-annotation-processor/src/main/java/ru/tinkoff/kora/database/annotation/processor/jdbc/JdbcTypes.java
+++ b/database/database-annotation-processor/src/main/java/ru/tinkoff/kora/database/annotation/processor/jdbc/JdbcTypes.java
@@ -8,6 +8,7 @@ public class JdbcTypes {
     public static final ClassName JDBC_REPOSITORY = ClassName.get("ru.tinkoff.kora.database.jdbc", "JdbcRepository");
 
     public static final String RESULT_PACKAGE = "ru.tinkoff.kora.database.jdbc.mapper.result";
+    public static final ClassName JDBC_DATABASE = ClassName.get("ru.tinkoff.kora.database.jdbc", "JdbcDatabase");
     public static final ClassName RESULT_SET_MAPPER = ClassName.get(RESULT_PACKAGE, "JdbcResultSetMapper");
     public static final ClassName ROW_MAPPER = ClassName.get(RESULT_PACKAGE, "JdbcRowMapper");
     public static final ClassName RESULT_COLUMN_MAPPER = ClassName.get(RESULT_PACKAGE, "JdbcResultColumnMapper");

--- a/database/database-annotation-processor/src/test/java/ru/tinkoff/kora/database/common/annotation/processor/jdbc/AbstractJdbcRepositoryTest.java
+++ b/database/database-annotation-processor/src/test/java/ru/tinkoff/kora/database/common/annotation/processor/jdbc/AbstractJdbcRepositoryTest.java
@@ -17,6 +17,9 @@ public abstract class AbstractJdbcRepositoryTest extends AbstractRepositoryTest 
             import ru.tinkoff.kora.database.jdbc.mapper.result.*;
             import ru.tinkoff.kora.database.jdbc.mapper.parameter.*;
             import ru.tinkoff.kora.common.Mapping;
+            import reactor.core.publisher.Mono;
+            import java.util.concurrent.CompletableFuture;
+            import java.util.concurrent.CompletionStage;
 
             import java.sql.*;
             import jakarta.annotation.Nullable;

--- a/database/database-annotation-processor/src/test/java/ru/tinkoff/kora/database/common/annotation/processor/jdbc/JdbcMacrosTest.java
+++ b/database/database-annotation-processor/src/test/java/ru/tinkoff/kora/database/common/annotation/processor/jdbc/JdbcMacrosTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 
 import java.sql.SQLException;
 import java.util.List;
+import java.util.concurrent.Executors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -40,9 +41,7 @@ final class JdbcMacrosTest extends AbstractJdbcRepositoryTest {
 
     @Test
     void returnSelectsAndTable() throws SQLException {
-        var repository = compileJdbc(List.of(newGeneratedObject("TestRowMapper")), """
-            import java.util.concurrent.CompletionStage;
-                            
+        var repository = compileJdbc(List.of(Executors.newCachedThreadPool(), newGeneratedObject("TestRowMapper")), """
             @Repository
             public interface TestRepository extends JdbcRepository {
                         

--- a/database/database-annotation-processor/src/test/java/ru/tinkoff/kora/database/common/annotation/processor/jdbc/JdbcResultsTest.java
+++ b/database/database-annotation-processor/src/test/java/ru/tinkoff/kora/database/common/annotation/processor/jdbc/JdbcResultsTest.java
@@ -108,7 +108,7 @@ public class JdbcResultsTest extends AbstractJdbcRepositoryTest {
     @Test
     public void testReturnMonoObject() throws SQLException {
         var mapper = Mockito.mock(JdbcResultSetMapper.class);
-        var repository = compileJdbc(List.of(mapper), """
+        var repository = compileJdbc(List.of(Executors.newCachedThreadPool(), mapper), """
             @Repository
             public interface TestRepository extends JdbcRepository {
                 @Query("SELECT count(*) FROM test")
@@ -147,7 +147,7 @@ public class JdbcResultsTest extends AbstractJdbcRepositoryTest {
 
     @Test
     public void testReturnMonoVoid() throws SQLException {
-        var repository = compileJdbc(List.of(), """
+        var repository = compileJdbc(List.of(Executors.newCachedThreadPool()), """
             @Repository
             public interface TestRepository extends JdbcRepository {
                 @Query("SELECT count(*) FROM test")
@@ -164,7 +164,7 @@ public class JdbcResultsTest extends AbstractJdbcRepositoryTest {
     @Test
     public void testReturnCompletionStageObject() throws SQLException {
         var mapper = Mockito.mock(JdbcResultSetMapper.class);
-        var repository = compileJdbc(List.of(mapper), """
+        var repository = compileJdbc(List.of(Executors.newCachedThreadPool(), mapper), """
             @Repository
             public interface TestRepository extends JdbcRepository {
                 @Query("SELECT count(*) FROM test")
@@ -203,7 +203,7 @@ public class JdbcResultsTest extends AbstractJdbcRepositoryTest {
 
     @Test
     public void testReturnCompletionStageVoid() throws SQLException {
-        var repository = compileJdbc(List.of(), """
+        var repository = compileJdbc(List.of(Executors.newCachedThreadPool()), """
             @Repository
             public interface TestRepository extends JdbcRepository {
                 @Query("SELECT count(*) FROM test")
@@ -220,7 +220,7 @@ public class JdbcResultsTest extends AbstractJdbcRepositoryTest {
     @Test
     public void testReturnCompletableFutureObject() throws SQLException {
         var mapper = Mockito.mock(JdbcResultSetMapper.class);
-        var repository = compileJdbc(List.of(mapper), """
+        var repository = compileJdbc(List.of(Executors.newCachedThreadPool(), mapper), """
             @Repository
             public interface TestRepository extends JdbcRepository {
                 @Query("SELECT count(*) FROM test")
@@ -259,7 +259,7 @@ public class JdbcResultsTest extends AbstractJdbcRepositoryTest {
 
     @Test
     public void testReturnCompletableFutureVoid() throws SQLException {
-        var repository = compileJdbc(List.of(), """
+        var repository = compileJdbc(List.of(Executors.newCachedThreadPool()), """
             @Repository
             public interface TestRepository extends JdbcRepository {
                 @Query("SELECT count(*) FROM test")

--- a/database/database-symbol-processor/src/main/kotlin/ru/tinkoff/kora/database/symbol/processor/jdbc/JdbcRepositoryGenerator.kt
+++ b/database/database-symbol-processor/src/main/kotlin/ru/tinkoff/kora/database/symbol/processor/jdbc/JdbcRepositoryGenerator.kt
@@ -28,6 +28,7 @@ import ru.tinkoff.kora.ksp.common.CommonClassNames.isList
 import ru.tinkoff.kora.ksp.common.FieldFactory
 import ru.tinkoff.kora.ksp.common.FunctionUtils.isSuspend
 import ru.tinkoff.kora.ksp.common.KotlinPoetUtils.controlFlow
+import ru.tinkoff.kora.ksp.common.TagUtils.addTag
 import ru.tinkoff.kora.ksp.common.parseMappingData
 import java.sql.Statement
 import java.util.concurrent.Executor
@@ -236,12 +237,18 @@ class JdbcRepositoryGenerator(private val resolver: Resolver) : RepositoryGenera
             constructorBuilder.addStatement("this._executor = _executor")
             if (executorTag != null) {
                 constructorBuilder.addParameter(
-                    ParameterSpec.builder("_executor", executor).addAnnotation(
-                        AnnotationSpec.builder(CommonClassNames.tag).addMember("value = %L", executorTag).build()
-                    ).build()
+                    ParameterSpec.builder("_executor", executor)
+                        .addAnnotation(
+                            AnnotationSpec.builder(CommonClassNames.tag)
+                                .addMember("value = %L", executorTag)
+                                .build()
+                        )
+                        .build()
                 )
             } else {
-                constructorBuilder.addParameter(ParameterSpec.builder("_executor", executor).build())
+                constructorBuilder.addParameter(ParameterSpec.builder("_executor", executor)
+                    .addTag(JdbcTypes.jdbcDatabase)
+                    .build())
             }
         }
     }

--- a/database/database-symbol-processor/src/main/kotlin/ru/tinkoff/kora/database/symbol/processor/jdbc/JdbcTypes.kt
+++ b/database/database-symbol-processor/src/main/kotlin/ru/tinkoff/kora/database/symbol/processor/jdbc/JdbcTypes.kt
@@ -6,6 +6,7 @@ object JdbcTypes {
     val connection = ClassName("java.sql", "Connection")
     val resultSet = ClassName("java.sql", "ResultSet")
     val connectionFactory = ClassName("ru.tinkoff.kora.database.jdbc", "JdbcConnectionFactory")
+    val jdbcDatabase = ClassName("ru.tinkoff.kora.database.jdbc", "JdbcDatabase")
     val jdbcRepository = ClassName("ru.tinkoff.kora.database.jdbc", "JdbcRepository")
     val jdbcResultSetMapper = ClassName("ru.tinkoff.kora.database.jdbc.mapper.result", "JdbcResultSetMapper")
     val jdbcRowMapper = ClassName("ru.tinkoff.kora.database.jdbc.mapper.result", "JdbcRowMapper")

--- a/database/database-symbol-processor/src/test/kotlin/ru/tinkoff/kora/database/symbol/processor/jdbc/JdbcSuspendResultsTest.kt
+++ b/database/database-symbol-processor/src/test/kotlin/ru/tinkoff/kora/database/symbol/processor/jdbc/JdbcSuspendResultsTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.TestInstance
 import ru.tinkoff.kora.annotation.processor.common.TestContext
 import ru.tinkoff.kora.application.graph.TypeRef
 import ru.tinkoff.kora.database.jdbc.JdbcConnectionFactory
+import ru.tinkoff.kora.database.jdbc.JdbcDatabase
 import ru.tinkoff.kora.database.jdbc.mapper.result.JdbcResultSetMapper
 import ru.tinkoff.kora.database.symbol.processor.DbTestUtils
 import ru.tinkoff.kora.database.symbol.processor.jdbc.repository.AllowedSuspendResultsRepository
@@ -26,6 +27,7 @@ class JdbcSuspendResultsTest {
             ), executor
         )
         ctx.addContextElement(TypeRef.of(Executor::class.java),
+            arrayOf(JdbcDatabase::class.java),
             Executor { obj: Runnable -> obj.run() })
         ctx.addMock(TypeRef.of(TestEntityJdbcRowMapperNonFinal::class.java))
         ctx.addMock(TypeRef.of(TestEntityFieldJdbcResultColumnMapperNonFinal::class.java))

--- a/symbol-processor-common/src/main/kotlin/ru/tinkoff/kora/ksp/common/TagUtils.kt
+++ b/symbol-processor-common/src/main/kotlin/ru/tinkoff/kora/ksp/common/TagUtils.kt
@@ -28,6 +28,13 @@ object TagUtils {
         return this.addAnnotation(tag.toTagAnnotation())
     }
 
+    fun ParameterSpec.Builder.addTag(vararg tags: TypeName): ParameterSpec.Builder {
+        if (tags.isEmpty()) {
+            return this
+        }
+        return this.addAnnotation(tags.toList().toTagTypesAnnotation())
+    }
+
     fun TypeSpec.Builder.addTag(tag: Set<String>): TypeSpec.Builder {
         if (tag.isEmpty()) {
             return this
@@ -92,5 +99,23 @@ object TagUtils {
         }
         val value = codeBlock.add("]").build()
         return AnnotationSpec.builder(CommonClassNames.tag).addMember(value).build()
+    }
+
+    fun Collection<TypeName>.toTagTypesAnnotation(): AnnotationSpec {
+        if(size == 1) {
+            return AnnotationSpec.builder(CommonClassNames.tag)
+                .addMember("%T::class", this.first())
+                .build()
+        } else {
+            val codeBlock = CodeBlock.builder().add("value = [")
+            forEachIndexed { i, type ->
+                if (i > 0) {
+                    codeBlock.add(", ")
+                }
+                codeBlock.add("%T::class", type)
+            }
+            val value = codeBlock.add("]").build()
+            return AnnotationSpec.builder(CommonClassNames.tag).addMember(value).build()
+        }
     }
 }


### PR DESCRIPTION
- JDBC CompletionStage signature support fixed
- Executor unused when `executorTag` specified fixed