### PR TITLE
Added Tag propagation for Repository codegen

### DIFF
--- a/annotation-processor-common/src/main/java/ru/tinkoff/kora/annotation/processor/common/TagUtils.java
+++ b/annotation-processor-common/src/main/java/ru/tinkoff/kora/annotation/processor/common/TagUtils.java
@@ -12,6 +12,7 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.RecordComponentElement;
 import javax.lang.model.type.TypeMirror;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -143,5 +144,23 @@ public final class TagUtils {
             b.add("$T.class, ", typeMirrorValue);
         }
         return b.add("}").build();
+    }
+
+    public static Boolean tagsMatch(Collection<String> requiredTags, Collection<String> providedTags) {
+        if (requiredTags.isEmpty() && providedTags.isEmpty()) {
+            return true;
+        }
+        if (requiredTags.isEmpty()) {
+            return false;
+        }
+        if (requiredTags.contains(CommonClassNames.tagAny.canonicalName())) {
+            return true;
+        }
+        for (var tag : requiredTags) {
+            if (!providedTags.contains(tag)) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/database/database-annotation-processor/src/main/java/ru/tinkoff/kora/database/annotation/processor/RepositoryBuilder.java
+++ b/database/database-annotation-processor/src/main/java/ru/tinkoff/kora/database/annotation/processor/RepositoryBuilder.java
@@ -1,8 +1,11 @@
 package ru.tinkoff.kora.database.annotation.processor;
 
-import com.squareup.javapoet.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.squareup.javapoet.AnnotationSpec;
+import com.squareup.javapoet.CodeBlock;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.ParameterSpec;
+import com.squareup.javapoet.TypeName;
+import com.squareup.javapoet.TypeSpec;
 import ru.tinkoff.kora.annotation.processor.common.CommonUtils;
 import ru.tinkoff.kora.annotation.processor.common.NameUtils;
 import ru.tinkoff.kora.annotation.processor.common.ProcessingErrorException;
@@ -19,6 +22,9 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.Types;
 import java.io.IOException;
 import java.util.List;
+
+import static ru.tinkoff.kora.annotation.processor.common.TagUtils.makeAnnotationSpec;
+import static ru.tinkoff.kora.annotation.processor.common.TagUtils.parseTagValue;
 
 public class RepositoryBuilder {
 
@@ -43,6 +49,12 @@ public class RepositoryBuilder {
         var builder = CommonUtils.extendsKeepAop(repositoryElement, name)
             .addAnnotation(AnnotationSpec.builder(Generated.class).addMember("value", CodeBlock.of("$S", RepositoryAnnotationProcessor.class.getCanonicalName())).build())
             .addOriginatingElement(repositoryElement);
+
+        var tags = parseTagValue(repositoryElement);
+        if (!tags.isEmpty()) {
+            builder.addAnnotation(makeAnnotationSpec(tags));
+        }
+
         var constructorBuilder = MethodSpec.constructorBuilder()
             .addModifiers(Modifier.PUBLIC);
         if (repositoryElement.getKind().isClass()) {

--- a/database/database-annotation-processor/src/main/java/ru/tinkoff/kora/database/annotation/processor/extension/RepositoryKoraExtension.java
+++ b/database/database-annotation-processor/src/main/java/ru/tinkoff/kora/database/annotation/processor/extension/RepositoryKoraExtension.java
@@ -18,6 +18,9 @@ import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 import java.util.Set;
 
+import static ru.tinkoff.kora.annotation.processor.common.TagUtils.parseTagValue;
+import static ru.tinkoff.kora.annotation.processor.common.TagUtils.tagsMatch;
+
 public class RepositoryKoraExtension implements KoraExtension {
     private final Elements elements;
     private final Types types;
@@ -29,7 +32,6 @@ public class RepositoryKoraExtension implements KoraExtension {
 
     @Override
     public KoraExtensionDependencyGenerator getDependencyGenerator(RoundEnvironment roundEnvironment, TypeMirror typeMirror, Set<String> tags) {
-        if (!tags.isEmpty()) return null;
         if (typeMirror.getKind() != TypeKind.DECLARED) {
             return null;
         }
@@ -38,6 +40,9 @@ public class RepositoryKoraExtension implements KoraExtension {
             return null;
         }
         if (AnnotationUtils.findAnnotation(element, DbUtils.REPOSITORY_ANNOTATION) == null) {
+            return null;
+        }
+        if (!tagsMatch(tags, parseTagValue(element))) {
             return null;
         }
         var typeElement = (TypeElement) this.types.asElement(typeMirror);

--- a/database/database-annotation-processor/src/test/java/ru/tinkoff/kora/database/common/annotation/processor/TagPropagationTest.java
+++ b/database/database-annotation-processor/src/test/java/ru/tinkoff/kora/database/common/annotation/processor/TagPropagationTest.java
@@ -1,0 +1,50 @@
+package ru.tinkoff.kora.database.common.annotation.processor;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import ru.tinkoff.kora.common.Tag;
+import ru.tinkoff.kora.database.annotation.processor.RepositoryAnnotationProcessor;
+import ru.tinkoff.kora.database.common.annotation.processor.jdbc.AbstractJdbcRepositoryTest;
+import ru.tinkoff.kora.database.jdbc.JdbcRepository;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class TagPropagationTest extends AbstractJdbcRepositoryTest {
+
+    @Test
+    public void testAbstractClassRepository() {
+        var result = compile(
+            List.of(new RepositoryAnnotationProcessor()),
+            """
+            @Repository
+            @Tag({TestRepository.class, JdbcRepository.class, Integer.class})
+            public interface TestRepository extends JdbcRepository {
+                @Query("INSERT INTO table(value) VALUES (:value)")
+                void abstractMethod(String value);
+            }
+            """
+        );
+
+        result.assertSuccess();
+
+        var repositoryClass = result.loadClass("$TestRepository_Impl");
+
+        var annotation = repositoryClass.getAnnotation(Tag.class);
+
+        assertNotNull(annotation, "@Tag annotation is not propagated");
+
+        var tagClasses = Arrays.stream(annotation.value())
+            .map(Class::getCanonicalName)
+            .toList();
+
+        Assertions.assertThat(tagClasses)
+            .containsExactlyInAnyOrder(
+                testPackage() + ".TestRepository",
+                JdbcRepository.class.getCanonicalName(),
+                Integer.class.getCanonicalName()
+            );
+    }
+}

--- a/database/database-annotation-processor/src/test/java/ru/tinkoff/kora/database/common/annotation/processor/app/TestKoraAppExecutorTagged.java
+++ b/database/database-annotation-processor/src/test/java/ru/tinkoff/kora/database/common/annotation/processor/app/TestKoraAppExecutorTagged.java
@@ -11,7 +11,7 @@ import ru.tinkoff.kora.database.jdbc.JdbcRepository;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
-public interface TestKoraAppTagged {
+public interface TestKoraAppExecutorTagged {
 
     class ExampleTag {}
 

--- a/database/database-annotation-processor/src/test/java/ru/tinkoff/kora/database/common/annotation/processor/app/TestKoraAppRepoTagged.java
+++ b/database/database-annotation-processor/src/test/java/ru/tinkoff/kora/database/common/annotation/processor/app/TestKoraAppRepoTagged.java
@@ -1,0 +1,37 @@
+package ru.tinkoff.kora.database.common.annotation.processor.app;
+
+import org.mockito.Mockito;
+import ru.tinkoff.kora.common.KoraApp;
+import ru.tinkoff.kora.common.Tag;
+import ru.tinkoff.kora.common.annotation.Root;
+import ru.tinkoff.kora.database.common.annotation.Query;
+import ru.tinkoff.kora.database.common.annotation.Repository;
+import ru.tinkoff.kora.database.jdbc.JdbcConnectionFactory;
+import ru.tinkoff.kora.database.jdbc.JdbcRepository;
+
+@KoraApp
+public interface TestKoraAppRepoTagged {
+
+    class RepositoryTag {}
+
+    @Repository
+    @Tag(RepositoryTag.class)
+    interface TestRepository extends JdbcRepository {
+        @Query("INSERT INTO table(value) VALUES (:value)")
+        void abstractMethod(String value);
+
+        default String test() {
+            return "i'm in tagged repo";
+        }
+    }
+
+    default JdbcConnectionFactory jdbcQueryExecutorAccessor() {
+        return Mockito.mock(JdbcConnectionFactory.class);
+    }
+
+    @Root
+    default String rootTestString(@Tag(RepositoryTag.class) TestKoraAppRepoTagged.TestRepository testRepository) {
+        return testRepository.test();
+    }
+
+}

--- a/database/database-symbol-processor/src/main/kotlin/ru/tinkoff/kora/database/symbol/processor/RepositoryBuilder.kt
+++ b/database/database-symbol-processor/src/main/kotlin/ru/tinkoff/kora/database/symbol/processor/RepositoryBuilder.kt
@@ -6,8 +6,13 @@ import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.ClassKind
 import com.google.devtools.ksp.symbol.KSClassDeclaration
-import com.squareup.kotlinpoet.*
+import com.squareup.kotlinpoet.AnnotationSpec
+import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.ParameterSpec
+import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.ksp.addOriginatingKSFile
+import com.squareup.kotlinpoet.ksp.toAnnotationSpec
 import com.squareup.kotlinpoet.ksp.toClassName
 import com.squareup.kotlinpoet.ksp.toTypeName
 import org.slf4j.LoggerFactory
@@ -15,7 +20,9 @@ import ru.tinkoff.kora.database.symbol.processor.cassandra.CassandraRepositoryGe
 import ru.tinkoff.kora.database.symbol.processor.jdbc.JdbcRepositoryGenerator
 import ru.tinkoff.kora.database.symbol.processor.r2dbc.R2DbcRepositoryGenerator
 import ru.tinkoff.kora.database.symbol.processor.vertx.VertxRepositoryGenerator
+import ru.tinkoff.kora.ksp.common.AnnotationUtils.findAnnotation
 import ru.tinkoff.kora.ksp.common.CommonAopUtils.extendsKeepAop
+import ru.tinkoff.kora.ksp.common.CommonClassNames
 import ru.tinkoff.kora.ksp.common.KspCommonUtils.generated
 import ru.tinkoff.kora.ksp.common.exception.ProcessingErrorException
 import ru.tinkoff.kora.ksp.common.getOuterClassesAsPrefix
@@ -39,6 +46,10 @@ class RepositoryBuilder(
         val builder = repositoryDeclaration.extendsKeepAop(name)
             .generated(RepositoryBuilder::class)
             .addOriginatingKSFile(repositoryDeclaration.containingFile!!)
+
+        repositoryDeclaration.findAnnotation(CommonClassNames.tag)
+            ?.let { builder.addAnnotation(it.toAnnotationSpec()) }
+
         val constructorBuilder = FunSpec.constructorBuilder()
         if (repositoryDeclaration.classKind == ClassKind.CLASS) {
             this.enrichConstructorFromParentClass(builder, constructorBuilder, repositoryDeclaration)

--- a/database/database-symbol-processor/src/main/kotlin/ru/tinkoff/kora/database/symbol/processor/extension/RepositoryKoraExtension.kt
+++ b/database/database-symbol-processor/src/main/kotlin/ru/tinkoff/kora/database/symbol/processor/extension/RepositoryKoraExtension.kt
@@ -15,20 +15,24 @@ import ru.tinkoff.kora.kora.app.ksp.extension.ExtensionResult
 import ru.tinkoff.kora.kora.app.ksp.extension.KoraExtension
 import ru.tinkoff.kora.ksp.common.AnnotationUtils.findAnnotation
 import ru.tinkoff.kora.ksp.common.CommonAopUtils.hasAopAnnotations
+import ru.tinkoff.kora.ksp.common.TagUtils.parseTags
+import ru.tinkoff.kora.ksp.common.TagUtils.tagsMatch
 import ru.tinkoff.kora.ksp.common.getOuterClassesAsPrefix
 
 @KspExperimental
 class RepositoryKoraExtension(private val kspLogger: KSPLogger) : KoraExtension {
     override fun getDependencyGenerator(resolver: Resolver, type: KSType, tags: Set<String>): (() -> ExtensionResult)? {
-        if (tags.isNotEmpty()) return null
         if (type.declaration !is KSClassDeclaration) {
             return null
         }
         val declaration = type.declaration as KSClassDeclaration
-        if (declaration.classKind != ClassKind.INTERFACE && (declaration.classKind != ClassKind.CLASS || !declaration.modifiers.contains(Modifier.ABSTRACT))) {
+        if (declaration.classKind != ClassKind.INTERFACE && !(declaration.classKind == ClassKind.CLASS && Modifier.ABSTRACT in declaration.modifiers)) {
             return null
         }
         if (declaration.findAnnotation(DbUtils.repositoryAnnotation) == null) {
+            return null
+        }
+        if (!tags.tagsMatch(declaration.parseTags())) {
             return null
         }
         return lambda@{

--- a/database/database-symbol-processor/src/test/kotlin/ru/tinkoff/kora/database/symbol/processor/RepositoryTagPropagationTest.kt
+++ b/database/database-symbol-processor/src/test/kotlin/ru/tinkoff/kora/database/symbol/processor/RepositoryTagPropagationTest.kt
@@ -1,0 +1,46 @@
+package ru.tinkoff.kora.database.symbol.processor
+
+import kotlin.reflect.KClass
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import ru.tinkoff.kora.common.Tag
+import ru.tinkoff.kora.database.jdbc.JdbcRepository
+import ru.tinkoff.kora.database.symbol.processor.jdbc.AbstractJdbcRepositoryTest
+
+class RepositoryTagPropagationTest : AbstractJdbcRepositoryTest() {
+
+    @Test
+    fun tagsFromInterfaceArePropagatedToImpl() {
+        compile0(
+            """
+            @Repository
+            @Tag(value = [TestRepository::class, JdbcRepository::class, Int::class])
+            interface TestRepository : JdbcRepository {
+                @Query("SELECT 1;")
+                fun select1()
+            }
+            """.trimIndent(),
+        )
+
+        compileResult.assertSuccess()
+
+        val repository = compileResult.loadClass("\$TestRepository_Impl").kotlin
+
+        val repoInterfaceClass = repository.supertypes
+            .map { it.classifier }
+            .filterIsInstance<KClass<*>>()
+            .first { it.simpleName == "TestRepository" }
+
+        val tagClasses = repository.annotations
+            .filterIsInstance<Tag>()
+            .flatMap { it.value.toList() }
+
+        Assertions.assertThat(tagClasses)
+            .isNotEmpty
+            .containsExactlyInAnyOrder(
+                repoInterfaceClass,
+                JdbcRepository::class,
+                Int::class,
+            )
+    }
+}

--- a/database/database-symbol-processor/src/test/kotlin/ru/tinkoff/kora/database/symbol/processor/jdbc/JdbcExtensionTests.kt
+++ b/database/database-symbol-processor/src/test/kotlin/ru/tinkoff/kora/database/symbol/processor/jdbc/JdbcExtensionTests.kt
@@ -3,21 +3,9 @@ package ru.tinkoff.kora.database.symbol.processor.jdbc
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
 import ru.tinkoff.kora.common.Tag
-import ru.tinkoff.kora.ksp.common.AbstractSymbolProcessorTest
 import ru.tinkoff.kora.ksp.common.GraphUtil.toGraphDraw
 
-class JdbcExtensionTests : AbstractSymbolProcessorTest() {
-
-    override fun commonImports(): String {
-        return super.commonImports() + """
-            import ru.tinkoff.kora.database.jdbc.*;
-            import ru.tinkoff.kora.database.jdbc.mapper.result.*;
-            import ru.tinkoff.kora.database.jdbc.mapper.parameter.*;
-            import ru.tinkoff.kora.common.Mapping;
-
-            import java.sql.*;
-        """.trimIndent()
-    }
+class JdbcExtensionTests : AbstractJdbcRepositoryTest() {
 
     @Test
     fun testRowMapper() {

--- a/kora-app-annotation-processor/src/main/java/ru/tinkoff/kora/kora/app/annotation/processor/component/DependencyClaim.java
+++ b/kora-app-annotation-processor/src/main/java/ru/tinkoff/kora/kora/app/annotation/processor/component/DependencyClaim.java
@@ -1,6 +1,6 @@
 package ru.tinkoff.kora.kora.app.annotation.processor.component;
 
-import ru.tinkoff.kora.annotation.processor.common.CommonClassNames;
+import ru.tinkoff.kora.annotation.processor.common.TagUtils;
 import ru.tinkoff.kora.annotation.processor.common.TypeParameterUtils;
 
 import javax.lang.model.type.TypeMirror;
@@ -19,21 +19,7 @@ public record DependencyClaim(TypeMirror type, Set<String> tags, DependencyClaim
     }
 
     public boolean tagsMatches(Collection<String> other) {
-        if (this.tags.isEmpty() && other.isEmpty()) {
-            return true;
-        }
-        if (this.tags.isEmpty()) {
-            return false;
-        }
-        if (this.tags.contains(CommonClassNames.tagAny.canonicalName())) {
-            return true;
-        }
-        for (var tag : this.tags) {
-            if (!other.contains(tag)) {
-                return false;
-            }
-        }
-        return true;
+        return TagUtils.tagsMatch(this.tags, other);
     }
 
     public enum DependencyClaimType {

--- a/kora-app-symbol-processor/src/main/kotlin/ru/tinkoff/kora/kora/app/ksp/component/DependencyClaim.kt
+++ b/kora-app-symbol-processor/src/main/kotlin/ru/tinkoff/kora/kora/app/ksp/component/DependencyClaim.kt
@@ -1,25 +1,11 @@
 package ru.tinkoff.kora.kora.app.ksp.component
 
 import com.google.devtools.ksp.symbol.KSType
-import ru.tinkoff.kora.ksp.common.CommonClassNames
+import ru.tinkoff.kora.ksp.common.TagUtils.tagsMatch
 
 data class DependencyClaim(val type: KSType, val tags: Set<String>, val claimType: DependencyClaimType) {
-    fun tagsMatches(other: Collection<String?>): Boolean {
-        if (tags.isEmpty() && other.isEmpty()) {
-            return true
-        }
-        if (tags.isEmpty()) {
-            return false
-        }
-        if (tags.contains(CommonClassNames.tagAny.canonicalName)) {
-            return true
-        }
-        for (tag in tags) {
-            if (!other.contains(tag)) {
-                return false
-            }
-        }
-        return true
+    fun tagsMatches(other: Collection<String>): Boolean {
+        return tags.tagsMatch(other)
     }
 
     enum class DependencyClaimType {

--- a/kora-app-symbol-processor/src/main/kotlin/ru/tinkoff/kora/kora/app/ksp/declaration/ComponentDeclaration.kt
+++ b/kora-app-symbol-processor/src/main/kotlin/ru/tinkoff/kora/kora/app/ksp/declaration/ComponentDeclaration.kt
@@ -2,7 +2,12 @@ package ru.tinkoff.kora.kora.app.ksp.declaration
 
 import com.google.devtools.ksp.closestClassDeclaration
 import com.google.devtools.ksp.isConstructor
-import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSDeclaration
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.google.devtools.ksp.symbol.KSType
+import com.google.devtools.ksp.symbol.KSTypeArgument
+import com.google.devtools.ksp.symbol.KSTypeParameter
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.MemberName
 import com.squareup.kotlinpoet.TypeName
@@ -172,7 +177,11 @@ sealed interface ComponentDeclaration {
             if (type.isError) {
                 throw ProcessingErrorException("Component type is not resolvable in the current round of processing", sourceMethod)
             }
-            val tag = sourceMethod.parseTags()
+            val tag = if (sourceMethod.isConstructor()) {
+                sourceMethod.closestClassDeclaration()!!.parseTags()
+            } else {
+                sourceMethod.parseTags()
+            }
 
             return FromExtensionComponent(type, sourceMethod, parameterTypes, parameterTags, tag) {
                 if (sourceMethod.isConstructor()) {

--- a/symbol-processor-common/src/main/kotlin/ru/tinkoff/kora/ksp/common/TagUtils.kt
+++ b/symbol-processor-common/src/main/kotlin/ru/tinkoff/kora/ksp/common/TagUtils.kt
@@ -1,7 +1,17 @@
 package ru.tinkoff.kora.ksp.common
 
-import com.google.devtools.ksp.symbol.*
-import com.squareup.kotlinpoet.*
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSAnnotation
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSPropertyDeclaration
+import com.google.devtools.ksp.symbol.KSType
+import com.google.devtools.ksp.symbol.Modifier
+import com.squareup.kotlinpoet.AnnotationSpec
+import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.ParameterSpec
+import com.squareup.kotlinpoet.TypeName
+import com.squareup.kotlinpoet.TypeSpec
 
 object TagUtils {
     val ignoreList = setOf("Component", "DefaultComponent")
@@ -117,5 +127,24 @@ object TagUtils {
             val value = codeBlock.add("]").build()
             return AnnotationSpec.builder(CommonClassNames.tag).addMember(value).build()
         }
+    }
+
+    fun Collection<String>.tagsMatch(other: Collection<String>): Boolean {
+        if (this.isEmpty() && other.isEmpty()) {
+            return true
+        }
+        if (this.isEmpty()) {
+            return false
+        }
+        if (this.contains(CommonClassNames.tagAny.canonicalName)) {
+            return true
+        }
+
+        for (tag in this) {
+            if (tag !in other) {
+                return false
+            }
+        }
+        return true
     }
 }


### PR DESCRIPTION
I noticed that it's impossible to put tags on `@Repository` interfaces:

```kotlin
@Repository
@Tag(MyRepo::class) // Impl won't have this Tag
interface MyRepo : JdbcRepository
```

The only current workaround for this issue:

```kotlin
interface MyRepoModule {
  @Tag(MyRepo::class)
  fun myRepo(factory: JdbcConnectionFactory) = `\$MyRepo_Impl`(factory)
}
```

I think this is unnecessary complication, so in this PR I adding `@Tag` propagation from `@Repository` marked interface/abstract class to it's generated `Impl`