### PR TITLE
Fix JsonReader/JsonWriter for JSON fields with '$' in name

### DIFF
--- a/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/writer/JsonWriterGenerator.kt
+++ b/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/writer/JsonWriterGenerator.kt
@@ -114,7 +114,7 @@ class JsonWriterGenerator(private val resolver: Resolver) {
 
     private fun addWriteParam(function: CodeBlock.Builder, field: JsonClassWriterMeta.FieldMeta) {
         val read = CodeBlock.builder()
-            .add("_gen.writeFieldName(%L)\n", jsonNameStaticName(field))
+            .add("_gen.writeFieldName(%N)\n", jsonNameStaticName(field))
         if (field.writer == null && field.typeMeta is WriterFieldType.KnownWriterFieldType) {
             read.add(writeKnownType(field.typeMeta.knownType))
         } else {

--- a/json/json-symbol-processor/src/test/kotlin/ru/tinkoff/kora/json/ksp/SpecialCharsInJsonFieldsTest.kt
+++ b/json/json-symbol-processor/src/test/kotlin/ru/tinkoff/kora/json/ksp/SpecialCharsInJsonFieldsTest.kt
@@ -1,0 +1,71 @@
+package ru.tinkoff.kora.json.ksp
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Test
+
+class SpecialCharsInJsonFieldsTest : AbstractJsonSymbolProcessorTest() {
+    @Test
+    fun testDollarInFieldNames() {
+        compile(
+            """
+            @Json
+            data class DtoWithDollarFields(
+                @Suppress("PropertyName")
+                val `${'$'}ref`: String,
+                @Suppress("PropertyName")
+                val `ref${'$'}`: String,
+                @JsonField("${"\\$\\$"}ref")
+                val ref: String,
+            )
+            """.trimIndent(),
+        )
+
+        assertAll(
+            {
+                val reader = reader("DtoWithDollarFields")
+
+                val readerResult =
+                    reader.read(
+                        """
+                        {
+                            "${'$'}ref": "ref 1",
+                            "ref${'$'}": "ref 2",
+                            "${"$$"}ref": "ref 3"
+                        }
+                        """.trimIndent(),
+                    )
+
+                assertThat(readerResult)
+                    .isEqualTo(
+                        new(
+                            "DtoWithDollarFields",
+                            "ref 1",
+                            "ref 2",
+                            "ref 3",
+                        )
+                    )
+            },
+            {
+                val writer = writer("DtoWithDollarFields")
+
+                val writerResult =
+                    writer.toString(
+                        new(
+                            "DtoWithDollarFields",
+                            "ref with first dollar",
+                            "ref with last",
+                            "ref with two",
+                        ),
+                    )
+
+                assertThat(writerResult)
+                    .isEqualTo(
+                        """
+                        {"${'$'}ref":"ref with first dollar","ref${'$'}":"ref with last","${"$$"}ref":"ref with two"}
+                        """.trimIndent(),
+                    )
+            },
+        )
+    }
+}


### PR DESCRIPTION
I fixed generation of Kotlin JsonReaders/JsonWriters for data classes with props with `$` sign in name and in `@JsonField`.

Now it's possible to write:

```
@Json
data class DtoWithDollarFields(
    val `$ref`: String,
    val `ref$`: String,
    @JsonField("\$\$ref")
    val ref: String,
)
```