### PR TITLE
[Draft] @JsonUnboxed annotation

### DIFF
--- a/annotation-processor-common/src/testFixtures/java/ru/tinkoff/kora/annotation/processor/common/CompileResult.java
+++ b/annotation-processor-common/src/testFixtures/java/ru/tinkoff/kora/annotation/processor/common/CompileResult.java
@@ -71,9 +71,9 @@ public record CompileResult(String testPackage, List<Diagnostic<? extends JavaFi
                 .filter(d -> d.getKind() == Diagnostic.Kind.ERROR)
                 .map(Object::toString)
                 .collect(Collectors.joining("\n"));
-            throw new RuntimeException("CompilationError: \n" + errors.indent(2) + "\n" + j.toString().indent(2));
+            return new RuntimeException("CompilationError: \n" + errors.indent(2) + "\n" + j.toString().indent(2));
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            return new RuntimeException(e);
         }
 
     }

--- a/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/JsonTypes.java
+++ b/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/JsonTypes.java
@@ -7,6 +7,7 @@ public class JsonTypes {
     public static final ClassName jsonInclude = ClassName.get("ru.tinkoff.kora.json.common.annotation", "JsonInclude");
     public static final ClassName jsonDiscriminatorField = ClassName.get("ru.tinkoff.kora.json.common.annotation", "JsonDiscriminatorField");
     public static final ClassName jsonDiscriminatorValue = ClassName.get("ru.tinkoff.kora.json.common.annotation", "JsonDiscriminatorValue");
+    public static final ClassName jsonUnboxed = ClassName.get("ru.tinkoff.kora.json.common.annotation", "JsonUnboxed");
 
 
     public static final ClassName jsonReaderAnnotation = ClassName.get("ru.tinkoff.kora.json.common.annotation", "JsonReader");

--- a/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/reader/JsonReaderGenerator.java
+++ b/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/reader/JsonReaderGenerator.java
@@ -65,7 +65,7 @@ public class JsonReaderGenerator {
             .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
             .addException(IOException.class)
             .addParameter(JsonTypes.jsonParser, "_parser")
-            .returns(TypeName.get(meta.typeElement().asType()))
+            .returns(TypeName.get(meta.typeMirror()))
             .addAnnotation(Override.class)
             .addAnnotation(Nullable.class);
         method.addStatement("var _token = _parser.currentToken()");

--- a/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/reader/UnboxedReaderGenerator.java
+++ b/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/reader/UnboxedReaderGenerator.java
@@ -1,0 +1,93 @@
+package ru.tinkoff.kora.json.annotation.processor.reader;
+
+import com.squareup.javapoet.AnnotationSpec;
+import com.squareup.javapoet.CodeBlock;
+import com.squareup.javapoet.FieldSpec;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.ParameterSpec;
+import com.squareup.javapoet.ParameterizedTypeName;
+import com.squareup.javapoet.TypeName;
+import com.squareup.javapoet.TypeSpec;
+import com.squareup.javapoet.TypeVariableName;
+import jakarta.annotation.Nullable;
+import java.io.IOException;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeParameterElement;
+import ru.tinkoff.kora.annotation.processor.common.CommonClassNames;
+import ru.tinkoff.kora.annotation.processor.common.CommonUtils;
+import ru.tinkoff.kora.json.annotation.processor.JsonTypes;
+import ru.tinkoff.kora.json.annotation.processor.JsonUtils;
+
+public class UnboxedReaderGenerator {
+
+    public TypeSpec generateForUnboxed(UnboxedReaderMeta meta) {
+
+        var typeBuilder = TypeSpec.classBuilder(JsonUtils.jsonReaderName(meta.typeElement()))
+            .addAnnotation(AnnotationSpec.builder(CommonClassNames.koraGenerated)
+                .addMember("value", CodeBlock.of("$S", UnboxedReaderGenerator.class.getCanonicalName()))
+                .build())
+            .addSuperinterface(ParameterizedTypeName.get(JsonTypes.jsonReader, TypeName.get(meta.typeMirror())))
+            .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+            .addOriginatingElement(meta.typeElement());
+
+        for (TypeParameterElement typeParameter : meta.typeElement().getTypeParameters()) {
+            typeBuilder.addTypeVariable(TypeVariableName.get(typeParameter));
+        }
+
+        var field = meta.field();
+
+        var fieldName = this.readerFieldName(field);
+        var fieldType = ParameterizedTypeName.get(JsonTypes.jsonReader, field.typeName());
+        var readerField = FieldSpec.builder(fieldType, fieldName, Modifier.PRIVATE, Modifier.FINAL).build();
+        var readerParameter = ParameterSpec.builder(fieldType, fieldName).build();
+
+        var constructor = MethodSpec.constructorBuilder()
+            .addModifiers(Modifier.PUBLIC)
+            .addParameter(readerParameter)
+            .addStatement("this.$N = $N", readerField, readerParameter);
+
+        typeBuilder.addField(readerField);
+        typeBuilder.addMethod(constructor.build());
+
+        var method = MethodSpec.methodBuilder("read")
+            .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+            .addException(IOException.class)
+            .addParameter(JsonTypes.jsonParser, "_parser")
+            .returns(TypeName.get(meta.typeMirror()))
+            .addAnnotation(Override.class)
+            .addAnnotation(Nullable.class);
+
+        method.addStatement("var _token = _parser.currentToken()");
+        method.beginControlFlow("if (_token == $T.VALUE_NULL)", JsonTypes.jsonToken);
+
+        if (isNullable(field)) {
+            method.addStatement("return new $T(null)", meta.typeElement());
+        } else {
+            method.addStatement(
+                "throw new $T(_parser, $S)",
+                JsonTypes.jsonParseException,
+                "Expecting nonnull value, got VALUE_NULL token"
+            );
+        }
+
+        method.endControlFlow();
+
+        method.addStatement("return new $T($N.read(_parser))",  meta.typeElement(), readerField);
+
+        typeBuilder.addMethod(method.build());
+
+        return typeBuilder.build();
+    }
+
+    private String readerFieldName(UnboxedReaderMeta.FieldMeta field) {
+        return field.parameter().getSimpleName() + "Reader";
+    }
+
+    private boolean isNullable(UnboxedReaderMeta.FieldMeta field) {
+        if (field.parameter().asType().getKind().isPrimitive()) {
+            return false;
+        }
+
+        return CommonUtils.isNullable(field.parameter());
+    }
+}

--- a/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/reader/UnboxedReaderMeta.java
+++ b/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/reader/UnboxedReaderMeta.java
@@ -1,0 +1,10 @@
+package ru.tinkoff.kora.json.annotation.processor.reader;
+
+import com.squareup.javapoet.TypeName;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.TypeMirror;
+
+public record UnboxedReaderMeta(TypeMirror typeMirror, TypeElement typeElement, FieldMeta field) {
+    public record FieldMeta(VariableElement parameter, TypeName typeName) {}
+}

--- a/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/writer/UnboxedWriterGenerator.java
+++ b/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/writer/UnboxedWriterGenerator.java
@@ -1,0 +1,68 @@
+package ru.tinkoff.kora.json.annotation.processor.writer;
+
+import com.squareup.javapoet.AnnotationSpec;
+import com.squareup.javapoet.CodeBlock;
+import com.squareup.javapoet.FieldSpec;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.ParameterSpec;
+import com.squareup.javapoet.ParameterizedTypeName;
+import com.squareup.javapoet.TypeName;
+import com.squareup.javapoet.TypeSpec;
+import com.squareup.javapoet.TypeVariableName;
+import jakarta.annotation.Nullable;
+import java.io.IOException;
+import javax.lang.model.element.Modifier;
+import ru.tinkoff.kora.annotation.processor.common.CommonClassNames;
+import ru.tinkoff.kora.json.annotation.processor.JsonTypes;
+import ru.tinkoff.kora.json.annotation.processor.JsonUtils;
+
+public class UnboxedWriterGenerator {
+
+    @Nullable
+    public TypeSpec generate(UnboxedWriterMeta meta) {
+        var typeBuilder = TypeSpec.classBuilder(JsonUtils.jsonWriterName(meta.typeElement()))
+            .addAnnotation(AnnotationSpec.builder(CommonClassNames.koraGenerated)
+                .addMember("value", CodeBlock.of("$S", UnboxedWriterGenerator.class.getCanonicalName()))
+                .build())
+            .addSuperinterface(ParameterizedTypeName.get(JsonTypes.jsonWriter, TypeName.get(meta.typeMirror())))
+            .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+            .addOriginatingElement(meta.typeElement());
+
+        for (var typeParameter : meta.typeElement().getTypeParameters()) {
+            typeBuilder.addTypeVariable(TypeVariableName.get(typeParameter));
+        }
+
+        var field = meta.field();
+
+        var fieldName = this.writerFieldName(field);
+        var fieldType = ParameterizedTypeName.get(JsonTypes.jsonWriter, TypeName.get(field.typeMirror()));
+
+        var writerField = FieldSpec.builder(fieldType, fieldName, Modifier.PRIVATE, Modifier.FINAL).build();
+        var writerParameter = ParameterSpec.builder(fieldType, fieldName).build();
+
+        var constructor = MethodSpec.constructorBuilder()
+            .addModifiers(Modifier.PUBLIC)
+            .addParameter(writerParameter)
+            .addStatement("this.$N = $N", writerField, writerParameter);
+
+        typeBuilder.addField(writerField);
+        typeBuilder.addMethod(constructor.build());
+
+        var method = MethodSpec.methodBuilder("write")
+            .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+            .addException(IOException.class)
+            .addParameter(JsonTypes.jsonGenerator, "_gen")
+            .addParameter(ParameterSpec.builder(TypeName.get(meta.typeMirror()), "_object").addAnnotation(Nullable.class).build())
+            .addAnnotation(Override.class)
+            .addCode("if (_object == null) {$>\n_gen.writeNull();\nreturn;$<\n}\n");
+
+        method.addStatement("$N.write(_gen, _object.$L)", writerField, field.accessor());
+
+        typeBuilder.addMethod(method.build());
+        return typeBuilder.build();
+    }
+
+    private String writerFieldName(UnboxedWriterMeta.FieldMeta field) {
+        return field.accessor().getSimpleName() + "Writer";
+    }
+}

--- a/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/writer/UnboxedWriterMeta.java
+++ b/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/writer/UnboxedWriterMeta.java
@@ -1,0 +1,16 @@
+package ru.tinkoff.kora.json.annotation.processor.writer;
+
+import com.squareup.javapoet.TypeName;
+import jakarta.annotation.Nullable;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.TypeMirror;
+
+public record UnboxedWriterMeta(TypeMirror typeMirror, TypeElement typeElement, FieldMeta field) {
+    public record FieldMeta(
+        VariableElement field,
+        TypeMirror typeMirror,
+        ExecutableElement accessor
+    ) {}
+}

--- a/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/writer/WriterTypeMetaParser.java
+++ b/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/writer/WriterTypeMetaParser.java
@@ -54,6 +54,34 @@ public class WriterTypeMetaParser {
         return new JsonClassWriterMeta(typeMirror, jsonClass, fieldMetas);
     }
 
+    public UnboxedWriterMeta parseUnboxed(TypeElement jsonClass, TypeMirror typeMirror) {
+        if (jsonClass.getKind() != ElementKind.CLASS && jsonClass.getKind() != ElementKind.RECORD) {
+            throw new IllegalArgumentException("Should not be called for non classes");
+        }
+        if (jsonClass.getModifiers().contains(Modifier.ABSTRACT)) {
+            throw new IllegalArgumentException("Should not be called for abstract classes");
+        }
+
+        var fieldElements = this.parseFields(jsonClass);
+
+        if (fieldElements.size() != 1) {
+            throw new ProcessingErrorException(
+                "@JsonUnboxed JsonWriter can be created only for classes with single field",
+                jsonClass
+            );
+        }
+
+        VariableElement field = fieldElements.get(0);
+
+        var fieldMeta = new UnboxedWriterMeta.FieldMeta(
+            field,
+            field.asType(),
+            this.getAccessorMethod(jsonClass, field)
+        );
+
+        return new UnboxedWriterMeta(typeMirror, jsonClass, fieldMeta);
+    }
+
     private List<VariableElement> parseFields(TypeElement typeElement) {
         return typeElement.getEnclosedElements()
             .stream()

--- a/json/json-annotation-processor/src/test/java/ru/tinkoff/kora/json/annotation/processor/UnboxedTest.java
+++ b/json/json-annotation-processor/src/test/java/ru/tinkoff/kora/json/annotation/processor/UnboxedTest.java
@@ -1,0 +1,324 @@
+package ru.tinkoff.kora.json.annotation.processor;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import java.io.IOException;
+import java.lang.reflect.TypeVariable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import org.junit.jupiter.api.Test;
+import ru.tinkoff.kora.json.common.JsonReader;
+import ru.tinkoff.kora.json.common.JsonWriter;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class UnboxedTest extends AbstractJsonAnnotationProcessorTest {
+
+    JsonReader<String> stringReader = JsonParser::getValueAsString;
+    JsonWriter<String> stringWriter = JsonGenerator::writeString;
+
+
+    @Test
+    public void unboxedRecordReader() throws IOException {
+        compile(
+            """
+            @JsonReader
+            @JsonUnboxed
+            public record TestUnboxed(String a) {
+            }
+            """
+        );
+
+        var reader = reader("TestUnboxed", stringReader);
+
+        assertThat(reader.read("\"test string\""))
+            .isEqualTo(newObject("TestUnboxed", "test string"));
+    }
+
+    @Test
+    public void unboxedRecordReaderNullableField() throws IOException {
+        compile(
+            """
+            @JsonReader
+            @JsonUnboxed
+            public record TestUnboxed(@Nullable String a) {
+            }
+            """
+        );
+
+        var reader = reader("TestUnboxed", stringReader);
+
+        assertThat(reader.read("null"))
+            .isEqualTo(newObject("TestUnboxed", (Object) null));
+    }
+
+    @Test
+    public void unboxedRecordReaderNonNullableField() {
+        compile(
+            """
+            @JsonReader
+            @JsonUnboxed
+            public record TestUnboxed(String a) {
+            }
+            """
+        );
+
+        var reader = reader("TestUnboxed", stringReader);
+
+        assertThatThrownBy(() -> reader.read("null"))
+            .isInstanceOf(JsonParseException.class)
+            .hasMessageStartingWith("Expecting nonnull value, got VALUE_NULL token");
+    }
+
+    @Test
+    public void unboxedClassReader() throws IOException {
+        compile(
+            """
+            @JsonReader
+            @JsonUnboxed
+            public class TestUnboxedClass {
+                private final String value;
+            
+                public TestUnboxedClass(String value) {
+                    this.value = value;
+                }
+            
+                public String getValue() {
+                    return value;
+                }
+            }
+            """
+        );
+
+        var reader = reader("TestUnboxedClass", stringReader);
+
+        var actual = reader.read("\"test string\"");
+
+        assertThat(invoke(actual, "getValue"))
+            .isEqualTo("test string");
+    }
+
+    @Test
+    public void genericUnboxedRecordReader() {
+        compile(
+            """
+            @JsonReader
+            @JsonUnboxed
+            public record TestUnboxedGeneric<T>(T value) {}
+            """
+        );
+
+        var readerClass = compileResult.loadClass("$TestUnboxedGeneric_JsonReader");
+
+        var readerClassTypeParams = Arrays.stream(readerClass.getTypeParameters()).map(TypeVariable::getName);
+
+        assertThat(readerClassTypeParams)
+            .containsExactly("T");
+
+        var parameterTypeName = readerClass.getConstructors()[0].getParameters()[0].getParameterizedType().getTypeName();
+
+        assertThat(parameterTypeName)
+            .isEqualTo("ru.tinkoff.kora.json.common.JsonReader<T>");
+    }
+
+    @Test
+    public void errorIfJsonReaderPutOnTypeWithMultipleConstructorParams() {
+        var compileResult = compile(
+            List.of(new JsonAnnotationProcessor()),
+            """
+            @JsonReader
+            @JsonUnboxed
+            public record TestBadValueRecord(String value1, int value2) {}
+            """
+        );
+
+        assertThat(compileResult.isFailed())
+            .isTrue();
+
+        var errors = compileResult.errors();
+
+        assertThat(errors)
+            .hasSize(1);
+
+        assertThat(errors.get(0).getMessage(Locale.getDefault()))
+            .isEqualTo("@JsonUnboxed JsonReader can be created only for constructors with single parameter");
+    }
+
+    @Test
+    public void readerAnnotationOnConstructor() throws IOException {
+        compile(
+            """
+            @JsonUnboxed
+            public record TestUnboxed(String a, String b) {
+                @JsonReader
+                public TestUnboxed(String joined) {
+                    this(joined.split("\\\\."));
+                }
+            
+                private TestUnboxed(String[] parts) {
+                    this(parts[0], parts[1]);
+                }
+            }
+            """
+        );
+
+        var reader = reader("TestUnboxed", stringReader);
+
+        var actual = reader.read("\"test.string\"");
+
+        var a = invoke(actual, "a");
+        var b = invoke(actual, "b");
+
+        assertThat(a)
+            .isEqualTo("test");
+
+        assertThat(b)
+            .isEqualTo("string");
+    }
+
+    @Test
+    public void unboxedRecordWriter() throws IOException {
+        compile(
+            """
+            @JsonWriter
+            @JsonUnboxed
+            public record TestUnboxed(String a) {
+            }
+            """
+        );
+
+        var writer = writer("TestUnboxed", stringWriter);
+
+        assertThat(writer.toString(newObject("TestUnboxed", "test string")))
+            .isEqualTo("\"test string\"");
+    }
+
+    @Test
+    public void unboxedRecordWriterNullableField() throws IOException {
+        compile(
+            """
+            @JsonWriter
+            @JsonUnboxed
+            public record TestUnboxed(@Nullable String a) {
+            }
+            """
+        );
+
+        var writer = writer("TestUnboxed", stringWriter);
+
+        assertThat(writer.toString(newObject("TestUnboxed", (Object) null)))
+            .isEqualTo("null");
+    }
+
+    @Test
+    public void unboxedClassWriter() throws IOException {
+        compile(
+            """
+            @JsonWriter
+            @JsonUnboxed
+            public class TestUnboxedClass {
+                private final String value;
+
+                public TestUnboxedClass(String value) {
+                    this.value = value;
+                }
+
+                public String getValue() {
+                    return value;
+                }
+            }
+            """
+        );
+
+        var writer = writer("TestUnboxedClass", stringWriter);
+
+        var actual = writer.toString(newObject("TestUnboxedClass", "test string"));
+
+        assertThat(actual)
+            .isEqualTo("\"test string\"");
+    }
+
+    @Test
+    public void genericUnboxedRecordWriter() {
+        compile(
+            """
+            @JsonWriter
+            @JsonUnboxed
+            public record TestUnboxedGeneric<T>(T value) {}
+            """
+        );
+
+        var readerClass = compileResult.loadClass("$TestUnboxedGeneric_JsonWriter");
+
+        var readerClassTypeParams = Arrays.stream(readerClass.getTypeParameters()).map(TypeVariable::getName);
+
+        assertThat(readerClassTypeParams)
+            .containsExactly("T");
+
+        var parameterTypeName = readerClass.getConstructors()[0].getParameters()[0].getParameterizedType().getTypeName();
+
+        assertThat(parameterTypeName)
+            .isEqualTo("ru.tinkoff.kora.json.common.JsonWriter<T>");
+    }
+
+    @Test
+    public void errorIfJsonWriterPutOnTypeWithMultipleFields() {
+        var compileResult = compile(
+            List.of(new JsonAnnotationProcessor()),
+            """
+            @JsonWriter
+            @JsonUnboxed
+            public record TestBadValueRecord(String value1, int value2) {}
+            """
+        );
+
+        assertThat(compileResult.isFailed())
+            .isTrue();
+
+        var errors = compileResult.errors();
+
+        assertThat(errors)
+            .hasSize(1);
+
+        assertThat(errors.get(0).getMessage(Locale.getDefault()))
+            .isEqualTo("@JsonUnboxed JsonWriter can be created only for classes with single field");
+    }
+
+    @Test
+    public void noUnboxedErrorWithSkippedFields() throws IOException {
+        compile(
+            """
+            @Json
+            @JsonUnboxed
+            public class TestValueClass {
+                private final String value1;
+                @JsonSkip
+                private final int value2;
+
+                public TestValueClass(String value1) {
+                    this.value1 = value1;
+                    this.value2 = value1.length();
+                }
+
+                public String getValue1() { return value1; }
+                public int getValue2() { return value2; }
+            }
+            """
+        );
+
+        var mapper = mapper("TestValueClass", List.of(stringReader), List.of(stringWriter));
+
+        mapper.verifyWrite(newObject("TestValueClass", "my string"), "\"my string\"");
+
+        var readObject = mapper.read("\"test string\"");
+
+        assertThat(invoke(readObject, "getValue1"))
+            .isEqualTo("test string");
+
+        assertThat(invoke(readObject, "getValue2"))
+            .isEqualTo("test string".length());
+
+    }
+}

--- a/json/json-common/src/main/java/ru/tinkoff/kora/json/common/annotation/JsonUnboxed.java
+++ b/json/json-common/src/main/java/ru/tinkoff/kora/json/common/annotation/JsonUnboxed.java
@@ -1,0 +1,50 @@
+package ru.tinkoff.kora.json.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Use on single-field value-class to indicate that
+ * it should be (de)serialized as it's field, not as object.
+ * <p>
+ *     Given the following class:
+ *     <pre>{@code
+ *     @Json
+ *     record ValueClass(String value) {}
+ *     }</pre>
+ *
+ *     Then {@code new ValueClass("test")} will be (de)serialized as:
+ *     <pre>{@code
+ *     {"value": "test"}
+ *     }</pre>
+ *
+ *     But after adding {@code @JsonUnboxed}:
+ *     <pre>{@code
+ *     @Json
+ *     @JsonUnboxed
+ *     record ValueClass(String value) {}
+ *     }</pre>
+ *
+ *     {@code new ValueClass("test")} will be (de)serialized as:
+ *     <pre>{@code
+ *     "test"
+ *     }</pre>
+ * </p>
+ * <p>
+ *     Old-fashioned Java value-classes, Kotlin {@code data} and {@code value} classes are also supported.
+ * </p>
+ * <p>
+ *     If annotation is placed on a class with more than one field,
+ *     error will be raised.
+ * </p>
+ * <p>
+ *     Don't be confused with Jackson's {@code @JsonUnwrapped} annotation which is used
+ *     to move object's fields one level up.
+ * </p>
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface JsonUnboxed {
+}


### PR DESCRIPTION
Added new annotation `@JsonUnboxed` to indicate that class should be (de)serialized as it's underlying field.

It can only be used on value classes. This draft atm contains only Java implementation to raise a discussion. Kotlin support  is to be added to this PR.

## Reasoning

The original intention was to add implicit conversion of [Kotlin's `value class`](https://kotlinlang.org/docs/inline-classes.html) to/from JSON as it's field value. But after taking a closer look at `value class` I realised that it has all the properties of regular `class`, and implicit conversion is not an option.

Then I looked it up and found similar approach in Rust's Serde, where this conversion is made explicit by adding `transparent` to `serde` attribute.

## Naming

I've picked `Unboxed` as this feature reminded me Java's [Autoboxing and Unboxing](https://docs.oracle.com/javase/tutorial/java/data/autoboxing.html).

## Unsolved problems

By placing `@JsonReader` on single parameter constructor and by marking all the fields except one with `@JsonSkip` it is possible to use `@JsonUnboxed` with regular classes. Is it good? Is it bad? I've added tests for this case.

It is possible to restrict usage of this annotation only to single field records, for example. Discussion is needed.

## Similar technologies in other frameworks/languages

### Jackson

`@JsonValue` annotation can be placed on a class' field to serialize an entire object using this single field. `@JsonValue` can be placed on getter methods too.

BUT there's a problem with deserialization. The following code

```java
class ValueTest {
    private final String myValue;

    ValueTest(String myValue) { this.myValue = myValue; }
    ValueTest(String a,String b) { this(a + b); }

    // @JsonValue <-- THIS IS COMMENTED OUT
    public String getMyValue() { return myValue; }

    public String toString() { return "ValueTest(" + myValue + ")"; }
}

// boilerplate omitted
public static void main(String[] args) throws JsonProcessingException {
    var valueTest = new ValueTest("123");
    System.out.println(new ObjectMapper().writeValueAsString(valueTest));
    var test2 = new ObjectMapper().readValue("\"hi!\"", new TypeReference<ValueTest>() {});
    System.out.println(test2);
}
```

Will output:

```
{"myValue":"123"}
ValueTest(hi!)
```

This is because from-value deserialization is used **by default**, and from-object is explicitly enabled by adding `@JsonCreator` on constructor and `@JsonProperty` on `String myValue` parameter. This is very confusing and inconsistent.

**NOTE:** We can create `@JsonValue` annotation in Kora but make corresponding behavior consistent between reading and writing JSON.

### Gson

TODO

### Rust serde

https://serde.rs/container-attrs.html#transparent

`#[serde(transparent)]`
Serialize and deserialize a newtype struct or a braced struct with one field exactly the same as if its one field were serialized and deserialized by itself.

```rust
#[serde(transparent)]
struct W {
    a: i32
}
```