### PR TITLE
[Draft] Fix revealing sensitive headers in http client logs

### DIFF
--- a/http/http-common/src/main/java/ru/tinkoff/kora/http/common/header/HttpHeaders.java
+++ b/http/http-common/src/main/java/ru/tinkoff/kora/http/common/header/HttpHeaders.java
@@ -6,6 +6,8 @@ import java.util.*;
 
 public interface HttpHeaders extends Iterable<Map.Entry<String, List<String>>> {
 
+    Set<String> MASKED_HEADERS = Set.of("authorization", "cookie", "set-cookie");
+
     @Nullable
     String getFirst(String name);
 
@@ -165,16 +167,21 @@ public interface HttpHeaders extends Iterable<Map.Entry<String, List<String>>> {
                 sb.append('\n');
             }
 
-            sb.append(entry.getKey());
-            boolean first = true;
-            for (var val : entry.getValue()) {
-                if (first) {
-                    first = false;
-                    sb.append(": ");
-                } else {
-                    sb.append(", ");
+            final String headerKey = entry.getKey();
+            sb.append(headerKey);
+            if (shouldHeaderBeMasked(headerKey)) {
+                sb.append(": ***");
+            } else {
+                boolean first = true;
+                for (var val : entry.getValue()) {
+                    if (first) {
+                        first = false;
+                        sb.append(": ");
+                    } else {
+                        sb.append(", ");
+                    }
+                    sb.append(val);
                 }
-                sb.append(val);
             }
         }
         return sb.toString();
@@ -194,20 +201,29 @@ public interface HttpHeaders extends Iterable<Map.Entry<String, List<String>>> {
                 sb.append(", ");
             }
 
-            sb.append(entry.getKey()).append(": [");
-            boolean first = true;
-            for (var val : entry.getValue()) {
-                if (first) {
-                    first = false;
-                    sb.append(": ");
-                } else {
-                    sb.append(", ");
+            final String headerKey = entry.getKey();
+            sb.append(headerKey).append(": [");
+
+            if (shouldHeaderBeMasked(headerKey)) {
+                sb.append("***");
+            } else {
+                boolean first = true;
+                for (var val : entry.getValue()) {
+                    if (first) {
+                        first = false;
+                    } else {
+                        sb.append(", ");
+                    }
+                    sb.append(val);
                 }
-                sb.append(val);
             }
 
             sb.append("]");
         }
         return sb.toString();
+    }
+
+    private static boolean shouldHeaderBeMasked(String headerKey) {
+        return MASKED_HEADERS.contains(headerKey);
     }
 }

--- a/http/http-common/src/test/java/ru/tinkoff/kora/http/common/HttpHeadersImplTest.java
+++ b/http/http-common/src/test/java/ru/tinkoff/kora/http/common/HttpHeadersImplTest.java
@@ -67,4 +67,32 @@ class HttpHeadersImplTest {
         assertThat(headers.remove("test-header-2").has("test-header-2")).isFalse();
     }
 
+    @Test
+    void toStringTest() {
+        var headers = HttpHeaders.of(
+            "test-header-1", "test-value-1",
+            "test-header-1", "test-value-2",
+            "Authorization", "TOP_SECRET",
+            "Cookie", "ANOTHER_SECRET"
+        );
+
+        assertThat(HttpHeaders.toString(headers))
+            .isEqualTo("""
+                           test-header-1: test-value-1, test-value-2
+                           authorization: ***
+                           cookie: ***""");
+    }
+
+    @Test
+    void toStringPlainTest() {
+        var headers = HttpHeaders.of(
+            "test-header-1", "test-value-1",
+            "test-header-1", "test-value-2",
+            "Authorization", "TOP_SECRET",
+            "Cookie", "ANOTHER_SECRET"
+        );
+
+        assertThat(HttpHeaders.toStringPlain(headers))
+            .isEqualTo("test-header-1: [test-value-1, test-value-2], authorization: [***], cookie: [***]");
+    }
 }


### PR DESCRIPTION
При включенной телеметрии HTTP клиента в логи пишутся сообщения вида:
```
Requesting POST /some-url
header1: value1
header2: value2
authorization: Bearer abcdef
```
Логирование осуществляется в классе Sl4fjHttpClientLogger, однако судя по коду аналогичная проблема есть и в Slf4jHttpServerLogger.

Итого я хотел бы добавить логику маскирования в методы строкового представления заголовков, что должно поправить ситуацию во всех местах. Маскируемые заголовки: authorization, cookie, set-cookie.