### PR TITLE
GraphInterceptor support for AOP Proxy

### DIFF
--- a/annotation-processor-common/build.gradle
+++ b/annotation-processor-common/build.gradle
@@ -4,14 +4,15 @@ plugins {
 
 
 dependencies {
-    api libs.javapoet
     api project(':common')
 
+    api libs.javapoet
     implementation libs.slf4j.api
     implementation(libs.logback.classic) {
         exclude group: 'org.slf4j', module: 'slf4j-api'
     }
 
+    testFixturesApi project(':aop:aop-annotation-processor')
     testFixturesImplementation project(':common')
     testFixturesImplementation libs.reactor.core
 

--- a/annotation-processor-common/src/testFixtures/java/ru/tinkoff/kora/annotation/processor/common/AbstractAnnotationProcessorTest.java
+++ b/annotation-processor-common/src/testFixtures/java/ru/tinkoff/kora/annotation/processor/common/AbstractAnnotationProcessorTest.java
@@ -173,7 +173,7 @@ public abstract class AbstractAnnotationProcessorTest {
                     return method.invoke(target, params);
                 }
             }
-            throw new RuntimeException("Method " + name + " was not found");
+            throw new RuntimeException("Method " + name + " wasn't found");
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/annotation-processor-common/src/testFixtures/java/ru/tinkoff/kora/annotation/processor/common/TestAspect.java
+++ b/annotation-processor-common/src/testFixtures/java/ru/tinkoff/kora/annotation/processor/common/TestAspect.java
@@ -1,0 +1,15 @@
+package ru.tinkoff.kora.annotation.processor.common;
+
+import ru.tinkoff.kora.common.AopAnnotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@AopAnnotation
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TestAspect {
+
+}

--- a/annotation-processor-common/src/testFixtures/java/ru/tinkoff/kora/annotation/processor/common/TestAspectKoraAspect.java
+++ b/annotation-processor-common/src/testFixtures/java/ru/tinkoff/kora/annotation/processor/common/TestAspectKoraAspect.java
@@ -1,0 +1,19 @@
+package ru.tinkoff.kora.annotation.processor.common;
+
+import ru.tinkoff.kora.aop.annotation.processor.KoraAspect;
+
+import javax.lang.model.element.ExecutableElement;
+import java.util.Set;
+
+public final class TestAspectKoraAspect implements KoraAspect {
+
+    @Override
+    public Set<String> getSupportedAnnotationTypes() {
+        return Set.of(TestAspect.class.getCanonicalName());
+    }
+
+    @Override
+    public ApplyResult apply(ExecutableElement executableElement, String superCall, AspectContext aspectContext) {
+        return ApplyResult.Noop.INSTANCE;
+    }
+}

--- a/annotation-processor-common/src/testFixtures/java/ru/tinkoff/kora/annotation/processor/common/TestAspectKoraAspectFactory.java
+++ b/annotation-processor-common/src/testFixtures/java/ru/tinkoff/kora/annotation/processor/common/TestAspectKoraAspectFactory.java
@@ -1,0 +1,15 @@
+package ru.tinkoff.kora.annotation.processor.common;
+
+import ru.tinkoff.kora.aop.annotation.processor.KoraAspect;
+import ru.tinkoff.kora.aop.annotation.processor.KoraAspectFactory;
+
+import javax.annotation.processing.ProcessingEnvironment;
+import java.util.Optional;
+
+public final class TestAspectKoraAspectFactory implements KoraAspectFactory {
+
+    @Override
+    public Optional<KoraAspect> create(ProcessingEnvironment processingEnvironment) {
+        return Optional.of(new TestAspectKoraAspect());
+    }
+}

--- a/annotation-processor-common/src/testFixtures/java/ru/tinkoff/kora/annotation/processor/common/TestContext.java
+++ b/annotation-processor-common/src/testFixtures/java/ru/tinkoff/kora/annotation/processor/common/TestContext.java
@@ -64,7 +64,7 @@ public class TestContext {
                     continue param;
                 }
             }
-            throw new RuntimeException("Constructor param of type %s with tags %s was not found".formatted(paramType, Arrays.toString(tags)));
+            throw new RuntimeException("Constructor param of type %s with tags %s wasn't found".formatted(paramType, Arrays.toString(tags)));
         }
         try {
             return constructor.newInstance(params);

--- a/annotation-processor-common/src/testFixtures/resources/META-INF/services/ru.tinkoff.kora.aop.annotation.processor.KoraAspectFactory
+++ b/annotation-processor-common/src/testFixtures/resources/META-INF/services/ru.tinkoff.kora.aop.annotation.processor.KoraAspectFactory
@@ -1,0 +1,1 @@
+ru.tinkoff.kora.annotation.processor.common.TestAspectKoraAspectFactory

--- a/aop/aop-symbol-processor/build.gradle
+++ b/aop/aop-symbol-processor/build.gradle
@@ -3,11 +3,6 @@ apply from: "${project.rootDir}/gradle/kotlin-plugin.gradle"
 dependencies {
     api(project(":symbol-processor-common"))
 
-    implementation libs.ksp.api
-    implementation libs.kotlin.reflect
-    implementation libs.kotlinpoet
-    implementation libs.kotlinpoet.ksp
-
     testImplementation testFixtures(project(':symbol-processor-common'))
 }
 

--- a/cache/cache-symbol-processor/build.gradle
+++ b/cache/cache-symbol-processor/build.gradle
@@ -7,11 +7,6 @@ apply from: "${project.rootDir}/gradle/kotlin-plugin.gradle"
 dependencies {
     implementation project(":aop:aop-symbol-processor")
 
-    implementation libs.ksp.api
-    implementation libs.kotlin.reflect
-    implementation libs.kotlinpoet
-    implementation libs.kotlinpoet.ksp
-
     testImplementation libs.prometheus.collector.caffeine
     testImplementation project(":internal:test-logging")
     testImplementation project(":cache:cache-caffeine")

--- a/database/database-annotation-processor/src/main/java/ru/tinkoff/kora/database/annotation/processor/QueryWithParameters.java
+++ b/database/database-annotation-processor/src/main/java/ru/tinkoff/kora/database/annotation/processor/QueryWithParameters.java
@@ -91,7 +91,7 @@ public record QueryWithParameters(String rawQuery, List<QueryParameter> paramete
                 }
             }
             if (params.size() == size) {
-                throw new ProcessingErrorException("Parameter usage was not found in query: " + parameterName, parameter.variable());
+                throw new ProcessingErrorException("Parameter usage wasn't found in query: " + parameterName, parameter.variable());
             }
         }
 

--- a/database/database-annotation-processor/src/test/java/ru/tinkoff/kora/database/common/annotation/processor/RepositoryErrorsTest.java
+++ b/database/database-annotation-processor/src/test/java/ru/tinkoff/kora/database/common/annotation/processor/RepositoryErrorsTest.java
@@ -11,7 +11,7 @@ public class RepositoryErrorsTest {
     void testParameterUsage() throws Exception {
         Assertions.assertThatThrownBy(() -> process(InvalidParameterUsage.class))
             .isInstanceOf(TestUtils.CompilationErrorException.class)
-            .hasMessageContaining("Parameter usage was not found in query: param2");
+            .hasMessageContaining("Parameter usage wasn't found in query: param2");
     }
 
     public <T> void process(Class<T> repository) throws Exception {

--- a/database/database-symbol-processor/src/main/kotlin/ru/tinkoff/kora/database/symbol/processor/QueryWithParameters.kt
+++ b/database/database-symbol-processor/src/main/kotlin/ru/tinkoff/kora/database/symbol/processor/QueryWithParameters.kt
@@ -70,7 +70,7 @@ data class QueryWithParameters(val rawQuery: String, val parameters: List<QueryP
                 }
                 if (params.size == size) {
                     throw ProcessingErrorException(
-                        "Parameter usage was not found in sql: ${parameter.name}",
+                        "Parameter usage wasn't found in sql: ${parameter.name}",
                         parameter.variable
                     )
                 }

--- a/database/database-symbol-processor/src/test/kotlin/ru/tinkoff/kora/database/symbol/processor/RepositoryErrorsTest.kt
+++ b/database/database-symbol-processor/src/test/kotlin/ru/tinkoff/kora/database/symbol/processor/RepositoryErrorsTest.kt
@@ -14,7 +14,7 @@ class RepositoryErrorsTest {
         Assertions.assertThatThrownBy { process(InvalidParameterUsage::class) }
             .isInstanceOfSatisfying(CompilationErrorException::class.java) { e: CompilationErrorException ->
                 SoftAssertions.assertSoftly { s: SoftAssertions ->
-                    s.assertThat(e.messages).anyMatch { it.contains("Parameter usage was not found in sql: param2") }
+                    s.assertThat(e.messages).anyMatch { it.contains("Parameter usage wasn't found in sql: param2") }
                 }
             }
     }

--- a/experimental/s3-client-annotation-processor/src/main/java/ru/tinkoff/kora/s3/client/annotation/processor/S3ClientAnnotationProcessor.java
+++ b/experimental/s3-client-annotation-processor/src/main/java/ru/tinkoff/kora/s3/client/annotation/processor/S3ClientAnnotationProcessor.java
@@ -1055,7 +1055,7 @@ public class S3ClientAnnotationProcessor extends AbstractKoraProcessor {
                 })
                 .filter(p -> p.getSimpleName().contentEquals(paramName))
                 .findFirst()
-                .orElseThrow(() -> new ProcessingErrorException("@S3 operation key part named '%s' expected, but was not found".formatted(paramName), method));
+                .orElseThrow(() -> new ProcessingErrorException("@S3 operation key part named '%s' expected, but wasn't found".formatted(paramName), method));
 
             if (CommonUtils.isCollection(parameter.asType()) || CommonUtils.isMap(parameter.asType())) {
                 throw new ProcessingErrorException("@S3 operation key part '%s' can't be Collection or Map".formatted(paramName), method);

--- a/experimental/s3-client-symbol-processor/src/main/kotlin/ru/tinkoff/kora/s3/client/symbol/processor/S3ClientSymbolProcessor.kt
+++ b/experimental/s3-client-symbol-processor/src/main/kotlin/ru/tinkoff/kora/s3/client/symbol/processor/S3ClientSymbolProcessor.kt
@@ -894,7 +894,7 @@ class S3ClientSymbolProcessor(
                 .findFirst()
                 .orElseThrow {
                     ProcessingErrorException(
-                        "@S3 operation key part named '${paramName}' expected, but was not found",
+                        "@S3 operation key part named '${paramName}' expected, but wasn't found",
                         method
                     )
                 }

--- a/http/soap-client-annotation-processor/src/test/java/ru/tinkoff/kora/soap/client/annotation/processor/WebServiceClientAnnotationProcessorTest.java
+++ b/http/soap-client-annotation-processor/src/test/java/ru/tinkoff/kora/soap/client/annotation/processor/WebServiceClientAnnotationProcessorTest.java
@@ -260,7 +260,7 @@ class WebServiceClientAnnotationProcessorTest {
                 return;
             }
         }
-        throw new RuntimeException("Field was not found: " + fieldName);
+        throw new RuntimeException("Field wasn't found: " + fieldName);
     }
 
     private Object get(Object object, String fieldName) throws IllegalAccessException {
@@ -270,7 +270,7 @@ class WebServiceClientAnnotationProcessorTest {
                 return f.get(object);
             }
         }
-        throw new RuntimeException("Field was not found: " + fieldName);
+        throw new RuntimeException("Field wasn't found: " + fieldName);
     }
 
     private Object createClient(ClassLoader cl, String className, String url) throws Exception {

--- a/json/json-annotation-processor/build.gradle
+++ b/json/json-annotation-processor/build.gradle
@@ -1,20 +1,19 @@
 plugins {
-    id "me.champeau.jmh" version "0.6.5"
+    id "me.champeau.jmh" version "0.7.2"
 }
-apply from: "${project.rootDir}/gradle/kotlin-plugin.gradle"
 
 dependencies {
-    api project(':annotation-processor-common')
-    api project(':kora-app-annotation-processor')
+    api project(":annotation-processor-common")
+    api project(":kora-app-annotation-processor")
 
-    jmh 'com.fasterxml.jackson.module:jackson-module-blackbird:2.12.3'
-    jmh 'com.fasterxml.jackson.module:jackson-module-afterburner:2.12.3'
-    jmh 'org.apache.commons:commons-lang3:3.11'
-    jmh project(':json:json-common')
-    jmhAnnotationProcessor project(':json:json-annotation-processor')
+    jmh "com.fasterxml.jackson.module:jackson-module-blackbird:${libs.versions.jackson.get()}"
+    jmh "com.fasterxml.jackson.module:jackson-module-afterburner:${libs.versions.jackson.get()}"
+    jmh "org.apache.commons:commons-lang3:3.11"
+    jmh project(":json:json-common")
+    jmhAnnotationProcessor project(":json:json-annotation-processor")
 
-    testImplementation project(':json:json-common')
-    testImplementation testFixtures(project(':annotation-processor-common'))
+    testImplementation project(":json:json-common")
+    testImplementation testFixtures(project(":annotation-processor-common"))
 }
 
 apply from: "${project.rootDir}/gradle/in-test-generated.gradle"

--- a/json/json-annotation-processor/src/test/java/ru/tinkoff/kora/json/annotation/processor/extension/JsonKoraExtensionTest.java
+++ b/json/json-annotation-processor/src/test/java/ru/tinkoff/kora/json/annotation/processor/extension/JsonKoraExtensionTest.java
@@ -27,7 +27,7 @@ class JsonKoraExtensionTest extends AbstractJsonAnnotationProcessorTest {
 
         Assertions.assertThat(compileResult.isFailed()).isTrue();
         Assertions.assertThat(compileResult.diagnostic()).anyMatch(d -> d.getKind() == Diagnostic.Kind.ERROR
-            && d.getMessage(Locale.US).contains("Required dependency type was not found and can't be auto created: " +
+            && d.getMessage(Locale.US).contains("Required dependency type wasn't found and can't be auto created: " +
             "ru.tinkoff.kora.json.common.JsonReader<ru.tinkoff.kora.json.annotation.processor.extension.packageForJsonKoraExtensionTest.testReaderFromExtensionNotFoundForInterface.TestApp.TestInterface>"));
     }
 
@@ -45,7 +45,7 @@ class JsonKoraExtensionTest extends AbstractJsonAnnotationProcessorTest {
 
         Assertions.assertThat(compileResult.isFailed()).isTrue();
         Assertions.assertThat(compileResult.diagnostic()).anyMatch(d -> d.getKind() == Diagnostic.Kind.ERROR
-            && d.getMessage(Locale.US).contains("Required dependency type was not found and can't be auto created: " +
+            && d.getMessage(Locale.US).contains("Required dependency type wasn't found and can't be auto created: " +
             "ru.tinkoff.kora.json.common.JsonWriter<ru.tinkoff.kora.json.annotation.processor.extension.packageForJsonKoraExtensionTest.testWriterFromExtensionNotFoundForInterface.TestApp.TestInterface>"));
     }
 }

--- a/json/json-symbol-processor/build.gradle
+++ b/json/json-symbol-processor/build.gradle
@@ -1,21 +1,15 @@
 plugins {
-    id "me.champeau.jmh" version "0.6.5"
+    id "me.champeau.jmh" version "0.7.2"
     id "java-test-fixtures"
 }
-apply from: "${project.rootDir}/gradle/kotlin-plugin.gradle"
 
 dependencies {
     api project(':symbol-processor-common')
     api project(':kora-app-symbol-processor')
 
-    implementation libs.ksp.api
-    implementation libs.kotlin.reflect
-    implementation libs.kotlinpoet
-    implementation libs.kotlinpoet.ksp
-
     testImplementation project(':json:json-common')
     testImplementation testFixtures(project(':symbol-processor-common'))
 }
 
-
+apply from: "${project.rootDir}/gradle/kotlin-plugin.gradle"
 apply from: "${project.rootDir}/gradle/in-test-generated.gradle"

--- a/kafka/kafka/src/main/java/ru/tinkoff/kora/kafka/common/consumer/containers/handlers/impl/RecordHandler.java
+++ b/kafka/kafka/src/main/java/ru/tinkoff/kora/kafka/common/consumer/containers/handlers/impl/RecordHandler.java
@@ -38,6 +38,10 @@ public class RecordHandler<K, V> implements BaseKafkaRecordsHandler<K, V> {
                 try {
                     handler.handle(consumer, recordCtx, record);
                     if (this.shouldCommit && commitAllowed) {
+                        /**
+                         * The committed offset should be the next message your application will consume, i.e. lastProcessedMessageOffset + 1
+                         * @see org.apache.kafka.clients.consumer.KafkaConsumer#commitSync(Map)
+                         */
                         var topicAndOffsetAndMeta = Map.of(new TopicPartition(record.topic(), record.partition()),
                             new OffsetAndMetadata(record.offset() + 1, record.leaderEpoch(), OffsetFetchResponse.NO_METADATA));
 

--- a/kora-app-annotation-processor/build.gradle
+++ b/kora-app-annotation-processor/build.gradle
@@ -5,11 +5,6 @@ dependencies {
     implementation libs.jackson.core
 
     testImplementation testFixtures(project(":annotation-processor-common"))
-    testImplementation project(":annotation-processor-common")
-    testImplementation project(":kora-app-annotation-processor")
-    testImplementation project(":aop:aop-annotation-processor")
-    testImplementation project(":logging:logging-logback")
-    testImplementation project(":logging:declarative-logging:declarative-logging-annotation-processor")
 }
 
 apply from: "${project.rootDir}/gradle/in-test-generated.gradle"

--- a/kora-app-annotation-processor/build.gradle
+++ b/kora-app-annotation-processor/build.gradle
@@ -1,10 +1,15 @@
 import java.nio.file.Files
 
 dependencies {
-    api project(':annotation-processor-common')
+    api project(":annotation-processor-common")
     implementation libs.jackson.core
 
-    testImplementation testFixtures(project(':annotation-processor-common'))
+    testImplementation testFixtures(project(":annotation-processor-common"))
+    testImplementation project(":annotation-processor-common")
+    testImplementation project(":kora-app-annotation-processor")
+    testImplementation project(":aop:aop-annotation-processor")
+    testImplementation project(":logging:logging-logback")
+    testImplementation project(":logging:declarative-logging:declarative-logging-annotation-processor")
 }
 
 apply from: "${project.rootDir}/gradle/in-test-generated.gradle"
@@ -20,10 +25,10 @@ sourceSets {
 
 project.tasks.register("copyModules", Copy) {
     def counter = 0
-    from('..') {
+    from("..") {
         includeEmptyDirs = false
-        include '/**/src/main/resources/modules.json'
-        exclude '**/build/**/*'
+        include "/**/src/main/resources/modules.json"
+        exclude "**/build/**/*"
         rename {
             counter++
             return "module-" + counter + ".json";
@@ -32,17 +37,17 @@ project.tasks.register("copyModules", Copy) {
             path = name
         }
     }
-    into 'build/kora-modules/parts'
+    into "build/kora-modules/parts"
 }
 
 
 project.tasks.register("buildModules") {
-    it.dependsOn('copyModules')
+    it.dependsOn("copyModules")
     it.outputs.file("build/kora-modules/kora-modules.json")
-    it.inputs.dir('build/kora-modules/parts')
+    it.inputs.dir("build/kora-modules/parts")
     doLast {
         def list = new ArrayList<>()
-        fileTree(dir: 'build/kora-modules/parts', include: '*.json').visit {
+        fileTree(dir: "build/kora-modules/parts", include: "*.json").visit {
             def result = new groovy.json.JsonSlurper().parseText(it.file.text)
             list.addAll(result)
         }

--- a/kora-app-annotation-processor/src/main/java/ru/tinkoff/kora/kora/app/annotation/processor/GraphBuilder.java
+++ b/kora-app-annotation-processor/src/main/java/ru/tinkoff/kora/kora/app/annotation/processor/GraphBuilder.java
@@ -221,12 +221,12 @@ public class GraphBuilder {
                 var hints = ctx.dependencyModuleHintProvider.findHints(dependencyClaim.type(), dependencyClaim.tags());
                 var msg = new StringBuilder();
                 if (dependencyClaim.tags().isEmpty()) {
-                    msg.append(String.format("Required dependency type was not found and can't be auto created: %s.\n" +
+                    msg.append(String.format("Required dependency type wasn't found and can't be auto created: %s.\n" +
                             "Please check class for @%s annotation or that required module with component is plugged in.",
                         claimTypeName, CommonClassNames.component.simpleName()));
                 } else {
                     var tagMsg = dependencyClaim.tags().stream().collect(Collectors.joining(", ", "@Tag(", ")"));
-                    msg.append(String.format("Required dependency type was not found and can't be auto created: %s with tag %s.\n" +
+                    msg.append(String.format("Required dependency type wasn't found and can't be auto created: %s with tag %s.\n" +
                             "Please check class for @%s annotation or that required module with component is plugged in.",
                         claimTypeName, tagMsg, CommonClassNames.component.simpleName()));
                 }

--- a/kora-app-annotation-processor/src/main/java/ru/tinkoff/kora/kora/app/annotation/processor/interceptor/ComponentInterceptors.java
+++ b/kora-app-annotation-processor/src/main/java/ru/tinkoff/kora/kora/app/annotation/processor/interceptor/ComponentInterceptors.java
@@ -1,6 +1,7 @@
 package ru.tinkoff.kora.kora.app.annotation.processor.interceptor;
 
 import jakarta.annotation.Nullable;
+import ru.tinkoff.kora.annotation.processor.common.TagUtils;
 import ru.tinkoff.kora.kora.app.annotation.processor.ProcessingContext;
 import ru.tinkoff.kora.kora.app.annotation.processor.component.ResolvedComponent;
 
@@ -40,11 +41,8 @@ public class ComponentInterceptors {
     public List<ComponentInterceptor> interceptorsFor(ResolvedComponent component) {
         var type = component.type();
         return this.interceptors.stream()
-            .filter(interceptor -> this.ctx.types.isSameType(type, interceptor.interceptType()))
-            .filter(interceptor -> {
-                // todo tag matches
-                return interceptor.component().tags().equals(component.tags());
-            })
+            .filter(interceptor -> this.ctx.serviceTypeHelper.isInterceptable(interceptor.interceptType(), type))
+            .filter(interceptor -> TagUtils.tagsMatch(interceptor.component().tags(), component.tags()))
             .toList();
     }
 }

--- a/kora-app-annotation-processor/src/test/java/ru/tinkoff/kora/kora/app/annotation/processor/DependencyTest.java
+++ b/kora-app-annotation-processor/src/test/java/ru/tinkoff/kora/kora/app/annotation/processor/DependencyTest.java
@@ -262,7 +262,7 @@ public class DependencyTest extends AbstractKoraAppTest {
         assertThat(compileResult.errors()).hasSize(1);
         assertThat(compileResult.errors().get(0).getMessage(Locale.ENGLISH)).startsWith(
             """
-                Required dependency type was not found and can't be auto created: ru.tinkoff.kora.kora.app.annotation.processor.packageForDependencyTest.testDiscoveredFinalClassDependencyTaggedDependencyNoTagOnClass.ExampleApplication.TestClass1 with tag @Tag(ru.tinkoff.kora.kora.app.annotation.processor.packageForDependencyTest.testDiscoveredFinalClassDependencyTaggedDependencyNoTagOnClass.ExampleApplication.TestClass1).
+                Required dependency type wasn't found and can't be auto created: ru.tinkoff.kora.kora.app.annotation.processor.packageForDependencyTest.testDiscoveredFinalClassDependencyTaggedDependencyNoTagOnClass.ExampleApplication.TestClass1 with tag @Tag(ru.tinkoff.kora.kora.app.annotation.processor.packageForDependencyTest.testDiscoveredFinalClassDependencyTaggedDependencyNoTagOnClass.ExampleApplication.TestClass1).
                   Please check class for @Component annotation or that required module with component is plugged in.
                 """);
     }

--- a/kora-app-annotation-processor/src/test/java/ru/tinkoff/kora/kora/app/annotation/processor/GraphInterceptorTest.java
+++ b/kora-app-annotation-processor/src/test/java/ru/tinkoff/kora/kora/app/annotation/processor/GraphInterceptorTest.java
@@ -1,6 +1,7 @@
 package ru.tinkoff.kora.kora.app.annotation.processor;
 
 import org.junit.jupiter.api.Test;
+import ru.tinkoff.kora.application.graph.RefreshableGraph;
 import ru.tinkoff.kora.application.graph.internal.NodeImpl;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -46,12 +47,10 @@ public class GraphInterceptorTest extends AbstractKoraAppTest {
     }
 
     @Test
-    public void testGraphInterceptorForAopParent() {
+    public void testGraphInterceptorForAopParent() throws Exception {
         var draw = compileWithAop(
             """
-                import ch.qos.logback.classic.LoggerContext;
-                import org.slf4j.ILoggerFactory;
-                import ru.tinkoff.kora.logging.common.annotation.Log;
+                import ru.tinkoff.kora.annotation.processor.common.TestAspect;
                 import ru.tinkoff.kora.application.graph.GraphInterceptor;
 
                 @KoraApp
@@ -62,7 +61,7 @@ public class GraphInterceptorTest extends AbstractKoraAppTest {
                     @Component
                     class TestClass {
                                
-                        @Log
+                        @TestAspect
                         public String getSome() {
                             return "1";
                         }
@@ -86,15 +85,15 @@ public class GraphInterceptorTest extends AbstractKoraAppTest {
                     default TestInterceptor interceptor() {
                         return new TestInterceptor();
                     }
-                    
-                    default ILoggerFactory someLoggerFactory() {
-                        return new LoggerContext();
-                    }
                 }
                 """);
-        assertThat(draw.getNodes()).hasSize(4);
-        draw.init();
-        assertThat(((NodeImpl<?>) draw.getNodes().get(2)).getInterceptors()).hasSize(1);
+        assertThat(draw.getNodes()).hasSize(3);
+        RefreshableGraph init = draw.init();
+
+        NodeImpl<?> node = (NodeImpl<?>) draw.getNodes().get(1);
+        assertThat((node).getInterceptors()).hasSize(1);
+        var value = node.factory.get(init);
+        assertThat(value.getClass().getSimpleName()).isEqualTo("$ExampleApplication_TestClass__AopProxy");
     }
 
     @Test

--- a/kora-app-annotation-processor/src/test/java/ru/tinkoff/kora/kora/app/annotation/processor/KoraAppProcessorTest.java
+++ b/kora-app-annotation-processor/src/test/java/ru/tinkoff/kora/kora/app/annotation/processor/KoraAppProcessorTest.java
@@ -157,7 +157,7 @@ class KoraAppProcessorTest {
         assertThatThrownBy(() -> testClass(AppWithUnresolvedDependency.class))
             .isInstanceOfSatisfying(CompilationErrorException.class, e -> SoftAssertions.assertSoftly(s -> {
                 s.assertThat(e.getMessage()).startsWith("""
-                    Required dependency type was not found and can't be auto created: ru.tinkoff.kora.kora.app.annotation.processor.app.AppWithUnresolvedDependency.Class3.
+                    Required dependency type wasn't found and can't be auto created: ru.tinkoff.kora.kora.app.annotation.processor.app.AppWithUnresolvedDependency.Class3.
                       Please check class for @Component annotation or that required module with component is plugged in.
                       Dependency chain:
                         ru.tinkoff.kora.kora.app.annotation.processor.app.AppWithUnresolvedDependency.class2
@@ -203,13 +203,13 @@ class KoraAppProcessorTest {
         testClass(AppWithFactories9.class).init();
         assertThatThrownBy(() -> testClass(AppWithFactories10.class))
             .isInstanceOf(CompilationErrorException.class)
-            .hasMessageStartingWith("Required dependency type was not found and can't be auto created: java.io.Closeable")
+            .hasMessageStartingWith("Required dependency type wasn't found and can't be auto created: java.io.Closeable")
             .asInstanceOf(type(CompilationErrorException.class))
             .extracting(CompilationErrorException::getDiagnostics, list(Diagnostic.class))
             .anySatisfy(d -> {
                 assertThat(d.getKind()).isEqualTo(Diagnostic.Kind.ERROR);
                 assertThat(d.getMessage(Locale.ENGLISH)).isEqualTo("""
-                    Required dependency type was not found and can't be auto created: java.io.Closeable.
+                    Required dependency type wasn't found and can't be auto created: java.io.Closeable.
                       Please check class for @Component annotation or that required module with component is plugged in.
                       Dependency chain:
                         ru.tinkoff.kora.kora.app.annotation.processor.app.AppWithFactories10.mock1
@@ -218,21 +218,21 @@ class KoraAppProcessorTest {
             });
 //        assertThatThrownBy(() -> testClass(AppWithFactories11.class))
 //            .isInstanceOf(CompilationErrorException.class)
-//            .hasMessageContaining("Required dependency was not found and candidate class ru.tinkoff.kora.kora.app.annotation.processor.app.AppWithFactories11.GenericClass<java.lang.String> is not final")
+//            .hasMessageContaining("Required dependency wasn't found and candidate class ru.tinkoff.kora.kora.app.annotation.processor.app.AppWithFactories11.GenericClass<java.lang.String> is not final")
 //            .asInstanceOf(type(CompilationErrorException.class))
 //            .extracting(CompilationErrorException::getDiagnostics, list(Diagnostic.class))
 //            .anySatisfy(d -> {
 //                assertThat(d.getKind()).isEqualTo(Diagnostic.Kind.ERROR);
 //                assertThat(d.getMessage(Locale.ENGLISH)).isEqualTo("""
-//                      Required dependency was not found and candidate class java.lang.Long has more then one public constructor
+//                      Required dependency wasn't found and candidate class java.lang.Long has more then one public constructor
 //                        Requested at: ru.tinkoff.kora.kora.app.annotation.processor.app.AppWithFactories11.<T>factory2(java.lang.Long)
 //                     \s
 //                      Factory ru.tinkoff.kora.kora.app.annotation.processor.app.AppWithFactories11#factory2 failed to produce component because of missing dependency of type java.lang.Long
 //                      Factory ru.tinkoff.kora.kora.app.annotation.processor.app.AppWithFactories11#factory1 failed to produce component because of missing dependency of type java.io.Closeable
-//                        Required dependency implementation was not found java.io.Closeable, check if it is declared or appropriate module is declared in @KoraApp
+//                        Required dependency implementation wasn't found java.io.Closeable, check if it is declared or appropriate module is declared in @KoraApp
 //                        Requested at: ru.tinkoff.kora.kora.app.annotation.processor.app.AppWithFactories11.<T>factory1(java.io.Closeable)
 //                     \s
-//                      Required dependency was not found and candidate class ru.tinkoff.kora.kora.app.annotation.processor.app.AppWithFactories11.GenericClass<java.lang.String> is not final
+//                      Required dependency wasn't found and candidate class ru.tinkoff.kora.kora.app.annotation.processor.app.AppWithFactories11.GenericClass<java.lang.String> is not final
 //                      Requested at: ru.tinkoff.kora.kora.app.annotation.processor.app.AppWithFactories11.mock1(ru.tinkoff.kora.kora.app.annotation.processor.app.AppWithFactories11.GenericClass<java.lang.String>)
 //                    """.stripTrailing());
 //

--- a/kora-app-symbol-processor/build.gradle
+++ b/kora-app-symbol-processor/build.gradle
@@ -6,7 +6,7 @@ plugins {
 apply from: "${project.rootDir}/gradle/kotlin-plugin.gradle"
 
 dependencies {
-    api project(':symbol-processor-common')
+    api project(":symbol-processor-common")
     api libs.kotlin.reflect
 
     implementation "org.reflections:reflections:0.10.2"
@@ -16,12 +16,18 @@ dependencies {
     implementation libs.kotlinpoet.ksp
     implementation libs.jackson.core
 
-    testImplementation testFixtures(project(':annotation-processor-common'))
-    testImplementation testFixtures(project(':symbol-processor-common'))
+    testImplementation testFixtures(project(":annotation-processor-common"))
+    testImplementation testFixtures(project(":symbol-processor-common"))
+    testImplementation project(":symbol-processor-common")
+    testImplementation project(":kora-app-symbol-processor")
+    testImplementation project(":aop:aop-symbol-processor")
+    testImplementation project(":logging:logging-logback")
+    testImplementation project(":logging:declarative-logging:declarative-logging-symbol-processor")
+
 }
 
 test {
-    jvmArgs(['--enable-preview'])
+    jvmArgs(["--enable-preview"])
 }
 
 
@@ -37,10 +43,10 @@ sourceSets {
 
 project.tasks.register("copyModules", Copy) {
     def counter = 0
-    from('..') {
+    from("..") {
         includeEmptyDirs = false
-        include '/**/src/main/resources/modules.json'
-        exclude '**/build/**/*'
+        include "/**/src/main/resources/modules.json"
+        exclude "**/build/**/*"
         rename {
             counter++
             return "module-" + counter + ".json"
@@ -49,17 +55,17 @@ project.tasks.register("copyModules", Copy) {
             path = name
         }
     }
-    into 'build/kora-modules/parts'
+    into "build/kora-modules/parts"
 }
 
 
 project.tasks.register("buildModules") {
-    it.dependsOn('copyModules')
+    it.dependsOn("copyModules")
     it.outputs.file("build/kora-modules/kora-modules.json")
-    it.inputs.dir('build/kora-modules/parts')
+    it.inputs.dir("build/kora-modules/parts")
     doLast {
         def list = new ArrayList<>()
-        fileTree(dir: 'build/kora-modules/parts', include: '*.json').visit {
+        fileTree(dir: "build/kora-modules/parts", include: "*.json").visit {
             def result = new groovy.json.JsonSlurper().parseText(it.file.text)
             list.addAll(result)
         }

--- a/kora-app-symbol-processor/build.gradle
+++ b/kora-app-symbol-processor/build.gradle
@@ -7,23 +7,10 @@ apply from: "${project.rootDir}/gradle/kotlin-plugin.gradle"
 
 dependencies {
     api project(":symbol-processor-common")
-    api libs.kotlin.reflect
-
-    implementation "org.reflections:reflections:0.10.2"
-    implementation libs.ksp.api
-    implementation libs.kotlin.reflect
-    implementation libs.kotlinpoet
-    implementation libs.kotlinpoet.ksp
     implementation libs.jackson.core
 
     testImplementation testFixtures(project(":annotation-processor-common"))
     testImplementation testFixtures(project(":symbol-processor-common"))
-    testImplementation project(":symbol-processor-common")
-    testImplementation project(":kora-app-symbol-processor")
-    testImplementation project(":aop:aop-symbol-processor")
-    testImplementation project(":logging:logging-logback")
-    testImplementation project(":logging:declarative-logging:declarative-logging-symbol-processor")
-
 }
 
 test {

--- a/kora-app-symbol-processor/src/main/kotlin/ru/tinkoff/kora/kora/app/ksp/GraphBuilder.kt
+++ b/kora-app-symbol-processor/src/main/kotlin/ru/tinkoff/kora/kora/app/ksp/GraphBuilder.kt
@@ -210,13 +210,13 @@ object GraphBuilder {
                 val hints = ctx.dependencyHintProvider.findHints(dependencyClaim.type, dependencyClaim.tags)
                 val msg = if (dependencyClaim.tags.isEmpty()) {
                     StringBuilder(
-                        "Required dependency type was not found and can't be auto created: ${dependencyClaim.type.toTypeName()}.\n" +
+                        "Required dependency type wasn't found and can't be auto created: ${dependencyClaim.type.toTypeName()}.\n" +
                             "Please check class for @${CommonClassNames.component.canonicalName} annotation or that required module with component is plugged in."
                     )
                 } else {
                     val tagMsg = dependencyClaim.tags.joinToString(", ", "@Tag(", ")")
                     StringBuilder(
-                        "Required dependency type was not found and can't be auto created: ${dependencyClaim.type.toTypeName()} with tag ${tagMsg}.\n" +
+                        "Required dependency type wasn't found and can't be auto created: ${dependencyClaim.type.toTypeName()} with tag ${tagMsg}.\n" +
                             "Please check class for @${CommonClassNames.component.canonicalName} annotation or that required module with component is plugged in."
                     )
                 }

--- a/kora-app-symbol-processor/src/main/kotlin/ru/tinkoff/kora/kora/app/ksp/KoraAppProcessor.kt
+++ b/kora-app-symbol-processor/src/main/kotlin/ru/tinkoff/kora/kora/app/ksp/KoraAppProcessor.kt
@@ -211,7 +211,7 @@ class KoraAppProcessor(
                 .map { it.declaration as KSClassDeclaration }
                 .filter { it.findAnnotation(CommonClassNames.koraSubmodule) != null }
                 .map { resolver.getKSNameFromString(it.qualifiedName!!.asString() + "SubmoduleImpl") }
-                .map { resolver.getClassDeclarationByName(it) ?: throw java.lang.IllegalStateException("Declaration of ${it.asString()} was not found") }
+                .map { resolver.getClassDeclarationByName(it) ?: throw java.lang.IllegalStateException("Declaration of ${it.asString()} wasn't found") }
                 .toList()
             val allModules = (submodules + annotatedModules)
                 .flatMap { it.getAllSuperTypes().map { it.declaration as KSClassDeclaration } + it }
@@ -523,7 +523,11 @@ class KoraAppProcessor(
                 }
             }
             val component = graph[i];
-            currentClass!!.addProperty(component.fieldName, CommonClassNames.node.parameterizedBy(component.type.toTypeName()))
+
+            val aopProxySuperClass = ServiceTypesHelper.findAopProxySuperClass(component.type)
+            val propertyType: TypeName = aopProxySuperClass?.toTypeName() ?: component.type.toTypeName()
+
+            currentClass!!.addProperty(component.fieldName, CommonClassNames.node.parameterizedBy(propertyType))
             val statement = this.generateComponentStatement(allModules, interceptors, graph, component)
             currentConstructor!!.addCode(statement).addCode("\n")
         }

--- a/kora-app-symbol-processor/src/main/kotlin/ru/tinkoff/kora/kora/app/ksp/ServiceTypesHelper.kt
+++ b/kora-app-symbol-processor/src/main/kotlin/ru/tinkoff/kora/kora/app/ksp/ServiceTypesHelper.kt
@@ -3,9 +3,14 @@ package ru.tinkoff.kora.kora.app.ksp
 import com.google.devtools.ksp.getAllSuperTypes
 import com.google.devtools.ksp.getDeclaredFunctions
 import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.ClassKind
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSType
+import com.squareup.kotlinpoet.ksp.toTypeName
+import ru.tinkoff.kora.ksp.common.AnnotationUtils.findAnnotation
 import ru.tinkoff.kora.ksp.common.CommonClassNames
+import ru.tinkoff.kora.ksp.common.CommonClassNames.isVoid
+import ru.tinkoff.kora.ksp.common.getOuterClassesAsPrefix
 
 
 class ServiceTypesHelper(val resolver: Resolver) {
@@ -22,6 +27,30 @@ class ServiceTypesHelper(val resolver: Resolver) {
         .filter { it.simpleName.asString() == "value" && it.parameters.isEmpty() }
         .first()
 
+    companion object {
+
+        fun findAopProxySuperClass(maybeAopProxy: KSType): KSType? {
+            val aopProxyAnnotation = maybeAopProxy.declaration.findAnnotation(CommonClassNames.aopProxy)
+            val proxyDeclaration = maybeAopProxy.declaration
+            if (aopProxyAnnotation != null && proxyDeclaration is KSClassDeclaration) {
+                val proxyParent = (maybeAopProxy.declaration as KSClassDeclaration).superTypes
+                    .map { it.resolve() }
+                    .filter { (it.declaration as? KSClassDeclaration)?.classKind == ClassKind.CLASS }
+                    .firstOrNull()
+
+                if (proxyParent != null) {
+                    val proxyParentDeclaration = proxyParent.declaration
+                    val aopProxyName = proxyParentDeclaration.getOuterClassesAsPrefix() + proxyParentDeclaration.simpleName.asString() + "__AopProxy"
+                    val aopProxyCanonical = proxyParentDeclaration.packageName.asString() + "." + aopProxyName
+                    if (aopProxyCanonical == maybeAopProxy.declaration.qualifiedName!!.asString()) {
+                        return proxyParent
+                    }
+                }
+            }
+
+            return null
+        }
+    }
 
     fun isAssignableToUnwrapped(maybeWrapped: KSType, type: KSType): Boolean {
         if (!wrappedType.isAssignableFrom(maybeWrapped)) {
@@ -42,6 +71,7 @@ class ServiceTypesHelper(val resolver: Resolver) {
         if (!wrappedType.isAssignableFrom(maybeWrapped)) {
             return false
         }
+        //TODO check if also is not working?
         val unwrappedType = wrappedValueFunction.asMemberOf(maybeWrapped).returnType!!
         return unwrappedType.makeNotNullable() == type // platform nullability ruins equality
     }
@@ -51,17 +81,45 @@ class ServiceTypesHelper(val resolver: Resolver) {
             return false
         }
 
-        val interceptsType = interceptorInitFunction.asMemberOf(maybeInterceptor).parameterTypes[0]!!
-        return type == interceptsType.makeNotNullable()
+        return try {
+            val interceptType = interceptType(maybeInterceptor)
+            return isInterceptable(interceptType, type)
+        } catch (e: IllegalArgumentException) {
+            false
+        }
     }
 
+    fun isInterceptable(interceptedType: KSType, targetType: KSType): Boolean {
+        if (targetType == interceptedType.makeNotNullable()) {
+            return true
+        } else if (interceptedType.isAssignableFrom(targetType)) {
+            val aopProxyAnnotation = targetType.declaration.findAnnotation(CommonClassNames.aopProxy)
+            val proxyDeclaration = interceptedType.declaration
+            if (aopProxyAnnotation != null && proxyDeclaration.parentDeclaration != null) {
+                val aopProxyName = proxyDeclaration.getOuterClassesAsPrefix() + proxyDeclaration.simpleName.asString() + "__AopProxy"
+                val aopProxyCanonical = proxyDeclaration.packageName.asString() + "." + aopProxyName
+                return aopProxyCanonical == targetType.declaration.qualifiedName!!.asString()
+            }
+        }
+
+        return false
+    }
 
     fun interceptType(maybeInterceptor: KSType): KSType {
         if (!interceptorType.isAssignableFrom(maybeInterceptor)) {
             throw IllegalArgumentException()
         }
 
-        return interceptorInitFunction.asMemberOf(maybeInterceptor).parameterTypes[0]!!.makeNotNullable()
+//        return if (maybeInterceptor.declaration is KSClassDeclaration) {
+//            (maybeInterceptor.declaration as KSClassDeclaration).getDeclaredFunctions()
+//                .filter { f -> f.simpleName.asString() == "init" && f.parameters.size == 1 && f.returnType != null && !f.returnType!!.isVoid() }
+//                .filter { f -> f.parameters.first().type.toTypeName() == f.returnType!!.toTypeName() }
+//                .map { it.returnType!!.resolve() }
+//                .firstOrNull() ?: throw IllegalArgumentException()
+//        } else {
+        val memberOf = interceptorInitFunction.asMemberOf(maybeInterceptor)
+        return memberOf.parameterTypes[0]!!.makeNotNullable()
+//        }
     }
 
     fun isInterceptor(type: KSType) = interceptorType.isAssignableFrom(type)

--- a/kora-app-symbol-processor/src/main/kotlin/ru/tinkoff/kora/kora/app/ksp/ServiceTypesHelper.kt
+++ b/kora-app-symbol-processor/src/main/kotlin/ru/tinkoff/kora/kora/app/ksp/ServiceTypesHelper.kt
@@ -110,16 +110,16 @@ class ServiceTypesHelper(val resolver: Resolver) {
             throw IllegalArgumentException()
         }
 
-//        return if (maybeInterceptor.declaration is KSClassDeclaration) {
-//            (maybeInterceptor.declaration as KSClassDeclaration).getDeclaredFunctions()
-//                .filter { f -> f.simpleName.asString() == "init" && f.parameters.size == 1 && f.returnType != null && !f.returnType!!.isVoid() }
-//                .filter { f -> f.parameters.first().type.toTypeName() == f.returnType!!.toTypeName() }
-//                .map { it.returnType!!.resolve() }
-//                .firstOrNull() ?: throw IllegalArgumentException()
-//        } else {
-        val memberOf = interceptorInitFunction.asMemberOf(maybeInterceptor)
-        return memberOf.parameterTypes[0]!!.makeNotNullable()
-//        }
+        return if (maybeInterceptor.declaration is KSClassDeclaration) {
+            (maybeInterceptor.declaration as KSClassDeclaration).getDeclaredFunctions()
+                .filter { f -> f.simpleName.asString() == "init" && f.parameters.size == 1 && f.returnType != null && !f.returnType!!.isVoid() }
+                .filter { f -> f.parameters.first().type.toTypeName() == f.returnType!!.toTypeName() }
+                .map { it.returnType!!.resolve() }
+                .firstOrNull() ?: throw IllegalArgumentException()
+        } else {
+            val memberOf = interceptorInitFunction.asMemberOf(maybeInterceptor)
+            return memberOf.parameterTypes[0]!!.makeNotNullable()
+        }
     }
 
     fun isInterceptor(type: KSType) = interceptorType.isAssignableFrom(type)

--- a/kora-app-symbol-processor/src/main/kotlin/ru/tinkoff/kora/kora/app/ksp/interceptor/ComponentInterceptors.kt
+++ b/kora-app-symbol-processor/src/main/kotlin/ru/tinkoff/kora/kora/app/ksp/interceptor/ComponentInterceptors.kt
@@ -2,10 +2,12 @@ package ru.tinkoff.kora.kora.app.ksp.interceptor
 
 import com.google.devtools.ksp.processing.Resolver
 import ru.tinkoff.kora.kora.app.ksp.ProcessingContext
+import ru.tinkoff.kora.kora.app.ksp.ServiceTypesHelper
 import ru.tinkoff.kora.kora.app.ksp.component.ResolvedComponent
 import ru.tinkoff.kora.kora.app.ksp.declaration.ComponentDeclaration
 
 data class ComponentInterceptors(
+    private val serviceTypesHelper: ServiceTypesHelper,
     private val resolver: Resolver,
     private val interceptors: MutableList<ComponentInterceptor> = mutableListOf()
 ) {
@@ -19,7 +21,7 @@ data class ComponentInterceptors(
                     interceptors.add(factory)
                 }
             }
-            return ComponentInterceptors(ctx.resolver, interceptors)
+            return ComponentInterceptors(ServiceTypesHelper(ctx.resolver), ctx.resolver, interceptors)
         }
 
         private fun parseInterceptor(ctx: ProcessingContext, component: ResolvedComponent): ComponentInterceptor? {
@@ -36,7 +38,8 @@ data class ComponentInterceptors(
 
         return this.interceptors.filter { interceptor ->
             val realInterceptorType = interceptor.interceptType.makeNotNullable()
-            type == realInterceptorType && descriptor.tags.containsAll(interceptor.declaration.tags)
+            serviceTypesHelper.isInterceptable(realInterceptorType, type)
+                && descriptor.tags.containsAll(interceptor.declaration.tags)
         }
     }
 }

--- a/kora-app-symbol-processor/src/test/kotlin/ru/tinkoff/kora/kora/app/ksp/AbstractKoraAppProcessorTest.kt
+++ b/kora-app-symbol-processor/src/test/kotlin/ru/tinkoff/kora/kora/app/ksp/AbstractKoraAppProcessorTest.kt
@@ -23,5 +23,4 @@ abstract class AbstractKoraAppProcessorTest : AbstractSymbolProcessorTest() {
         val `object` = appClass.getConstructor().newInstance() as Supplier<ApplicationGraphDraw>
         return `object`.get()
     }
-
 }

--- a/kora-app-symbol-processor/src/test/kotlin/ru/tinkoff/kora/kora/app/ksp/DependencyTest.kt
+++ b/kora-app-symbol-processor/src/test/kotlin/ru/tinkoff/kora/kora/app/ksp/DependencyTest.kt
@@ -57,7 +57,7 @@ open class DependencyTest : AbstractKoraAppProcessorTest() {
         Assertions.assertThat(compileResult.isFailed()).isTrue()
 //        Assertions.assertThat<Diagnostic<out JavaFileObject?>>(compileResult.errors()).hasSize(1)
 //        Assertions.assertThat(compileResult.errors().get(0).getMessage(Locale.ENGLISH)).startsWith(
-//            "Required dependency was not found: " +
+//            "Required dependency wasn't found: " +
 //                "@Tag(ru.tinkoff.kora.kora.app.annotation.processor.packageForDependencyTest.testDiscoveredFinalClassDependencyTaggedDependencyNoTagOnClass.ExampleApplication.TestClass1) " +
 //                "ru.tinkoff.kora.kora.app.annotation.processor.packageForDependencyTest.testDiscoveredFinalClassDependencyTaggedDependencyNoTagOnClass.ExampleApplication.TestClass1"
 //        )

--- a/kora-app-symbol-processor/src/test/kotlin/ru/tinkoff/kora/kora/app/ksp/GraphInterceptorTests.kt
+++ b/kora-app-symbol-processor/src/test/kotlin/ru/tinkoff/kora/kora/app/ksp/GraphInterceptorTests.kt
@@ -1,0 +1,109 @@
+package ru.tinkoff.kora.kora.app.ksp
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import ru.tinkoff.kora.application.graph.internal.NodeImpl
+
+class GraphInterceptorTests :AbstractKoraAppProcessorTest() {
+
+    @Test
+    fun interceptor() {
+        val draw = compile(
+            """
+                import ru.tinkoff.kora.application.graph.GraphInterceptor
+
+                @KoraApp
+                interface ExampleApplication {
+                            
+                    class TestRoot 
+                    
+                    class TestClass
+                    
+                    class TestInterceptor : GraphInterceptor<TestClass> {
+                        override fun init(value: TestClass) = value
+
+                        override fun release(value: TestClass) = value
+                    }
+
+                    @Root
+                    fun root(testClass: TestClass) = TestRoot()
+                    
+                    fun interceptor(): TestInterceptor = TestInterceptor()
+                }
+                """.trimIndent(),
+        )
+        Assertions.assertThat(draw.nodes).hasSize(3)
+        draw.init()
+        Assertions.assertThat((draw.nodes[1] as NodeImpl<*>).interceptors).hasSize(1)
+    }
+
+    @Test
+    fun interceptorForAopParent() {
+        val draw = compile(
+            """
+                import ch.qos.logback.classic.LoggerContext
+                import org.slf4j.ILoggerFactory
+                import ru.tinkoff.kora.logging.common.annotation.Log
+                import ru.tinkoff.kora.application.graph.GraphInterceptor
+
+                @KoraApp
+                interface ExampleApplication {
+                            
+                    class TestRoot 
+                    
+                    @Component
+                    open class TestClass {
+                               
+                        @Log
+                        open fun getSome() = "1"
+                    }
+                    
+                    class TestInterceptor : GraphInterceptor<TestClass> {
+                        override fun init(value: TestClass) = value
+
+                        override fun release(value: TestClass) = value
+                    }
+
+                    @Root
+                    fun root(testClass: TestClass) = TestRoot()
+                    
+                    fun interceptor(): TestInterceptor = TestInterceptor()
+                    
+                    fun someLoggerFactory(): ILoggerFactory = LoggerContext()
+                }
+                """.trimIndent(),
+        )
+        Assertions.assertThat(draw.nodes).hasSize(4)
+        draw.init()
+        Assertions.assertThat((draw.nodes[2] as NodeImpl<*>).interceptors).hasSize(1)
+    }
+
+    @Test
+    fun interceptorForRoot() {
+        val draw = compile(
+            """
+                import ru.tinkoff.kora.application.graph.GraphInterceptor
+
+                @KoraApp
+                interface ExampleApplication {
+                            
+                    class TestRoot 
+                    
+                    class TestInterceptor : GraphInterceptor<TestRoot> {
+                        override fun init(value: TestRoot) = value
+
+                        override fun release(value: TestRoot) = value
+                    }
+
+                    @Root
+                    fun root() = TestRoot()
+                    
+                    fun interceptor(): TestInterceptor = TestInterceptor()
+                }
+                """.trimIndent(),
+        )
+        Assertions.assertThat(draw.nodes).hasSize(2)
+        draw.init()
+        Assertions.assertThat((draw.nodes[1] as NodeImpl<*>).interceptors).hasSize(1)
+    }
+}

--- a/kora-app-symbol-processor/src/test/kotlin/ru/tinkoff/kora/kora/app/ksp/GraphInterceptorTests.kt
+++ b/kora-app-symbol-processor/src/test/kotlin/ru/tinkoff/kora/kora/app/ksp/GraphInterceptorTests.kt
@@ -41,10 +41,8 @@ class GraphInterceptorTests :AbstractKoraAppProcessorTest() {
     fun interceptorForAopParent() {
         val draw = compile(
             """
-                import ch.qos.logback.classic.LoggerContext
-                import org.slf4j.ILoggerFactory
-                import ru.tinkoff.kora.logging.common.annotation.Log
                 import ru.tinkoff.kora.application.graph.GraphInterceptor
+                import ru.tinkoff.kora.ksp.common.TestAspect
 
                 @KoraApp
                 interface ExampleApplication {
@@ -54,7 +52,7 @@ class GraphInterceptorTests :AbstractKoraAppProcessorTest() {
                     @Component
                     open class TestClass {
                                
-                        @Log
+                        @TestAspect
                         open fun getSome() = "1"
                     }
                     
@@ -68,14 +66,16 @@ class GraphInterceptorTests :AbstractKoraAppProcessorTest() {
                     fun root(testClass: TestClass) = TestRoot()
                     
                     fun interceptor(): TestInterceptor = TestInterceptor()
-                    
-                    fun someLoggerFactory(): ILoggerFactory = LoggerContext()
                 }
                 """.trimIndent(),
         )
-        Assertions.assertThat(draw.nodes).hasSize(4)
-        draw.init()
-        Assertions.assertThat((draw.nodes[2] as NodeImpl<*>).interceptors).hasSize(1)
+        Assertions.assertThat(draw.nodes).hasSize(3)
+        val init = draw.init()
+
+        val node = draw.nodes[1] as NodeImpl<*>
+        Assertions.assertThat(node.interceptors).hasSize(1)
+        val value = node.factory[init]
+        Assertions.assertThat(value.javaClass.simpleName).isEqualTo("\$ExampleApplication_TestClass__AopProxy")
     }
 
     @Test

--- a/kora-app-symbol-processor/src/test/kotlin/ru/tinkoff/kora/kora/app/ksp/KoraAppKspTest.kt
+++ b/kora-app-symbol-processor/src/test/kotlin/ru/tinkoff/kora/kora/app/ksp/KoraAppKspTest.kt
@@ -206,7 +206,7 @@ class KoraAppKspTest {
             .isInstanceOfSatisfying(CompilationErrorException::class.java) { e ->
                 SoftAssertions.assertSoftly { s: SoftAssertions ->
                     s.assertThat(e.messages)
-                        .anyMatch { it.contains("Required dependency type was not found and can't be auto created: ru.tinkoff.kora.kora.app.ksp.app.AppWithUnresolvedDependency.Class3") }
+                        .anyMatch { it.contains("Required dependency type wasn't found and can't be auto created: ru.tinkoff.kora.kora.app.ksp.app.AppWithUnresolvedDependency.Class3") }
                 }
             }
     }
@@ -257,7 +257,7 @@ class KoraAppKspTest {
             .isInstanceOfSatisfying(CompilationErrorException::class.java) { e ->
                 SoftAssertions.assertSoftly { s: SoftAssertions ->
                     s.assertThat(e.messages).anyMatch {
-                        it.contains("Required dependency type was not found and can't be auto created: java.io.Closeable")
+                        it.contains("Required dependency type wasn't found and can't be auto created: java.io.Closeable")
                     }
                 }
             }
@@ -266,7 +266,7 @@ class KoraAppKspTest {
 //            .isInstanceOfSatisfying(CompilationErrorException::class.java) { e ->
 //                SoftAssertions.assertSoftly { s: SoftAssertions ->
 //                    s.assertThat(e.messages).contains(
-//                        "Required dependency was not found and candidate class ru.tinkoff.kora.kora.app.ksp.app.AppWithFactories11.GenericClass<kotlin.String> is not final"
+//                        "Required dependency wasn't found and candidate class ru.tinkoff.kora.kora.app.ksp.app.AppWithFactories11.GenericClass<kotlin.String> is not final"
 //                    )
 //                }
 //            } delete or fix?

--- a/symbol-processor-common/build.gradle
+++ b/symbol-processor-common/build.gradle
@@ -4,13 +4,14 @@ plugins {
 apply from: "${project.rootDir}/gradle/kotlin-plugin.gradle"
 
 dependencies {
+    api project(':common') // todo delete
+
     api libs.kotlinpoet
     api libs.kotlinpoet.ksp
     api libs.ksp.api
-    api project(':common')// todo delete
-
     implementation libs.kotlin.reflect
 
+    testFixturesApi project(':aop:aop-symbol-processor')
     testFixturesImplementation libs.classgraph
 
     testFixturesImplementation libs.kotlin.compiler
@@ -21,5 +22,4 @@ dependencies {
     testFixturesImplementation libs.kotlin.reflect
     testFixturesImplementation libs.kotlin.coroutines.reactor
     testFixturesImplementation libs.kotlin.coroutines.jdk8
-
 }

--- a/symbol-processor-common/build.gradle
+++ b/symbol-processor-common/build.gradle
@@ -9,17 +9,17 @@ dependencies {
     api libs.kotlinpoet
     api libs.kotlinpoet.ksp
     api libs.ksp.api
-    implementation libs.kotlin.reflect
+    api libs.kotlin.reflect
 
     testFixturesApi project(':aop:aop-symbol-processor')
-    testFixturesImplementation libs.classgraph
+    testFixturesApi libs.kotlin.reflect
 
+    testFixturesImplementation libs.classgraph
     testFixturesImplementation libs.kotlin.compiler
     testFixturesImplementation libs.kotlin.compiler
     testFixturesImplementation libs.junit.jupiter
     testFixturesImplementation libs.ksp
     testFixturesImplementation libs.ksp.api
-    testFixturesImplementation libs.kotlin.reflect
     testFixturesImplementation libs.kotlin.coroutines.reactor
     testFixturesImplementation libs.kotlin.coroutines.jdk8
 }

--- a/symbol-processor-common/src/testFixtures/kotlin/ru/tinkoff/kora/ksp/common/TestAspect.kt
+++ b/symbol-processor-common/src/testFixtures/kotlin/ru/tinkoff/kora/ksp/common/TestAspect.kt
@@ -1,0 +1,24 @@
+package ru.tinkoff.kora.ksp.common
+
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import ru.tinkoff.kora.aop.symbol.processor.KoraAspect
+import ru.tinkoff.kora.aop.symbol.processor.KoraAspectFactory
+import ru.tinkoff.kora.common.AopAnnotation
+import java.util.*
+
+@AopAnnotation
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class TestAspect
+
+class TestAspectKoraAspect : KoraAspect {
+
+    override fun getSupportedAnnotationTypes(): Set<String> = setOf(TestAspect::class.qualifiedName!!)
+
+    override fun apply(ksFunction: KSFunctionDeclaration, superCall: String, aspectContext: KoraAspect.AspectContext): KoraAspect.ApplyResult = KoraAspect.ApplyResult.Noop.INSTANCE
+}
+
+class TestAspectKoraAspectFactory : KoraAspectFactory {
+    override fun create(resolver: Resolver) = TestAspectKoraAspect()
+}

--- a/symbol-processor-common/src/testFixtures/resources/META-INF/services/ru.tinkoff.kora.aop.symbol.processor.KoraAspectFactory
+++ b/symbol-processor-common/src/testFixtures/resources/META-INF/services/ru.tinkoff.kora.aop.symbol.processor.KoraAspectFactory
@@ -1,0 +1,1 @@
+ru.tinkoff.kora.ksp.common.TestAspectKoraAspectFactory

--- a/test/test-junit5/build.gradle
+++ b/test/test-junit5/build.gradle
@@ -3,7 +3,7 @@ apply from: "${project.rootDir}/gradle/kotlin-plugin.gradle"
 
 dependencies {
     compileOnly libs.mockito.core
-    compileOnly "io.mockk:mockk:1.13.10"
+    compileOnly "io.mockk:mockk:1.13.12"
     compileOnly libs.kotlin.reflect
 
     api libs.junit.platform.launcher

--- a/test/test-junit5/build.gradle
+++ b/test/test-junit5/build.gradle
@@ -3,7 +3,7 @@ apply from: "${project.rootDir}/gradle/kotlin-plugin.gradle"
 
 dependencies {
     compileOnly libs.mockito.core
-    compileOnly "io.mockk:mockk:1.13.12"
+    compileOnly "io.mockk:mockk:1.13.11"
     compileOnly libs.kotlin.reflect
 
     api libs.junit.platform.launcher
@@ -16,7 +16,7 @@ dependencies {
     testImplementation project(":annotation-processors")
     testImplementation project(":config:config-hocon")
 
-    testImplementation "io.mockk:mockk:1.13.8"
+    testImplementation "io.mockk:mockk:1.13.11"
     testImplementation libs.mockito.core
     testImplementation libs.kotlin.stdlib.lib
 }

--- a/test/test-junit5/src/main/java/ru/tinkoff/kora/test/extension/junit5/KoraJUnit5Extension.java
+++ b/test/test-junit5/src/main/java/ru/tinkoff/kora/test/extension/junit5/KoraJUnit5Extension.java
@@ -614,7 +614,7 @@ final class KoraJUnit5Extension implements BeforeAllCallback, BeforeEachCallback
                 throw new ExtensionConfigurationException(candidate + " expected to have one suitable component, got " + objects.size());
             }
         }
-        throw new ExtensionConfigurationException(candidate + " was not found in graph, please check @KoraAppTest configuration");
+        throw new ExtensionConfigurationException(candidate + " wasn't found in graph, please check @KoraAppTest configuration");
     }
 
     private static boolean doesImplement(Class<?> aClass, ParameterizedType parameterizedType) {

--- a/validation/validation-symbol-processor/build.gradle
+++ b/validation/validation-symbol-processor/build.gradle
@@ -7,11 +7,6 @@ dependencies {
     implementation project(":kora-app-symbol-processor")
     implementation project(":aop:aop-symbol-processor")
 
-    implementation libs.ksp.api
-    implementation libs.kotlin.reflect
-    implementation libs.kotlinpoet
-    implementation libs.kotlinpoet.ksp
-
     testImplementation testFixtures(project(":annotation-processor-common"))
     testImplementation testFixtures(project(":symbol-processor-common"))
     testImplementation project(":validation:validation-common")


### PR DESCRIPTION
AOP Proxy proper handling and GraphInterception, now AOP Proxy child class can't be used for injection cause this is implementation details and should be hidden from user