### PR TITLE
Add `@Deprecated` annotation for OpenAPI generated HTTP Client methods

### DIFF
--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaClientApi.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaClientApi.mustache
@@ -64,6 +64,9 @@ public interface {{classname}} {
     {{/interceptorTags}}
     {{/koraInterceptors}}
     {{#isAsync}}
+    {{#isDeprecated}}
+    @Deprecated
+    {{/isDeprecated}}
     CompletionStage<{{classname}}Responses.{{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}ApiResponse> {{operationId}}(
     {{/isAsync}}
     {{#isReactive}}

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaClientApi.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaClientApi.mustache
@@ -63,10 +63,10 @@ public interface {{classname}} {
     @ru.tinkoff.kora.http.common.annotation.InterceptWith({{interceptorImpl}})
     {{/interceptorTags}}
     {{/koraInterceptors}}
-    {{#isAsync}}
     {{#isDeprecated}}
     @Deprecated
     {{/isDeprecated}}
+    {{#isAsync}}
     CompletionStage<{{classname}}Responses.{{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}ApiResponse> {{operationId}}(
     {{/isAsync}}
     {{#isReactive}}

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinClientApi.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinClientApi.mustache
@@ -54,6 +54,9 @@ interface {{classname}} {
     @ru.tinkoff.kora.http.common.annotation.InterceptWith({{interceptorImpl}})
     {{/interceptorTags}}
     {{/koraInterceptors}}
+    {{#isDeprecated}}
+    @Deprecated(message = "Deprecated")
+    {{/isDeprecated}}
     {{#isSuspend}}suspend {{/isSuspend}}fun {{operationId}}({{>kotlinAnnotatedParams}}): {{classname}}Responses.{{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}ApiResponse
 
 {{#hasFormParams}}


### PR DESCRIPTION
Javadoc for deprecated OpenAPI method contains `@deprecated` marker. See example below:
```java
/**
     * GET /api/v2/my_url
     * Получение чего-там )
     *
     * @param *** (required)
     * @param *** (required)
     * @param *** (required)
     * @return Получение ответа (status code 200)
     *         or Сообщение об ошибке (status code 400)
     * @deprecated
     */
    @ru.tinkoff.kora.http.common.annotation.HttpRoute(method = "GET", path = "/api/v2/my_url")
    @ru.tinkoff.kora.http.client.common.annotation.ResponseCodeMapper(code = 200, mapper = ApiResponseMapper.class)
    ApiResponse getResponse(      
      @ru.tinkoff.kora.http.common.annotation.Path("param")
      String param,
```

And after compilation there was a warning like that:

```
.../MyApi.java:165: warning: [dep-ann] deprecated item is not annotated with @Deprecated
    ApiResponse getResponse(    
```

So put `@Deprecated` annotation should fix that warning.