### PR TITLE
Do not wrap quartz job exceptions to prevent incorrect logging

### DIFF
--- a/scheduling/scheduling-quartz/src/main/java/ru/tinkoff/kora/scheduling/quartz/KoraQuartzJob.java
+++ b/scheduling/scheduling-quartz/src/main/java/ru/tinkoff/kora/scheduling/quartz/KoraQuartzJob.java
@@ -22,7 +22,7 @@ public abstract class KoraQuartzJob implements Job {
     }
 
     @Override
-    public final void execute(JobExecutionContext jobExecutionContext) throws JobExecutionException {
+    public final void execute(JobExecutionContext jobExecutionContext) {
         MDC.clear();
         Context.clear();
 
@@ -33,7 +33,7 @@ public abstract class KoraQuartzJob implements Job {
             telemetryCtx.close(null);
         } catch (Exception e) {
             telemetryCtx.close(e);
-            throw new JobExecutionException(e);
+            throw e;
         }
     }
 


### PR DESCRIPTION
Quartz job runner logs `JobExecutionException`-s as INFO:
https://github.com/quartz-scheduler/quartz/blob/9035cb472a15f34b378e8e0c41aa428350b0188b/quartz/src/main/java/org/quartz/core/JobRunShell.java#L205-L220

`KoraQuartzJob` wrapper should preserve the exception type in order to log errors with correct log level