### PR TITLE
HTTP Client telemetry config backward compatibility

### DIFF
--- a/http/http-client-annotation-processor/src/main/java/ru/tinkoff/kora/http/client/annotation/processor/ConfigClassGenerator.java
+++ b/http/http-client-annotation-processor/src/main/java/ru/tinkoff/kora/http/client/annotation/processor/ConfigClassGenerator.java
@@ -12,8 +12,7 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 
-import static ru.tinkoff.kora.http.client.annotation.processor.HttpClientClassNames.declarativeHttpClientConfig;
-import static ru.tinkoff.kora.http.client.annotation.processor.HttpClientClassNames.httpClientOperationConfig;
+import static ru.tinkoff.kora.http.client.annotation.processor.HttpClientClassNames.*;
 
 public class ConfigClassGenerator {
 
@@ -30,6 +29,13 @@ public class ConfigClassGenerator {
             .addModifiers(Modifier.PUBLIC)
             .addSuperinterface(declarativeHttpClientConfig)
             .addAnnotation(CommonClassNames.configValueExtractorAnnotation);
+
+        b.addMethod(MethodSpec.methodBuilder("telemetry")
+            .addAnnotation(Override.class)
+            .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+            .returns(telemetryHttpClientConfig)
+            .build());
+
         for (var enclosedElement : element.getEnclosedElements()) {
             if (enclosedElement.getKind() != ElementKind.METHOD || enclosedElement.getModifiers().contains(Modifier.STATIC) || enclosedElement.getModifiers().contains(Modifier.DEFAULT)) {
                 continue;

--- a/http/http-client-annotation-processor/src/main/java/ru/tinkoff/kora/http/client/annotation/processor/HttpClientClassNames.java
+++ b/http/http-client-annotation-processor/src/main/java/ru/tinkoff/kora/http/client/annotation/processor/HttpClientClassNames.java
@@ -22,8 +22,9 @@ public class HttpClientClassNames {
     public static final ClassName httpHeaders = ClassName.get("ru.tinkoff.kora.http.common.header", "HttpHeaders");
     public static final ClassName httpRoute = ClassName.get("ru.tinkoff.kora.http.common.annotation", "HttpRoute");
     public static final ClassName httpClientUnknownException = ClassName.get("ru.tinkoff.kora.http.client.common", "HttpClientUnknownException");
-    public static final ClassName httpClientOperationConfig  = ClassName.get("ru.tinkoff.kora.http.client.common.declarative", "HttpClientOperationConfig");
-    public static final ClassName declarativeHttpClientConfig  = ClassName.get("ru.tinkoff.kora.http.client.common.declarative", "DeclarativeHttpClientConfig");
+    public static final ClassName httpClientOperationConfig = ClassName.get("ru.tinkoff.kora.http.client.common.declarative", "HttpClientOperationConfig");
+    public static final ClassName declarativeHttpClientConfig = ClassName.get("ru.tinkoff.kora.http.client.common.declarative", "DeclarativeHttpClientConfig");
+    public static final ClassName telemetryHttpClientConfig = ClassName.get("ru.tinkoff.kora.http.client.common.telemetry", "HttpClientTelemetryConfig");
     public static final ClassName interceptWithClassName = ClassName.get("ru.tinkoff.kora.http.common.annotation", "InterceptWith");
     public static final ClassName interceptWithContainerClassName = ClassName.get("ru.tinkoff.kora.http.common.annotation", "InterceptWith", "InterceptWithContainer");
 

--- a/http/http-client-annotation-processor/src/test/java/ru/tinkoff/kora/http/client/annotation/processor/AbstractHttpClientTest.java
+++ b/http/http-client-annotation-processor/src/test/java/ru/tinkoff/kora/http/client/annotation/processor/AbstractHttpClientTest.java
@@ -15,13 +15,8 @@ import ru.tinkoff.kora.config.common.factory.MapConfigFactory;
 import ru.tinkoff.kora.http.client.common.HttpClient;
 import ru.tinkoff.kora.http.client.common.declarative.$HttpClientOperationConfig_ConfigValueExtractor;
 import ru.tinkoff.kora.http.client.common.request.HttpClientRequest;
-import ru.tinkoff.kora.http.client.common.telemetry.$HttpClientLoggerConfig_ConfigValueExtractor;
-import ru.tinkoff.kora.http.client.common.telemetry.$HttpClientTelemetryConfig_ConfigValueExtractor;
-import ru.tinkoff.kora.http.client.common.telemetry.HttpClientTelemetry;
-import ru.tinkoff.kora.http.client.common.telemetry.HttpClientTelemetryFactory;
-import ru.tinkoff.kora.telemetry.common.$TelemetryConfig_LogConfig_ConfigValueExtractor;
-import ru.tinkoff.kora.telemetry.common.$TelemetryConfig_MetricsConfig_ConfigValueExtractor;
-import ru.tinkoff.kora.telemetry.common.$TelemetryConfig_TracingConfig_ConfigValueExtractor;
+import ru.tinkoff.kora.http.client.common.telemetry.*;
+import ru.tinkoff.kora.telemetry.common.*;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -102,15 +97,19 @@ public abstract class AbstractHttpClientTest extends AbstractAnnotationProcessor
 
         var clientClass = compileResult.loadClass("$TestClient_ClientImpl");
         var durationCVE = new DurationConfigValueExtractor();
-        var telemetryCVE = new $HttpClientTelemetryConfig_ConfigValueExtractor(
+//        var telemetryCVE = new $TelemetryConfig_ConfigValueExtractor(
+//            new $TelemetryConfig_LogConfig_ConfigValueExtractor(new BooleanConfigValueExtractor()),
+//            new $TelemetryConfig_TracingConfig_ConfigValueExtractor(new BooleanConfigValueExtractor()),
+//            new $TelemetryConfig_MetricsConfig_ConfigValueExtractor(new BooleanConfigValueExtractor(), new DoubleArrayConfigValueExtractor(c -> c.asNumber().doubleValue()))
+//        );
+        var telemetryCVE = (ConfigValueExtractor) new $HttpClientTelemetryConfig_ConfigValueExtractor(
             new $HttpClientLoggerConfig_ConfigValueExtractor(new SetConfigValueExtractor<>(new StringConfigValueExtractor()), new BooleanConfigValueExtractor()),
             new $TelemetryConfig_TracingConfig_ConfigValueExtractor(new BooleanConfigValueExtractor()),
             new $TelemetryConfig_MetricsConfig_ConfigValueExtractor(new BooleanConfigValueExtractor(), new DoubleArrayConfigValueExtractor(c -> c.asNumber().doubleValue()))
         );
         var configCVE = new $HttpClientOperationConfig_ConfigValueExtractor(durationCVE, telemetryCVE);
 
-
-        var configValueExtractor = (ConfigValueExtractor<?>) newObject("$$TestClient_Config_ConfigValueExtractor", configCVE, telemetryCVE, durationCVE);
+        var configValueExtractor = (ConfigValueExtractor<?>) newObject("$$TestClient_Config_ConfigValueExtractor", telemetryCVE, durationCVE, configCVE);
         var config = configValueExtractor.extract(MapConfigFactory.fromMap(Map.of(
             "url", "http://test-url:8080"
         )).root());

--- a/http/http-client-common/build.gradle
+++ b/http/http-client-common/build.gradle
@@ -3,11 +3,11 @@ plugins {
 }
 
 dependencies {
+    annotationProcessor project(':config:config-annotation-processor')
+
     api project(':logging:logging-common')
     api project(':http:http-common')
     api project(':telemetry:telemetry-common')
-
-    annotationProcessor project(':config:config-annotation-processor')
 
     testImplementation libs.reactor.core
 

--- a/http/http-client-common/src/main/java/ru/tinkoff/kora/http/client/common/declarative/DeclarativeHttpClientConfig.java
+++ b/http/http-client-common/src/main/java/ru/tinkoff/kora/http/client/common/declarative/DeclarativeHttpClientConfig.java
@@ -5,13 +5,15 @@ import ru.tinkoff.kora.http.client.common.HttpClient;
 import ru.tinkoff.kora.http.client.common.interceptor.TelemetryInterceptor;
 import ru.tinkoff.kora.http.client.common.telemetry.HttpClientTelemetryConfig;
 import ru.tinkoff.kora.http.client.common.telemetry.HttpClientTelemetryFactory;
+import ru.tinkoff.kora.telemetry.common.TelemetryConfig;
 
 import java.time.Duration;
 
 public interface DeclarativeHttpClientConfig {
+
     String url();
 
-    HttpClientTelemetryConfig telemetry();
+    TelemetryConfig telemetry();
 
     @Nullable
     Duration requestTimeout();

--- a/http/http-client-common/src/main/java/ru/tinkoff/kora/http/client/common/declarative/HttpClientOperationConfig.java
+++ b/http/http-client-common/src/main/java/ru/tinkoff/kora/http/client/common/declarative/HttpClientOperationConfig.java
@@ -3,6 +3,7 @@ package ru.tinkoff.kora.http.client.common.declarative;
 import jakarta.annotation.Nullable;
 import ru.tinkoff.kora.config.common.annotation.ConfigValueExtractor;
 import ru.tinkoff.kora.http.client.common.telemetry.HttpClientTelemetryConfig;
+import ru.tinkoff.kora.telemetry.common.TelemetryConfig;
 
 import java.time.Duration;
 
@@ -11,5 +12,5 @@ public interface HttpClientOperationConfig {
     @Nullable
     Duration requestTimeout();
 
-    HttpClientTelemetryConfig telemetry();
+    TelemetryConfig telemetry();
 }

--- a/http/http-client-common/src/main/java/ru/tinkoff/kora/http/client/common/declarative/HttpClientOperationTelemetryConfig.java
+++ b/http/http-client-common/src/main/java/ru/tinkoff/kora/http/client/common/declarative/HttpClientOperationTelemetryConfig.java
@@ -4,6 +4,7 @@ import jakarta.annotation.Nullable;
 import ru.tinkoff.kora.http.client.common.telemetry.$HttpClientLoggerConfig_ConfigValueExtractor;
 import ru.tinkoff.kora.http.client.common.telemetry.HttpClientLoggerConfig;
 import ru.tinkoff.kora.http.client.common.telemetry.HttpClientTelemetryConfig;
+import ru.tinkoff.kora.telemetry.common.TelemetryConfig;
 
 import java.util.Objects;
 import java.util.Set;
@@ -13,8 +14,40 @@ public final class HttpClientOperationTelemetryConfig implements HttpClientTelem
     private final OperationMetricConfig metrics;
     private final OperationTracingConfig tracing;
 
-    public HttpClientOperationTelemetryConfig(HttpClientTelemetryConfig client, HttpClientTelemetryConfig operation) {
-        this.logging = new OperationLogConfig(client.logging(), operation.logging());
+    public HttpClientOperationTelemetryConfig(TelemetryConfig client, TelemetryConfig operation) {
+        var loggingClientConfig = (client instanceof HttpClientTelemetryConfig hcc)
+            ? hcc.logging()
+            : new HttpClientLoggerConfig() {
+            @Nullable
+            @Override
+            public Boolean pathTemplate() {
+                return null;
+            }
+
+            @Nullable
+            @Override
+            public Boolean enabled() {
+                return client.logging().enabled();
+            }
+        };
+
+        var loggingOperationConfig = (operation instanceof HttpClientTelemetryConfig hcc)
+            ? hcc.logging()
+            : new HttpClientLoggerConfig() {
+            @Nullable
+            @Override
+            public Boolean pathTemplate() {
+                return null;
+            }
+
+            @Nullable
+            @Override
+            public Boolean enabled() {
+                return operation.logging().enabled();
+            }
+        };
+
+        this.logging = new OperationLogConfig(loggingClientConfig, loggingOperationConfig);
         this.metrics = new OperationMetricConfig(client.metrics(), operation.metrics());
         this.tracing = new OperationTracingConfig(client.tracing(), operation.tracing());
     }

--- a/http/http-client-symbol-processor/src/main/kotlin/ru/tinkoff/kora/http/client/symbol/processor/ConfigClassGenerator.kt
+++ b/http/http-client-symbol-processor/src/main/kotlin/ru/tinkoff/kora/http/client/symbol/processor/ConfigClassGenerator.kt
@@ -23,6 +23,11 @@ class ConfigClassGenerator {
             .addSuperinterface(declarativeHttpClientConfig)
             .addAnnotation(configValueExtractorAnnotation)
 
+        tb.addFunction(FunSpec.builder("telemetry")
+            .addModifiers(KModifier.ABSTRACT, KModifier.OVERRIDE)
+            .returns(HttpClientClassNames.telemetryHttpClientConfig)
+            .build())
+
         functions.forEach { function ->
             tb.addFunction(FunSpec.builder(function)
                 .returns(httpClientOperationConfig)

--- a/http/http-client-symbol-processor/src/main/kotlin/ru/tinkoff/kora/http/client/symbol/processor/HttpClientClassNames.kt
+++ b/http/http-client-symbol-processor/src/main/kotlin/ru/tinkoff/kora/http/client/symbol/processor/HttpClientClassNames.kt
@@ -20,6 +20,7 @@ object HttpClientClassNames {
     val httpClientUnknownException = ClassName("ru.tinkoff.kora.http.client.common", "HttpClientUnknownException")
     val httpClientOperationConfig = ClassName("ru.tinkoff.kora.http.client.common.declarative", "HttpClientOperationConfig")
     val declarativeHttpClientConfig = ClassName("ru.tinkoff.kora.http.client.common.declarative", "DeclarativeHttpClientConfig")
+    val telemetryHttpClientConfig = ClassName("ru.tinkoff.kora.http.client.common.telemetry", "HttpClientTelemetryConfig")
     val interceptWithClassName = ClassName("ru.tinkoff.kora.http.common.annotation", "InterceptWith")
     val interceptWithContainerClassName = ClassName("ru.tinkoff.kora.http.common.annotation", "InterceptWith", "InterceptWithContainer")
 


### PR DESCRIPTION
HTTP Client telemetry config introduced in Kora 1.1.11 fixes backward compatibility with old Kora versions libraries