### PR TITLE
OpenAPI Codegen allows additionalContractAnnotations without validation

### DIFF
--- a/openapi/openapi-generator/src/main/java/ru/tinkoff/kora/openapi/generator/KoraCodegen.java
+++ b/openapi/openapi-generator/src/main/java/ru/tinkoff/kora/openapi/generator/KoraCodegen.java
@@ -433,6 +433,7 @@ public class KoraCodegen extends DefaultCodegen {
             }
         }
         this.vendorExtensions.put("enableValidation", params.enableValidation());
+        this.vendorExtensions.put("allowAspects", params.enableValidation() || !params.additionalContractAnnotations.isEmpty());
 
         embeddedTemplateDir = templateDir = "openapi/templates/kora";
         if (!params.codegenMode.isJava()) {

--- a/openapi/openapi-generator/src/main/java/ru/tinkoff/kora/openapi/generator/KoraCodegen.java
+++ b/openapi/openapi-generator/src/main/java/ru/tinkoff/kora/openapi/generator/KoraCodegen.java
@@ -20,6 +20,7 @@ import io.swagger.v3.oas.models.media.StringSchema;
 import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.oas.models.parameters.RequestBody;
 import io.swagger.v3.oas.models.servers.Server;
+import io.swagger.v3.oas.models.tags.Tag;
 import io.swagger.v3.parser.util.SchemaTypeUtil;
 import jakarta.annotation.Nullable;
 import org.apache.commons.io.FilenameUtils;
@@ -1816,7 +1817,18 @@ public class KoraCodegen extends DefaultCodegen {
                 }
             }
             if (params.enableValidation) {
-                op.vendorExtensions.put("enableValidation", params.enableValidation);
+                List<AdditionalAnnotation> additionalAnnotations = List.of();
+                for (Tag tag : op.tags) {
+                    additionalAnnotations = params.additionalContractAnnotations.get(tag.getName());
+                    if(additionalAnnotations != null) {
+                        break;
+                    }
+                }
+                if (additionalAnnotations == null) {
+                    additionalAnnotations = params.additionalContractAnnotations.get("*");
+                }
+                op.vendorExtensions.put("allowAspects", params.enableValidation() || !additionalAnnotations.isEmpty());
+
                 for (var p : op.allParams) {
                     var validation = false;
                     if (p.isModel) {

--- a/openapi/openapi-generator/src/main/java/ru/tinkoff/kora/openapi/generator/KoraCodegen.java
+++ b/openapi/openapi-generator/src/main/java/ru/tinkoff/kora/openapi/generator/KoraCodegen.java
@@ -432,7 +432,6 @@ public class KoraCodegen extends DefaultCodegen {
                 apiTemplateFiles.put("kotlinServerResponseMappers.mustache", "ServerResponseMappers.kt");
             }
         }
-        this.vendorExtensions.put("enableValidation", params.enableValidation());
         this.vendorExtensions.put("allowAspects", params.enableValidation() || !params.additionalContractAnnotations.isEmpty());
 
         embeddedTemplateDir = templateDir = "openapi/templates/kora";

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaAsyncServerApi.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaAsyncServerApi.mustache
@@ -18,9 +18,9 @@ import java.util.Map;
 import jakarta.annotation.Nullable;
 
 @ru.tinkoff.kora.common.annotation.Generated("openapi generator kora server"){{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
-@ru.tinkoff.kora.http.server.common.annotation.HttpController{{#vendorExtensions.enableValidation}}
-@ru.tinkoff.kora.common.Component{{/vendorExtensions.enableValidation}}
-public{{^vendorExtensions.enableValidation}} final{{/vendorExtensions.enableValidation}} class {{classname}}Controller {
+@ru.tinkoff.kora.http.server.common.annotation.HttpController{{#vendorExtensions.allowAspects}}
+@ru.tinkoff.kora.common.Component{{/vendorExtensions.allowAspects}}
+public{{^vendorExtensions.allowAspects}} final{{/vendorExtensions.allowAspects}} class {{classname}}Controller {
     private final {{classname}}Delegate delegate;
 
     public {{classname}}Controller({{classname}}Delegate delegate) {

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaServerApi.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaServerApi.mustache
@@ -17,9 +17,9 @@ import ru.tinkoff.kora.http.server.common.HttpServerRequest;
 
 
 @ru.tinkoff.kora.common.annotation.Generated("openapi generator kora server"){{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
-@ru.tinkoff.kora.http.server.common.annotation.HttpController{{#vendorExtensions.enableValidation}}
-@ru.tinkoff.kora.common.Component{{/vendorExtensions.enableValidation}}
-public{{^vendorExtensions.enableValidation}} final{{/vendorExtensions.enableValidation}} class {{classname}}Controller {
+@ru.tinkoff.kora.http.server.common.annotation.HttpController{{#vendorExtensions.allowAspects}}
+@ru.tinkoff.kora.common.Component{{/vendorExtensions.allowAspects}}
+public{{^vendorExtensions.allowAspects}} final{{/vendorExtensions.allowAspects}} class {{classname}}Controller {
     private final {{classname}}Delegate delegate;
 
     public {{classname}}Controller({{classname}}Delegate delegate) {

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinServerApi.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinServerApi.mustache
@@ -15,9 +15,9 @@ import ru.tinkoff.kora.http.server.common.HttpServerRequest
 {{/requestInDelegateParams}}
 
 @ru.tinkoff.kora.common.annotation.Generated("openapi generator kora server"){{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
-@ru.tinkoff.kora.http.server.common.annotation.HttpController{{#vendorExtensions.enableValidation}}
-@ru.tinkoff.kora.common.Component{{/vendorExtensions.enableValidation}}
-{{#vendorExtensions.enableValidation}}open {{/vendorExtensions.enableValidation}}class {{classname}}Controller(private val delegate: {{classname}}Delegate) {
+@ru.tinkoff.kora.http.server.common.annotation.HttpController{{#vendorExtensions.allowAspects}}
+@ru.tinkoff.kora.common.Component{{/vendorExtensions.allowAspects}}
+{{#vendorExtensions.allowAspects}}open {{/vendorExtensions.allowAspects}}class {{classname}}Controller(private val delegate: {{classname}}Delegate) {
 {{#operations}}
 {{#operation}}
     /**
@@ -63,7 +63,7 @@ import ru.tinkoff.kora.http.server.common.HttpServerRequest
     {{/interceptorTags}}
     {{/koraInterceptors}}
     @ru.tinkoff.kora.common.Mapping({{classname}}ServerResponseMappers.{{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}ResponseMapper::class)
-    {{#vendorExtensions.enableValidation}}open {{/vendorExtensions.enableValidation}}{{#isSuspend}}suspend {{/isSuspend}}fun {{operationId}}({{#vendorExtensions.requestInDelegateParams}}_serverRequest: HttpServerRequest{{#hasParams}}, {{/hasParams}}{{/vendorExtensions.requestInDelegateParams}}{{>kotlinAnnotatedParams}}): {{classname}}Responses.{{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}ApiResponse {
+    {{#vendorExtensions.allowAspects}}open {{/vendorExtensions.allowAspects}}{{#isSuspend}}suspend {{/isSuspend}}fun {{operationId}}({{#vendorExtensions.requestInDelegateParams}}_serverRequest: HttpServerRequest{{#hasParams}}, {{/hasParams}}{{/vendorExtensions.requestInDelegateParams}}{{>kotlinAnnotatedParams}}): {{classname}}Responses.{{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}ApiResponse {
       return this.delegate.{{operationId}}({{#vendorExtensions.requestInDelegateParams}}_serverRequest{{#hasParams}}, {{/hasParams}}{{/vendorExtensions.requestInDelegateParams}}
         {{#allParams}}{{#lambda.trim}}
         {{#hasFormParams}}{{^isFormParam}}{{paramName}},{{/isFormParam}}{{/hasFormParams}}


### PR DESCRIPTION
OpenAPI Codegen allows aspects if only additionalContractAnnotations specified without validation enabled