### PR TITLE
OpenAPI enableJsonNullable option support added

### DIFF
--- a/openapi/openapi-generator/src/main/java/ru/tinkoff/kora/openapi/generator/KoraCodegen.java
+++ b/openapi/openapi-generator/src/main/java/ru/tinkoff/kora/openapi/generator/KoraCodegen.java
@@ -588,6 +588,9 @@ public class KoraCodegen extends DefaultCodegen {
                         variable.vendorExtensions.put("x-json-nullable", true);
                     } else {
                         variable.vendorExtensions.put("x-json-include-always", true);
+                        //TODO remove in 2.0 and make default behavior that ENABLE_JSON_NULLABLE is enabled
+                        LOGGER.warn("Detected isNullable and NonRequired field: {}#{}\nYou may want add option '{}' in configOptions to treat it as JsonNullable<T>, this will be default behavior in 2.0",
+                            model.name, variable.name, ENABLE_JSON_NULLABLE);
                     }
                 }
             }
@@ -609,6 +612,9 @@ public class KoraCodegen extends DefaultCodegen {
                         variable.vendorExtensions.put("x-json-nullable", true);
                     } else {
                         variable.vendorExtensions.put("x-json-include-always", true);
+                        //TODO remove in 2.0 and make default behavior that ENABLE_JSON_NULLABLE is enabled
+                        LOGGER.warn("Detected isNullable and NonRequired field: {}#{}\nYou may want add option '{}' in configOptions to treat it as JsonNullable<T>, this will be default behavior in 2.0",
+                            model.name, variable.name, ENABLE_JSON_NULLABLE);
                     }
                 }
             }

--- a/openapi/openapi-generator/src/main/java/ru/tinkoff/kora/openapi/generator/KoraCodegen.java
+++ b/openapi/openapi-generator/src/main/java/ru/tinkoff/kora/openapi/generator/KoraCodegen.java
@@ -132,7 +132,8 @@ public class KoraCodegen extends DefaultCodegen {
         Map<String, TagClient> clientTags,
         Map<String, List<Interceptor>> interceptors,
         Map<String, List<AdditionalAnnotation>> additionalContractAnnotations,
-        boolean requestInDelegateParams
+        boolean requestInDelegateParams,
+        boolean enableJsonNullable
     ) {
         static List<CliOption> cliOptions() {
             var cliOptions = new ArrayList<CliOption>();
@@ -147,6 +148,7 @@ public class KoraCodegen extends DefaultCodegen {
             cliOptions.add(CliOption.newBoolean(REQUEST_DELEGATE_PARAMS, "Generate HttpServerRequest parameter in delegate methods"));
             cliOptions.add(CliOption.newString(ADDITIONAL_CONTRACT_ANNOTATIONS, "Additional annotations for HTTP client/server methods"));
             cliOptions.add(CliOption.newBoolean(AUTH_AS_METHOD_ARGUMENT, "HTTP client authorization as method argument"));
+            cliOptions.add(CliOption.newBoolean(ENABLE_JSON_NULLABLE, "If enabled then wraps Nullable and NonRequired fields with JsonNullable type"));
             return cliOptions;
         }
 
@@ -162,6 +164,7 @@ public class KoraCodegen extends DefaultCodegen {
             var interceptors = new HashMap<String, List<Interceptor>>();
             var additionalContractAnnotations = new HashMap<String, List<AdditionalAnnotation>>();
             var requestInDelegateParams = false;
+            var enableJsonNullable = false;
 
             if (additionalProperties.containsKey(CODEGEN_MODE)) {
                 codegenMode = Mode.ofMode(additionalProperties.get(CODEGEN_MODE).toString());
@@ -215,9 +218,12 @@ public class KoraCodegen extends DefaultCodegen {
             if (additionalProperties.containsKey(REQUEST_DELEGATE_PARAMS) && codegenMode.isServer()) {
                 requestInDelegateParams = Boolean.parseBoolean(additionalProperties.get(REQUEST_DELEGATE_PARAMS).toString());
             }
+            if (additionalProperties.containsKey(ENABLE_JSON_NULLABLE)) {
+                enableJsonNullable = Boolean.parseBoolean(additionalProperties.get(ENABLE_JSON_NULLABLE).toString());
+            }
 
             return new CodegenParams(codegenMode, jsonAnnotation, enableServerValidation, authAsMethodArgument, primaryAuth, clientConfigPrefix,
-                securityConfigPrefix, clientTags, interceptors, additionalContractAnnotations, requestInDelegateParams);
+                securityConfigPrefix, clientTags, interceptors, additionalContractAnnotations, requestInDelegateParams, enableJsonNullable);
         }
 
         void processAdditionalProperties(Map<String, Object> additionalProperties) {
@@ -273,6 +279,7 @@ public class KoraCodegen extends DefaultCodegen {
     public static final String INTERCEPTORS = "interceptors";
     public static final String ADDITIONAL_CONTRACT_ANNOTATIONS = "additionalContractAnnotations";
     public static final String AUTH_AS_METHOD_ARGUMENT = "authAsMethodArgument";
+    public static final String ENABLE_JSON_NULLABLE = "enableJsonNullable";
 
     protected String invokerPackage = "org.openapitools";
     protected boolean fullJavaUtil;
@@ -563,8 +570,10 @@ public class KoraCodegen extends DefaultCodegen {
         Map<String, CodegenModel> allModels = getAllModels(objs);
         for (var model : allModels.values()) {
             model.vendorExtensions.put("x-enable-validation", params.enableValidation);
-            if (params.enableValidation) {
-                for (var variable : model.allVars) {
+
+            // All-vars visit
+            for (var variable : model.allVars) {
+                if (params.enableValidation) {
                     if (variable.getRef() != null) {
                         var variableModelField = allModels.get(variable.openApiType);
                         if (variableModelField != null) {
@@ -573,7 +582,37 @@ public class KoraCodegen extends DefaultCodegen {
                     }
                     this.visitVariableValidation(variable, variable.openApiType, variable.dataFormat, variable.vendorExtensions);
                 }
+
+                if (variable.isNullable && !variable.required) {
+                    if (params.enableJsonNullable) {
+                        variable.vendorExtensions.put("x-json-nullable", true);
+                    } else {
+                        variable.vendorExtensions.put("x-json-include-always", true);
+                    }
+                }
             }
+
+            // Optional-vars visit
+            for (var variable : model.optionalVars) {
+                if (params.enableValidation) {
+                    if (variable.getRef() != null) {
+                        var variableModelField = allModels.get(variable.openApiType);
+                        if (variableModelField != null) {
+                            variable.vendorExtensions.put("x-has-valid-model", true);
+                        }
+                    }
+                    this.visitVariableValidation(variable, variable.openApiType, variable.dataFormat, variable.vendorExtensions);
+                }
+
+                if (variable.isNullable && !variable.required) {
+                    if (params.enableJsonNullable) {
+                        variable.vendorExtensions.put("x-json-nullable", true);
+                    } else {
+                        variable.vendorExtensions.put("x-json-include-always", true);
+                    }
+                }
+            }
+
             if (model.discriminator != null) {
                 var map = model.discriminator.getMappedModels().stream()
                     .collect(Collectors.toMap(CodegenDiscriminator.MappedModel::getModelName, m -> List.of(m.getMappingName()), (l1, l2) -> {
@@ -1820,7 +1859,7 @@ public class KoraCodegen extends DefaultCodegen {
                 List<AdditionalAnnotation> additionalAnnotations = List.of();
                 for (Tag tag : op.tags) {
                     additionalAnnotations = params.additionalContractAnnotations.get(tag.getName());
-                    if(additionalAnnotations != null) {
+                    if (additionalAnnotations != null) {
                         break;
                     }
                 }

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaModel.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaModel.mustache
@@ -28,34 +28,35 @@ public sealed interface {{classname}} permits {{#vendorExtensions.x-unique-mappe
   /**
    * {{#description}}{{.}}{{/description}}{{^description}}{{name}}{{/description}}
    */
-  {{{datatypeWithEnum}}} {{name}}();
-
-  {{{classname}}} with{{#lambda.titlecase}}{{name}}{{/lambda.titlecase}}({{^required}}@jakarta.annotation.Nullable{{/required}} {{{datatypeWithEnum}}} {{name}});
+  {{^vendorExtensions.x-json-nullable}}{{^required}}@Nullable {{/required}}{{{datatypeWithEnum}}}{{/vendorExtensions.x-json-nullable}}{{#vendorExtensions.x-json-nullable}}ru.tinkoff.kora.json.common.JsonNullable<{{{datatypeWithEnum}}}>{{/vendorExtensions.x-json-nullable}} {{name}}();
+{{/isDiscriminator}}{{/allVars}}{{#allVars}}{{^isDiscriminator}}
+    {{#example}}/** (example: {{.}}) */{{/example}}
+  {{{classname}}} with{{#lambda.titlecase}}{{name}}{{/lambda.titlecase}}({{^vendorExtensions.x-json-nullable}}{{^required}}@Nullable {{/required}}{{{datatypeWithEnum}}}{{/vendorExtensions.x-json-nullable}}{{#vendorExtensions.x-json-nullable}}ru.tinkoff.kora.json.common.JsonNullable<{{{datatypeWithEnum}}}>{{/vendorExtensions.x-json-nullable}} {{name}});
 {{/isDiscriminator}}{{/allVars}}
 }
 {{/discriminator}}
 {{^discriminator}}
 /**
  * {{#description}}{{.}}{{/description}}{{^description}}{{classname}}{{/description}}{{#allVars}}
- * @param {{name}} {{#description}}{{.}}{{/description}}{{^description}}{{name}}{{/description}}{{/allVars}}
+ * @param {{name}} {{#description}}{{.}}{{/description}}{{^description}}{{name}}{{/description}}{{#example}} (example: {{.}}){{/example}}{{/allVars}}
  */
 @ru.tinkoff.kora.common.annotation.Generated("openapi generator kora java")
 {{#additionalModelTypeAnnotations}}
 {{{.}}}
 {{/additionalModelTypeAnnotations}}
-@ru.tinkoff.kora.json.common.annotation.JsonWriter
-{{#vendorExtensions.x-discriminator-value}}@ru.tinkoff.kora.json.common.annotation.JsonDiscriminatorValue({{{vendorExtensions.x-discriminator-value}}}){{/vendorExtensions.x-discriminator-value}}
-{{#vendorExtensions.x-enable-validation}}@ru.tinkoff.kora.validation.common.annotation.Valid{{/vendorExtensions.x-enable-validation}}
-public record {{classname}} (
+@ru.tinkoff.kora.json.common.annotation.JsonWriter{{#vendorExtensions.x-discriminator-value}}
+@ru.tinkoff.kora.json.common.annotation.JsonDiscriminatorValue({{{vendorExtensions.x-discriminator-value}}}){{/vendorExtensions.x-discriminator-value}}{{#vendorExtensions.x-enable-validation}}
+@ru.tinkoff.kora.validation.common.annotation.Valid{{/vendorExtensions.x-enable-validation}}
+public record {{classname}}(
 {{#allVars}}
-  @ru.tinkoff.kora.json.common.annotation.JsonField("{{baseName}}"){{^required}}
-  @Nullable{{/required}}
+  @ru.tinkoff.kora.json.common.annotation.JsonField("{{baseName}}"){{#vendorExtensions.x-json-include-always}}
+  @ru.tinkoff.kora.json.common.annotation.JsonInclude(ru.tinkoff.kora.json.common.annotation.JsonInclude.IncludeType.ALWAYS){{/vendorExtensions.x-json-include-always}}
   {{#vendorExtensions.x-has-min-max}}@ru.tinkoff.kora.validation.common.annotation.Range(from = {{minimum}}, to = {{maximum}}, boundary = ru.tinkoff.kora.validation.common.annotation.Range.Boundary.{{#exclusiveMinimum}}EXCLUSIVE{{/exclusiveMinimum}}{{^exclusiveMinimum}}INCLUSIVE{{/exclusiveMinimum}}_{{#exclusiveMaximum}}EXCLUSIVE{{/exclusiveMaximum}}{{^exclusiveMaximum}}INCLUSIVE{{/exclusiveMaximum}})
   {{/vendorExtensions.x-has-min-max}}{{#vendorExtensions.x-has-min-max-items}}@ru.tinkoff.kora.validation.common.annotation.Size(min = {{minItems}}, max = {{maxItems}})
   {{/vendorExtensions.x-has-min-max-items}}{{#vendorExtensions.x-has-min-max-length}}@ru.tinkoff.kora.validation.common.annotation.Size(min = {{minLength}}, max = {{maxLength}})
   {{/vendorExtensions.x-has-min-max-length}}{{#vendorExtensions.x-has-pattern}}@ru.tinkoff.kora.validation.common.annotation.Pattern("{{{pattern}}}")
   {{/vendorExtensions.x-has-pattern}}{{#vendorExtensions.x-has-valid-model}}@ru.tinkoff.kora.validation.common.annotation.Valid
-  {{/vendorExtensions.x-has-valid-model}}{{{datatypeWithEnum}}} {{name}}{{^-last}},{{/-last}}
+  {{/vendorExtensions.x-has-valid-model}}{{^vendorExtensions.x-json-nullable}}{{^required}}@Nullable {{/required}}{{{datatypeWithEnum}}}{{/vendorExtensions.x-json-nullable}}{{#vendorExtensions.x-json-nullable}}ru.tinkoff.kora.json.common.JsonNullable<{{{datatypeWithEnum}}}>{{/vendorExtensions.x-json-nullable}} {{name}}{{^-last}},{{/-last}}
 {{/allVars}}){{#vendorExtensions.x-discriminator-value}} implements {{parent}} {{/vendorExtensions.x-discriminator-value}}{
 {{#vendorExtensions.x-discriminator-constant}}
 
@@ -77,11 +78,12 @@ public static String schema = """
 {{#additionalConstructor}}
   public {{classname}}(
 {{#requiredVars}}
-    {{{datatypeWithEnum}}} {{name}}{{^-last}},{{/-last}}
+    {{^vendorExtensions.x-json-nullable}}{{^required}}@Nullable {{/required}}{{{datatypeWithEnum}}}{{/vendorExtensions.x-json-nullable}}{{#vendorExtensions.x-json-nullable}}ru.tinkoff.kora.json.common.JsonNullable<{{{datatypeWithEnum}}}>{{/vendorExtensions.x-json-nullable}} {{name}}{{^-last}},{{/-last}}
 {{/requiredVars}}  ) {
     this({{#allVars}}{{#required}}{{name}}{{/required}}{{^required}}null{{/required}}{{^-last}}, {{/-last}}{{/allVars}});
   }
 {{/additionalConstructor}}
+
   @ru.tinkoff.kora.json.common.annotation.JsonReader
   public {{classname}} { {{#vendorExtensions.x-discriminator-values-check}}
     if {{{vendorExtensions.x-discriminator-values-check}}} {
@@ -89,7 +91,6 @@ public static String schema = """
     }
 {{/vendorExtensions.x-discriminator-values-check}}
   }
-
 
   {{#allVars}}
       {{#isEnum}}
@@ -103,19 +104,18 @@ public static String schema = """
       {{/isContainer}}
       {{/isEnum}}
   {{/allVars}}
-
 {{#allVars}}
 
-{{#vendorExtensions.x-discriminator-value}}{{#isOverridden}}  @Override
-{{/isOverridden}}{{/vendorExtensions.x-discriminator-value}}  public {{{classname}}} with{{#lambda.titlecase}}{{name}}{{/lambda.titlecase}}({{^required}}@Nullable{{/required}} {{{datatypeWithEnum}}} {{name}}) {
+{{#example}}
+  /** (example: {{.}}) */{{/example}}{{#vendorExtensions.x-discriminator-value}}{{#isOverridden}}
+  @Override{{/isOverridden}}{{/vendorExtensions.x-discriminator-value}}
+  public {{{classname}}} with{{#lambda.titlecase}}{{name}}{{/lambda.titlecase}}({{^vendorExtensions.x-json-nullable}}{{^required}}@Nullable {{/required}}{{{datatypeWithEnum}}}{{/vendorExtensions.x-json-nullable}}{{#vendorExtensions.x-json-nullable}}ru.tinkoff.kora.json.common.JsonNullable<{{{datatypeWithEnum}}}>{{/vendorExtensions.x-json-nullable}} {{name}}) {
     if (this.{{name}} == {{name}}) return this;
     return new {{{classname}}}({{#allVars}}
       {{name}}{{^-last}},{{/-last}}{{/allVars}}
     );
   }
-
 {{/allVars}}
-
 }
 
 {{/discriminator}}

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinModel.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinModel.mustache
@@ -22,24 +22,25 @@ package {{package}}
 sealed interface {{classname}} {
 {{#allVars}}{{^isDiscriminator}}
   /**
-   * {{#description}}{{.}}{{/description}}{{^description}}name{{/description}}
+   * {{#description}}{{.}}{{/description}}{{^description}}{{name}}{{/description}} {{#example}}
+   * (example: {{.}}){{/example}}
    */
-  val {{name}}: {{{datatypeWithEnum}}}{{^required}}?{{/required}}
+  val {{name}}: {{^vendorExtensions.x-json-nullable}}{{{datatypeWithEnum}}}{{^required}}?{{/required}}{{/vendorExtensions.x-json-nullable}}{{#vendorExtensions.x-json-nullable}}ru.tinkoff.kora.json.common.JsonNullable<{{{datatypeWithEnum}}}>{{/vendorExtensions.x-json-nullable}}
 {{/isDiscriminator}}{{/allVars}}
 }
 {{/discriminator}}
 {{^discriminator}}
 /**
  * {{#description}}{{.}}{{/description}}{{^description}}{{classname}}{{/description}}{{#allVars}}
- * @param {{name}} {{#description}}{{.}}{{/description}}{{^description}}{{name}}{{/description}}{{/allVars}}
+ * @param {{name}} {{#description}}{{.}}{{/description}}{{^description}}{{name}}{{/description}}{{#example}} (example: {{.}}){{/example}}{{/allVars}}
  */
 @ru.tinkoff.kora.common.annotation.Generated("openapi generator kora kotlin")
 {{#additionalModelTypeAnnotations}}
 {{{.}}}
 {{/additionalModelTypeAnnotations}}
-@ru.tinkoff.kora.json.common.annotation.JsonWriter
-{{#vendorExtensions.x-discriminator-value}}@ru.tinkoff.kora.json.common.annotation.JsonDiscriminatorValue(value = {{{vendorExtensions.x-discriminator-value}}}){{/vendorExtensions.x-discriminator-value}}
-{{#vendorExtensions.x-enable-validation}}@ru.tinkoff.kora.validation.common.annotation.Valid{{/vendorExtensions.x-enable-validation}}
+@ru.tinkoff.kora.json.common.annotation.JsonWriter{{#vendorExtensions.x-discriminator-value}}
+@ru.tinkoff.kora.json.common.annotation.JsonDiscriminatorValue(value = {{{vendorExtensions.x-discriminator-value}}}){{/vendorExtensions.x-discriminator-value}}{{#vendorExtensions.x-enable-validation}}
+@ru.tinkoff.kora.validation.common.annotation.Valid{{/vendorExtensions.x-enable-validation}}
 {{#hasVars}}data {{/hasVars}}class {{classname}} @ru.tinkoff.kora.json.common.annotation.JsonReader constructor (
 {{#requiredVars}}
   @ru.tinkoff.kora.json.common.annotation.JsonField("{{baseName}}")
@@ -49,7 +50,7 @@ sealed interface {{classname}} {
   {{/vendorExtensions.x-has-min-max-length}}{{#vendorExtensions.x-has-pattern}}@ru.tinkoff.kora.validation.common.annotation.Pattern("{{{pattern}}}")
   {{/vendorExtensions.x-has-pattern}}{{#vendorExtensions.x-has-valid-model}}@ru.tinkoff.kora.validation.common.annotation.Valid
   {{/vendorExtensions.x-has-valid-model}}
-{{^isDiscriminator}}{{#isOverridden}}override {{/isOverridden}}{{/isDiscriminator}}val {{name}}: {{{datatypeWithEnum}}}{{^-last}},{{/-last}}{{#-last}}{{#hasOptional}},{{/hasOptional}}{{/-last}}
+{{^isDiscriminator}}{{#isOverridden}}override {{/isOverridden}}{{/isDiscriminator}}val {{name}}: {{^vendorExtensions.x-json-nullable}}{{{datatypeWithEnum}}}{{/vendorExtensions.x-json-nullable}}{{#vendorExtensions.x-json-nullable}}ru.tinkoff.kora.json.common.JsonNullable<{{{datatypeWithEnum}}}>{{/vendorExtensions.x-json-nullable}}{{^-last}},{{/-last}}{{#-last}}{{#hasOptional}},{{/hasOptional}}{{/-last}}
 {{/requiredVars}}{{#optionalVars}}
   @ru.tinkoff.kora.json.common.annotation.JsonField("{{baseName}}")
   {{#vendorExtensions.x-has-min-max}}@ru.tinkoff.kora.validation.common.annotation.Range(from = {{minimum}}.toDouble(), to = {{maximum}}.toDouble(), boundary = ru.tinkoff.kora.validation.common.annotation.Range.Boundary.{{#exclusiveMinimum}}EXCLUSIVE{{/exclusiveMinimum}}{{^exclusiveMinimum}}INCLUSIVE{{/exclusiveMinimum}}_{{#exclusiveMaximum}}EXCLUSIVE{{/exclusiveMaximum}}{{^exclusiveMaximum}}INCLUSIVE{{/exclusiveMaximum}})
@@ -58,8 +59,8 @@ sealed interface {{classname}} {
   {{/vendorExtensions.x-has-min-max-length}}{{#vendorExtensions.x-has-pattern}}@ru.tinkoff.kora.validation.common.annotation.Pattern("{{{pattern}}}")
   {{/vendorExtensions.x-has-pattern}}{{#vendorExtensions.x-has-valid-model}}@ru.tinkoff.kora.validation.common.annotation.Valid
   {{/vendorExtensions.x-has-valid-model}}
-{{^isDiscriminator}}{{#isOverridden}}override {{/isOverridden}}{{/isDiscriminator}}val {{name}}: {{{datatypeWithEnum}}}? = null{{^-last}},{{/-last}}
-{{/optionalVars}}){{#vendorExtensions.x-discriminator-value}} : {{parent}} {{/vendorExtensions.x-discriminator-value}}{
+{{^isDiscriminator}}{{#isOverridden}}override {{/isOverridden}}{{/isDiscriminator}}val {{name}}: {{^vendorExtensions.x-json-nullable}}{{{datatypeWithEnum}}}? = null{{/vendorExtensions.x-json-nullable}}{{#vendorExtensions.x-json-nullable}}ru.tinkoff.kora.json.common.JsonNullable<{{{datatypeWithEnum}}}>{{/vendorExtensions.x-json-nullable}}{{^-last}},{{/-last}}
+{{/optionalVars}}){{#vendorExtensions.x-discriminator-value}} : {{parent}} {{/vendorExtensions.x-discriminator-value}} {
 {{#vendorExtensions.x-discriminator-constant}}
 
   companion object {

--- a/openapi/openapi-generator/src/test/resources/example/petstoreV3_discriminator.yaml
+++ b/openapi/openapi-generator/src/test/resources/example/petstoreV3_discriminator.yaml
@@ -52,21 +52,33 @@ components:
     ValidationErrorDto:
       title: ValidationErrorDto
       type: object
+      required:
+        - fieldRequired
+        - fieldRequiredNullable
+        - fieldRequiredNonNullable
       properties:
-        fieldNonRequired:
+        type:
           type: string
         fieldRequired:
           type: string
-        type:
+          example: 123
+        fieldNullable:
           type: string
+          nullable: true
+          example: 123
+        fieldRequiredNullable:
+          type: string
+          nullable: true
+          example: 123
+        fieldRequiredNonNullable:
+          type: string
+          example: 123
       discriminator:
         propertyName: type
         mapping:
           'Block.Error1': '#/components/schemas/BlockValidationErrorDto'
           'Block.Error2': '#/components/schemas/BlockValidationErrorDto'
           'Prop.Error': '#/components/schemas/PropValidationErrorDto'
-      required:
-        - fieldRequired
 
     PropValidationErrorDto:
       title: PropValidationErrorDto

--- a/openapi/openapi-generator/src/test/resources/example/petstoreV3_nullable.yaml
+++ b/openapi/openapi-generator/src/test/resources/example/petstoreV3_nullable.yaml
@@ -1,0 +1,149 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: A paged array of pets
+          headers:
+            x-next:
+              description: A link to the next page of responses
+              required: true
+              schema:
+                type: string
+            x-optional-next:
+              description: A link to the next page of responses
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pets"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      summary: Create a pet
+      operationId: createPets
+      tags:
+        - pets
+      responses:
+        '201':
+          description: Null response
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /pets/{petId}:
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+  /pets/{petId}/photo:
+    get:
+      summary: Photo of a specific pet
+      operationId: petPhotoById
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            image/jpeg:
+              schema:
+                type: string
+                format: binary
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - fieldRequired
+        - fieldRequiredNullable
+        - fieldRequiredNonNullable
+      properties:
+        id:
+          type: integer
+          format: int64
+        fieldRequired:
+          type: string
+          example: 123
+        fieldNullable:
+          type: string
+          nullable: true
+          example: 123
+        fieldRequiredNullable:
+          type: string
+          nullable: true
+          example: 123
+        fieldRequiredNonNullable:
+          type: string
+          example: 123
+    Pets:
+      type: array
+      items:
+        $ref: "#/components/schemas/Pet"
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string


### PR DESCRIPTION
- [x] OpenAPI option `enableJsonNullable` to process `nullable=true` & `required=false` [as JsonNullable](https://github.com/OpenAPITools/openapi-generator/issues/14765#issuecomment-1437450306) added

Part of #170 