### PR TITLE
quartz job registrar npe is fixed

### DIFF
--- a/scheduling/scheduling-quartz/src/main/java/ru/tinkoff/kora/scheduling/quartz/KoraQuartzJobRegistrar.java
+++ b/scheduling/scheduling-quartz/src/main/java/ru/tinkoff/kora/scheduling/quartz/KoraQuartzJobRegistrar.java
@@ -8,6 +8,7 @@ import ru.tinkoff.kora.application.graph.ValueOf;
 import ru.tinkoff.kora.common.util.TimeUtils;
 
 import java.util.List;
+import java.util.Objects;
 
 public class KoraQuartzJobRegistrar implements Lifecycle {
 
@@ -61,8 +62,8 @@ public class KoraQuartzJobRegistrar implements Lifecycle {
         if (oldTrigger.getClass() != newTrigger.getClass()) {
             return false;
         }
-        if (!oldTrigger.getStartTime().equals(newTrigger.getStartTime())) return false;
-        if (!oldTrigger.getEndTime().equals(oldTrigger.getEndTime())) return false;
+        if (!Objects.equals(oldTrigger.getStartTime(), newTrigger.getStartTime())) return false;
+        if (!Objects.equals(oldTrigger.getEndTime(), newTrigger.getEndTime())) return false;
         if (oldTrigger instanceof CronTrigger oldCron && newTrigger instanceof CronTrigger newCron) {
             return oldCron.getCronExpression().equals(newCron.getCronExpression());
         }


### PR DESCRIPTION
- NPE is occured in **KoraQuartzJobRegistrar** if **oldTrigger.getEndTime()** is null (**endTime** can be unspecified));

Stacktrace (message: **_Error on checking config for changes_** in **ru.tinkoff.kora.config.common.ConfigWatcher**): 
```
java.lang.NullPointerException: Cannot invoke "java.util.Date.equals(Object)" because the return value of "org.quartz.Trigger.getEndTime()" is null
	at ru.tinkoff.kora.scheduling.quartz.KoraQuartzJobRegistrar.triggersEqual(KoraQuartzJobRegistrar.java:65)
	at ru.tinkoff.kora.scheduling.quartz.KoraQuartzJobRegistrar.init(KoraQuartzJobRegistrar.java:49)
	at ru.tinkoff.kora.application.graph.internal.GraphImpl$TmpGraph.lambda$initializeNode$6(GraphImpl.java:513)
	at java.base/java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1804)
	at java.base/java.lang.VirtualThread.run(VirtualThread.java:329)
```
- The second problem is comparison of **oldTrigger.getEndTime()** with itself.
