### PR TITLE
Fix sql.Types in JdbcNativeType.bindNull for byte[]

### DIFF
--- a/database/database-annotation-processor/src/main/java/ru/tinkoff/kora/database/annotation/processor/jdbc/JdbcNativeTypes.java
+++ b/database/database-annotation-processor/src/main/java/ru/tinkoff/kora/database/annotation/processor/jdbc/JdbcNativeTypes.java
@@ -75,7 +75,7 @@ public class JdbcNativeTypes {
             ArrayTypeName.of(TypeName.BYTE),
             (rsName, i) -> CodeBlock.of("$L.getBytes($L)", rsName, i),
             (stmt, var, i) -> CodeBlock.of("$L.setBytes($L, $L)", stmt, i, var),
-            (stmtName, i) -> CodeBlock.of("$L.setNull($L, $T.BINARY)", stmtName, i, java.sql.Types.class)
+            (stmtName, i) -> CodeBlock.of("$L.setNull($L, $T.VARBINARY)", stmtName, i, java.sql.Types.class)
         );
         var localDateTime = JdbcNativeType.of(
             TypeName.get(LocalDateTime.class),

--- a/database/database-symbol-processor/src/main/kotlin/ru/tinkoff/kora/database/symbol/processor/jdbc/JdbcNativeTypes.kt
+++ b/database/database-symbol-processor/src/main/kotlin/ru/tinkoff/kora/database/symbol/processor/jdbc/JdbcNativeTypes.kt
@@ -98,13 +98,13 @@ object JdbcNativeTypes {
             ByteArray::class.asTypeName(),
             { rsName, i -> CodeBlock.of("%N.getBytes(%L)", rsName, i) },
             { stmt, variableName, idx -> CodeBlock.of("%N.setBytes(%L, %L)", stmt, idx, variableName) },
-            { stmt, idx -> CodeBlock.of("%N.setNull(%L, %T.NUMERIC)", stmt, idx, Types::class) }
+            { stmt, idx -> CodeBlock.of("%N.setNull(%L, %T.VARBINARY)", stmt, idx, Types::class) }
         ),
         JdbcNativeType.of(
             ByteArray::class.asTypeName().copy(true),
             { rsName, i -> CodeBlock.of("%N.getBytes(%L)", rsName, i) },
             { stmt, variableName, idx -> CodeBlock.of("%N.setBytes(%L, %L)", stmt, idx, variableName) },
-            { stmt, idx -> CodeBlock.of("%N.setNull(%L, %T.NUMERIC)", stmt, idx, Types::class) }
+            { stmt, idx -> CodeBlock.of("%N.setNull(%L, %T.VARBINARY)", stmt, idx, Types::class) }
         ),
         JdbcNativeType.of(
             LocalDateTime::class.asTypeName(),


### PR DESCRIPTION
This MR fixes the following bug:

Kora generates incorrect parameter binding for `@Nullable byte[]` parameters in JdbcRepository.

### Test case

Consider the repository interface:

```kotlin
interface BytesRepo : JdbcRepository {
  @Query(
    """
    INSERT INTO bytes_table (bytes_col)
    VALUES (:bytes)
    """,
  )
  fun insertBytes(bytes: ByteArray?) // bytes is nullable
}
```

### Actual behaviour

```kotlin
bytes.let {
  if (it == null) {
    _stmt.setNull(1, Types.NUMERIC)
  } else {
    _stmt.setBytes(1, it)
  }
}
```

The above code leads to SQLException

### Expected behaviour

Generated code contains:

```kotlin
_stmt.setBytes(1, bytes)
```
As `setBytes` accepts `null`.

Or fixed version of the current variant (with proper sql type):
```
bytes.let {
  if (it == null) {
    _stmt.setNull(1, Types.VARBINARY)
  } else {
    _stmt.setBytes(1, it)
  }
}
```
