### PR TITLE
Cache Redis multiple key get fix

### DIFF
--- a/cache/cache-annotation-processor/src/test/java/ru/tinkoff/kora/cache/annotation/processor/CacheRunner.java
+++ b/cache/cache-annotation-processor/src/test/java/ru/tinkoff/kora/cache/annotation/processor/CacheRunner.java
@@ -2,10 +2,9 @@ package ru.tinkoff.kora.cache.annotation.processor;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
-import org.jetbrains.annotations.NotNull;
 import ru.tinkoff.kora.cache.caffeine.CaffeineCacheConfig;
-import ru.tinkoff.kora.cache.redis.RedisCacheConfig;
 import ru.tinkoff.kora.cache.redis.RedisCacheClient;
+import ru.tinkoff.kora.cache.redis.RedisCacheConfig;
 
 import java.nio.ByteBuffer;
 import java.time.Duration;

--- a/cache/cache-annotation-processor/src/test/java/ru/tinkoff/kora/cache/annotation/processor/CacheRunner.java
+++ b/cache/cache-annotation-processor/src/test/java/ru/tinkoff/kora/cache/annotation/processor/CacheRunner.java
@@ -2,6 +2,7 @@ package ru.tinkoff.kora.cache.annotation.processor;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
 import ru.tinkoff.kora.cache.caffeine.CaffeineCacheConfig;
 import ru.tinkoff.kora.cache.redis.RedisCacheConfig;
 import ru.tinkoff.kora.cache.redis.RedisCacheClient;
@@ -106,6 +107,11 @@ final class CacheRunner {
             }
 
             @Override
+            public CompletionStage<Boolean> psetex(Map<byte[], byte[]> keyAndValue, long expireAfterMillis) {
+                return mset(keyAndValue);
+            }
+
+            @Override
             public CompletionStage<Boolean> psetex(byte[] key, byte[] value, long expireAfterMillis) {
                 return set(key, value);
             }
@@ -128,16 +134,6 @@ final class CacheRunner {
             public CompletionStage<Boolean> flushAll() {
                 cache.clear();
                 return CompletableFuture.completedFuture(true);
-            }
-
-            @Override
-            public void init() throws Exception {
-
-            }
-
-            @Override
-            public void release() throws Exception {
-
             }
         };
     }

--- a/cache/cache-redis/build.gradle
+++ b/cache/cache-redis/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     implementation libs.netty.common
     implementation libs.netty.handlers
     implementation libs.netty.transports
+    implementation libs.apache.pool
 
     testImplementation testFixtures(project(":annotation-processor-common"))
     testImplementation project(":annotation-processor-common")

--- a/cache/cache-redis/build.gradle
+++ b/cache/cache-redis/build.gradle
@@ -17,16 +17,8 @@ dependencies {
     implementation libs.netty.transports
     implementation libs.apache.pool
 
-    testImplementation testFixtures(project(":annotation-processor-common"))
-    testImplementation project(":annotation-processor-common")
-    testImplementation project(":aop:aop-annotation-processor")
-    testImplementation project(":cache:cache-annotation-processor")
-    testImplementation project(":config:config-annotation-processor")
-    testImplementation project(":kora-app-annotation-processor")
-    testImplementation project(":json:json-annotation-processor")
     testImplementation project(":internal:test-logging")
     testImplementation project(":internal:test-redis")
-    testImplementation libs.testcontainers.junit.jupiter
 }
 
 apply from: "${project.rootDir}/gradle/in-test-generated.gradle"

--- a/cache/cache-redis/src/main/java/ru/tinkoff/kora/cache/redis/AbstractRedisCache.java
+++ b/cache/cache-redis/src/main/java/ru/tinkoff/kora/cache/redis/AbstractRedisCache.java
@@ -1,6 +1,8 @@
 package ru.tinkoff.kora.cache.redis;
 
 import jakarta.annotation.Nonnull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import ru.tinkoff.kora.cache.AsyncCache;
 
 import java.nio.charset.StandardCharsets;
@@ -12,6 +14,8 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public abstract class AbstractRedisCache<K, V> implements AsyncCache<K, V> {
+
+    private static final Logger logger = LoggerFactory.getLogger(RedisCache.class);
 
     private final String name;
     private final RedisCacheClient redisClient;
@@ -42,7 +46,7 @@ public abstract class AbstractRedisCache<K, V> implements AsyncCache<K, V> {
             ? null
             : config.expireAfterWrite().toMillis();
 
-        if(config.keyPrefix().isEmpty()) {
+        if (config.keyPrefix().isEmpty()) {
             this.keyPrefix = null;
         } else {
             var prefixRaw = config.keyPrefix().getBytes(StandardCharsets.UTF_8);
@@ -193,7 +197,9 @@ public abstract class AbstractRedisCache<K, V> implements AsyncCache<K, V> {
                 : redisClient.getex(keyAsBytes, expireAfterAccessMillis).toCompletableFuture().join();
 
             fromCache = valueMapper.read(jsonAsBytes);
-        } catch (Exception ignored) {}
+        } catch (Exception e) {
+            logger.error(e.getMessage(), e);
+        }
 
         if (fromCache != null) {
             telemetryContext.recordSuccess();
@@ -211,7 +217,9 @@ public abstract class AbstractRedisCache<K, V> implements AsyncCache<K, V> {
                     } else {
                         redisClient.psetex(keyAsBytes, valueAsBytes, expireAfterWriteMillis).toCompletableFuture().join();
                     }
-                } catch (Exception ignored) {}
+                } catch (Exception e) {
+                    logger.error(e.getMessage(), e);
+                }
             }
 
             telemetryContext.recordSuccess();
@@ -252,7 +260,9 @@ public abstract class AbstractRedisCache<K, V> implements AsyncCache<K, V> {
                     }
                 });
             }
-        } catch (Exception ignored) {}
+        } catch (Exception e) {
+            logger.error(e.getMessage(), e);
+        }
 
         if (fromCache.size() == keys.size()) {
             telemetryContext.recordSuccess();
@@ -279,7 +289,9 @@ public abstract class AbstractRedisCache<K, V> implements AsyncCache<K, V> {
                     } else {
                         redisClient.psetex(keyAndValuesAsBytes, expireAfterWriteMillis).toCompletableFuture().join();
                     }
-                } catch (Exception ignored) {}
+                } catch (Exception e) {
+                    logger.error(e.getMessage(), e);
+                }
             }
 
             telemetryContext.recordSuccess();
@@ -637,7 +649,7 @@ public abstract class AbstractRedisCache<K, V> implements AsyncCache<K, V> {
 
     private byte[] mapKey(K key) {
         final byte[] suffixAsBytes = keyMapper.apply(key);
-        if(this.keyPrefix == null) {
+        if (this.keyPrefix == null) {
             return suffixAsBytes;
         } else {
             var keyAsBytes = new byte[keyPrefix.length + suffixAsBytes.length];

--- a/cache/cache-redis/src/main/java/ru/tinkoff/kora/cache/redis/AbstractRedisCache.java
+++ b/cache/cache-redis/src/main/java/ru/tinkoff/kora/cache/redis/AbstractRedisCache.java
@@ -85,7 +85,7 @@ public abstract class AbstractRedisCache<K, V> implements AsyncCache<K, V> {
     @Override
     public Map<K, V> get(@Nonnull Collection<K> keys) {
         if (keys == null || keys.isEmpty()) {
-            return null;
+            return Collections.emptyMap();
         }
 
         var telemetryContext = telemetry.create("GET_MANY", name);
@@ -184,7 +184,7 @@ public abstract class AbstractRedisCache<K, V> implements AsyncCache<K, V> {
     @Override
     public V computeIfAbsent(@Nonnull K key, @Nonnull Function<K, V> mappingFunction) {
         if (key == null) {
-            return mappingFunction.apply(key);
+            return null;
         }
 
         var telemetryContext = telemetry.create("COMPUTE_IF_ABSENT", name);
@@ -237,7 +237,7 @@ public abstract class AbstractRedisCache<K, V> implements AsyncCache<K, V> {
     @Override
     public Map<K, V> computeIfAbsent(@Nonnull Collection<K> keys, @Nonnull Function<Set<K>, Map<K, V>> mappingFunction) {
         if (keys == null || keys.isEmpty()) {
-            return mappingFunction.apply(Collections.emptySet());
+            return Collections.emptyMap();
         }
 
         var telemetryContext = telemetry.create("COMPUTE_IF_ABSENT_MANY", name);
@@ -488,7 +488,6 @@ public abstract class AbstractRedisCache<K, V> implements AsyncCache<K, V> {
 
         return responseCompletionStage
             .thenApply(valueMapper::read)
-            .exceptionally(e -> null)
             .thenCompose(fromCache -> {
                 if (fromCache != null) {
                     return CompletableFuture.completedFuture(fromCache);
@@ -510,11 +509,11 @@ public abstract class AbstractRedisCache<K, V> implements AsyncCache<K, V> {
                                 telemetryContext.recordSuccess();
                                 return value;
                             });
-                    })
-                    .exceptionally(e -> {
-                        telemetryContext.recordFailure(e);
-                        return null;
                     });
+            })
+            .exceptionally(e -> {
+                telemetryContext.recordFailure(e);
+                return null;
             });
     }
 
@@ -548,7 +547,6 @@ public abstract class AbstractRedisCache<K, V> implements AsyncCache<K, V> {
 
                 return fromCache;
             })
-            .exceptionally(e -> null)
             .thenCompose(fromCache -> {
                 if (fromCache.size() == keys.size()) {
                     return CompletableFuture.completedFuture(fromCache);
@@ -581,11 +579,11 @@ public abstract class AbstractRedisCache<K, V> implements AsyncCache<K, V> {
                                 fromCache.putAll(values);
                                 return fromCache;
                             });
-                    })
-                    .exceptionally(e -> {
-                        telemetryContext.recordFailure(e);
-                        return null;
                     });
+            })
+            .exceptionally(e -> {
+                telemetryContext.recordFailure(e);
+                return Collections.emptyMap();
             });
     }
 

--- a/cache/cache-redis/src/main/java/ru/tinkoff/kora/cache/redis/RedisCacheClient.java
+++ b/cache/cache-redis/src/main/java/ru/tinkoff/kora/cache/redis/RedisCacheClient.java
@@ -1,15 +1,11 @@
 package ru.tinkoff.kora.cache.redis;
 
 import jakarta.annotation.Nonnull;
-import ru.tinkoff.kora.application.graph.Lifecycle;
 
-import java.util.Arrays;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import java.util.stream.Collectors;
 
-public interface RedisCacheClient extends Lifecycle {
+public interface RedisCacheClient {
 
     @Nonnull
     CompletionStage<byte[]> get(byte[] key);
@@ -21,35 +17,19 @@ public interface RedisCacheClient extends Lifecycle {
     CompletionStage<byte[]> getex(byte[] key, long expireAfterMillis);
 
     @Nonnull
-    default CompletionStage<Map<byte[], byte[]>> getex(byte[][] keys, long expireAfterMillis) {
-        final CompletableFuture[] values = Arrays.stream(keys)
-            .map(k -> getex(k, expireAfterMillis)
-                .thenApply(v -> Map.entry(k, v)).toCompletableFuture())
-            .toArray(CompletableFuture[]::new);
-
-        return CompletableFuture.allOf(values)
-            .thenApply(v -> Arrays.stream(values)
-                .map(f -> ((Map.Entry<byte[], byte[]>) f.join()))
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
-    }
+    CompletionStage<Map<byte[], byte[]>> getex(byte[][] keys, long expireAfterMillis);
 
     @Nonnull
     CompletionStage<Boolean> set(byte[] key, byte[] value);
 
     @Nonnull
-    CompletionStage<Boolean> mset(Map<byte[], byte[]> keyAndValue);
+    CompletionStage<Boolean> mset(@Nonnull Map<byte[], byte[]> keyAndValue);
 
     @Nonnull
     CompletionStage<Boolean> psetex(byte[] key, byte[] value, long expireAfterMillis);
 
     @Nonnull
-    default CompletionStage<Boolean> psetex(Map<byte[], byte[]> keyAndValue, long expireAfterMillis) {
-        final CompletableFuture[] values = keyAndValue.entrySet().stream()
-            .map(e -> psetex(e.getKey(), e.getValue(), expireAfterMillis).toCompletableFuture())
-            .toArray(CompletableFuture[]::new);
-
-        return CompletableFuture.allOf(values).thenApply(v -> true);
-    }
+    CompletionStage<Boolean> psetex(@Nonnull Map<byte[], byte[]> keyAndValue, long expireAfterMillis);
 
     @Nonnull
     CompletionStage<Long> del(byte[] key);

--- a/cache/cache-redis/src/main/java/ru/tinkoff/kora/cache/redis/RedisCacheMapperModule.java
+++ b/cache/cache-redis/src/main/java/ru/tinkoff/kora/cache/redis/RedisCacheMapperModule.java
@@ -1,8 +1,6 @@
 package ru.tinkoff.kora.cache.redis;
 
 import jakarta.annotation.Nullable;
-import ru.tinkoff.kora.application.graph.TypeRef;
-import ru.tinkoff.kora.cache.redis.lettuce.LettuceModule;
 import ru.tinkoff.kora.cache.telemetry.CacheMetrics;
 import ru.tinkoff.kora.cache.telemetry.CacheTracer;
 import ru.tinkoff.kora.common.DefaultComponent;

--- a/cache/cache-redis/src/main/java/ru/tinkoff/kora/cache/redis/lettuce/LettuceClientConfig.java
+++ b/cache/cache-redis/src/main/java/ru/tinkoff/kora/cache/redis/lettuce/LettuceClientConfig.java
@@ -4,48 +4,33 @@ import io.lettuce.core.RedisURI;
 import io.lettuce.core.SocketOptions;
 import io.lettuce.core.protocol.ProtocolVersion;
 import jakarta.annotation.Nullable;
+import ru.tinkoff.kora.config.common.annotation.ConfigValueExtractor;
 
 import java.time.Duration;
-import java.util.Arrays;
 
-public record LettuceClientConfig(String uri,
-                                  @Nullable Integer database,
-                                  @Nullable String user,
-                                  @Nullable String password,
-                                  @Nullable String protocol,
-                                  @Nullable Duration socketTimeout,
-                                  @Nullable Duration commandTimeout) {
+@ConfigValueExtractor
+public interface LettuceClientConfig {
 
-    public LettuceClientConfig(String uri,
-                               @Nullable Integer database,
-                               @Nullable String user,
-                               @Nullable String password,
-                               @Nullable String protocol,
-                               @Nullable Duration socketTimeout,
-                               @Nullable Duration commandTimeout) {
-        this.uri = uri;
-        this.database = database;
-        this.user = user;
-        this.password = password;
-        this.protocol = (protocol == null)
-            ? ProtocolVersion.RESP3.name()
-            : protocol;
-        this.commandTimeout = (commandTimeout == null)
-            ? Duration.ofSeconds(RedisURI.DEFAULT_TIMEOUT)
-            : commandTimeout;
-        this.socketTimeout = (socketTimeout == null)
-            ? Duration.ofSeconds(SocketOptions.DEFAULT_CONNECT_TIMEOUT)
-            : socketTimeout;
+    String uri();
+
+    @Nullable
+    Integer database();
+
+    @Nullable
+    String user();
+
+    @Nullable
+    String password();
+
+    default ProtocolVersion protocol() {
+        return ProtocolVersion.RESP3;
     }
 
-    public ProtocolVersion protocolVersion() {
-        if (ProtocolVersion.RESP3.name().equals(protocol)) {
-            return ProtocolVersion.RESP3;
-        } else if (ProtocolVersion.RESP2.name().equals(protocol)) {
-            return ProtocolVersion.RESP2;
-        } else {
-            throw new IllegalArgumentException("Unknown protocol value '" + protocol
-                + "', expected value one of: " + Arrays.toString(ProtocolVersion.values()));
-        }
+    default Duration socketTimeout() {
+        return Duration.ofSeconds(SocketOptions.DEFAULT_CONNECT_TIMEOUT);
+    }
+
+    default Duration commandTimeout() {
+        return Duration.ofSeconds(RedisURI.DEFAULT_TIMEOUT);
     }
 }

--- a/cache/cache-redis/src/main/java/ru/tinkoff/kora/cache/redis/lettuce/LettuceClientConfig.java
+++ b/cache/cache-redis/src/main/java/ru/tinkoff/kora/cache/redis/lettuce/LettuceClientConfig.java
@@ -37,7 +37,7 @@ public interface LettuceClientConfig {
 
         /** Redis 2 to Redis 5 */
         RESP2,
-        /** Redis 6 */
+        /** Redis 6+ */
         RESP3
     }
 }

--- a/cache/cache-redis/src/main/java/ru/tinkoff/kora/cache/redis/lettuce/LettuceClientConfig.java
+++ b/cache/cache-redis/src/main/java/ru/tinkoff/kora/cache/redis/lettuce/LettuceClientConfig.java
@@ -2,7 +2,6 @@ package ru.tinkoff.kora.cache.redis.lettuce;
 
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.SocketOptions;
-import io.lettuce.core.protocol.ProtocolVersion;
 import jakarta.annotation.Nullable;
 import ru.tinkoff.kora.config.common.annotation.ConfigValueExtractor;
 
@@ -22,8 +21,8 @@ public interface LettuceClientConfig {
     @Nullable
     String password();
 
-    default ProtocolVersion protocol() {
-        return ProtocolVersion.RESP3;
+    default Protocol protocol() {
+        return Protocol.RESP3;
     }
 
     default Duration socketTimeout() {
@@ -32,5 +31,13 @@ public interface LettuceClientConfig {
 
     default Duration commandTimeout() {
         return Duration.ofSeconds(RedisURI.DEFAULT_TIMEOUT);
+    }
+
+    enum Protocol {
+
+        /** Redis 2 to Redis 5 */
+        RESP2,
+        /** Redis 6 */
+        RESP3
     }
 }

--- a/cache/cache-redis/src/main/java/ru/tinkoff/kora/cache/redis/lettuce/LettuceClientFactory.java
+++ b/cache/cache-redis/src/main/java/ru/tinkoff/kora/cache/redis/lettuce/LettuceClientFactory.java
@@ -17,7 +17,7 @@ public final class LettuceClientFactory {
     public AbstractRedisClient build(LettuceClientConfig config) {
         final Duration commandTimeout = config.commandTimeout();
         final Duration socketTimeout = config.socketTimeout();
-        final ProtocolVersion protocolVersion = config.protocolVersion();
+        final ProtocolVersion protocolVersion = config.protocol();
 
         final List<RedisURI> mappedRedisUris = buildRedisURI(config);
 
@@ -30,7 +30,7 @@ public final class LettuceClientFactory {
     public RedisClusterClient buildRedisClusterClient(LettuceClientConfig config) {
         final Duration commandTimeout = config.commandTimeout();
         final Duration socketTimeout = config.socketTimeout();
-        final ProtocolVersion protocolVersion = config.protocolVersion();
+        final ProtocolVersion protocolVersion = config.protocol();
         final List<RedisURI> mappedRedisUris = buildRedisURI(config);
         return buildRedisClusterClientInternal(mappedRedisUris, commandTimeout, socketTimeout, protocolVersion);
     }
@@ -39,7 +39,7 @@ public final class LettuceClientFactory {
     public RedisClient buildRedisClient(LettuceClientConfig config) {
         final Duration commandTimeout = config.commandTimeout();
         final Duration socketTimeout = config.socketTimeout();
-        final ProtocolVersion protocolVersion = config.protocolVersion();
+        final ProtocolVersion protocolVersion = config.protocol();
         final List<RedisURI> mappedRedisUris = buildRedisURI(config);
         return buildRedisClientInternal(mappedRedisUris.get(0), commandTimeout, socketTimeout, protocolVersion);
     }
@@ -96,7 +96,7 @@ public final class LettuceClientFactory {
         return client;
     }
 
-    private static List<RedisURI> buildRedisURI(LettuceClientConfig config) {
+    static List<RedisURI> buildRedisURI(LettuceClientConfig config) {
         final String uri = config.uri();
         final Integer database = config.database();
         final String user = config.user();
@@ -115,7 +115,9 @@ public final class LettuceClientFactory {
                     builder = builder.withPassword(((CharSequence) password));
                 }
 
-                return builder.build();
+                return builder
+                    .withTimeout(config.commandTimeout())
+                    .build();
             })
             .toList();
     }

--- a/cache/cache-redis/src/main/java/ru/tinkoff/kora/cache/redis/lettuce/LettuceClientFactory.java
+++ b/cache/cache-redis/src/main/java/ru/tinkoff/kora/cache/redis/lettuce/LettuceClientFactory.java
@@ -17,7 +17,10 @@ public final class LettuceClientFactory {
     public AbstractRedisClient build(LettuceClientConfig config) {
         final Duration commandTimeout = config.commandTimeout();
         final Duration socketTimeout = config.socketTimeout();
-        final ProtocolVersion protocolVersion = config.protocol();
+        final ProtocolVersion protocolVersion = switch (config.protocol()) {
+            case RESP2 -> ProtocolVersion.RESP2;
+            case RESP3 -> ProtocolVersion.RESP3;
+        };
 
         final List<RedisURI> mappedRedisUris = buildRedisURI(config);
 
@@ -30,7 +33,10 @@ public final class LettuceClientFactory {
     public RedisClusterClient buildRedisClusterClient(LettuceClientConfig config) {
         final Duration commandTimeout = config.commandTimeout();
         final Duration socketTimeout = config.socketTimeout();
-        final ProtocolVersion protocolVersion = config.protocol();
+        final ProtocolVersion protocolVersion = switch (config.protocol()) {
+            case RESP2 -> ProtocolVersion.RESP2;
+            case RESP3 -> ProtocolVersion.RESP3;
+        };
         final List<RedisURI> mappedRedisUris = buildRedisURI(config);
         return buildRedisClusterClientInternal(mappedRedisUris, commandTimeout, socketTimeout, protocolVersion);
     }
@@ -39,7 +45,10 @@ public final class LettuceClientFactory {
     public RedisClient buildRedisClient(LettuceClientConfig config) {
         final Duration commandTimeout = config.commandTimeout();
         final Duration socketTimeout = config.socketTimeout();
-        final ProtocolVersion protocolVersion = config.protocol();
+        final ProtocolVersion protocolVersion = switch (config.protocol()) {
+            case RESP2 -> ProtocolVersion.RESP2;
+            case RESP3 -> ProtocolVersion.RESP3;
+        };
         final List<RedisURI> mappedRedisUris = buildRedisURI(config);
         return buildRedisClientInternal(mappedRedisUris.get(0), commandTimeout, socketTimeout, protocolVersion);
     }

--- a/cache/cache-redis/src/main/java/ru/tinkoff/kora/cache/redis/lettuce/LettuceClusterRedisCacheClient.java
+++ b/cache/cache-redis/src/main/java/ru/tinkoff/kora/cache/redis/lettuce/LettuceClusterRedisCacheClient.java
@@ -35,10 +35,10 @@ final class LettuceClusterRedisCacheClient implements RedisCacheClient, Lifecycl
 
     private final RedisClusterClient redisClient;
 
-    // use for pipeline commands
+    // use for pipeline commands only cause lettuce have bad performance when using pool
     private BoundedAsyncPool<StatefulRedisClusterConnection<byte[], byte[]>> pool;
 
-    // always use async cause sync uses JDK Proxy
+    // always use async cause sync uses JDK Proxy wrapped async impl
     private RedisStringAsyncCommands<byte[], byte[]> stringCommands;
     private RedisServerAsyncCommands<byte[], byte[]> serverCommands;
     private RedisKeyAsyncCommands<byte[], byte[]> keyCommands;

--- a/cache/cache-redis/src/main/java/ru/tinkoff/kora/cache/redis/lettuce/LettuceClusterRedisCacheClient.java
+++ b/cache/cache-redis/src/main/java/ru/tinkoff/kora/cache/redis/lettuce/LettuceClusterRedisCacheClient.java
@@ -62,7 +62,7 @@ final class LettuceClusterRedisCacheClient implements RedisCacheClient, Lifecycl
     @Nonnull
     @Override
     public CompletionStage<byte[]> getex(byte[] key, long expireAfterMillis) {
-        return commands.getex(key, GetExArgs.Builder.ex(Duration.ofMillis(expireAfterMillis)));
+        return commands.getex(key, GetExArgs.Builder.px(expireAfterMillis));
     }
 
     @SuppressWarnings("unchecked")
@@ -76,7 +76,7 @@ final class LettuceClusterRedisCacheClient implements RedisCacheClient, Lifecycl
 
             var async = connection.async();
             for (byte[] key : keys) {
-                var future = async.getex(key, GetExArgs.Builder.ex(Duration.ofMillis(expireAfterMillis)))
+                var future = async.getex(key, GetExArgs.Builder.px(expireAfterMillis))
                     .thenApply(v -> (v == null) ? null : Map.entry(key, v))
                     .toCompletableFuture();
 

--- a/cache/cache-redis/src/main/java/ru/tinkoff/kora/cache/redis/lettuce/LettuceModule.java
+++ b/cache/cache-redis/src/main/java/ru/tinkoff/kora/cache/redis/lettuce/LettuceModule.java
@@ -1,9 +1,12 @@
 package ru.tinkoff.kora.cache.redis.lettuce;
 
 import io.lettuce.core.cluster.RedisClusterClient;
+import io.lettuce.core.protocol.ProtocolVersion;
+import jakarta.annotation.Nullable;
 import ru.tinkoff.kora.cache.redis.RedisCacheClient;
 import ru.tinkoff.kora.common.DefaultComponent;
 import ru.tinkoff.kora.config.common.Config;
+import ru.tinkoff.kora.config.common.ConfigValue;
 import ru.tinkoff.kora.config.common.extractor.ConfigValueExtractor;
 
 import java.time.Duration;

--- a/cache/cache-redis/src/main/java/ru/tinkoff/kora/cache/redis/lettuce/LettuceModule.java
+++ b/cache/cache-redis/src/main/java/ru/tinkoff/kora/cache/redis/lettuce/LettuceModule.java
@@ -1,5 +1,6 @@
 package ru.tinkoff.kora.cache.redis.lettuce;
 
+import io.lettuce.core.cluster.RedisClusterClient;
 import ru.tinkoff.kora.cache.redis.RedisCacheClient;
 import ru.tinkoff.kora.common.DefaultComponent;
 import ru.tinkoff.kora.config.common.Config;
@@ -18,6 +19,13 @@ public interface LettuceModule {
 
     @DefaultComponent
     default RedisCacheClient lettuceRedisClient(LettuceClientFactory factory, LettuceClientConfig config) {
-        return new LettuceRedisCacheClient(factory.build(config));
+        var redisClient = factory.build(config);
+        if (redisClient instanceof io.lettuce.core.RedisClient rc) {
+            return new LettuceRedisCacheClient(rc, config);
+        } else if (redisClient instanceof RedisClusterClient rcc) {
+            return new LettuceClusterRedisCacheClient(rcc);
+        } else {
+            throw new UnsupportedOperationException("Unknown Redis Client: " + redisClient.getClass());
+        }
     }
 }

--- a/cache/cache-redis/src/main/java/ru/tinkoff/kora/cache/redis/lettuce/LettuceModule.java
+++ b/cache/cache-redis/src/main/java/ru/tinkoff/kora/cache/redis/lettuce/LettuceModule.java
@@ -6,6 +6,8 @@ import ru.tinkoff.kora.common.DefaultComponent;
 import ru.tinkoff.kora.config.common.Config;
 import ru.tinkoff.kora.config.common.extractor.ConfigValueExtractor;
 
+import java.time.Duration;
+
 public interface LettuceModule {
 
     default LettuceClientConfig lettuceConfig(Config config, ConfigValueExtractor<LettuceClientConfig> extractor) {

--- a/cache/cache-redis/src/main/java/ru/tinkoff/kora/cache/redis/lettuce/LettuceRedisCacheClient.java
+++ b/cache/cache-redis/src/main/java/ru/tinkoff/kora/cache/redis/lettuce/LettuceRedisCacheClient.java
@@ -32,10 +32,10 @@ final class LettuceRedisCacheClient implements RedisCacheClient, Lifecycle {
     private final RedisURI redisURI;
     private final RedisClient redisClient;
 
-    // use for pipeline commands
+    // use for pipeline commands only cause lettuce have bad performance when using pool
     private BoundedAsyncPool<StatefulRedisConnection<byte[], byte[]>> pool;
 
-    // always use async cause sync uses JDK Proxy
+    // always use async cause sync uses JDK Proxy wrapped async impl
     private RedisStringAsyncCommands<byte[], byte[]> stringCommands;
     private RedisServerAsyncCommands<byte[], byte[]> serverCommands;
     private RedisKeyAsyncCommands<byte[], byte[]> keyCommands;

--- a/cache/cache-redis/src/main/java/ru/tinkoff/kora/cache/redis/lettuce/LettuceRedisCacheClient.java
+++ b/cache/cache-redis/src/main/java/ru/tinkoff/kora/cache/redis/lettuce/LettuceRedisCacheClient.java
@@ -61,7 +61,7 @@ final class LettuceRedisCacheClient implements RedisCacheClient, Lifecycle {
     @Nonnull
     @Override
     public CompletionStage<byte[]> getex(byte[] key, long expireAfterMillis) {
-        return commands.getex(key, GetExArgs.Builder.ex(Duration.ofMillis(expireAfterMillis)));
+        return commands.getex(key, GetExArgs.Builder.px(expireAfterMillis));
     }
 
     @SuppressWarnings("unchecked")
@@ -75,7 +75,7 @@ final class LettuceRedisCacheClient implements RedisCacheClient, Lifecycle {
 
             var async = connection.async();
             for (byte[] key : keys) {
-                var future = async.getex(key, GetExArgs.Builder.ex(Duration.ofMillis(expireAfterMillis)))
+                var future = async.getex(key, GetExArgs.Builder.px(expireAfterMillis))
                     .thenApply(v -> (v == null) ? null : Map.entry(key, v))
                     .toCompletableFuture();
 

--- a/cache/cache-redis/src/test/java/ru/tinkoff/kora/cache/redis/AbstractAsyncCacheTests.java
+++ b/cache/cache-redis/src/test/java/ru/tinkoff/kora/cache/redis/AbstractAsyncCacheTests.java
@@ -1,0 +1,252 @@
+package ru.tinkoff.kora.cache.redis;
+
+import org.junit.jupiter.api.Test;
+import ru.tinkoff.kora.cache.redis.testdata.DummyCache;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+abstract class AbstractAsyncCacheTests extends CacheRunner {
+
+    protected DummyCache cache = null;
+
+    @Test
+    void getWhenCacheEmpty() {
+        // given
+        var key = "1";
+
+        // when
+        assertNull(cache.getAsync(key).toCompletableFuture().join());
+    }
+
+    @Test
+    void getWhenCacheFilled() {
+        // given
+        var key = "1";
+        var value = "1";
+
+        // when
+        cache.putAsync(key, value).toCompletableFuture().join();
+
+        // then
+        final String fromCache = cache.getAsync(key).toCompletableFuture().join();
+        assertEquals(value, fromCache);
+    }
+
+    @Test
+    void getMultiWhenCacheEmpty() {
+        // given
+        List<String> keys = List.of("1", "2");
+
+        // when
+        Map<String, String> keyToValue = cache.getAsync(keys).toCompletableFuture().join();
+        assertTrue(keyToValue.isEmpty());
+    }
+
+    @Test
+    void getMultiWhenCacheFilledPartly() {
+        // given
+        List<String> keys = List.of("1");
+        for (String key : keys) {
+            cache.putAsync(key, key).toCompletableFuture().join();
+        }
+
+        // when
+        Map<String, String> keyToValue = cache.getAsync(keys).toCompletableFuture().join();
+        assertEquals(1, keyToValue.size());
+        keyToValue.forEach((k, v) -> assertTrue(keys.stream().anyMatch(key -> key.equals(k) && key.equals(v))));
+    }
+
+    @Test
+    void getMultiWhenCacheFilled() {
+        // given
+        List<String> keys = List.of("1", "2");
+        for (String key : keys) {
+            cache.putAsync(key, key).toCompletableFuture().join();
+        }
+
+        // when
+        Map<String, String> keyToValue = cache.getAsync(keys).toCompletableFuture().join();
+        assertEquals(2, keyToValue.size());
+        keyToValue.forEach((k, v) -> assertTrue(keys.stream().anyMatch(key -> key.equals(k) && key.equals(v))));
+    }
+
+    @Test
+    void computeIfAbsentWhenCacheEmpty() {
+        // given
+
+        // when
+        assertNull(cache.getAsync("1").toCompletableFuture().join());
+        final String valueComputed = cache.computeIfAbsent("1", k -> "1");
+        assertEquals("1", valueComputed);
+
+        // then
+        final String cached = cache.getAsync("1").toCompletableFuture().join();
+        assertEquals(valueComputed, cached);
+    }
+
+    @Test
+    void computeIfAbsentMultiWhenCacheEmpty() {
+        // given
+        List<String> keys = List.of("1", "2");
+        for (String key : keys) {
+            assertNull(cache.getAsync(key).toCompletableFuture().join());
+        }
+
+        // when
+        final Map<String, String> valueComputed = cache.computeIfAbsentAsync(keys, keysCompute -> {
+            if (keysCompute.size() == 2) {
+                return CompletableFuture.completedFuture(Map.of("1", "1", "2", "2"));
+            } else if ("1".equals(keysCompute.iterator().next())) {
+                return CompletableFuture.completedFuture(Map.of("1", "1"));
+            } else if ("2".equals(keysCompute.iterator().next())) {
+                return CompletableFuture.completedFuture(Map.of("2", "2"));
+            }
+
+            throw new IllegalStateException("Should not happen");
+        }).toCompletableFuture().join();
+        assertEquals(2, valueComputed.size());
+        assertEquals(Set.copyOf(keys), valueComputed.keySet());
+        assertEquals(Set.copyOf(keys), Set.copyOf(valueComputed.values()));
+
+        // then
+        final Map<String, String> cached = cache.getAsync(keys).toCompletableFuture().join();
+        assertEquals(valueComputed, cached);
+    }
+
+    @Test
+    void computeIfAbsentMultiOneWhenCachePartly() {
+        // given
+        List<String> keys = List.of("1");
+        for (String key : keys) {
+            assertNull(cache.getAsync(key).toCompletableFuture().join());
+            cache.putAsync(key, key).toCompletableFuture().join();
+        }
+
+        // when
+        final Map<String, String> valueComputed = cache.computeIfAbsentAsync(keys, keysCompute -> {
+            if (keysCompute.size() == 2) {
+                return CompletableFuture.completedFuture(Map.of("1", "1", "2", "2"));
+            } else if ("1".equals(keysCompute.iterator().next())) {
+                return CompletableFuture.completedFuture(Map.of("1", "1"));
+            } else if ("2".equals(keysCompute.iterator().next())) {
+                return CompletableFuture.completedFuture(Map.of("2", "2"));
+            }
+
+            throw new IllegalStateException("Should not happen");
+        }).toCompletableFuture().join();
+        assertEquals(1, valueComputed.size());
+        assertEquals(Set.copyOf(keys), valueComputed.keySet());
+        assertEquals(Set.copyOf(keys), Set.copyOf(valueComputed.values()));
+
+        // then
+        final Map<String, String> cached = cache.getAsync(keys).toCompletableFuture().join();
+        assertEquals(valueComputed, cached);
+    }
+
+    @Test
+    void computeIfAbsentMultiAllWhenCachePartly() {
+        // given
+        List<String> keys = List.of("1");
+        for (String key : keys) {
+            assertNull(cache.getAsync(key).toCompletableFuture().join());
+            cache.putAsync(key, key).toCompletableFuture().join();
+        }
+
+        // when
+        final Map<String, String> valueComputed = cache.computeIfAbsentAsync(Set.of("1", "2"), keysCompute -> {
+            if (keysCompute.size() == 2) {
+                return CompletableFuture.completedFuture(Map.of("1", "1", "2", "2"));
+            } else if ("1".equals(keysCompute.iterator().next())) {
+                return CompletableFuture.completedFuture(Map.of("1", "1"));
+            } else if ("2".equals(keysCompute.iterator().next())) {
+                return CompletableFuture.completedFuture(Map.of("2", "2"));
+            }
+
+            throw new IllegalStateException("Should not happen");
+        }).toCompletableFuture().join();
+        assertEquals(2, valueComputed.size());
+        assertEquals(Set.of("1", "2"), valueComputed.keySet());
+        assertEquals(Set.of("1", "2"), Set.copyOf(valueComputed.values()));
+
+        // then
+        final Map<String, String> cached = cache.getAsync(Set.of("1", "2")).toCompletableFuture().join();
+        assertEquals(valueComputed, cached);
+    }
+
+    @Test
+    void computeIfAbsentMultiWhenCacheFilled() {
+        // given
+        List<String> keys = List.of("1", "2");
+        for (String key : keys) {
+            assertNull(cache.getAsync(key).toCompletableFuture().join());
+            cache.putAsync(key, key).toCompletableFuture().join();
+        }
+
+        // when
+        final Map<String, String> valueComputed = cache.computeIfAbsentAsync(keys, keysCompute -> {
+            if (keysCompute.size() == 2) {
+                return CompletableFuture.completedFuture(Map.of("1", "???", "2", "???"));
+            } else if ("1".equals(keysCompute.iterator().next())) {
+                return CompletableFuture.completedFuture(Map.of("1", "???"));
+            } else if ("2".equals(keysCompute.iterator().next())) {
+                return CompletableFuture.completedFuture(Map.of("2", "???"));
+            }
+
+            throw new IllegalStateException("Should not happen");
+        }).toCompletableFuture().join();
+        assertEquals(2, valueComputed.size());
+        assertEquals(Set.copyOf(keys), valueComputed.keySet());
+        assertEquals(Set.copyOf(keys), Set.copyOf(valueComputed.values()));
+
+        // then
+        final Map<String, String> cached = cache.getAsync(keys).toCompletableFuture().join();
+        assertEquals(valueComputed, cached);
+    }
+
+    @Test
+    void getWrongKeyWhenCacheFilled() {
+        // given
+        var key = "1";
+        var value = "1";
+
+        // when
+        cache.putAsync(key, value).toCompletableFuture().join();
+
+        // then
+        final String fromCache = cache.getAsync("2").toCompletableFuture().join();
+        assertNull(fromCache);
+    }
+
+    @Test
+    void getWhenCacheInvalidate() {
+        // given
+        var key = "1";
+        var value = "1";
+        cache.putAsync(key, value).toCompletableFuture().join();
+
+        // when
+        cache.invalidate(key);
+
+        // then
+        final String fromCache = cache.getAsync(key).toCompletableFuture().join();
+        assertNull(fromCache);
+    }
+
+    @Test
+    void getFromCacheWhenCacheInvalidateAll() {
+        // given
+        var key = "1";
+        var value = "1";
+        cache.putAsync(key, value).toCompletableFuture().join();
+
+        // when
+        cache.invalidateAll();
+
+        // then
+        final String fromCache = cache.getAsync(key).toCompletableFuture().join();
+        assertNull(fromCache);
+    }
+}

--- a/cache/cache-redis/src/test/java/ru/tinkoff/kora/cache/redis/AbstractSyncCacheTests.java
+++ b/cache/cache-redis/src/test/java/ru/tinkoff/kora/cache/redis/AbstractSyncCacheTests.java
@@ -1,0 +1,229 @@
+package ru.tinkoff.kora.cache.redis;
+
+import org.junit.jupiter.api.Test;
+import ru.tinkoff.kora.cache.redis.testdata.DummyCache;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+abstract class AbstractSyncCacheTests extends CacheRunner {
+
+    protected DummyCache cache = null;
+
+    @Test
+    void getWhenCacheEmpty() {
+        // given
+        var key = "1";
+
+        // when
+        assertNull(cache.get(key));
+    }
+
+    @Test
+    void getWhenCacheFilled() {
+        // given
+        var key = "1";
+        var value = "1";
+
+        // when
+        cache.put(key, value);
+
+        // then
+        final String fromCache = cache.get(key);
+        assertEquals(value, fromCache);
+    }
+
+    @Test
+    void getMultiWhenCacheEmpty() {
+        // given
+        List<String> keys = List.of("1", "2");
+
+        // when
+        Map<String, String> keyToValue = cache.get(keys);
+        assertTrue(keyToValue.isEmpty());
+    }
+
+    @Test
+    void getMultiWhenCacheFilledPartly() {
+        // given
+        List<String> keys = List.of("1");
+        for (String key : keys) {
+            assertNull(cache.get(key));
+            cache.put(key, key);
+        }
+
+        // when
+        Map<String, String> keyToValue = cache.get(keys);
+        assertEquals(1, keyToValue.size());
+        keyToValue.forEach((k, v) -> assertTrue(keys.stream().anyMatch(key -> key.equals(k) && key.equals(v))));
+    }
+
+    @Test
+    void getMultiWhenCacheFilled() {
+        // given
+        List<String> keys = List.of("1", "2");
+        for (String key : keys) {
+            assertNull(cache.get(key));
+            cache.put(key, key);
+        }
+
+        // when
+        Map<String, String> keyToValue = cache.get(keys);
+        assertEquals(2, keyToValue.size());
+        keyToValue.forEach((k, v) -> assertTrue(keys.stream().anyMatch(key -> key.equals(k) && key.equals(v))));
+    }
+
+    @Test
+    void computeIfAbsentWhenCacheEmpty() {
+        // given
+
+        // when
+        assertNull(cache.get("1"));
+        final String valueComputed = cache.computeIfAbsent("1", k -> "1");
+        assertEquals("1", valueComputed);
+
+        // then
+        final String cached = cache.get("1");
+        assertEquals(valueComputed, cached);
+    }
+
+    @Test
+    void computeIfAbsentMultiWhenCacheEmpty() {
+        // given
+        List<String> keys = List.of("1", "2");
+        for (String key : keys) {
+            assertNull(cache.get(key));
+        }
+
+        // when
+        final Map<String, String> valueComputed = cache.computeIfAbsent(keys, keysCompute -> {
+            if (keysCompute.size() == 2) {
+                return Map.of("1", "1", "2", "2");
+            }
+
+            throw new IllegalStateException("Should not happen");
+        });
+        assertEquals(2, valueComputed.size());
+        assertEquals(Set.copyOf(keys), valueComputed.keySet());
+        assertEquals(Set.copyOf(keys), Set.copyOf(valueComputed.values()));
+
+        // then
+        final Map<String, String> cached = cache.get(keys);
+        assertEquals(valueComputed, cached);
+    }
+
+    @Test
+    void computeIfAbsentMultiOneWhenCachePartly() {
+        // given
+        List<String> keys = List.of("1");
+        for (String key : keys) {
+            assertNull(cache.get(key));
+            cache.put(key, key);
+        }
+
+        // when
+        final Map<String, String> valueComputed = cache.computeIfAbsent(keys, keysCompute -> {
+            throw new IllegalStateException("Should not happen");
+        });
+        assertEquals(1, valueComputed.size());
+        assertEquals(Set.copyOf(keys), valueComputed.keySet());
+        assertEquals(Set.copyOf(keys), Set.copyOf(valueComputed.values()));
+
+        // then
+        final Map<String, String> cached = cache.get(keys);
+        assertEquals(valueComputed, cached);
+    }
+
+    @Test
+    void computeIfAbsentMultiAllWhenCachePartly() {
+        // given
+        List<String> keys = List.of("1");
+        for (String key : keys) {
+            assertNull(cache.get(key));
+            cache.put(key, key);
+        }
+
+        // when
+        final Map<String, String> valueComputed = cache.computeIfAbsent(Set.of("1", "2"), keysCompute -> {
+            if ("2".equals(keysCompute.iterator().next())) {
+                return Map.of("2", "2");
+            }
+
+            throw new IllegalStateException("Should not happen");
+        });
+        assertEquals(2, valueComputed.size());
+        assertEquals(Set.of("1", "2"), valueComputed.keySet());
+        assertEquals(Set.of("1", "2"), Set.copyOf(valueComputed.values()));
+
+        // then
+        final Map<String, String> cached = cache.get(Set.of("1", "2"));
+        assertEquals(valueComputed, cached);
+    }
+
+    @Test
+    void computeIfAbsentMultiWhenCacheFilled() {
+        // given
+        List<String> keys = List.of("1", "2");
+        for (String key : keys) {
+            assertNull(cache.get(key));
+            cache.put(key, key);
+        }
+
+        // when
+        final Map<String, String> valueComputed = cache.computeIfAbsent(keys, keysCompute -> {
+            throw new IllegalStateException("Should not happen");
+        });
+        assertEquals(2, valueComputed.size());
+        assertEquals(Set.copyOf(keys), valueComputed.keySet());
+        assertEquals(Set.copyOf(keys), Set.copyOf(valueComputed.values()));
+
+        // then
+        final Map<String, String> cached = cache.get(keys);
+        assertEquals(valueComputed, cached);
+    }
+
+    @Test
+    void getWrongKeyWhenCacheFilled() {
+        // given
+        var key = "1";
+        var value = "1";
+
+        // when
+        cache.put(key, value);
+
+        // then
+        final String fromCache = cache.get("2");
+        assertNull(fromCache);
+    }
+
+    @Test
+    void getWhenCacheInvalidate() {
+        // given
+        var key = "1";
+        var value = "1";
+        cache.put(key, value);
+
+        // when
+        cache.invalidate(key);
+
+        // then
+        final String fromCache = cache.get(key);
+        assertNull(fromCache);
+    }
+
+    @Test
+    void getFromCacheWhenCacheInvalidateAll() {
+        // given
+        var key = "1";
+        var value = "1";
+        cache.put(key, value);
+
+        // when
+        cache.invalidateAll();
+
+        // then
+        final String fromCache = cache.get(key);
+        assertNull(fromCache);
+    }
+}

--- a/cache/cache-redis/src/test/java/ru/tinkoff/kora/cache/redis/AsyncCacheExpireReadTests.java
+++ b/cache/cache-redis/src/test/java/ru/tinkoff/kora/cache/redis/AsyncCacheExpireReadTests.java
@@ -6,15 +6,17 @@ import org.junit.jupiter.api.TestInstance;
 import ru.tinkoff.kora.test.redis.RedisParams;
 import ru.tinkoff.kora.test.redis.RedisTestContainer;
 
+import java.time.Duration;
+
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @RedisTestContainer
-class AsyncCacheTests extends AbstractAsyncCacheTests {
+class AsyncCacheExpireReadTests extends AbstractAsyncCacheTests {
 
     @BeforeEach
     void setup(RedisParams redisParams) throws Exception {
         redisParams.execute(cmd -> cmd.flushall(FlushMode.SYNC));
         if (cache == null) {
-            cache = createCache(redisParams);
+            cache = createCacheExpireRead(redisParams, Duration.ofSeconds(1));
         }
     }
 }

--- a/cache/cache-redis/src/test/java/ru/tinkoff/kora/cache/redis/AsyncCacheExpireWriteTests.java
+++ b/cache/cache-redis/src/test/java/ru/tinkoff/kora/cache/redis/AsyncCacheExpireWriteTests.java
@@ -6,15 +6,17 @@ import org.junit.jupiter.api.TestInstance;
 import ru.tinkoff.kora.test.redis.RedisParams;
 import ru.tinkoff.kora.test.redis.RedisTestContainer;
 
+import java.time.Duration;
+
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @RedisTestContainer
-class AsyncCacheTests extends AbstractAsyncCacheTests {
+class AsyncCacheExpireWriteTests extends AbstractAsyncCacheTests {
 
     @BeforeEach
     void setup(RedisParams redisParams) throws Exception {
         redisParams.execute(cmd -> cmd.flushall(FlushMode.SYNC));
         if (cache == null) {
-            cache = createCache(redisParams);
+            cache = createCacheExpireWrite(redisParams, Duration.ofSeconds(1));
         }
     }
 }

--- a/cache/cache-redis/src/test/java/ru/tinkoff/kora/cache/redis/CacheRunner.java
+++ b/cache/cache-redis/src/test/java/ru/tinkoff/kora/cache/redis/CacheRunner.java
@@ -2,6 +2,7 @@ package ru.tinkoff.kora.cache.redis;
 
 import jakarta.annotation.Nullable;
 import org.junit.jupiter.api.Assertions;
+import ru.tinkoff.kora.application.graph.Lifecycle;
 import ru.tinkoff.kora.cache.redis.lettuce.LettuceClientConfig;
 import ru.tinkoff.kora.cache.redis.testdata.DummyCache;
 import ru.tinkoff.kora.test.redis.RedisParams;
@@ -10,7 +11,8 @@ import java.time.Duration;
 
 abstract class CacheRunner extends Assertions implements RedisCacheModule {
 
-    public static RedisCacheConfig getConfig() {
+    public static RedisCacheConfig getConfig(@Nullable Duration expireWrite,
+                                             @Nullable Duration expireRead) {
         return new RedisCacheConfig() {
 
             @Override
@@ -21,24 +23,63 @@ abstract class CacheRunner extends Assertions implements RedisCacheModule {
             @Nullable
             @Override
             public Duration expireAfterWrite() {
-                return null;
+                return expireWrite;
             }
 
             @Nullable
             @Override
             public Duration expireAfterAccess() {
-                return null;
+                return expireRead;
             }
         };
     }
 
-    protected DummyCache createCache(RedisParams redisParams) throws Exception {
+    private RedisCacheClient createLettuce(RedisParams redisParams) throws Exception {
         var lettuceClientFactory = lettuceClientFactory();
-        var lettuceClientConfig = new LettuceClientConfig(redisParams.uri().toString(), null, null, null, null, null, null);
-        var lettuceClient = lettuceRedisClient(lettuceClientFactory, lettuceClientConfig);
-        lettuceClient.init();
+        var lettuceClientConfig = new LettuceClientConfig() {
+            @Override
+            public String uri() {
+                return redisParams.uri().toString();
+            }
 
-        return new DummyCache(getConfig(), lettuceClient, redisCacheTelemetry(null, null),
+            @Override
+            public Integer database() {
+                return null;
+            }
+
+            @Override
+            public String user() {
+                return null;
+            }
+
+            @Override
+            public String password() {
+                return null;
+            }
+        };
+
+        var lettuceClient = lettuceRedisClient(lettuceClientFactory, lettuceClientConfig);
+        if (lettuceClient instanceof Lifecycle lc) {
+            lc.init();
+        }
+        return lettuceClient;
+    }
+
+    private DummyCache createDummyCache(RedisParams redisParams, Duration expireWrite, Duration expireRead) throws Exception {
+        var lettuceClient = createLettuce(redisParams);
+        return new DummyCache(getConfig(expireWrite, expireRead), lettuceClient, redisCacheTelemetry(null, null),
             stringRedisKeyMapper(), stringRedisValueMapper());
+    }
+
+    protected DummyCache createCache(RedisParams redisParams) throws Exception {
+        return createDummyCache(redisParams, null, null);
+    }
+
+    protected DummyCache createCacheExpireWrite(RedisParams redisParams, Duration expireWrite) throws Exception {
+        return createDummyCache(redisParams, expireWrite, null);
+    }
+
+    protected DummyCache createCacheExpireRead(RedisParams redisParams, Duration expireRead) throws Exception {
+        return createDummyCache(redisParams, null, expireRead);
     }
 }

--- a/cache/cache-redis/src/test/java/ru/tinkoff/kora/cache/redis/SyncCacheExpireReadTests.java
+++ b/cache/cache-redis/src/test/java/ru/tinkoff/kora/cache/redis/SyncCacheExpireReadTests.java
@@ -6,15 +6,17 @@ import org.junit.jupiter.api.TestInstance;
 import ru.tinkoff.kora.test.redis.RedisParams;
 import ru.tinkoff.kora.test.redis.RedisTestContainer;
 
+import java.time.Duration;
+
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @RedisTestContainer
-class AsyncCacheTests extends AbstractAsyncCacheTests {
+class SyncCacheExpireReadTests extends AbstractSyncCacheTests {
 
     @BeforeEach
     void setup(RedisParams redisParams) throws Exception {
         redisParams.execute(cmd -> cmd.flushall(FlushMode.SYNC));
         if (cache == null) {
-            cache = createCache(redisParams);
+            cache = createCacheExpireRead(redisParams, Duration.ofSeconds(1));
         }
     }
 }

--- a/cache/cache-redis/src/test/java/ru/tinkoff/kora/cache/redis/SyncCacheExpireWriteTests.java
+++ b/cache/cache-redis/src/test/java/ru/tinkoff/kora/cache/redis/SyncCacheExpireWriteTests.java
@@ -6,15 +6,17 @@ import org.junit.jupiter.api.TestInstance;
 import ru.tinkoff.kora.test.redis.RedisParams;
 import ru.tinkoff.kora.test.redis.RedisTestContainer;
 
+import java.time.Duration;
+
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @RedisTestContainer
-class AsyncCacheTests extends AbstractAsyncCacheTests {
+class SyncCacheExpireWriteTests extends AbstractSyncCacheTests {
 
     @BeforeEach
     void setup(RedisParams redisParams) throws Exception {
         redisParams.execute(cmd -> cmd.flushall(FlushMode.SYNC));
         if (cache == null) {
-            cache = createCache(redisParams);
+            cache = createCacheExpireWrite(redisParams, Duration.ofSeconds(1));
         }
     }
 }

--- a/cache/cache-redis/src/test/java/ru/tinkoff/kora/cache/redis/SyncCacheTests.java
+++ b/cache/cache-redis/src/test/java/ru/tinkoff/kora/cache/redis/SyncCacheTests.java
@@ -2,17 +2,13 @@ package ru.tinkoff.kora.cache.redis;
 
 import io.lettuce.core.FlushMode;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
-import ru.tinkoff.kora.cache.redis.testdata.DummyCache;
 import ru.tinkoff.kora.test.redis.RedisParams;
 import ru.tinkoff.kora.test.redis.RedisTestContainer;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @RedisTestContainer
-class SyncCacheTests extends CacheRunner {
-
-    private DummyCache cache = null;
+class SyncCacheTests extends AbstractSyncCacheTests {
 
     @BeforeEach
     void setup(RedisParams redisParams) throws Exception {
@@ -20,72 +16,5 @@ class SyncCacheTests extends CacheRunner {
         if (cache == null) {
             cache = createCache(redisParams);
         }
-    }
-
-    @Test
-    void getWhenCacheEmpty() {
-        // given
-        var key = "1";
-
-        // when
-        assertNull(cache.get(key));
-    }
-
-    @Test
-    void getWhenCacheFilled() {
-        // given
-        var key = "1";
-        var value = "1";
-
-        // when
-        cache.put(key, value);
-
-        // then
-        final String fromCache = cache.get(key);
-        assertEquals(value, fromCache);
-    }
-
-    @Test
-    void getWrongKeyWhenCacheFilled() {
-        // given
-        var key = "1";
-        var value = "1";
-
-        // when
-        cache.put(key, value);
-
-        // then
-        final String fromCache = cache.get("2");
-        assertNull(fromCache);
-    }
-
-    @Test
-    void getWhenCacheInvalidate() {
-        // given
-        var key = "1";
-        var value = "1";
-        cache.put(key, value);
-
-        // when
-        cache.invalidate(key);
-
-        // then
-        final String fromCache = cache.get(key);
-        assertNull(fromCache);
-    }
-
-    @Test
-    void getFromCacheWhenCacheInvalidateAll() {
-        // given
-        var key = "1";
-        var value = "1";
-        cache.put(key, value);
-
-        // when
-        cache.invalidateAll();
-
-        // then
-        final String fromCache = cache.get(key);
-        assertNull(fromCache);
     }
 }

--- a/cache/cache-redis/src/test/java/ru/tinkoff/kora/cache/redis/testdata/DummyCache.java
+++ b/cache/cache-redis/src/test/java/ru/tinkoff/kora/cache/redis/testdata/DummyCache.java
@@ -1,7 +1,6 @@
 package ru.tinkoff.kora.cache.redis.testdata;
 
 import ru.tinkoff.kora.cache.redis.*;
-import ru.tinkoff.kora.cache.redis.RedisCacheClient;
 
 public final class DummyCache extends AbstractRedisCache<String, String> {
 

--- a/cache/cache-symbol-processor/src/test/kotlin/ru/tinkoff/kora/cache/symbol/processor/CacheRunner.kt
+++ b/cache/cache-symbol-processor/src/test/kotlin/ru/tinkoff/kora/cache/symbol/processor/CacheRunner.kt
@@ -77,6 +77,11 @@ class CacheRunner {
                     return CompletableFuture.completedFuture(true)
                 }
 
+                override fun psetex(keyAndValue: MutableMap<ByteArray, ByteArray>, expireAfterMillis: Long): CompletionStage<Boolean> {
+                    mset(keyAndValue)
+                    return CompletableFuture.completedFuture(true)
+                }
+
                 override fun psetex(key: ByteArray, value: ByteArray, expireAfterMillis: Long): CompletionStage<Boolean> {
                     return set(key, value)
                 }
@@ -98,10 +103,6 @@ class CacheRunner {
                     cache.clear()
                     return CompletableFuture.completedFuture(true)
                 }
-
-                override fun init() { }
-
-                override fun release() { }
             }
         }
     }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -120,7 +120,7 @@ dependencyResolutionManagement { DependencyResolutionManagement it ->
             library("classgraph", "io.github.classgraph", "classgraph").version("4.8.170")
 
             library('lettuce-core', 'io.lettuce', 'lettuce-core').version('6.5.2.RELEASE')
-            library('apache-pool', 'org.apache.commons', 'commons-pool2').version('2.12.0')
+            library('apache-pool', 'org.apache.commons', 'commons-pool2').version('2.12.1')
             library('quartz', 'org.quartz-scheduler', 'quartz').version('2.3.2')
 
             library('caffeine', 'com.github.ben-manes.caffeine', 'caffeine').version('3.1.8')

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -119,7 +119,8 @@ dependencyResolutionManagement { DependencyResolutionManagement it ->
             library("javapoet", "com.squareup", "javapoet").version("1.13.0")
             library("classgraph", "io.github.classgraph", "classgraph").version("4.8.170")
 
-            library('lettuce-core', 'io.lettuce', 'lettuce-core').version('6.3.2.RELEASE')
+            library('lettuce-core', 'io.lettuce', 'lettuce-core').version('6.5.2.RELEASE')
+            library('apache-pool', 'org.apache.commons', 'commons-pool2').version('2.12.0')
             library('quartz', 'org.quartz-scheduler', 'quartz').version('2.3.2')
 
             library('caffeine', 'com.github.ben-manes.caffeine', 'caffeine').version('3.1.8')


### PR DESCRIPTION
- RedisCacheClient `mget#hasValue()` fixed
- RedisCacheClient pool support for pipeline command for mset and pget commands with expire