### PR TITLE
More flexible way of grpc component configuration

### DIFF
--- a/experimental/camunda-zeebe-worker/src/main/java/ru/tinkoff/kora/camunda/zeebe/worker/ZeebeManagedChannelFactory.java
+++ b/experimental/camunda-zeebe-worker/src/main/java/ru/tinkoff/kora/camunda/zeebe/worker/ZeebeManagedChannelFactory.java
@@ -5,6 +5,7 @@ import io.camunda.zeebe.client.impl.util.VersionUtil;
 import io.grpc.*;
 import jakarta.annotation.Nullable;
 import ru.tinkoff.grpc.client.GrpcClientChannelFactory;
+import ru.tinkoff.grpc.client.config.DefaultServiceConfig;
 import ru.tinkoff.grpc.client.config.GrpcClientConfig;
 import ru.tinkoff.grpc.client.telemetry.GrpcClientTelemetryFactory;
 import ru.tinkoff.kora.application.graph.All;
@@ -51,6 +52,12 @@ final class ZeebeManagedChannelFactory {
             @Override
             public TelemetryConfig telemetry() {
                 return clientConfig.telemetry();
+            }
+
+            @Override
+            @Nullable
+            public DefaultServiceConfig defaultServiceConfig() {
+                return null;
             }
         };
     }

--- a/grpc/grpc-client-annotation-processor/src/main/java/ru/tinkoff/grpc/client/annotation/processor/GrpcClientExtension.java
+++ b/grpc/grpc-client-annotation-processor/src/main/java/ru/tinkoff/grpc/client/annotation/processor/GrpcClientExtension.java
@@ -86,7 +86,7 @@ public final class GrpcClientExtension implements KoraExtension {
         var parameterTypes = new ArrayList<TypeMirror>(managedChannelConstructor.getParameters().size() - 1);
         for (int i = 0; i < managedChannelConstructor.getParameters().size() - 1; i++) {
             var parameter = managedChannelConstructor.getParameters().get(i);
-            parameterTags.add(i < 3 ? tag : Set.of());
+            parameterTags.add(i < 4 ? tag : Set.of());
             parameterTypes.add(parameter.asType());
         }
         return () -> new ExtensionResult.CodeBlockResult(

--- a/grpc/grpc-client-annotation-processor/src/test/java/ru/tinkoff/grpc/client/annotation/processor/GrpcClientExtensionTest.java
+++ b/grpc/grpc-client-annotation-processor/src/test/java/ru/tinkoff/grpc/client/annotation/processor/GrpcClientExtensionTest.java
@@ -52,11 +52,12 @@ class GrpcClientExtensionTest extends AbstractAnnotationProcessorTest {
               15. netty event loop group
               16. netty channel factory
               17. channel factory
-              18. channel lifecycle
-              19. the stub
-              20. test root
+              18. config parser
+              19. channel lifecycle
+              20. the stub
+              21. test root
              */
-            Assertions.assertThat(g.draw().size()).isEqualTo(20);
+            Assertions.assertThat(g.draw().size()).isEqualTo(21);
         }
     }
 

--- a/grpc/grpc-client-symbol-processor/src/main/kotlin/ru.tinkoff.grpc.client.ksp/GrpcClientExtension.kt
+++ b/grpc/grpc-client-symbol-processor/src/main/kotlin/ru.tinkoff.grpc.client.ksp/GrpcClientExtension.kt
@@ -86,12 +86,12 @@ class GrpcClientExtension(
         val parameterTags = arrayListOf<Set<String>>()
         val parameterTypes = arrayListOf<KSType>()
         for ((i, parameter) in managedChannelConstructor.parameters.dropLast(1).withIndex()) {
-            if (i < 3) {
+            if (i < 4) {
                 parameterTags.add(tag)
             } else {
                 parameterTags.add(setOf())
             }
-            if (i == 1) {
+            if (i == 1 || i == 3) {
                 parameterTypes.add(parameter.type.resolve().makeNullable())
             } else {
                 parameterTypes.add(parameter.type.resolve().makeNotNullable())

--- a/grpc/grpc-client-symbol-processor/src/test/kotlin/ru/tinkoff/grpc/client/ksp/GrpcClientExtensionTest.kt
+++ b/grpc/grpc-client-symbol-processor/src/test/kotlin/ru/tinkoff/grpc/client/ksp/GrpcClientExtensionTest.kt
@@ -47,10 +47,11 @@ class GrpcClientExtensionTest : AbstractSymbolProcessorTest() {
               16. netty channel factory
               17. channel factory
               18. channel lifecycle
-              19. the stub
-              20. test root
+              19. config mapper
+              20. the stub
+              21. test root
              */
-            Assertions.assertThat(g.draw.size()).isEqualTo(20)
+            Assertions.assertThat(g.draw.size()).isEqualTo(21)
         }
     }
 

--- a/grpc/grpc-client/src/main/java/ru/tinkoff/grpc/client/GrpcClientBuilderConfigurer.java
+++ b/grpc/grpc-client/src/main/java/ru/tinkoff/grpc/client/GrpcClientBuilderConfigurer.java
@@ -1,0 +1,7 @@
+package ru.tinkoff.grpc.client;
+
+import io.grpc.ManagedChannelBuilder;
+
+public interface GrpcClientBuilderConfigurer {
+    ManagedChannelBuilder<?> configure(ManagedChannelBuilder<?> builder);
+}

--- a/grpc/grpc-client/src/main/java/ru/tinkoff/grpc/client/GrpcClientModule.java
+++ b/grpc/grpc-client/src/main/java/ru/tinkoff/grpc/client/GrpcClientModule.java
@@ -2,6 +2,7 @@ package ru.tinkoff.grpc.client;
 
 import io.netty.channel.EventLoopGroup;
 import jakarta.annotation.Nullable;
+import ru.tinkoff.grpc.client.config.DefaultServiceConfigConfigValueExtractor;
 import ru.tinkoff.grpc.client.telemetry.DefaultGrpcClientTelemetryFactory;
 import ru.tinkoff.grpc.client.telemetry.GrpcClientLoggerFactory;
 import ru.tinkoff.grpc.client.telemetry.GrpcClientMetricsFactory;
@@ -12,6 +13,10 @@ import ru.tinkoff.kora.netty.common.NettyChannelFactory;
 import ru.tinkoff.kora.netty.common.NettyCommonModule;
 
 public interface GrpcClientModule extends NettyCommonModule {
+    @DefaultComponent
+    default DefaultServiceConfigConfigValueExtractor defaultServiceConfigConfigValueExtractor() {
+        return new DefaultServiceConfigConfigValueExtractor();
+    }
 
     @DefaultComponent
     default DefaultGrpcClientTelemetryFactory defaultGrpcClientTelemetryFactory(@Nullable GrpcClientMetricsFactory metrics, @Nullable GrpcClientTracerFactory tracer, @Nullable GrpcClientLoggerFactory logger) {

--- a/grpc/grpc-client/src/main/java/ru/tinkoff/grpc/client/GrpcNettyClientChannelFactory.java
+++ b/grpc/grpc-client/src/main/java/ru/tinkoff/grpc/client/GrpcNettyClientChannelFactory.java
@@ -5,7 +5,6 @@ import io.grpc.ManagedChannelBuilder;
 import io.grpc.netty.NettyChannelBuilder;
 import io.netty.channel.EventLoopGroup;
 import ru.tinkoff.kora.netty.common.NettyChannelFactory;
-import ru.tinkoff.kora.netty.common.NettyCommonModule;
 
 import java.net.SocketAddress;
 

--- a/grpc/grpc-client/src/main/java/ru/tinkoff/grpc/client/config/DefaultServiceConfig.java
+++ b/grpc/grpc-client/src/main/java/ru/tinkoff/grpc/client/config/DefaultServiceConfig.java
@@ -1,0 +1,12 @@
+package ru.tinkoff.grpc.client.config;
+
+import java.util.Map;
+import java.util.Objects;
+
+public final class DefaultServiceConfig {
+    public final Map<String, Object> content;
+
+    public DefaultServiceConfig(Map<String, Object> content) {
+        this.content = Objects.requireNonNull(content);
+    }
+}

--- a/grpc/grpc-client/src/main/java/ru/tinkoff/grpc/client/config/DefaultServiceConfigConfigValueExtractor.java
+++ b/grpc/grpc-client/src/main/java/ru/tinkoff/grpc/client/config/DefaultServiceConfigConfigValueExtractor.java
@@ -1,0 +1,60 @@
+package ru.tinkoff.grpc.client.config;
+
+import jakarta.annotation.Nullable;
+import ru.tinkoff.kora.config.common.ConfigValue;
+import ru.tinkoff.kora.config.common.extractor.ConfigValueExtractor;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+public final class DefaultServiceConfigConfigValueExtractor implements ConfigValueExtractor<DefaultServiceConfig> {
+    @Nullable
+    @Override
+    public DefaultServiceConfig extract(ConfigValue<?> value) {
+        if (value.isNull()) {
+            return null;
+        }
+        var object = value.asObject();
+        var map = this.toMap(object);
+        return new DefaultServiceConfig(map);
+    }
+
+    private Map<String, Object> toMap(ConfigValue.ObjectValue objectValue) {
+        var result = new HashMap<String, Object>();
+        for (var entry : objectValue) {
+            var key = entry.getKey();
+            var value = entry.getValue();
+            var object = this.toObject(value);
+            if (object != null) {
+                result.put(key, object);
+            }
+        }
+        return result;
+    }
+
+    private Object toObject(ConfigValue<?> value) {
+        if (value instanceof ConfigValue.StringValue str) {
+            return str.value();
+        } else if (value instanceof ConfigValue.BooleanValue bool) {
+            return bool;
+        } else if (value instanceof ConfigValue.NumberValue num) {
+            return num.value().doubleValue(); // service config accepts only double values
+        } else if (value instanceof ConfigValue.ObjectValue obj) {
+            return this.toMap(obj);
+        } else if (value instanceof ConfigValue.ArrayValue arr) {
+            var list = new ArrayList<>();
+            for (var item : arr) {
+                var object = this.toObject(item);
+                if (object != null) {
+                    list.add(object);
+                }
+            }
+            return list;
+        } else if (value instanceof ConfigValue.NullValue) {
+            return null;
+        } else {
+            throw new IllegalArgumentException("Unsupported config value type: " + value.getClass());
+        }
+    }
+}

--- a/grpc/grpc-client/src/main/java/ru/tinkoff/grpc/client/config/GrpcClientConfig.java
+++ b/grpc/grpc-client/src/main/java/ru/tinkoff/grpc/client/config/GrpcClientConfig.java
@@ -17,11 +17,14 @@ public interface GrpcClientConfig {
 
     TelemetryConfig telemetry();
 
+    @Nullable
+    DefaultServiceConfig defaultServiceConfig();
+
     static GrpcClientConfig defaultConfig(Config config, ru.tinkoff.kora.config.common.extractor.ConfigValueExtractor<GrpcClientConfig> extractor, String serviceName) {
         var packageEnding = serviceName.lastIndexOf('.');
         var serviceSimpleName = (packageEnding == -1)
-                ? serviceName
-                : serviceName.substring(packageEnding + 1);
+            ? serviceName
+            : serviceName.substring(packageEnding + 1);
 
         return Objects.requireNonNull(extractor.extract(config.get("grpcClient." + serviceSimpleName)));
     }

--- a/grpc/grpc-server/src/main/java/ru/tinkoff/kora/grpc/server/GrpcServerBuilderConfigurer.java
+++ b/grpc/grpc-server/src/main/java/ru/tinkoff/kora/grpc/server/GrpcServerBuilderConfigurer.java
@@ -1,0 +1,7 @@
+package ru.tinkoff.kora.grpc.server;
+
+import io.grpc.netty.NettyServerBuilder;
+
+public interface GrpcServerBuilderConfigurer {
+    NettyServerBuilder configure(NettyServerBuilder builder);
+}

--- a/grpc/grpc-server/src/main/java/ru/tinkoff/kora/grpc/server/GrpcServerModule.java
+++ b/grpc/grpc-server/src/main/java/ru/tinkoff/kora/grpc/server/GrpcServerModule.java
@@ -53,6 +53,8 @@ public interface GrpcServerModule extends NettyCommonModule {
         @Tag(WorkerLoopGroup.class) EventLoopGroup eventLoop,
         @Tag(BossLoopGroup.class) EventLoopGroup bossEventLoop,
         NettyChannelFactory nettyChannelFactory,
+        @Nullable
+        GrpcServerBuilderConfigurer configurer,
         ValueOf<GrpcServerTelemetry> telemetry) {
 
         GrpcServerConfig grpcServerConfig = config.get();
@@ -74,6 +76,10 @@ public interface GrpcServerModule extends NettyCommonModule {
             .intercept(CoroutineContextInjectInterceptor.newInstance());
 
         services.forEach(builder::addService);
+
+        if (configurer != null) {
+            builder = configurer.configure(builder);
+        }
 
         return builder;
     }


### PR DESCRIPTION
- Introduced `GrpcClientBuilderConfigurer` and `GrpcServerBuilderConfigurer` interfaces.
- Updated grpc client module to use [service config](https://grpc.io/docs/guides/service-config/) from application configuration.