### PR TITLE
HTTP Server query and header retrieval optimized

### DIFF
--- a/http/http-server-undertow/src/main/java/ru/tinkoff/kora/http/server/undertow/UndertowHttpHeaders.java
+++ b/http/http-server-undertow/src/main/java/ru/tinkoff/kora/http/server/undertow/UndertowHttpHeaders.java
@@ -27,7 +27,7 @@ public class UndertowHttpHeaders extends AbstractHttpHeaders implements HttpHead
         if (headers == null) {
             return null;
         }
-        return List.copyOf(headers);
+        return Collections.unmodifiableList(headers);
     }
 
     @Override

--- a/http/http-server-undertow/src/main/java/ru/tinkoff/kora/http/server/undertow/request/UndertowPublicApiRequest.java
+++ b/http/http-server-undertow/src/main/java/ru/tinkoff/kora/http/server/undertow/request/UndertowPublicApiRequest.java
@@ -76,16 +76,19 @@ public class UndertowPublicApiRequest implements PublicApiRequest {
 
     private static Map<String, List<String>> queryParams(HttpServerExchange httpServerExchange) {
         var undertowQueryParams = httpServerExchange.getQueryParameters();
-        if(undertowQueryParams.isEmpty()) {
+        if (undertowQueryParams.isEmpty()) {
             return Map.of();
         }
 
         var queryParams = new LinkedHashMap<String, List<String>>(undertowQueryParams.size());
         for (var entry : undertowQueryParams.entrySet()) {
             var key = entry.getKey();
-            var value = entry.getValue().stream()
-                .filter(Predicate.not(String::isEmpty))
-                .toList();
+            var value = new ArrayList<String>(entry.getValue().size());
+            for (var it : entry.getValue()) {
+                if (!it.isEmpty()) {
+                    value.add(it);
+                }
+            }
             queryParams.put(key, value);
         }
         return Collections.unmodifiableMap(queryParams);

--- a/http/http-server-undertow/src/main/java/ru/tinkoff/kora/http/server/undertow/request/UndertowPublicApiRequest.java
+++ b/http/http-server-undertow/src/main/java/ru/tinkoff/kora/http/server/undertow/request/UndertowPublicApiRequest.java
@@ -76,15 +76,19 @@ public class UndertowPublicApiRequest implements PublicApiRequest {
 
     private static Map<String, List<String>> queryParams(HttpServerExchange httpServerExchange) {
         var undertowQueryParams = httpServerExchange.getQueryParameters();
-        var queryParams = new HashMap<String, List<String>>(undertowQueryParams.size());
+        if(undertowQueryParams.isEmpty()) {
+            return Map.of();
+        }
+
+        var queryParams = new LinkedHashMap<String, List<String>>(undertowQueryParams.size());
         for (var entry : undertowQueryParams.entrySet()) {
             var key = entry.getKey();
             var value = entry.getValue().stream()
                 .filter(Predicate.not(String::isEmpty))
                 .toList();
-            queryParams.put(key, List.copyOf(value));
+            queryParams.put(key, value);
         }
-        return Map.copyOf(queryParams);
+        return Collections.unmodifiableMap(queryParams);
     }
 
     private HttpBodyInput getContent(HttpServerExchange exchange) throws IOException {


### PR DESCRIPTION
Optimize `List.copyOf()` and `Map.copyOf()` usage with unmodifiable collections wrappers