### PR TITLE
JUnit5 mock component not found in graph fixed

### DIFF
--- a/test/test-junit5/src/main/java/ru/tinkoff/kora/test/extension/junit5/KoraJUnit5Extension.java
+++ b/test/test-junit5/src/main/java/ru/tinkoff/kora/test/extension/junit5/KoraJUnit5Extension.java
@@ -866,7 +866,11 @@ final class KoraJUnit5Extension implements BeforeAllCallback, BeforeEachCallback
 
         final ApplicationGraphDraw subGraph;
         if (nodesForSubGraph.isEmpty()) {
-            subGraph = graphDraw;
+            if (mocks.isEmpty()) {
+                subGraph = graphDraw;
+            } else {
+                subGraph = graphDraw.subgraph(mocks, graphDraw.getNodes());
+            }
         } else {
             subGraph = graphDraw.subgraph(mocks, nodesForSubGraph);
         }

--- a/test/test-junit5/src/main/java/ru/tinkoff/kora/test/extension/junit5/KoraJUnit5Extension.java
+++ b/test/test-junit5/src/main/java/ru/tinkoff/kora/test/extension/junit5/KoraJUnit5Extension.java
@@ -814,18 +814,16 @@ final class KoraJUnit5Extension implements BeforeAllCallback, BeforeEachCallback
             }
         }
 
-        var spyGraphComponents = Stream.of(
+        var mockGraphComponents = Stream.of(
                 metadata.classMetadata.fieldMocks,
                 metadata.parameterMocks,
                 metadata.classMetadata.constructorMocks)
             .flatMap(Collection::stream)
-            .filter(m -> m instanceof GraphMockitoSpy spy && spy.isSpyGraph()
-                         || m instanceof GraphMockkSpyk spyk && spyk.isSpyGraph())
             .map(GraphModification::candidate)
             .collect(Collectors.toSet());
 
         var result = new HashSet<>(components);
-        result.addAll(spyGraphComponents);
+        result.addAll(mockGraphComponents);
         return result;
     }
 
@@ -868,11 +866,7 @@ final class KoraJUnit5Extension implements BeforeAllCallback, BeforeEachCallback
 
         final ApplicationGraphDraw subGraph;
         if (nodesForSubGraph.isEmpty()) {
-            if (mocks.isEmpty()) {
-                subGraph = graphDraw;
-            } else {
-                subGraph = graphDraw.subgraph(mocks, graphDraw.getNodes());
-            }
+            subGraph = graphDraw;
         } else {
             subGraph = graphDraw.subgraph(mocks, nodesForSubGraph);
         }

--- a/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/mockito/MockOnlyTests.java
+++ b/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/mockito/MockOnlyTests.java
@@ -1,0 +1,37 @@
+package ru.tinkoff.kora.test.extension.junit5.mockito;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import ru.tinkoff.kora.test.extension.junit5.KoraAppTest;
+import ru.tinkoff.kora.test.extension.junit5.TestComponent;
+import ru.tinkoff.kora.test.extension.junit5.testdata.TestApplication;
+import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent1;
+import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent12;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@KoraAppTest(TestApplication.class)
+public class MockOnlyTests {
+
+    @Mock
+    @TestComponent
+    private TestComponent12 mock;
+
+    @BeforeEach
+    void setupMocks() {
+        Mockito.when(mock.get()).thenReturn("?");
+    }
+
+    @Test
+    void fieldMocked() {
+        assertEquals("?", mock.get());
+    }
+
+    @Test
+    void fieldMockedAndInBeanDependency() {
+        assertEquals("?", mock.get());
+    }
+}


### PR DESCRIPTION
KoraJUnit5Extension do not exclude mock components from graph root, so their nodes will stay in Graph or they can't be mocked cause not found in graph