### PR TITLE
Some base Json mappers as default factories

### DIFF
--- a/json/json-module/src/main/java/ru/tinkoff/kora/json/module/JsonModule.java
+++ b/json/json-module/src/main/java/ru/tinkoff/kora/json/module/JsonModule.java
@@ -1,5 +1,6 @@
 package ru.tinkoff.kora.json.module;
 
+import ru.tinkoff.kora.common.DefaultComponent;
 import ru.tinkoff.kora.json.common.JsonCommonModule;
 import ru.tinkoff.kora.json.common.JsonReader;
 import ru.tinkoff.kora.json.common.JsonWriter;
@@ -10,7 +11,9 @@ import ru.tinkoff.kora.json.module.kafka.JsonKafkaDeserializer;
 import ru.tinkoff.kora.json.module.kafka.JsonKafkaSerializer;
 
 public interface JsonModule extends JsonCommonModule {
+
     @Json
+    @DefaultComponent
     default <T> JsonReaderHttpServerRequestMapper<T> jsonRequestMapper(JsonReader<T> reader) {
         return new JsonReaderHttpServerRequestMapper<>(reader);
     }
@@ -21,6 +24,7 @@ public interface JsonModule extends JsonCommonModule {
     }
 
     @Json
+    @DefaultComponent
     default <T> JsonWriterHttpServerResponseMapper<T> jsonResponseMapper(JsonWriter<T> writer) {
         return new JsonWriterHttpServerResponseMapper<>(writer);
     }
@@ -31,11 +35,13 @@ public interface JsonModule extends JsonCommonModule {
     }
 
     @Json
+    @DefaultComponent
     default <T> JsonHttpClientRequestMapper<T> jsonHttpClientRequestMapper(JsonWriter<T> jsonWriter) {
         return new JsonHttpClientRequestMapper<>(jsonWriter);
     }
 
     @Json
+    @DefaultComponent
     default <T> JsonHttpClientResponseMapper<T> jsonHttpClientResponseMapper(JsonReader<T> jsonReader) {
         return new JsonHttpClientResponseMapper<>(jsonReader);
     }
@@ -56,21 +62,25 @@ public interface JsonModule extends JsonCommonModule {
     }
 
     @Json
+    @DefaultComponent
     default <T> JsonStringParameterConverter<T> jsonStringParameterConverter(JsonWriter<T> writer) {
         return new JsonStringParameterConverter<>(writer);
     }
 
     @Json
+    @DefaultComponent
     default <T> JsonStringParameterReader<T> jsonStringParameterReader(JsonReader<T> reader) {
         return new JsonStringParameterReader<>(reader);
     }
 
     @Json
+    @DefaultComponent
     default <T> JsonKafkaDeserializer<T> jsonKafkaDeserializer(JsonReader<T> reader) {
         return new JsonKafkaDeserializer<>(reader);
     }
 
     @Json
+    @DefaultComponent
     default <T> JsonKafkaSerializer<T> jsonKafkaSerializer(JsonWriter<T> writer) {
         return new JsonKafkaSerializer<>(writer);
     }


### PR DESCRIPTION
Some base Json mappers as default factories or it might collide with near factories like `Mapper<T>` and `Mapper<HttpResponseEntity<T>>`