### PR TITLE
adding maxConnectionAge and maxConnectionAgeGrace configs to grpcServer

### DIFF
--- a/grpc/grpc-server/src/main/java/ru/tinkoff/kora/grpc/server/GrpcServerModule.java
+++ b/grpc/grpc-server/src/main/java/ru/tinkoff/kora/grpc/server/GrpcServerModule.java
@@ -23,6 +23,7 @@ import ru.tinkoff.kora.netty.common.NettyChannelFactory;
 import ru.tinkoff.kora.netty.common.NettyCommonModule;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 public interface GrpcServerModule extends NettyCommonModule {
 
@@ -64,6 +65,14 @@ public interface GrpcServerModule extends NettyCommonModule {
             .bossEventLoopGroup(bossEventLoop)
             .workerEventLoopGroup(eventLoop)
             .channelFactory(nettyChannelFactory.getServerFactory());
+
+        if (grpcServerConfig.maxConnectionAge() != null) {
+            builder.maxConnectionAge(grpcServerConfig.maxConnectionAge().toMillis(), TimeUnit.MILLISECONDS);
+        }
+
+        if (grpcServerConfig.maxConnectionAgeGrace() != null) {
+            builder.maxConnectionAgeGrace(grpcServerConfig.maxConnectionAgeGrace().toMillis(), TimeUnit.MILLISECONDS);
+        }
 
         if (grpcServerConfig.reflectionEnabled() && isClassPresent("io.grpc.protobuf.services.ProtoReflectionService")) {
             builder.addService(ProtoReflectionService.newInstance());

--- a/grpc/grpc-server/src/main/java/ru/tinkoff/kora/grpc/server/config/GrpcServerConfig.java
+++ b/grpc/grpc-server/src/main/java/ru/tinkoff/kora/grpc/server/config/GrpcServerConfig.java
@@ -1,5 +1,6 @@
 package ru.tinkoff.kora.grpc.server.config;
 
+import jakarta.annotation.Nullable;
 import ru.tinkoff.kora.common.util.Size;
 import ru.tinkoff.kora.config.common.annotation.ConfigValueExtractor;
 import ru.tinkoff.kora.telemetry.common.TelemetryConfig;
@@ -26,4 +27,10 @@ public interface GrpcServerConfig {
     }
 
     TelemetryConfig telemetry();
+
+    @Nullable
+    Duration maxConnectionAge();
+
+    @Nullable
+    Duration maxConnectionAgeGrace();
 }


### PR DESCRIPTION
adding 
https://grpc.github.io/grpc-java/javadoc/io/grpc/netty/NettyServerBuilder.html#maxConnectionAge(long,java.util.concurrent.TimeUnit)
https://grpc.github.io/grpc-java/javadoc/io/grpc/netty/NettyServerBuilder.html#maxConnectionAgeGrace(long,java.util.concurrent.TimeUnit)
props to GrpcServer config

Our devops says that we have some network policy, which restricts connection lifetime, so we should be able to finish our connections before this policy will kill them.
Also we see next grpc-errors in logs: "Cancellation received from client"