### PR TITLE
JUnit extension full graph only with mocked parts fixed

### DIFF
--- a/test/test-junit5/src/main/java/ru/tinkoff/kora/test/extension/junit5/TestGraphInitialized.java
+++ b/test/test-junit5/src/main/java/ru/tinkoff/kora/test/extension/junit5/TestGraphInitialized.java
@@ -3,6 +3,7 @@ package ru.tinkoff.kora.test.extension.junit5;
 import ru.tinkoff.kora.application.graph.ApplicationGraphDraw;
 import ru.tinkoff.kora.application.graph.RefreshableGraph;
 
-record TestGraphInitialized(RefreshableGraph refreshableGraph, ApplicationGraphDraw graphDraw,
+record TestGraphInitialized(RefreshableGraph refreshableGraph,
+                            ApplicationGraphDraw graphDraw,
                             KoraAppGraph koraAppGraph) {
 }

--- a/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/initializemode/FieldPerClassTests.java
+++ b/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/initializemode/FieldPerClassTests.java
@@ -7,7 +7,8 @@ import ru.tinkoff.kora.test.extension.junit5.testdata.TestApplication;
 import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent1;
 import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent12;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 @KoraAppTest(value = TestApplication.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)

--- a/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/initializemode/FieldPerMethodTests.java
+++ b/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/initializemode/FieldPerMethodTests.java
@@ -7,7 +7,8 @@ import ru.tinkoff.kora.test.extension.junit5.testdata.TestApplication;
 import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent1;
 import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent12;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 @KoraAppTest(value = TestApplication.class)
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)

--- a/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/initializemode/MethodPerClassTests.java
+++ b/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/initializemode/MethodPerClassTests.java
@@ -7,7 +7,8 @@ import ru.tinkoff.kora.test.extension.junit5.testdata.TestApplication;
 import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent1;
 import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent12;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 @KoraAppTest(value = TestApplication.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)

--- a/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/initializemode/MethodPerMethodTests.java
+++ b/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/initializemode/MethodPerMethodTests.java
@@ -7,7 +7,8 @@ import ru.tinkoff.kora.test.extension.junit5.testdata.TestApplication;
 import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent1;
 import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent12;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 @KoraAppTest(value = TestApplication.class)
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)

--- a/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/initializemode/NestedFieldPerClassTests.java
+++ b/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/initializemode/NestedFieldPerClassTests.java
@@ -7,7 +7,8 @@ import ru.tinkoff.kora.test.extension.junit5.testdata.TestApplication;
 import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent1;
 import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent12;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 @KoraAppTest(value = TestApplication.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)

--- a/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/initializemode/NestedFieldPerMethodTests.java
+++ b/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/initializemode/NestedFieldPerMethodTests.java
@@ -7,8 +7,8 @@ import ru.tinkoff.kora.test.extension.junit5.testdata.TestApplication;
 import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent1;
 import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent12;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 @KoraAppTest(value = TestApplication.class)
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)

--- a/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/mockito/MockAndFullGraphTests.java
+++ b/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/mockito/MockAndFullGraphTests.java
@@ -1,0 +1,32 @@
+package ru.tinkoff.kora.test.extension.junit5.mockito;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import ru.tinkoff.kora.application.graph.TypeRef;
+import ru.tinkoff.kora.test.extension.junit5.KoraAppGraph;
+import ru.tinkoff.kora.test.extension.junit5.KoraAppTest;
+import ru.tinkoff.kora.test.extension.junit5.TestComponent;
+import ru.tinkoff.kora.test.extension.junit5.testdata.GenericComponent;
+import ru.tinkoff.kora.test.extension.junit5.testdata.TestApplication;
+import ru.tinkoff.kora.test.extension.junit5.testdata.TestApplication.CustomWrapper;
+import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent1;
+import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent3;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@KoraAppTest(TestApplication.class)
+public class MockAndFullGraphTests {
+
+    @TestComponent
+    private KoraAppGraph graph;
+
+    @Mock
+    @TestComponent
+    private TestComponent3 mock;
+
+    @Test
+    void graphIsFull() {
+        assertNotNull(graph.getFirst(TypeRef.of(GenericComponent.class, String.class)));
+        assertNotNull(graph.getFirst(CustomWrapper.class));
+    }
+}

--- a/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/mockito/MockAndFullGraphTests.java
+++ b/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/mockito/MockAndFullGraphTests.java
@@ -9,7 +9,6 @@ import ru.tinkoff.kora.test.extension.junit5.TestComponent;
 import ru.tinkoff.kora.test.extension.junit5.testdata.GenericComponent;
 import ru.tinkoff.kora.test.extension.junit5.testdata.TestApplication;
 import ru.tinkoff.kora.test.extension.junit5.testdata.TestApplication.CustomWrapper;
-import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent1;
 import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent3;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/mockito/MockOnlyTests.java
+++ b/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/mockito/MockOnlyTests.java
@@ -7,18 +7,16 @@ import org.mockito.Mockito;
 import ru.tinkoff.kora.test.extension.junit5.KoraAppTest;
 import ru.tinkoff.kora.test.extension.junit5.TestComponent;
 import ru.tinkoff.kora.test.extension.junit5.testdata.TestApplication;
-import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent1;
-import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent12;
+import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent3;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 @KoraAppTest(TestApplication.class)
 public class MockOnlyTests {
 
     @Mock
     @TestComponent
-    private TestComponent12 mock;
+    private TestComponent3 mock;
 
     @BeforeEach
     void setupMocks() {

--- a/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/mockito/MockWrappedTests.java
+++ b/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/mockito/MockWrappedTests.java
@@ -3,7 +3,6 @@ package ru.tinkoff.kora.test.extension.junit5.mockito;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.Spy;
 import ru.tinkoff.kora.test.extension.junit5.KoraAppTest;
 import ru.tinkoff.kora.test.extension.junit5.TestComponent;
 import ru.tinkoff.kora.test.extension.junit5.testdata.TestApplication;

--- a/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/replace/ReplaceWrappedTests.java
+++ b/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/replace/ReplaceWrappedTests.java
@@ -2,7 +2,6 @@ package ru.tinkoff.kora.test.extension.junit5.replace;
 
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import ru.tinkoff.kora.test.extension.junit5.KoraAppTest;
 import ru.tinkoff.kora.test.extension.junit5.KoraAppTestGraphModifier;
 import ru.tinkoff.kora.test.extension.junit5.KoraGraphModification;

--- a/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/testdata/TestApplication.java
+++ b/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/testdata/TestApplication.java
@@ -5,7 +5,6 @@ import ru.tinkoff.kora.application.graph.Wrapped;
 import ru.tinkoff.kora.common.KoraApp;
 import ru.tinkoff.kora.common.annotation.Root;
 
-import java.math.BigInteger;
 import java.util.function.Function;
 
 @KoraApp


### PR DESCRIPTION
Inject full Graph with mocked parts and not consider mocks as roots when only mocks are specified