### PR TITLE
Generated impl support for interface `default` AOP method

### DIFF
--- a/cache/cache-annotation-processor/src/main/java/ru/tinkoff/kora/cache/annotation/processor/CacheAnnotationProcessor.java
+++ b/cache/cache-annotation-processor/src/main/java/ru/tinkoff/kora/cache/annotation/processor/CacheAnnotationProcessor.java
@@ -2,10 +2,7 @@ package ru.tinkoff.kora.cache.annotation.processor;
 
 import com.squareup.javapoet.*;
 import jakarta.annotation.Nullable;
-import ru.tinkoff.kora.annotation.processor.common.AbstractKoraProcessor;
-import ru.tinkoff.kora.annotation.processor.common.AnnotationUtils;
-import ru.tinkoff.kora.annotation.processor.common.CommonClassNames;
-import ru.tinkoff.kora.annotation.processor.common.TagUtils;
+import ru.tinkoff.kora.annotation.processor.common.*;
 import ru.tinkoff.kora.common.DefaultComponent;
 
 import javax.annotation.processing.ProcessingEnvironment;
@@ -80,13 +77,11 @@ public class CacheAnnotationProcessor extends AbstractKoraProcessor {
             }
 
             var cacheImplBase = getCacheImplBase(cacheContract, cacheContractType);
-            var implSpec = TypeSpec.classBuilder(getCacheImpl(cacheContract))
-                .addModifiers(Modifier.FINAL)
+            var implSpec = CommonUtils.extendsKeepAop(cacheContract, getCacheImpl(cacheContract).simpleName())
                 .addAnnotation(AnnotationSpec.builder(CommonClassNames.koraGenerated)
                     .addMember("value", CodeBlock.of("$S", CacheAnnotationProcessor.class.getCanonicalName())).build())
                 .addMethod(getCacheConstructor(configPath, cacheContractType))
                 .superclass(cacheImplBase)
-                .addSuperinterface(cacheContract.asType())
                 .build();
 
             try {
@@ -217,8 +212,8 @@ public class CacheAnnotationProcessor extends AbstractKoraProcessor {
 
             var keyName = "_key" + (i + 1);
             keyBuilder.addStatement("var $L = $L.apply($T.requireNonNull(key.$L(), $S))",
-                    keyName, mapperName, Objects.class, recordField.getSimpleName().toString(),
-                    "Cache key '%s' field '%s' must be non null".formatted(keyType.asElement().toString(), recordField.getSimpleName().toString()));
+                keyName, mapperName, Objects.class, recordField.getSimpleName().toString(),
+                "Cache key '%s' field '%s' must be non null".formatted(keyType.asElement().toString(), recordField.getSimpleName().toString()));
 
             if (i == 0) {
                 compositeKeyBuilder.add("var _compositeKey = new byte[");

--- a/cache/cache-symbol-processor/src/main/kotlin/ru/tinkoff/kora/cache/symbol/processor/CacheSymbolProcessor.kt
+++ b/cache/cache-symbol-processor/src/main/kotlin/ru/tinkoff/kora/cache/symbol/processor/CacheSymbolProcessor.kt
@@ -20,13 +20,13 @@ import ru.tinkoff.kora.ksp.common.AnnotationUtils.findAnnotations
 import ru.tinkoff.kora.ksp.common.AnnotationUtils.findValue
 import ru.tinkoff.kora.ksp.common.AnnotationUtils.findValueNoDefault
 import ru.tinkoff.kora.ksp.common.BaseSymbolProcessor
+import ru.tinkoff.kora.ksp.common.CommonAopUtils.extendsKeepAop
 import ru.tinkoff.kora.ksp.common.CommonClassNames
 import ru.tinkoff.kora.ksp.common.CommonClassNames.configValueExtractor
 import ru.tinkoff.kora.ksp.common.KspCommonUtils.generated
 import ru.tinkoff.kora.ksp.common.KspCommonUtils.toTypeName
 import ru.tinkoff.kora.ksp.common.TagUtils.parseTags
 import ru.tinkoff.kora.ksp.common.TagUtils.toTagAnnotation
-import ru.tinkoff.kora.ksp.common.exception.ProcessingErrorException
 
 class CacheSymbolProcessor(
     private val environment: SymbolProcessorEnvironment
@@ -68,12 +68,11 @@ class CacheSymbolProcessor(
             val cacheImplName = cacheContract.toClassName()
 
             val cacheImplBase = getCacheImplBase(cacheContractType)
-            val implSpec = TypeSpec.classBuilder(getCacheImpl(cacheContract))
+            val implSpec = cacheContract.extendsKeepAop(getCacheImpl(cacheContract).simpleName, resolver)
                 .generated(CacheSymbolProcessor::class)
                 .primaryConstructor(getCacheConstructor(cacheContractType))
                 .addSuperclassConstructorParameter(getCacheSuperConstructorCall(cacheContract, cacheContractType))
                 .superclass(cacheImplBase)
-                .addSuperinterface(cacheContract.toTypeName())
                 .build()
 
             val fileImplSpec = FileSpec.builder(cacheContract.packageName.asString(), implSpec.name.toString())

--- a/database/database-symbol-processor/src/main/kotlin/ru/tinkoff/kora/database/symbol/processor/RepositoryBuilder.kt
+++ b/database/database-symbol-processor/src/main/kotlin/ru/tinkoff/kora/database/symbol/processor/RepositoryBuilder.kt
@@ -43,7 +43,7 @@ class RepositoryBuilder(
     fun build(repositoryDeclaration: KSClassDeclaration): TypeSpec? {
         log.debug("Generating Repository for {}", repositoryDeclaration.simpleName.asString())
         val name = repositoryDeclaration.getOuterClassesAsPrefix() + repositoryDeclaration.simpleName.asString() + "_Impl"
-        val builder = repositoryDeclaration.extendsKeepAop(name)
+        val builder = repositoryDeclaration.extendsKeepAop(name, resolver)
             .generated(RepositoryBuilder::class)
             .addOriginatingKSFile(repositoryDeclaration.containingFile!!)
 

--- a/experimental/s3-client-annotation-processor/src/main/java/ru/tinkoff/kora/s3/client/annotation/processor/S3ClientAnnotationProcessor.java
+++ b/experimental/s3-client-annotation-processor/src/main/java/ru/tinkoff/kora/s3/client/annotation/processor/S3ClientAnnotationProcessor.java
@@ -119,11 +119,9 @@ public class S3ClientAnnotationProcessor extends AbstractKoraProcessor {
     }
 
     private TypeSpec generateClient(TypeElement s3client) {
-        var implSpecBuilder = TypeSpec.classBuilder(NameUtils.generatedType(s3client, "Impl"))
-            .addModifiers(Modifier.FINAL, Modifier.PUBLIC)
+        var implSpecBuilder = CommonUtils.extendsKeepAop(s3client, NameUtils.generatedType(s3client, "Impl"))
             .addAnnotation(AnnotationUtils.generated(S3ClientAnnotationProcessor.class))
-            .addAnnotation(Component.class)
-            .addSuperinterface(s3client.asType());
+            .addAnnotation(Component.class);
 
         final Set<Signature> constructed = new HashSet<>();
         var constructorBuilder = MethodSpec.constructorBuilder().addModifiers(Modifier.PUBLIC);

--- a/experimental/s3-client-symbol-processor/src/main/kotlin/ru/tinkoff/kora/s3/client/symbol/processor/S3ClientSymbolProcessor.kt
+++ b/experimental/s3-client-symbol-processor/src/main/kotlin/ru/tinkoff/kora/s3/client/symbol/processor/S3ClientSymbolProcessor.kt
@@ -16,6 +16,7 @@ import ru.tinkoff.kora.ksp.common.*
 import ru.tinkoff.kora.ksp.common.AnnotationUtils.findAnnotation
 import ru.tinkoff.kora.ksp.common.AnnotationUtils.findValue
 import ru.tinkoff.kora.ksp.common.AnnotationUtils.findValueNoDefault
+import ru.tinkoff.kora.ksp.common.CommonAopUtils.extendsKeepAop
 import ru.tinkoff.kora.ksp.common.CommonAopUtils.overridingKeepAop
 import ru.tinkoff.kora.ksp.common.CommonClassNames.isCollection
 import ru.tinkoff.kora.ksp.common.CommonClassNames.isMap
@@ -123,10 +124,9 @@ class S3ClientSymbolProcessor(
     }
 
     private fun generateClient(s3client: KSClassDeclaration, resolver: Resolver): TypeSpec {
-        val implSpecBuilder: TypeSpec.Builder = TypeSpec.classBuilder(s3client.generatedClassName("Impl"))
+        val implSpecBuilder: TypeSpec.Builder = s3client.extendsKeepAop(s3client.generatedClassName("Impl"), resolver)
             .generated(S3ClientSymbolProcessor::class)
             .addAnnotation(Component::class)
-            .addSuperinterface(s3client.toTypeName())
 
         val constructed = HashSet<Signature>()
         val constructorBuilder = FunSpec.constructorBuilder()

--- a/http/http-client-symbol-processor/src/main/kotlin/ru/tinkoff/kora/http/client/symbol/processor/ClientClassGenerator.kt
+++ b/http/http-client-symbol-processor/src/main/kotlin/ru/tinkoff/kora/http/client/symbol/processor/ClientClassGenerator.kt
@@ -63,7 +63,7 @@ class ClientClassGenerator(private val resolver: Resolver) {
     fun generate(declaration: KSClassDeclaration): TypeSpec {
         val typeName = declaration.clientName()
         val methods: List<MethodData> = this.parseMethods(declaration)
-        val builder = declaration.extendsKeepAop(typeName)
+        val builder = declaration.extendsKeepAop(typeName, resolver)
             .generated(ClientClassGenerator::class)
 
         if (declaration.findAnnotation(CommonClassNames.component) != null) {

--- a/kafka/kafka-symbol-processor/src/main/kotlin/ru/tinkoff/kora/kafka/symbol/processor/producer/KafkaPublisherGenerator.kt
+++ b/kafka/kafka-symbol-processor/src/main/kotlin/ru/tinkoff/kora/kafka/symbol/processor/producer/KafkaPublisherGenerator.kt
@@ -198,7 +198,7 @@ class KafkaPublisherGenerator(val env: SymbolProcessorEnvironment, val resolver:
         val packageName = classDeclaration.packageName.asString()
         val implementationName = classDeclaration.generatedClassName("Impl")
 
-        val b = classDeclaration.extendsKeepAop(implementationName)
+        val b = classDeclaration.extendsKeepAop(implementationName, resolver)
             .generated(KafkaPublisherSymbolProcessor::class)
             .addOriginatingKSFile(classDeclaration.containingFile!!)
             .addSuperinterface(KafkaClassNames.generatedPublisher)

--- a/kafka/kafka-symbol-processor/src/main/kotlin/ru/tinkoff/kora/kafka/symbol/processor/producer/KafkaPublisherTransactionalGenerator.kt
+++ b/kafka/kafka-symbol-processor/src/main/kotlin/ru/tinkoff/kora/kafka/symbol/processor/producer/KafkaPublisherTransactionalGenerator.kt
@@ -71,7 +71,7 @@ class KafkaPublisherTransactionalGenerator(
         val publisherPackageName = publisherTypeElement.packageName.asString()
         val implementationName = typeElement.generatedClassName("Impl")
         val publisherImplementationTypeName = ClassName(publisherPackageName, publisherTypeElement.generatedClassName("Impl"))
-        val b = typeElement.extendsKeepAop(implementationName)
+        val b = typeElement.extendsKeepAop(implementationName, resolver)
             .addSuperinterface(CommonClassNames.lifecycle)
             .addOriginatingKSFile(typeElement.containingFile!!)
             .addProperty(PropertySpec.builder("delegate", KafkaClassNames.transactionalPublisherImpl.parameterizedBy(publisherImplementationTypeName), KModifier.PRIVATE, KModifier.FINAL)


### PR DESCRIPTION
Interfaces where impl is generated by AP later like `@HttpClient` with `default` AOP method support fixed