### PR TITLE
Fixed AWS S3 Client objectMeta method

### DIFF
--- a/experimental/s3-client-aws/src/main/java/ru/tinkoff/kora/s3/client/aws/AwsS3KoraAsyncClient.java
+++ b/experimental/s3-client-aws/src/main/java/ru/tinkoff/kora/s3/client/aws/AwsS3KoraAsyncClient.java
@@ -8,8 +8,8 @@ import ru.tinkoff.kora.s3.client.S3DeleteException;
 import ru.tinkoff.kora.s3.client.S3Exception;
 import ru.tinkoff.kora.s3.client.S3KoraAsyncClient;
 import ru.tinkoff.kora.s3.client.S3NotFoundException;
-import ru.tinkoff.kora.s3.client.model.S3Object;
 import ru.tinkoff.kora.s3.client.model.*;
+import ru.tinkoff.kora.s3.client.model.S3Object;
 import ru.tinkoff.kora.s3.client.telemetry.S3KoraClientTelemetry;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
@@ -73,13 +73,12 @@ public class AwsS3KoraAsyncClient implements S3KoraAsyncClient {
     }
 
     private CompletionStage<S3ObjectMeta> getMetaInternal(String bucket, String key) {
-        var request = GetObjectAttributesRequest.builder()
+        var request = HeadObjectRequest.builder()
             .bucket(bucket)
             .key(key)
-            .objectAttributes(ObjectAttributes.OBJECT_SIZE)
             .build();
 
-        return asyncClient.getObjectAttributes(request)
+        return asyncClient.headObject(request)
             .thenApply(r -> new AwsS3ObjectMeta(key, r));
     }
 

--- a/experimental/s3-client-aws/src/main/java/ru/tinkoff/kora/s3/client/aws/AwsS3KoraClient.java
+++ b/experimental/s3-client-aws/src/main/java/ru/tinkoff/kora/s3/client/aws/AwsS3KoraClient.java
@@ -60,13 +60,12 @@ public class AwsS3KoraClient implements S3KoraClient {
     }
 
     private S3ObjectMeta getMetaInternal(String bucket, String key) throws S3NotFoundException {
-        var request = GetObjectAttributesRequest.builder()
+        var request = HeadObjectRequest.builder()
             .bucket(bucket)
             .key(key)
-            .objectAttributes(ObjectAttributes.OBJECT_SIZE)
             .build();
 
-        var response = syncClient.getObjectAttributes(request);
+        var response = syncClient.headObject(request);
         return new AwsS3ObjectMeta(key, response);
     }
 

--- a/experimental/s3-client-aws/src/main/java/ru/tinkoff/kora/s3/client/aws/AwsS3ObjectMeta.java
+++ b/experimental/s3-client-aws/src/main/java/ru/tinkoff/kora/s3/client/aws/AwsS3ObjectMeta.java
@@ -2,8 +2,8 @@ package ru.tinkoff.kora.s3.client.aws;
 
 import org.jetbrains.annotations.ApiStatus;
 import ru.tinkoff.kora.s3.client.model.S3ObjectMeta;
-import software.amazon.awssdk.services.s3.model.GetObjectAttributesResponse;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.S3Object;
 
 import java.time.Instant;
@@ -22,10 +22,10 @@ final class AwsS3ObjectMeta implements S3ObjectMeta {
         this.size = response.contentLength();
     }
 
-    public AwsS3ObjectMeta(String key, GetObjectAttributesResponse response) {
+    public AwsS3ObjectMeta(String key, HeadObjectResponse response) {
         this.key = key;
         this.modified = response.lastModified();
-        this.size = response.objectSize();
+        this.size = response.contentLength() == null ? -1 : response.contentLength();
     }
 
     public AwsS3ObjectMeta(S3Object object) {
@@ -65,8 +65,8 @@ final class AwsS3ObjectMeta implements S3ObjectMeta {
     @Override
     public String toString() {
         return "AwsS3ObjectMeta{key=" + key +
-            ", size=" + size +
-            ", modified=" + modified +
-            '}';
+               ", size=" + size +
+               ", modified=" + modified +
+               '}';
     }
 }


### PR DESCRIPTION
S3 aws client fix `AwsS3ObjectMeta` behavior with implementation replacement `objectAttributes` -> `headObject`