### PR TITLE
Fixed Kafka Consumer Telemetry Deprecated method library compatibility

### DIFF
--- a/kafka/kafka/src/main/java/ru/tinkoff/kora/kafka/common/consumer/telemetry/DefaultKafkaConsumerTelemetryFactory.java
+++ b/kafka/kafka/src/main/java/ru/tinkoff/kora/kafka/common/consumer/telemetry/DefaultKafkaConsumerTelemetryFactory.java
@@ -50,6 +50,19 @@ public final class DefaultKafkaConsumerTelemetryFactory<K, V> implements KafkaCo
         };
     }
 
+    @Deprecated
+    @Override
+    public KafkaConsumerTelemetry<K, V> get(Properties driverProperties, TelemetryConfig config) {
+        var logger = this.logger == null ? null : this.logger.get(driverProperties, config.logging());
+        var metrics = this.metrics == null ? null : this.metrics.get(driverProperties, config.metrics());
+        var tracer = this.tracer == null ? null : this.tracer.get(driverProperties, config.tracing());
+        if (logger == null && metrics == null && tracer == null) {
+            return empty;
+        }
+
+        return new DefaultKafkaConsumerTelemetry<>("", logger, tracer, metrics);
+    }
+
     @Override
     public KafkaConsumerTelemetry<K, V> get(String consumerName, Properties driverProperties, TelemetryConfig config) {
         var logger = this.logger == null ? null : this.logger.get(driverProperties, config.logging());


### PR DESCRIPTION
Kafka Consumer Telemetry factory deprecated method support for old Kora libraries compatibility