### PR TITLE
Fixed JUnit testing complex `Wrapped` support

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -127,6 +127,7 @@ junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher
 mockito-core = { module = "org.mockito:mockito-core", version = "5.11.0" }
 mockito-inline = { module = "org.mockito:mockito-inline", version = "5.2.0" }
 mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version = "5.3.1" }
+mockk = { module = "io.mockk:mockk", version = "1.13.11" }
 assertj = { module = "org.assertj:assertj-core", version = "3.25.3" }
 mockserver-netty = { module = "org.mock-server:mockserver-netty", version.ref = "mockserver" }
 mockserver-client = { module = "org.mock-server:mockserver-client-java", version.ref = "mockserver" }

--- a/test/test-junit5/build.gradle
+++ b/test/test-junit5/build.gradle
@@ -3,7 +3,7 @@ apply from: "${project.rootDir}/gradle/kotlin-plugin.gradle"
 
 dependencies {
     compileOnly libs.mockito.core
-    compileOnly "io.mockk:mockk:1.13.11"
+    compileOnly libs.mockk
     compileOnly libs.kotlin.reflect
 
     api libs.junit.platform.launcher
@@ -16,7 +16,7 @@ dependencies {
     testImplementation project(":annotation-processors")
     testImplementation project(":config:config-hocon")
 
-    testImplementation "io.mockk:mockk:1.13.11"
+    testImplementation libs.mockk
     testImplementation libs.mockito.core
     testImplementation libs.kotlin.stdlib.lib
 }

--- a/test/test-junit5/src/main/java/ru/tinkoff/kora/test/extension/junit5/GraphReplacementNoDeps.java
+++ b/test/test-junit5/src/main/java/ru/tinkoff/kora/test/extension/junit5/GraphReplacementNoDeps.java
@@ -1,16 +1,21 @@
 package ru.tinkoff.kora.test.extension.junit5;
 
+import io.mockk.MockKKt;
+import kotlin.jvm.JvmClassMappingKt;
+import kotlin.reflect.KClass;
 import org.junit.jupiter.api.extension.ExtensionConfigurationException;
+import org.mockito.Mockito;
 import ru.tinkoff.kora.application.graph.ApplicationGraphDraw;
 import ru.tinkoff.kora.application.graph.Node;
 import ru.tinkoff.kora.application.graph.Wrapped;
 
-import java.lang.reflect.ParameterizedType;
+import java.util.Optional;
 import java.util.function.Function;
 
 record GraphReplacementNoDeps<T>(Function<KoraAppGraph, ? extends T> function,
                                  GraphCandidate candidate) implements GraphModification {
 
+    @SuppressWarnings("unchecked")
     @Override
     public void accept(ApplicationGraphDraw graphDraw) {
         var nodesToReplace = GraphUtils.findNodeByTypeOrAssignable(graphDraw, candidate());
@@ -18,15 +23,28 @@ record GraphReplacementNoDeps<T>(Function<KoraAppGraph, ? extends T> function,
             throw new ExtensionConfigurationException("Can't find Nodes to Replace: " + candidate());
         }
 
-        for (var nodeToReplace : nodesToReplace) {
-            @SuppressWarnings("unchecked")
-            var casted = (Node<Object>) nodeToReplace;
+        for (var node : nodesToReplace) {
+            var casted = (Node<Object>) node;
             graphDraw.replaceNode(casted, g -> {
                 var replacement = function.apply(new DefaultKoraAppGraph(graphDraw, g));
-                if (nodeToReplace.type() instanceof Class<?> tc && Wrapped.class.isAssignableFrom(tc)) {
-                    return (Object) (Wrapped<?>) () -> replacement;
-                } else if (nodeToReplace.type() instanceof ParameterizedType pt && Wrapped.class.isAssignableFrom(((Class<?>) pt.getRawType()))) {
-                    return (Object) (Wrapped<?>) () -> replacement;
+
+                Optional<Class<?>> wrappedType = GraphUtils.findWrappedType(node.type());
+                if (wrappedType.isPresent() && wrappedType.get().isInstance(replacement)) {
+                    Optional<Class<?>> mockClass = GraphUtils.tryCastType(node.type());
+                    if (mockClass.isPresent() && !mockClass.get().equals(Wrapped.class) && MockUtils.haveAnyMockEngine()) {
+                        if (MockUtils.isMockitoAvailable()) {
+                            Wrapped<T> mockedWrapper = (Wrapped<T>) Mockito.mock(mockClass.get());
+                            Mockito.when(mockedWrapper.value()).thenReturn(replacement);
+                            return mockedWrapper;
+                        } else {
+                            var kotlinTC = JvmClassMappingKt.getKotlinClass(mockClass.get());
+                            Wrapped<T> mockedWrapper = (Wrapped<T>) MockKKt.mockkClass(kotlinTC, null, true, new KClass<?>[]{}, true, v -> null);
+                            MockKKt.every(mockKMatcherScope -> mockedWrapper.value()).returns(replacement);
+                            return mockedWrapper;
+                        }
+                    }
+
+                    return (Wrapped<T>) () -> replacement;
                 } else {
                     return replacement;
                 }

--- a/test/test-junit5/src/main/java/ru/tinkoff/kora/test/extension/junit5/GraphReplacementWithDeps.java
+++ b/test/test-junit5/src/main/java/ru/tinkoff/kora/test/extension/junit5/GraphReplacementWithDeps.java
@@ -1,16 +1,21 @@
 package ru.tinkoff.kora.test.extension.junit5;
 
+import io.mockk.MockKKt;
+import kotlin.jvm.JvmClassMappingKt;
+import kotlin.reflect.KClass;
 import org.junit.jupiter.api.extension.ExtensionConfigurationException;
+import org.mockito.Mockito;
 import ru.tinkoff.kora.application.graph.ApplicationGraphDraw;
 import ru.tinkoff.kora.application.graph.Node;
 import ru.tinkoff.kora.application.graph.Wrapped;
 
-import java.lang.reflect.ParameterizedType;
+import java.util.Optional;
 import java.util.function.Function;
 
 record GraphReplacementWithDeps<T>(Function<KoraAppGraph, ? extends T> function,
                                    GraphCandidate candidate) implements GraphModification {
 
+    @SuppressWarnings("unchecked")
     @Override
     public void accept(ApplicationGraphDraw graphDraw) {
         var nodesToReplace = GraphUtils.findNodeByTypeOrAssignable(graphDraw, candidate());
@@ -18,15 +23,28 @@ record GraphReplacementWithDeps<T>(Function<KoraAppGraph, ? extends T> function,
             throw new ExtensionConfigurationException("Can't find Nodes to Replace: " + candidate());
         }
 
-        for (var nodeToReplace : nodesToReplace) {
-            @SuppressWarnings("unchecked")
-            var casted = (Node<Object>) nodeToReplace;
+        for (var node : nodesToReplace) {
+            var casted = (Node<Object>) node;
             graphDraw.replaceNodeKeepDependencies(casted, g -> {
                 var replacement = function.apply(new DefaultKoraAppGraph(graphDraw, g));
-                if (nodeToReplace.type() instanceof Class<?> tc && Wrapped.class.isAssignableFrom(tc)) {
-                    return (Object) (Wrapped<?>) () -> replacement;
-                } else if (nodeToReplace.type() instanceof ParameterizedType pt && Wrapped.class.isAssignableFrom(((Class<?>) pt.getRawType()))) {
-                    return (Object) (Wrapped<?>) () -> replacement;
+
+                Optional<Class<?>> wrappedType = GraphUtils.findWrappedType(node.type());
+                if (wrappedType.isPresent() && wrappedType.get().isInstance(replacement)) {
+                    Optional<Class<?>> mockClass = GraphUtils.tryCastType(node.type());
+                    if (mockClass.isPresent() && !mockClass.get().equals(Wrapped.class) && MockUtils.haveAnyMockEngine()) {
+                        if (MockUtils.isMockitoAvailable()) {
+                            Wrapped<T> mockedWrapper = (Wrapped<T>) Mockito.mock(mockClass.get());
+                            Mockito.when(mockedWrapper.value()).thenReturn(replacement);
+                            return mockedWrapper;
+                        } else {
+                            var kotlinTC = JvmClassMappingKt.getKotlinClass(mockClass.get());
+                            Wrapped<T> mockedWrapper = (Wrapped<T>) MockKKt.mockkClass(kotlinTC, null, true, new KClass<?>[]{}, true, v -> null);
+                            MockKKt.every(mockKMatcherScope -> mockedWrapper.value()).returns(replacement);
+                            return mockedWrapper;
+                        }
+                    }
+
+                    return (Wrapped<T>) () -> replacement;
                 } else {
                     return replacement;
                 }

--- a/test/test-junit5/src/main/java/ru/tinkoff/kora/test/extension/junit5/KoraGraphModification.java
+++ b/test/test-junit5/src/main/java/ru/tinkoff/kora/test/extension/junit5/KoraGraphModification.java
@@ -76,7 +76,7 @@ public final class KoraGraphModification {
     @Nonnull
     public <T> KoraGraphModification replaceComponent(@Nonnull Type typeToReplace,
                                                       @Nonnull Supplier<? extends T> replacementSupplier) {
-        modifications.add(new GraphReplacementWithDeps<T>(g -> replacementSupplier.get(), new GraphCandidate(typeToReplace)));
+        modifications.add(new GraphReplacementNoDeps<>(g -> replacementSupplier.get(), new GraphCandidate(typeToReplace)));
         return this;
     }
 
@@ -90,7 +90,7 @@ public final class KoraGraphModification {
         if (tags.isEmpty()) {
             return replaceComponent(typeToReplace, replacementSupplier);
         } else {
-            modifications.add(new GraphReplacementWithDeps<T>(g -> replacementSupplier.get(), new GraphCandidate(typeToReplace, tags)));
+            modifications.add(new GraphReplacementNoDeps<T>(g -> replacementSupplier.get(), new GraphCandidate(typeToReplace, tags)));
             return this;
         }
     }

--- a/test/test-junit5/src/main/java/ru/tinkoff/kora/test/extension/junit5/KoraJUnit5Extension.java
+++ b/test/test-junit5/src/main/java/ru/tinkoff/kora/test/extension/junit5/KoraJUnit5Extension.java
@@ -707,8 +707,8 @@ final class KoraJUnit5Extension implements BeforeAllCallback, BeforeEachCallback
             var object = graph.refreshableGraph().get(node);
             boolean isNodeWrapped = GraphUtils.isWrapped(node.type());
             boolean isCandidateWrapped = GraphUtils.isWrapped(candidate.type());
-            if (isNodeWrapped && !isCandidateWrapped) {
-                return ((Wrapped<?>) object).value();
+            if (isNodeWrapped && !isCandidateWrapped && object instanceof Wrapped<?> w) {
+                return w.value();
             } else {
                 return object;
             }

--- a/test/test-junit5/src/main/java/ru/tinkoff/kora/test/extension/junit5/MockUtils.java
+++ b/test/test-junit5/src/main/java/ru/tinkoff/kora/test/extension/junit5/MockUtils.java
@@ -14,8 +14,7 @@ final class MockUtils {
     private static final boolean isMockitoAvailable = isClassPresent("org.mockito.internal.util.MockUtil");
     private static final boolean isMockkAvailable = isClassPresent("io.mockk.MockKKt");
 
-    private MockUtils() {
-    }
+    private MockUtils() { }
 
     private static boolean isClassPresent(String className) {
         try {
@@ -23,6 +22,14 @@ final class MockUtils {
         } catch (ClassNotFoundException e) {
             return false;
         }
+    }
+
+    static boolean isMockitoAvailable() {
+        return isMockitoAvailable;
+    }
+
+    static boolean isMockkAvailable() {
+        return isMockkAvailable;
     }
 
     static boolean haveKotlinReflect() {

--- a/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/replace/ReplaceComplexHolderDependencyTests.java
+++ b/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/replace/ReplaceComplexHolderDependencyTests.java
@@ -2,6 +2,8 @@ package ru.tinkoff.kora.test.extension.junit5.replace;
 
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import ru.tinkoff.kora.common.Tag;
 import ru.tinkoff.kora.test.extension.junit5.KoraAppTest;
 import ru.tinkoff.kora.test.extension.junit5.KoraAppTestGraphModifier;
 import ru.tinkoff.kora.test.extension.junit5.KoraGraphModification;
@@ -11,28 +13,26 @@ import ru.tinkoff.kora.test.extension.junit5.testdata.TestApplication;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @KoraAppTest(TestApplication.class)
-public class ReplaceWrappedTests implements KoraAppTestGraphModifier {
+public class ReplaceComplexHolderDependencyTests implements KoraAppTestGraphModifier {
 
+    @Tag(TestApplication.ComplexHolder.class)
     @TestComponent
-    private TestApplication.SomeWrapped someWrapped;
-    @TestComponent
-    private TestApplication.SomeContainer someContainer;
+    private String dep;
 
     @NotNull
     @Override
     public KoraGraphModification graph() {
         return KoraGraphModification.create()
-            .replaceComponent(TestApplication.SomeWrapped.class, () -> new TestApplication.SomeWrapped() {
-                @Override
-                public String toString() {
-                    return "12345";
-                }
+            .replaceComponent(TestApplication.ComplexHolder.class, () -> {
+                var mock = Mockito.mock(TestApplication.ComplexHolder.class);
+                Mockito.when(mock.other()).thenReturn("other");
+                Mockito.when(mock.value()).thenReturn(() -> "wrapped");
+                return mock;
             });
     }
 
     @Test
-    void wrappedReplaced() {
-        assertEquals("12345", someWrapped.toString());
-        assertEquals("12345", someContainer.wrapped().toString());
+    void holderDepReplaced() {
+        assertEquals("holder-wrapped-other", dep);
     }
 }

--- a/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/replace/ReplaceComplexHolderTests.java
+++ b/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/replace/ReplaceComplexHolderTests.java
@@ -2,6 +2,7 @@ package ru.tinkoff.kora.test.extension.junit5.replace;
 
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import ru.tinkoff.kora.test.extension.junit5.KoraAppTest;
 import ru.tinkoff.kora.test.extension.junit5.KoraAppTestGraphModifier;
 import ru.tinkoff.kora.test.extension.junit5.KoraGraphModification;
@@ -11,28 +12,24 @@ import ru.tinkoff.kora.test.extension.junit5.testdata.TestApplication;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @KoraAppTest(TestApplication.class)
-public class ReplaceWrappedTests implements KoraAppTestGraphModifier {
+public class ReplaceComplexHolderTests implements KoraAppTestGraphModifier {
 
     @TestComponent
-    private TestApplication.SomeWrapped someWrapped;
-    @TestComponent
-    private TestApplication.SomeContainer someContainer;
+    private TestApplication.ComplexHolder holder;
 
     @NotNull
     @Override
     public KoraGraphModification graph() {
         return KoraGraphModification.create()
-            .replaceComponent(TestApplication.SomeWrapped.class, () -> new TestApplication.SomeWrapped() {
-                @Override
-                public String toString() {
-                    return "12345";
-                }
+            .replaceComponent(TestApplication.ComplexHolder.class, () -> {
+                var mock = Mockito.mock(TestApplication.ComplexHolder.class);
+                Mockito.when(mock.other()).thenReturn("other");
+                return mock;
             });
     }
 
     @Test
-    void wrappedReplaced() {
-        assertEquals("12345", someWrapped.toString());
-        assertEquals("12345", someContainer.wrapped().toString());
+    void holderReplaced() {
+        assertEquals("other", holder.other());
     }
 }

--- a/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/replace/ReplaceComplexInterfaceHolderTests.java
+++ b/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/replace/ReplaceComplexInterfaceHolderTests.java
@@ -2,6 +2,8 @@ package ru.tinkoff.kora.test.extension.junit5.replace;
 
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import ru.tinkoff.kora.application.graph.TypeRef;
 import ru.tinkoff.kora.test.extension.junit5.KoraAppTest;
 import ru.tinkoff.kora.test.extension.junit5.KoraAppTestGraphModifier;
 import ru.tinkoff.kora.test.extension.junit5.KoraGraphModification;
@@ -11,28 +13,24 @@ import ru.tinkoff.kora.test.extension.junit5.testdata.TestApplication;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @KoraAppTest(TestApplication.class)
-public class ReplaceWrappedTests implements KoraAppTestGraphModifier {
+public class ReplaceComplexInterfaceHolderTests implements KoraAppTestGraphModifier {
 
     @TestComponent
-    private TestApplication.SomeWrapped someWrapped;
-    @TestComponent
-    private TestApplication.SomeContainer someContainer;
+    private TestApplication.ComplexInterfaceHolder<String> holder;
 
     @NotNull
     @Override
     public KoraGraphModification graph() {
         return KoraGraphModification.create()
-            .replaceComponent(TestApplication.SomeWrapped.class, () -> new TestApplication.SomeWrapped() {
-                @Override
-                public String toString() {
-                    return "12345";
-                }
+            .replaceComponent(TypeRef.of(TestApplication.ComplexInterfaceHolder.class, String.class), () -> {
+                var mock = Mockito.mock(TestApplication.ComplexInterfaceHolder.class);
+                Mockito.when(mock.other()).thenReturn("12345");
+                return mock;
             });
     }
 
     @Test
-    void wrappedReplaced() {
-        assertEquals("12345", someWrapped.toString());
-        assertEquals("12345", someContainer.wrapped().toString());
+    void holderReplaced() {
+        assertEquals("12345", holder.other());
     }
 }

--- a/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/replace/ReplaceComplexOtherDependencyTests.java
+++ b/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/replace/ReplaceComplexOtherDependencyTests.java
@@ -2,6 +2,7 @@ package ru.tinkoff.kora.test.extension.junit5.replace;
 
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
+import ru.tinkoff.kora.common.Tag;
 import ru.tinkoff.kora.test.extension.junit5.KoraAppTest;
 import ru.tinkoff.kora.test.extension.junit5.KoraAppTestGraphModifier;
 import ru.tinkoff.kora.test.extension.junit5.KoraGraphModification;
@@ -11,28 +12,21 @@ import ru.tinkoff.kora.test.extension.junit5.testdata.TestApplication;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @KoraAppTest(TestApplication.class)
-public class ReplaceWrappedTests implements KoraAppTestGraphModifier {
+public class ReplaceComplexOtherDependencyTests implements KoraAppTestGraphModifier {
 
+    @Tag(TestApplication.ComplexOther.class)
     @TestComponent
-    private TestApplication.SomeWrapped someWrapped;
-    @TestComponent
-    private TestApplication.SomeContainer someContainer;
+    private String dep;
 
     @NotNull
     @Override
     public KoraGraphModification graph() {
         return KoraGraphModification.create()
-            .replaceComponent(TestApplication.SomeWrapped.class, () -> new TestApplication.SomeWrapped() {
-                @Override
-                public String toString() {
-                    return "12345";
-                }
-            });
+            .replaceComponent(TestApplication.ComplexOther.class, () -> (TestApplication.ComplexOther) () -> "12345");
     }
 
     @Test
-    void wrappedReplaced() {
-        assertEquals("12345", someWrapped.toString());
-        assertEquals("12345", someContainer.wrapped().toString());
+    void otherDepReplaced() {
+        assertEquals("other-12345", dep);
     }
 }

--- a/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/replace/ReplaceComplexOtherTests.java
+++ b/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/replace/ReplaceComplexOtherTests.java
@@ -11,28 +11,20 @@ import ru.tinkoff.kora.test.extension.junit5.testdata.TestApplication;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @KoraAppTest(TestApplication.class)
-public class ReplaceWrappedTests implements KoraAppTestGraphModifier {
+public class ReplaceComplexOtherTests implements KoraAppTestGraphModifier {
 
     @TestComponent
-    private TestApplication.SomeWrapped someWrapped;
-    @TestComponent
-    private TestApplication.SomeContainer someContainer;
+    private TestApplication.ComplexOther other;
 
     @NotNull
     @Override
     public KoraGraphModification graph() {
         return KoraGraphModification.create()
-            .replaceComponent(TestApplication.SomeWrapped.class, () -> new TestApplication.SomeWrapped() {
-                @Override
-                public String toString() {
-                    return "12345";
-                }
-            });
+            .replaceComponent(TestApplication.ComplexOther.class, () -> (TestApplication.ComplexOther) () -> "12345");
     }
 
     @Test
-    void wrappedReplaced() {
-        assertEquals("12345", someWrapped.toString());
-        assertEquals("12345", someContainer.wrapped().toString());
+    void otherReplaced() {
+        assertEquals("12345", other.other());
     }
 }

--- a/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/replace/ReplaceComplexWrappedDependencyTests.java
+++ b/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/replace/ReplaceComplexWrappedDependencyTests.java
@@ -2,6 +2,7 @@ package ru.tinkoff.kora.test.extension.junit5.replace;
 
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
+import ru.tinkoff.kora.common.Tag;
 import ru.tinkoff.kora.test.extension.junit5.KoraAppTest;
 import ru.tinkoff.kora.test.extension.junit5.KoraAppTestGraphModifier;
 import ru.tinkoff.kora.test.extension.junit5.KoraGraphModification;
@@ -11,28 +12,21 @@ import ru.tinkoff.kora.test.extension.junit5.testdata.TestApplication;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @KoraAppTest(TestApplication.class)
-public class ReplaceWrappedTests implements KoraAppTestGraphModifier {
+public class ReplaceComplexWrappedDependencyTests implements KoraAppTestGraphModifier {
 
+    @Tag(TestApplication.ComplexWrapped.class)
     @TestComponent
-    private TestApplication.SomeWrapped someWrapped;
-    @TestComponent
-    private TestApplication.SomeContainer someContainer;
+    private String dep;
 
     @NotNull
     @Override
     public KoraGraphModification graph() {
         return KoraGraphModification.create()
-            .replaceComponent(TestApplication.SomeWrapped.class, () -> new TestApplication.SomeWrapped() {
-                @Override
-                public String toString() {
-                    return "12345";
-                }
-            });
+            .replaceComponent(TestApplication.ComplexWrapped.class, () -> (TestApplication.ComplexWrapped) () -> "12345");
     }
 
     @Test
-    void wrappedReplaced() {
-        assertEquals("12345", someWrapped.toString());
-        assertEquals("12345", someContainer.wrapped().toString());
+    void wrappedDepReplaced() {
+        assertEquals("wrapped-12345", dep);
     }
 }

--- a/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/replace/ReplaceComplexWrappedTests.java
+++ b/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/replace/ReplaceComplexWrappedTests.java
@@ -11,28 +11,20 @@ import ru.tinkoff.kora.test.extension.junit5.testdata.TestApplication;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @KoraAppTest(TestApplication.class)
-public class ReplaceWrappedTests implements KoraAppTestGraphModifier {
+public class ReplaceComplexWrappedTests implements KoraAppTestGraphModifier {
 
     @TestComponent
-    private TestApplication.SomeWrapped someWrapped;
-    @TestComponent
-    private TestApplication.SomeContainer someContainer;
+    private TestApplication.ComplexWrapped wrapped;
 
     @NotNull
     @Override
     public KoraGraphModification graph() {
         return KoraGraphModification.create()
-            .replaceComponent(TestApplication.SomeWrapped.class, () -> new TestApplication.SomeWrapped() {
-                @Override
-                public String toString() {
-                    return "12345";
-                }
-            });
+            .replaceComponent(TestApplication.ComplexWrapped.class, () -> (TestApplication.ComplexWrapped) () -> "12345");
     }
 
     @Test
     void wrappedReplaced() {
-        assertEquals("12345", someWrapped.toString());
-        assertEquals("12345", someContainer.wrapped().toString());
+        assertEquals("12345", wrapped.wrapped());
     }
 }

--- a/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/testdata/TestApplication.java
+++ b/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/testdata/TestApplication.java
@@ -1,8 +1,10 @@
 package ru.tinkoff.kora.test.extension.junit5.testdata;
 
+import ru.tinkoff.kora.application.graph.Lifecycle;
 import ru.tinkoff.kora.application.graph.LifecycleWrapper;
 import ru.tinkoff.kora.application.graph.Wrapped;
 import ru.tinkoff.kora.common.KoraApp;
+import ru.tinkoff.kora.common.Tag;
 import ru.tinkoff.kora.common.annotation.Root;
 
 import java.util.function.Function;
@@ -57,6 +59,56 @@ public interface TestApplication extends TestExtendModule {
     }
 
     @Root
+    default ComplexHolder complexWrap() {
+        return new ComplexHolder();
+    }
+
+    @Root
+    default ComplexInterfaceHolder<String> complexInterfaceStringWrap() {
+        return new ComplexInterfaceHolder<>() {
+
+            @Override
+            public void init() {}
+
+            @Override
+            public void release() {}
+
+            @Override
+            public String generic() {
+                return "1";
+            }
+
+            @Override
+            public ComplexWrapped value() {
+                return () -> "1";
+            }
+
+            @Override
+            public String other() {
+                return "1";
+            }
+        };
+    }
+
+    @Tag(ComplexHolder.class)
+    @Root
+    default String complexHolderDependency(ComplexHolder holder) {
+        return "holder-" + holder.value().wrapped() + "-" + holder.other();
+    }
+
+    @Tag(ComplexWrapped.class)
+    @Root
+    default String complexWrappedDependency(ComplexWrapped wrap) {
+        return "wrapped-" + wrap.wrapped();
+    }
+
+    @Tag(ComplexOther.class)
+    @Root
+    default String complexOtherDependency(ComplexOther other) {
+        return "other-" + other.other();
+    }
+
+    @Root
     default Function<String, Integer> consumerExample() {
         return (s) -> 1;
     }
@@ -72,6 +124,38 @@ public interface TestApplication extends TestExtendModule {
         public SomeContract value() {
             return () -> "1";
         }
+    }
+
+    class ComplexHolder implements Wrapped<ComplexWrapped>, Lifecycle, ComplexOther {
+
+        @Override
+        public void init() {}
+
+        @Override
+        public void release() {}
+
+        @Override
+        public ComplexWrapped value() {
+            return () -> "1";
+        }
+
+        @Override
+        public String other() {
+            return "1";
+        }
+    }
+
+    interface ComplexInterfaceHolder<T> extends Wrapped<ComplexWrapped>, Lifecycle, ComplexOther {
+
+        T generic();
+    }
+
+    interface ComplexWrapped {
+        String wrapped();
+    }
+
+    interface ComplexOther {
+        String other();
     }
 
     interface SomeContract {


### PR DESCRIPTION
JUnit test reinforced `Wrapped` support with complex type check and mocking if possible to exclude potential type misalignment when node type is more than just `Wrapped` and is indeed an instance and inherits `Wrapped` behavior