### PR TITLE
Database macros support for `@Column` type use and method argument pa…

### DIFF
--- a/database/database-annotation-processor/src/main/java/io/koraframework/database/annotation/processor/QueryMacrosParser.java
+++ b/database/database-annotation-processor/src/main/java/io/koraframework/database/annotation/processor/QueryMacrosParser.java
@@ -32,7 +32,7 @@ final class QueryMacrosParser {
 
     record Field(Element field, String column, String path, boolean isId) {}
 
-    record Target(DeclaredType type, String name) {}
+    record Target(DeclaredType type, String name, String column) {}
 
     public String parse(String sqlWithSyntax, DeclaredType repositoryType, ExecutableElement method) {
         var sqlBuilder = new StringBuilder();
@@ -144,6 +144,15 @@ final class QueryMacrosParser {
         }
     }
 
+    private List<Field> getFields(ExecutableElement method, Target target) {
+        final JdbcNativeType nativeType = JdbcNativeTypes.findNativeType(TypeName.get(target.type()));
+        if (nativeType != null && target.column() != null) {
+            return List.of(new Field(null, target.column(), target.name(), false));
+        }
+
+        return getPathField(method, target.type(), target.name(), "");
+    }
+
     private String getSubstitution(String targetAndCommand, DeclaredType repositoryType, ExecutableElement method) {
         try {
             var targetAndCmd = targetAndCommand.split("#");
@@ -168,8 +177,8 @@ final class QueryMacrosParser {
                 : Set.<String>of();
 
             var fields = paths.isEmpty()
-                ? getPathField(method, target.type(), target.name(), "")
-                : getPathField(method, target.type(), target.name(), "").stream()
+                ? getFields(method, target)
+                : getFields(method, target).stream()
                 .filter(f -> include == paths.contains(f.path()))
                 .toList();
 
@@ -261,9 +270,30 @@ final class QueryMacrosParser {
         }
 
         if (targetMirror instanceof DeclaredType dt) {
-            return new Target(dt, targetName);
+            return new Target(dt, targetName, getColumnName(method, targetName, targetMirror));
         } else {
             throw new ProcessingErrorException("Macros command unprocessable target type: " + targetName, method);
         }
+    }
+
+    private String getColumnName(ExecutableElement method, String targetName, TypeMirror targetMirror) {
+        if (!TARGET_RETURN.equals(targetName)) {
+            for (var parameter : method.getParameters()) {
+                if (parameter.getSimpleName().contentEquals(targetName)) {
+                    var column = AnnotationUtils.findAnnotation(parameter, DbUtils.COLUMN_ANNOTATION);
+                    var columnName = AnnotationUtils.<String>parseAnnotationValueWithoutDefault(column, "value");
+                    if (columnName != null && !columnName.isEmpty()) {
+                        return columnName;
+                    }
+                }
+            }
+        }
+
+        return targetMirror.getAnnotationMirrors().stream()
+            .filter(a -> DbUtils.COLUMN_ANNOTATION.equals(ClassName.get(a.getAnnotationType())))
+            .findFirst()
+            .map(a -> AnnotationUtils.<String>parseAnnotationValueWithoutDefault(a, "value"))
+            .filter(columnName -> !columnName.isEmpty())
+            .orElse(null);
     }
 }

--- a/database/database-annotation-processor/src/main/java/io/koraframework/database/annotation/processor/QueryMacrosParser.java
+++ b/database/database-annotation-processor/src/main/java/io/koraframework/database/annotation/processor/QueryMacrosParser.java
@@ -258,6 +258,10 @@ final class QueryMacrosParser {
             }
 
             if (targetMirror == null) {
+                var genericTarget = getTypeParameterTarget(repositoryType, method, targetName);
+                if (genericTarget != null) {
+                    return genericTarget;
+                }
                 throw new ProcessingErrorException("Macros command unspecified target received: " + targetName, method);
             }
 
@@ -274,6 +278,46 @@ final class QueryMacrosParser {
         } else {
             throw new ProcessingErrorException("Macros command unprocessable target type: " + targetName, method);
         }
+    }
+
+    private Target getTypeParameterTarget(DeclaredType repositoryType, ExecutableElement method, String targetName) {
+        var methodType = (ExecutableType) this.types.asMemberOf(repositoryType, method);
+        var parameters = method.getParameters();
+        for (int i = 0; i < parameters.size(); i++) {
+            var parameter = parameters.get(i);
+            if (parameter.asType() instanceof javax.lang.model.type.TypeVariable typeVariable
+                && typeVariable.asElement().getSimpleName().contentEquals(targetName)) {
+                var type = methodType.getParameterTypes().get(i);
+                if (type instanceof DeclaredType dt) {
+                    return new Target(dt, parameter.getSimpleName().toString(), getColumnName(method, targetName, type));
+                }
+                throw new ProcessingErrorException("Macros command unprocessable target type: " + targetName, method);
+            }
+        }
+
+        if (method.getEnclosingElement() instanceof TypeElement enclosingType) {
+            for (var typeParameter : enclosingType.getTypeParameters()) {
+                if (typeParameter.getSimpleName().contentEquals(targetName)) {
+                    var type = this.types.asMemberOf(repositoryType, typeParameter);
+                    if (type instanceof DeclaredType dt) {
+                        return new Target(dt, targetName, getColumnName(method, targetName, type));
+                    }
+                    throw new ProcessingErrorException("Macros command unprocessable target type: " + targetName, method);
+                }
+            }
+        }
+
+        for (var typeParameter : method.getTypeParameters()) {
+            if (typeParameter.getSimpleName().contentEquals(targetName)) {
+                var type = this.types.asMemberOf(repositoryType, typeParameter);
+                if (type instanceof DeclaredType dt) {
+                    return new Target(dt, targetName, getColumnName(method, targetName, type));
+                }
+                throw new ProcessingErrorException("Macros command unprocessable target type: " + targetName, method);
+            }
+        }
+
+        return null;
     }
 
     private String getColumnName(ExecutableElement method, String targetName, TypeMirror targetMirror) {

--- a/database/database-annotation-processor/src/test/java/io/koraframework/database/common/annotation/processor/jdbc/JdbcMacrosTest.java
+++ b/database/database-annotation-processor/src/test/java/io/koraframework/database/common/annotation/processor/jdbc/JdbcMacrosTest.java
@@ -439,4 +439,32 @@ final class JdbcMacrosTest extends AbstractJdbcRepositoryTest {
         repository.invoke("insert", newGeneratedObject("Entity", "1", 1, "1", "1").get());
         verify(executor.mockConnection).prepareStatement("UPDATE entities SET value1 = ? WHERE id = ?");
     }
+
+    @Test
+    void typeUseColumnArgumentWhere() throws SQLException {
+        var repository = compileJdbc(List.of(newGeneratedObject("TestRowMapper")), """
+            @Repository
+            public interface TestRepository extends AbstractJdbcRepository<@Column("id") String, TestRepository.Entity> {
+
+                @Table("entities")
+                record Entity(@Id String id, @Column("value1") int field1, String value2, @Nullable String value3) {}
+            }
+            """, """
+            public interface AbstractJdbcRepository<K, V> extends JdbcRepository {
+
+                @Query("SELECT %{return#selects} FROM %{return#table} WHERE %{keyArg#where}")
+                @Nullable
+                V findById(K keyArg);
+            }
+            """, """
+            public class TestRowMapper implements JdbcResultSetMapper<TestRepository.Entity> {
+                public TestRepository.Entity apply(ResultSet rs) {
+                  return null;
+                }
+            }
+            """);
+
+        repository.invoke("findById", "1");
+        verify(executor.mockConnection).prepareStatement("SELECT id, value1, value2, value3 FROM entities WHERE id = ?");
+    }
 }

--- a/database/database-annotation-processor/src/test/java/io/koraframework/database/common/annotation/processor/jdbc/JdbcMacrosTest.java
+++ b/database/database-annotation-processor/src/test/java/io/koraframework/database/common/annotation/processor/jdbc/JdbcMacrosTest.java
@@ -467,4 +467,60 @@ final class JdbcMacrosTest extends AbstractJdbcRepositoryTest {
         repository.invoke("findById", "1");
         verify(executor.mockConnection).prepareStatement("SELECT id, value1, value2, value3 FROM entities WHERE id = ?");
     }
+
+    @Test
+    void genericTypeArgumentSelectsAndTable() throws SQLException {
+        var repository = compileJdbc(List.of(newGeneratedObject("TestRowMapper")), """
+            @Repository
+            public interface TestRepository extends AbstractJdbcRepository<TestRepository.Entity> {
+
+                @Table("entities")
+                record Entity(@Id String id, @Column("value1") int field1, String value2, @Nullable String value3) {}
+            }
+            """, """
+            public interface AbstractJdbcRepository<V> extends JdbcRepository {
+
+                @Query("SELECT %{V#selects} FROM %{V#table}")
+                @Nullable
+                V findOne();
+            }
+            """, """
+            public class TestRowMapper implements JdbcResultSetMapper<TestRepository.Entity> {
+                public TestRepository.Entity apply(ResultSet rs) {
+                  return null;
+                }
+            }
+            """);
+
+        repository.invoke("findOne");
+        verify(executor.mockConnection).prepareStatement("SELECT id, value1, value2, value3 FROM entities");
+    }
+
+    @Test
+    void genericTypeArgumentWhereId() throws SQLException {
+        var repository = compileJdbc(List.of(newGeneratedObject("TestRowMapper")), """
+            @Repository
+            public interface TestRepository extends AbstractJdbcRepository<TestRepository.Entity> {
+
+                @Table("entities")
+                record Entity(@Id String id, @Column("value1") int field1, String value2, @Nullable String value3) {}
+            }
+            """, """
+            public interface AbstractJdbcRepository<V> extends JdbcRepository {
+
+                @Query("SELECT %{V#selects} FROM %{V#table} WHERE %{V#where = @id}")
+                @Nullable
+                V findByEntity(V entity);
+            }
+            """, """
+            public class TestRowMapper implements JdbcResultSetMapper<TestRepository.Entity> {
+                public TestRepository.Entity apply(ResultSet rs) {
+                  return null;
+                }
+            }
+            """);
+
+        repository.invoke("findByEntity", newGeneratedObject("TestRepository$Entity", "1", 1, "1", "1").get());
+        verify(executor.mockConnection).prepareStatement("SELECT id, value1, value2, value3 FROM entities WHERE id = ?");
+    }
 }

--- a/database/database-common/src/main/java/io/koraframework/database/common/annotation/Column.java
+++ b/database/database-common/src/main/java/io/koraframework/database/common/annotation/Column.java
@@ -21,7 +21,7 @@ import java.lang.annotation.Target;
  * @see Table
  * @see Repository
  */
-@Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.RECORD_COMPONENT})
+@Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.RECORD_COMPONENT, ElementType.TYPE_USE})
 @Retention(RetentionPolicy.CLASS)
 public @interface Column {
 

--- a/database/database-common/src/main/java/io/koraframework/database/common/annotation/Table.java
+++ b/database/database-common/src/main/java/io/koraframework/database/common/annotation/Table.java
@@ -20,7 +20,7 @@ import java.lang.annotation.Target;
  *
  * @see Repository
  */
-@Target({ElementType.TYPE, ElementType.TYPE_USE})
+@Target({ElementType.TYPE})
 @Retention(RetentionPolicy.CLASS)
 public @interface Table {
 

--- a/database/database-common/src/main/java/io/koraframework/database/common/annotation/Table.java
+++ b/database/database-common/src/main/java/io/koraframework/database/common/annotation/Table.java
@@ -20,7 +20,7 @@ import java.lang.annotation.Target;
  *
  * @see Repository
  */
-@Target({ElementType.TYPE})
+@Target({ElementType.TYPE, ElementType.TYPE_USE})
 @Retention(RetentionPolicy.CLASS)
 public @interface Table {
 

--- a/database/database-symbol-processor/src/main/kotlin/io/koraframework/database/symbol/processor/QueryMacrosParser.kt
+++ b/database/database-symbol-processor/src/main/kotlin/io/koraframework/database/symbol/processor/QueryMacrosParser.kt
@@ -1,8 +1,11 @@
 package io.koraframework.database.symbol.processor
 
 import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSFunction
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
+import com.google.devtools.ksp.symbol.KSType
+import com.google.devtools.ksp.symbol.KSTypeParameter
 import com.google.devtools.ksp.symbol.KSTypeReference
 import com.squareup.kotlinpoet.ksp.toClassName
 import com.squareup.kotlinpoet.ksp.toTypeName
@@ -30,7 +33,7 @@ class QueryMacrosParser {
     data class Target(val type: KSClassDeclaration, val name: String, val column: String?)
     data class Field(val field: KSPropertyDeclaration?, val column: String, val path: String, val isId: Boolean)
 
-    fun parse(sql: String, method: KSFunctionDeclaration): String {
+    fun parse(sql: String, method: KSFunctionDeclaration, methodType: KSFunction, repositoryType: KSType): String {
         val sqlBuilder = StringBuilder()
         var prevCmdIndex = 0
         while (true) {
@@ -40,7 +43,7 @@ class QueryMacrosParser {
             }
             val cmdIndexEnd = sql.indexOf(MACROS_END, cmdIndexStart)
             val targetAndCmdAsStr = sql.substring(cmdIndexStart + 2, cmdIndexEnd)
-            val substitution = getSubstitution(targetAndCmdAsStr, method)
+            val substitution = getSubstitution(targetAndCmdAsStr, method, methodType, repositoryType)
             sqlBuilder.append(sql, prevCmdIndex, cmdIndexStart).append(substitution)
             prevCmdIndex = cmdIndexEnd + 1
         }
@@ -140,7 +143,7 @@ class QueryMacrosParser {
 
     private fun parseDataClassFields(typeDecl: KSClassDeclaration) = typeDecl.getAllProperties()
 
-    private fun getSubstitution(targetAndCommand: String, method: KSFunctionDeclaration): String {
+    private fun getSubstitution(targetAndCommand: String, method: KSFunctionDeclaration, methodType: KSFunction, repositoryType: KSType): String {
         try {
             val targetAndCmd = targetAndCommand.split("#".toRegex()).dropLastWhile { it.isEmpty() }.toList()
             if (targetAndCmd.size == 1) {
@@ -149,7 +152,7 @@ class QueryMacrosParser {
                     method
                 )
             }
-            val target = getTarget(targetAndCmd[0].trim(), method)
+            val target = getTarget(targetAndCmd[0].trim(), method, methodType, repositoryType)
             var selectors = targetAndCmd[1].split("-=".toRegex()).dropLastWhile { it.isEmpty() }
                 .toTypedArray()
             val include: Boolean
@@ -199,8 +202,9 @@ class QueryMacrosParser {
         }
     }
 
-    private fun getTarget(targetName: String, method: KSFunctionDeclaration): Target {
-        val reference: KSTypeReference
+    private fun getTarget(targetName: String, method: KSFunctionDeclaration, methodType: KSFunction, repositoryType: KSType): Target {
+        var reference: KSTypeReference? = null
+        var type: KSType? = null
 
         if (TARGET_RETURN == targetName) {
             if (method.isVoid()) {
@@ -216,34 +220,44 @@ class QueryMacrosParser {
             }
 
             val resolved = method.returnType!!.resolve()
-            reference = if (method.isCompletionStage() || method.isMono() || method.isFlux() || resolved.isCollection()) {
-                resolved.arguments[0].type!!
+            if (method.isCompletionStage() || method.isMono() || method.isFlux() || resolved.isCollection()) {
+                reference = resolved.arguments[0].type
+                type = methodType.returnType!!.arguments[0].type!!.resolve()
             } else {
-                method.returnType!!
+                reference = method.returnType
+                type = methodType.returnType
             }
         } else {
-            reference = method.parameters.stream()
-                .filter { p -> p.name!!.asString().contentEquals(targetName) }
-                .findFirst()
-                .map { obj ->
-                    val resolved = obj.type.resolve()
+            for (i in method.parameters.indices) {
+                val parameter = method.parameters[i]
+                if (parameter.name!!.asString().contentEquals(targetName)) {
+                    val resolved = parameter.type.resolve()
                     if (resolved.isCollection()) {
-                        resolved.arguments[0].type!!
+                        reference = resolved.arguments[0].type
+                        type = methodType.parameterTypes[i]!!.arguments[0].type!!.resolve()
                     } else {
-                        obj.type
+                        reference = parameter.type
+                        type = methodType.parameterTypes[i]
                     }
+                    break
                 }
-                .orElseThrow {
-                    ProcessingErrorException(
-                        "Macros command unspecified target received: $targetName",
-                        method
-                    )
+            }
+
+            if (type == null) {
+                val genericType = getGenericTarget(targetName, method, methodType, repositoryType)
+                if (genericType != null) {
+                    return genericType
                 }
+                throw ProcessingErrorException(
+                    "Macros command unspecified target received: $targetName",
+                    method
+                )
+            }
         }
 
-        val resolved = reference.resolve().declaration
+        val resolved = type!!.declaration
         return if (resolved is KSClassDeclaration) {
-            Target(resolved, targetName, getColumnName(method, targetName, reference))
+            Target(resolved, targetName, getColumnName(method, targetName, reference, type))
         } else {
             throw ProcessingErrorException(
                 "Macros command unprocessable target type: $targetName",
@@ -252,17 +266,111 @@ class QueryMacrosParser {
         }
     }
 
-    private fun getColumnName(method: KSFunctionDeclaration, targetName: String, typeReference: KSTypeReference): String? {
+    private fun getGenericTarget(targetName: String, method: KSFunctionDeclaration, methodType: KSFunction, repositoryType: KSType): Target? {
+        getTypeParameterTargetName(method.returnType)?.takeIf { it == targetName }?.let {
+            val type = unwrapReturnType(method, methodType.returnType!!)
+            return targetFromType(targetName, type)
+        }
+
+        for (i in method.parameters.indices) {
+            val parameterTargetName = getTypeParameterTargetName(method.parameters[i].type)
+                ?: (methodType.parameterTypes[i]?.declaration as? KSTypeParameter)?.name?.asString()
+            parameterTargetName?.takeIf { it == targetName }?.let {
+                val type = unwrapParameterType(method.parameters[i].type.resolve(), methodType.parameterTypes[i]!!)
+                return targetFromType(method.parameters[i].name!!.asString(), type)
+            }
+        }
+
+        findGenericArgument(repositoryType, targetName)?.let {
+            val parameter = method.parameters.firstOrNull { parameter ->
+                parameter.type.resolve().declaration == it.declaration
+            }
+            return targetFromType(parameter?.name?.asString() ?: targetName, it)
+        }
+
+        val parent = method.parentDeclaration
+        if (parent is KSClassDeclaration) {
+            parent.typeParameters.firstOrNull { it.name.asString() == targetName } ?: return null
+        } else {
+            return null
+        }
+
+        val superType = findSuperType(repositoryType, parent) ?: return null
+        val index = parent.typeParameters.indexOfFirst { it.name.asString() == targetName }
+        val type = superType.arguments.getOrNull(index)?.type?.resolve() ?: return null
+        return targetFromType(targetName, type)
+    }
+
+    private fun findGenericArgument(type: KSType, targetName: String): KSType? {
+        val declaration = type.declaration as? KSClassDeclaration ?: return null
+        val index = declaration.typeParameters.indexOfFirst { it.name.asString() == targetName }
+        if (index >= 0) {
+            return type.arguments.getOrNull(index)?.type?.resolve()
+        }
+
+        return declaration.superTypes
+            .map { it.resolve() }
+            .firstNotNullOfOrNull { findGenericArgument(it, targetName) }
+    }
+
+    private fun targetFromType(targetName: String, type: KSType): Target {
+        val resolved = type.declaration
+        return if (resolved is KSClassDeclaration) {
+            Target(resolved, targetName, getColumnName(method = null, targetName, typeReference = null, type))
+        } else {
+            throw ProcessingErrorException("Macros command unprocessable target type: $targetName", resolved)
+        }
+    }
+
+    private fun getTypeParameterTargetName(typeReference: KSTypeReference?): String? {
+        val declaration = typeReference?.resolve()?.declaration
+        return if (declaration is KSTypeParameter) {
+            declaration.name.asString()
+        } else {
+            null
+        }
+    }
+
+    private fun unwrapReturnType(method: KSFunctionDeclaration, returnType: KSType): KSType {
+        val original = method.returnType!!.resolve()
+        return if (method.isCompletionStage() || method.isMono() || method.isFlux() || original.isCollection()) {
+            returnType.arguments[0].type!!.resolve()
+        } else {
+            returnType
+        }
+    }
+
+    private fun unwrapParameterType(originalType: KSType, parameterType: KSType): KSType {
+        return if (originalType.isCollection()) {
+            parameterType.arguments[0].type!!.resolve()
+        } else {
+            parameterType
+        }
+    }
+
+    private fun findSuperType(type: KSType, expectedDeclaration: KSClassDeclaration): KSType? {
+        if (type.declaration == expectedDeclaration) {
+            return type
+        }
+
+        val declaration = type.declaration as? KSClassDeclaration ?: return null
+        return declaration.superTypes
+            .map { it.resolve() }
+            .firstNotNullOfOrNull { findSuperType(it, expectedDeclaration) }
+    }
+
+    private fun getColumnName(method: KSFunctionDeclaration?, targetName: String, typeReference: KSTypeReference?, type: KSType): String? {
         if (TARGET_RETURN != targetName) {
-            method.parameters
-                .firstOrNull { it.name!!.asString().contentEquals(targetName) }
+            method?.parameters
+                ?.asSequence()
+                ?.firstOrNull { it.name!!.asString().contentEquals(targetName) }
                 ?.findAnnotation(DbUtils.columnAnnotation)
                 ?.findValueNoDefault<String>("value")
                 ?.takeIf { it.isNotEmpty() }
                 ?.let { return it }
         }
 
-        return typeReference.resolve().annotations
+        return (typeReference?.resolve()?.annotations ?: type.annotations)
             .firstOrNull { DbUtils.columnAnnotation == (it.annotationType.resolve().declaration as KSClassDeclaration).toClassName() }
             ?.findValueNoDefault<String>("value")
             ?.takeIf { it.isNotEmpty() }

--- a/database/database-symbol-processor/src/main/kotlin/io/koraframework/database/symbol/processor/QueryMacrosParser.kt
+++ b/database/database-symbol-processor/src/main/kotlin/io/koraframework/database/symbol/processor/QueryMacrosParser.kt
@@ -27,8 +27,8 @@ class QueryMacrosParser {
         private const val SPECIAL_ID = "@id"
     }
 
-    data class Target(val type: KSClassDeclaration, val name: String)
-    data class Field(val field: KSPropertyDeclaration, val column: String, val path: String, val isId: Boolean)
+    data class Target(val type: KSClassDeclaration, val name: String, val column: String?)
+    data class Field(val field: KSPropertyDeclaration?, val column: String, val path: String, val isId: Boolean)
 
     fun parse(sql: String, method: KSFunctionDeclaration): String {
         val sqlBuilder = StringBuilder()
@@ -87,6 +87,15 @@ class QueryMacrosParser {
         } else {
             return columnPrefix + nameConverter.convert(field.simpleName.asString())
         }
+    }
+
+    private fun getFields(method: KSFunctionDeclaration, target: Target): List<Field> {
+        val nativeType = JdbcNativeTypes.findNativeType(target.type.toClassName())
+        if (nativeType != null && target.column != null) {
+            return listOf(Field(field = null, column = target.column, path = target.name, isId = false))
+        }
+
+        return getPathField(method, target.type, target.name, "").toList()
     }
 
     private fun getCommandSelectorPaths(type: KSClassDeclaration, rootPath: String, selects: String): Set<String> {
@@ -158,9 +167,9 @@ class QueryMacrosParser {
                 setOf()
 
             val fields = if (paths.isEmpty()) {
-                getPathField(method, target.type, target.name, "").toList()
+                getFields(method, target)
             } else {
-                getPathField(method, target.type, target.name, "").filter { include == paths.contains(it.path) }.toList()
+                getFields(method, target).filter { include == paths.contains(it.path) }
             }
 
             val nameConverter = target.type.getNameConverter(snakeCaseNameConverter)
@@ -234,12 +243,28 @@ class QueryMacrosParser {
 
         val resolved = reference.resolve().declaration
         return if (resolved is KSClassDeclaration) {
-            Target(resolved, targetName)
+            Target(resolved, targetName, getColumnName(method, targetName, reference))
         } else {
             throw ProcessingErrorException(
                 "Macros command unprocessable target type: $targetName",
                 method
             )
         }
+    }
+
+    private fun getColumnName(method: KSFunctionDeclaration, targetName: String, typeReference: KSTypeReference): String? {
+        if (TARGET_RETURN != targetName) {
+            method.parameters
+                .firstOrNull { it.name!!.asString().contentEquals(targetName) }
+                ?.findAnnotation(DbUtils.columnAnnotation)
+                ?.findValueNoDefault<String>("value")
+                ?.takeIf { it.isNotEmpty() }
+                ?.let { return it }
+        }
+
+        return typeReference.resolve().annotations
+            .firstOrNull { DbUtils.columnAnnotation == (it.annotationType.resolve().declaration as KSClassDeclaration).toClassName() }
+            ?.findValueNoDefault<String>("value")
+            ?.takeIf { it.isNotEmpty() }
     }
 }

--- a/database/database-symbol-processor/src/main/kotlin/io/koraframework/database/symbol/processor/QueryWithParameters.kt
+++ b/database/database-symbol-processor/src/main/kotlin/io/koraframework/database/symbol/processor/QueryWithParameters.kt
@@ -1,6 +1,8 @@
 package io.koraframework.database.symbol.processor
 
+import com.google.devtools.ksp.symbol.KSFunction
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.google.devtools.ksp.symbol.KSType
 import io.koraframework.ksp.common.exception.ProcessingErrorException
 import java.io.BufferedInputStream
 import java.nio.charset.Charset
@@ -32,7 +34,13 @@ data class QueryWithParameters(val rawQuery: String, val parameters: List<QueryP
 
     companion object {
 
-        fun parse(rq: String, parameters: List<io.koraframework.database.symbol.processor.model.QueryParameter>, method: KSFunctionDeclaration): QueryWithParameters {
+        fun parse(
+            rq: String,
+            parameters: List<io.koraframework.database.symbol.processor.model.QueryParameter>,
+            method: KSFunctionDeclaration,
+            methodType: KSFunction,
+            repositoryType: KSType
+        ): QueryWithParameters {
             val params = mutableListOf<QueryParameter>()
             var rawSql = rq
             if (rawSql.startsWith("classpath:/")) {
@@ -45,7 +53,7 @@ data class QueryWithParameters(val rawQuery: String, val parameters: List<QueryP
             rawSql = rawSql.trim()
 
             val parser = QueryMacrosParser()
-            rawSql = parser.parse(rawSql, method)
+            rawSql = parser.parse(rawSql, method, methodType, repositoryType)
 
             parameters.forEachIndexed { i, _parameter ->
                 var parameter = _parameter

--- a/database/database-symbol-processor/src/main/kotlin/io/koraframework/database/symbol/processor/cassandra/CassandraRepositoryGenerator.kt
+++ b/database/database-symbol-processor/src/main/kotlin/io/koraframework/database/symbol/processor/cassandra/CassandraRepositoryGenerator.kt
@@ -46,10 +46,10 @@ class CassandraRepositoryGenerator(private val resolver: Resolver) : RepositoryG
         var methodCounter = 1
         for (method in repositoryType.findQueryMethods()) {
             val methodType = method.asMemberOf(repositoryResolvedType)
-            val parameters = QueryParameterParser.parse(CassandraTypes.connection, CassandraTypes.parameterColumnMapper, method, methodType)
+            val parameters = QueryParameterParser.parse(CassandraTypes.connection, CassandraTypes.parameterColumnMapper, method, methodType, repositoryResolvedType)
             val queryAnnotation = method.findAnnotation(DbUtils.queryAnnotation)!!
             val queryString = queryAnnotation.findValue<String>("value")!!
-            val query = QueryWithParameters.parse(queryString, parameters, method)
+            val query = QueryWithParameters.parse(queryString, parameters, method, methodType, repositoryResolvedType)
             val resultMapper = this.parseResultMapper(method, parameters, methodType)?.let { resultMappers.addMapper(it) }
             DbUtils.parseParameterMappers(method, parameters, query, CassandraTypes.parameterColumnMapper) { CassandraNativeTypes.findNativeType(it.toTypeName()) != null }
                 .forEach { parameterMappers.addMapper(it) }

--- a/database/database-symbol-processor/src/main/kotlin/io/koraframework/database/symbol/processor/jdbc/JdbcRepositoryGenerator.kt
+++ b/database/database-symbol-processor/src/main/kotlin/io/koraframework/database/symbol/processor/jdbc/JdbcRepositoryGenerator.kt
@@ -49,10 +49,10 @@ class JdbcRepositoryGenerator(private val resolver: Resolver) : RepositoryGenera
         var methodCounter = 1
         for (method in queryMethods) {
             val methodType = method.asMemberOf(repositoryResolvedType)
-            val parameters = QueryParameterParser.parse(JdbcTypes.connection, JdbcTypes.jdbcParameterColumnMapper, method, methodType)
+            val parameters = QueryParameterParser.parse(JdbcTypes.connection, JdbcTypes.jdbcParameterColumnMapper, method, methodType, repositoryResolvedType)
             val queryAnnotation = method.findAnnotation(DbUtils.queryAnnotation)!!
             val queryString = queryAnnotation.findValue<String>("value")!!
-            val query = QueryWithParameters.parse(queryString, parameters, method)
+            val query = QueryWithParameters.parse(queryString, parameters, method, methodType, repositoryResolvedType)
             val resultMapper = this.parseResultMapper(method, parameters, methodType)?.let { resultMappers.addMapper(it) }
             DbUtils.parseParameterMappers(method, parameters, query, JdbcTypes.jdbcParameterColumnMapper) { JdbcNativeTypes.findNativeType(it.toTypeName()) != null }
                 .forEach { parameterMappers.addMapper(it) }

--- a/database/database-symbol-processor/src/main/kotlin/io/koraframework/database/symbol/processor/model/QueryParameterParser.kt
+++ b/database/database-symbol-processor/src/main/kotlin/io/koraframework/database/symbol/processor/model/QueryParameterParser.kt
@@ -1,8 +1,11 @@
 package io.koraframework.database.symbol.processor.model
 
+import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSFunction
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.google.devtools.ksp.symbol.KSType
+import com.google.devtools.ksp.symbol.KSTypeParameter
+import com.google.devtools.ksp.symbol.KSTypeReference
 import com.google.devtools.ksp.symbol.KSValueParameter
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.ParameterizedTypeName
@@ -19,13 +22,55 @@ object QueryParameterParser {
         return parse(listOf(connectionType), parameterMapperType, method, methodType)
     }
 
+    fun parse(connectionType: ClassName, parameterMapperType: ClassName, method: KSFunctionDeclaration, methodType: KSFunction, repositoryType: KSType): List<QueryParameter> {
+        return parse(listOf(connectionType), parameterMapperType, method, methodType, repositoryType)
+    }
+
     fun parse(connectionTypes: List<ClassName>, parameterMapperType: ClassName, method: KSFunctionDeclaration, methodType: KSFunction): List<QueryParameter> {
+        return parse(connectionTypes, parameterMapperType, method, methodType, null)
+    }
+
+    fun parse(connectionTypes: List<ClassName>, parameterMapperType: ClassName, method: KSFunctionDeclaration, methodType: KSFunction, repositoryType: KSType?): List<QueryParameter> {
         val result = ArrayList<QueryParameter>(method.parameters.size)
         for (i in method.parameters.indices) {
-            val parameter = this.parse(connectionTypes, parameterMapperType, method.parameters[i], methodType.parameterTypes[i]!!)
+            val type = resolveTypeParameter(methodType.parameterTypes[i]!!, repositoryType, method.parameters[i].type)
+            val parameter = this.parse(connectionTypes, parameterMapperType, method.parameters[i], type)
             result.add(parameter)
         }
         return result
+    }
+
+    private fun resolveTypeParameter(type: KSType, repositoryType: KSType?, originalType: KSTypeReference): KSType {
+        if (repositoryType == null) {
+            return type
+        }
+
+        val declaration = originalType.resolve().declaration
+        if (declaration is KSClassDeclaration) {
+            return originalType.resolve()
+        }
+        val typeParameter = if (declaration is KSTypeParameter) {
+            declaration
+        } else {
+            type.declaration as? KSTypeParameter
+        }
+        if (typeParameter == null) {
+            return type
+        }
+
+        return findGenericArgument(repositoryType, typeParameter.name.asString()) ?: type
+    }
+
+    private fun findGenericArgument(type: KSType, targetName: String): KSType? {
+        val declaration = type.declaration as? KSClassDeclaration ?: return null
+        val index = declaration.typeParameters.indexOfFirst { it.name.asString() == targetName }
+        if (index >= 0) {
+            return type.arguments.getOrNull(index)?.type?.resolve()
+        }
+
+        return declaration.superTypes
+            .map { it.resolve() }
+            .firstNotNullOfOrNull { findGenericArgument(it, targetName) }
     }
 
     private fun parse(connectionTypes: List<ClassName>, parameterMapperType: ClassName, parameter: KSValueParameter, type: KSType): QueryParameter {

--- a/database/database-symbol-processor/src/test/kotlin/io/koraframework/database/symbol/processor/jdbc/JdbcMacrosTest.kt
+++ b/database/database-symbol-processor/src/test/kotlin/io/koraframework/database/symbol/processor/jdbc/JdbcMacrosTest.kt
@@ -596,4 +596,36 @@ class JdbcMacrosTest : AbstractJdbcRepositoryTest() {
         repository.invoke<Any>("insert", newGenerated("Entity", "1", 1, "1", "1").invoke())
         Mockito.verify(executor.mockConnection).prepareStatement("UPDATE entities SET value1 = ? WHERE id = ?")
     }
+
+    @Test
+    fun typeUseColumnArgumentWhere() {
+        val repository = compile(
+            listOf(newGenerated("TestRowMapper")), """
+            interface AbstractJdbcRepository<K, V> : JdbcRepository {
+
+                @Query("SELECT %{return#selects} FROM %{return#table} WHERE %{keyArg#where}")
+                fun findById(keyArg: K): V?
+            }
+
+            @Repository
+            interface TestRepository : AbstractJdbcRepository<@Column("id") String, TestRepository.Entity> {
+
+                @Table("entities")
+                data class Entity(@field:Id val id: String,
+                                  @field:Column("value1") val field1: Long,
+                                  val value2: String,
+                                  val value3: String?)
+            }
+            """.trimIndent(), """
+            class TestRowMapper : JdbcResultSetMapper<TestRepository.Entity?> {
+                override fun apply(rs: ResultSet): TestRepository.Entity? {
+                  return null
+                }
+            }
+            """.trimIndent()
+        )
+        repository.invoke<Any>("findById", "1")
+        Mockito.verify(executor.mockConnection)
+            .prepareStatement("SELECT id, value1, value2, value3 FROM entities WHERE id = ?")
+    }
 }

--- a/database/database-symbol-processor/src/test/kotlin/io/koraframework/database/symbol/processor/jdbc/JdbcMacrosTest.kt
+++ b/database/database-symbol-processor/src/test/kotlin/io/koraframework/database/symbol/processor/jdbc/JdbcMacrosTest.kt
@@ -628,4 +628,68 @@ class JdbcMacrosTest : AbstractJdbcRepositoryTest() {
         Mockito.verify(executor.mockConnection)
             .prepareStatement("SELECT id, value1, value2, value3 FROM entities WHERE id = ?")
     }
+
+    @Test
+    fun genericTypeArgumentSelectsAndTable() {
+        val repository = compile(
+            listOf(newGenerated("TestRowMapper")), """
+            interface AbstractJdbcRepository<V> : JdbcRepository {
+
+                @Query("SELECT %{V#selects} FROM %{V#table}")
+                fun findOne(): V?
+            }
+
+            @Repository
+            interface TestRepository : AbstractJdbcRepository<TestRepository.Entity> {
+
+                @Table("entities")
+                data class Entity(@field:Id val id: String,
+                                  @field:Column("value1") val field1: Long,
+                                  val value2: String,
+                                  val value3: String?)
+            }
+            """.trimIndent(), """
+            class TestRowMapper : JdbcResultSetMapper<TestRepository.Entity?> {
+                override fun apply(rs: ResultSet): TestRepository.Entity? {
+                  return null
+                }
+            }
+            """.trimIndent()
+        )
+        repository.invoke<Any>("findOne")
+        Mockito.verify(executor.mockConnection)
+            .prepareStatement("SELECT id, value1, value2, value3 FROM entities")
+    }
+
+    @Test
+    fun genericTypeArgumentWhereId() {
+        val repository = compile(
+            listOf(newGenerated("TestRowMapper")), """
+            interface AbstractJdbcRepository<V> : JdbcRepository {
+
+                @Query("SELECT %{V#selects} FROM %{V#table} WHERE %{V#where = @id}")
+                fun findByEntity(entity: V): V?
+            }
+
+            @Repository
+            interface TestRepository : AbstractJdbcRepository<TestRepository.Entity> {
+
+                @Table("entities")
+                data class Entity(@field:Id val id: String,
+                                  @field:Column("value1") val field1: Long,
+                                  val value2: String,
+                                  val value3: String?)
+            }
+            """.trimIndent(), """
+            class TestRowMapper : JdbcResultSetMapper<TestRepository.Entity?> {
+                override fun apply(rs: ResultSet): TestRepository.Entity? {
+                  return null
+                }
+            }
+            """.trimIndent()
+        )
+        repository.invoke<Any>("findByEntity", newGenerated("TestRepository\$Entity", "1", 1, "1", "1").invoke())
+        Mockito.verify(executor.mockConnection)
+            .prepareStatement("SELECT id, value1, value2, value3 FROM entities WHERE id = ?")
+    }
 }


### PR DESCRIPTION
Database macros support for `@Column` type use and method argument parameter mapping

Added database macros support for `@Column` type use and method argument parameter mapping

```java
            public interface AbstractJdbcRepository<K, V> extends JdbcRepository {

                @Query("SELECT %{return#selects} FROM %{return#table} WHERE %{keyArg#where}")
                @Nullable
                V findById(K keyArg);
            }

            @Repository
            public interface TestRepository extends AbstractJdbcRepository<@Column("id") String, TestRepository.Entity> {
            
                @Table("entities")
                record Entity(@Id String id, @Column("value1") int field1, String value2, @Nullable String value3) {}
            }
```

And support for generic args

```java
            public interface AbstractJdbcRepository<K, V> extends JdbcRepository {

                @Query("SELECT %{V#selects} FROM %{V#table} WHERE %{V#where = @id}")
                @Nullable
                V findById(K keyArg);
            }

            @Repository
            public interface TestRepository extends AbstractJdbcRepository<@Column("id") String, TestRepository.Entity> {
            
                @Table("entities")
                record Entity(@Id String id, @Column("value1") int field1, String value2, @Nullable String value3) {}
            }
```