### PR TITLE
Fixed OpenAPI generator failing `param:` annotation prefix

### DIFF
--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinClientAsyncResponseMappers.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinClientAsyncResponseMappers.mustache
@@ -21,9 +21,8 @@ interface {{classname}}ClientResponseMappers {
 {{#operation}}
   {{#responses}}
   @ru.tinkoff.kora.common.annotation.Generated("openapi generator kora client")
-  class {{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}{{code}}ApiResponseMapper(
-    {{#dataType}}
-    {{#vendorExtensions.hasMapperTag}}@param:{{vendorExtensions.mapperTag}}{{/vendorExtensions.hasMapperTag}}
+  class {{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}{{code}}ApiResponseMapper({{#dataType}}{{#vendorExtensions.hasMapperTag}}
+    @{{vendorExtensions.mapperTag}}{{/vendorExtensions.hasMapperTag}}
     private val delegate: HttpClientResponseMapper<CompletionStage<{{{dataType}}}>>
     {{/dataType}}
   ) : HttpClientResponseMapper<CompletionStage<{{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}ApiResponse>> {

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinClientResponseMappers.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinClientResponseMappers.mustache
@@ -20,7 +20,7 @@ interface {{classname}}ClientResponseMappers {
 
   @ru.tinkoff.kora.common.annotation.Generated("openapi generator kora client")
   class {{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}{{code}}ApiResponseMapper({{#dataType}}{{#vendorExtensions.hasMapperTag}}
-    @param:{{vendorExtensions.mapperTag}}{{/vendorExtensions.hasMapperTag}}
+    @{{vendorExtensions.mapperTag}}{{/vendorExtensions.hasMapperTag}}
     private val delegate: HttpClientResponseMapper<{{{dataType}}}>
   {{/dataType}}) : HttpClientResponseMapper<{{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}ApiResponse> {
 

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinServerResponseMappers.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinServerResponseMappers.mustache
@@ -25,7 +25,7 @@ interface {{classname}}ServerResponseMappers {
 
   @ru.tinkoff.kora.common.annotation.Generated("openapi generator kora server")
   class {{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}{{code}}ResponseMapper({{#responses}}{{#dataType}}{{#vendorExtensions.hasMapperTag}}
-    @param:{{vendorExtensions.mapperTag}}{{/vendorExtensions.hasMapperTag}}
+    @{{vendorExtensions.mapperTag}}{{/vendorExtensions.hasMapperTag}}
     response{{code}}Delegate: HttpServerResponseMapper<{{{dataType}}}>{{#vendorExtensions.hasMore}},{{/vendorExtensions.hasMore}}{{^vendorExtensions.hasMore}}
   {{/vendorExtensions.hasMore}}{{/dataType}}{{/responses}}): HttpServerResponseMapper<{{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}ApiResponse> {
     {{#responses}}{{#dataType}}


### PR DESCRIPTION
Fixed OpenAPI generator useless `param:` annotation prefix that was failing graph KSP compilation and annotation was missing