### PR TITLE
[Draft] Improved OpenAPI generator nullable support

### DIFF
--- a/openapi/openapi-generator/build.gradle
+++ b/openapi/openapi-generator/build.gradle
@@ -80,6 +80,7 @@ sourceSets {
             addOpenapiDir("petstoreV3_implicit_headers_regex")
             addOpenapiDir("petstoreV3_server_request")
             addOpenapiDir("petstoreV3_additional_props")
+            addOpenapiDir("petstoreV3_additional_props_enable_json_nullable")
             addOpenapiDir("petstoreV3_discriminator")
             addOpenapiDir("petstoreV3_discriminator_enable_json_nullable")
             addOpenapiDir("petstoreV3_default_delegate")
@@ -87,6 +88,7 @@ sourceSets {
             addOpenapiDir("petstoreV3_filter")
             addOpenapiDir("petstoreV3_form")
             addOpenapiDir("petstoreV3_nullable")
+            addOpenapiDir("petstoreV3_nullable_enable_json_nullable")
             addOpenapiDir("petstoreV3_request_parameters")
             addOpenapiDir("petstoreV3_security_all")
             addOpenapiDir("petstoreV3_security_api_key")
@@ -97,6 +99,7 @@ sourceSets {
             addOpenapiDir("petstoreV3_single_response")
             addOpenapiDir("petstoreV3_types")
             addOpenapiDir("petstoreV3_validation")
+            addOpenapiDir("petstoreV3_validation_enable_json_nullable")
         }
     }
 }

--- a/openapi/openapi-generator/src/main/java/ru/tinkoff/kora/openapi/generator/KoraCodegen.java
+++ b/openapi/openapi-generator/src/main/java/ru/tinkoff/kora/openapi/generator/KoraCodegen.java
@@ -14,7 +14,10 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.examples.Example;
-import io.swagger.v3.oas.models.media.*;
+import io.swagger.v3.oas.models.media.ComposedSchema;
+import io.swagger.v3.oas.models.media.ObjectSchema;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
 import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.oas.models.parameters.RequestBody;
 import io.swagger.v3.oas.models.servers.Server;
@@ -665,7 +668,7 @@ public class KoraCodegen extends DefaultCodegen {
                 if (variable.isNullable && !variable.required) {
                     if (params.enableJsonNullable) {
                         variable.vendorExtensions.put("x-json-nullable", true);
-                    } else if(params.forceIncludeOptional) {
+                    } else if (params.forceIncludeOptional) {
                         variable.vendorExtensions.put("x-json-include-always", true);
                     } else {
                         //TODO remove in 2.0 and make default behavior that ENABLE_JSON_NULLABLE is enabled
@@ -703,7 +706,7 @@ public class KoraCodegen extends DefaultCodegen {
                 if (variable.isNullable && !variable.required) {
                     if (params.enableJsonNullable) {
                         variable.vendorExtensions.put("x-json-nullable", true);
-                    } else if(params.forceIncludeOptional) {
+                    } else if (params.forceIncludeOptional) {
                         variable.vendorExtensions.put("x-json-include-always", true);
                     } else {
                         //TODO remove in 2.0 and make default behavior that ENABLE_JSON_NULLABLE is enabled
@@ -849,40 +852,47 @@ public class KoraCodegen extends DefaultCodegen {
                     if (!requiredVar.required) {
                         continue;
                     }
-                    if (requiredVar.isInteger) {
-                        if (!typeMapping.containsKey("Integer") && !typeMapping.containsKey(Integer.class.getCanonicalName())) {
-                            requiredVar.dataType = "int";
-                            requiredVar.datatypeWithEnum = "int";
-                        }
-                    }
-                    if (requiredVar.isLong) {
-                        if (!typeMapping.containsKey("Long") && !typeMapping.containsKey(Long.class.getCanonicalName())) {
-                            requiredVar.dataType = "long";
-                            requiredVar.datatypeWithEnum = "long";
-                        }
-                    }
-                    if (requiredVar.isFloat) {
-                        if (!typeMapping.containsKey("Float") && !typeMapping.containsKey(Float.class.getCanonicalName())) {
-                            requiredVar.dataType = "float";
-                            requiredVar.datatypeWithEnum = "float";
-                        }
-                    }
-                    if (requiredVar.isDouble) {
-                        if (!typeMapping.containsKey("Double") && !typeMapping.containsKey(Double.class.getCanonicalName())) {
-                            requiredVar.dataType = "double";
-                            requiredVar.datatypeWithEnum = "double";
-                        }
-                    }
-                    if (requiredVar.isBoolean) {
-                        if (!typeMapping.containsKey("Boolean") && !typeMapping.containsKey(Boolean.class.getCanonicalName())) {
-                            requiredVar.dataType = "boolean";
-                            requiredVar.datatypeWithEnum = "boolean";
-                        }
-                    }
+                    processRequiredModelVar(requiredVar);
+                }
+                for (var requiredVar : model.requiredVars) {
+                    processRequiredModelVar(requiredVar);
                 }
             }
         }
         return objs;
+    }
+
+    private void processRequiredModelVar(CodegenProperty requiredVar) {
+        if (requiredVar.isInteger) {
+            if (!typeMapping.containsKey("Integer") && !typeMapping.containsKey(Integer.class.getCanonicalName())) {
+                requiredVar.dataType = "int";
+                requiredVar.datatypeWithEnum = "int";
+            }
+        }
+        if (requiredVar.isLong) {
+            if (!typeMapping.containsKey("Long") && !typeMapping.containsKey(Long.class.getCanonicalName())) {
+                requiredVar.dataType = "long";
+                requiredVar.datatypeWithEnum = "long";
+            }
+        }
+        if (requiredVar.isFloat) {
+            if (!typeMapping.containsKey("Float") && !typeMapping.containsKey(Float.class.getCanonicalName())) {
+                requiredVar.dataType = "float";
+                requiredVar.datatypeWithEnum = "float";
+            }
+        }
+        if (requiredVar.isDouble) {
+            if (!typeMapping.containsKey("Double") && !typeMapping.containsKey(Double.class.getCanonicalName())) {
+                requiredVar.dataType = "double";
+                requiredVar.datatypeWithEnum = "double";
+            }
+        }
+        if (requiredVar.isBoolean) {
+            if (!typeMapping.containsKey("Boolean") && !typeMapping.containsKey(Boolean.class.getCanonicalName())) {
+                requiredVar.dataType = "boolean";
+                requiredVar.datatypeWithEnum = "boolean";
+            }
+        }
     }
 
     private String getUpperSnakeCase(String value, Locale locale) {
@@ -1222,10 +1232,21 @@ public class KoraCodegen extends DefaultCodegen {
     /**
      * Same as original, but have different mapping for Map of String to T
      */
-    public String getTypeDeclarationAndProp(Schema p, CodegenProperty property) {
+    public String getTypeDeclarationForProperty(Schema p, CodegenProperty property) {
         var schema = ModelUtils.unaliasSchema(this.openAPI, p, importMapping);
         var target = ModelUtils.isGenerateAliasAsModel() ? p : schema;
-        if (ModelUtils.isMapSchema(target)) {
+        if (ModelUtils.isArraySchema(target)) {
+            var items = getSchemaItems(target);
+            var itemsDataType = getTypeDeclarationForProperty(items, property);
+
+            final boolean isItemNullable = Boolean.TRUE.equals(items.getNullable())
+                                           || (target.getExtensions() != null && Boolean.parseBoolean(String.valueOf(target.getExtensions().get("x-items-nullable"))));
+            if(params.codegenMode.isKotlin() && isItemNullable) {
+                return getSchemaType(target) + "<" + itemsDataType + "?>";
+            } else {
+                return getSchemaType(target) + "<" + itemsDataType + ">";
+            }
+        } else if (ModelUtils.isMapSchema(target)) {
             // Note: ModelUtils.isMapSchema(p) returns true when p is a composed schema that also defines
             // additionalproperties: true
             var inner = ModelUtils.getAdditionalProperties(target);
@@ -1235,24 +1256,30 @@ public class KoraCodegen extends DefaultCodegen {
                 p.setAdditionalProperties(inner);
             }
 
-            if (params.codegenMode.isKotlin() && property.isNullable) {
-                if (params.enableJsonNullable) {
-                    if (property.required) {
-                        return getSchemaType(target) + "<String, ru.tinkoff.kora.json.common.JsonNullable<" + getTypeDeclaration(inner) + ">>";
-                    } else {
-                        return getSchemaType(target) + "<String, ru.tinkoff.kora.json.common.JsonNullable<" + getTypeDeclaration(inner) + ">>?";
-                    }
-                } else {
-                    return getSchemaType(target) + "<String, " + getTypeDeclaration(inner) + "?>";
-                }
-            } else if (property.isNullable && !property.required && params.enableJsonNullable) {
-                return getSchemaType(target) + "<String, ru.tinkoff.kora.json.common.JsonNullable<" + getTypeDeclaration(inner) + ">>";
-            } else {
-                return getSchemaType(target) + "<String, " + getTypeDeclaration(inner) + ">";
-            }
-        }
+            final boolean isKeyNullable = target.getExtensions() != null
+                                          && Boolean.parseBoolean(String.valueOf(target.getExtensions().get("x-key-nullable")));
+            final boolean isValueNullable = target.getExtensions() != null
+                                          && Boolean.parseBoolean(String.valueOf(target.getExtensions().get("x-items-nullable")));
 
-        return super.getTypeDeclaration(target);
+            String mapType = getSchemaType(target);
+            String keyType = (target.getExtensions() == null)
+                ? "String"
+                : String.valueOf(target.getExtensions().getOrDefault("x-key-type", "String"));
+            String valueType = getTypeDeclaration(inner);
+
+            if (params.codegenMode.isKotlin()) {
+                if (isKeyNullable) {
+                    keyType = keyType + "?";
+                }
+                if (isValueNullable) {
+                    valueType = valueType + "?";
+                }
+            }
+
+            return "%s<%s, %s>".formatted(mapType, keyType, valueType);
+        } else {
+            return getTypeDeclaration(target);
+        }
     }
 
     @Override
@@ -1260,11 +1287,17 @@ public class KoraCodegen extends DefaultCodegen {
         var property = super.fromProperty(name, p, required, schemaIsFromAdditionalProperties);
         var schema = ModelUtils.unaliasSchema(this.openAPI, p, importMapping);
         var target = ModelUtils.isGenerateAliasAsModel() ? p : schema;
-        if (ModelUtils.isMapSchema(target)) {
-            var dataType = getTypeDeclarationAndProp(p, property);
+        if (ModelUtils.isArraySchema(target)) {
+            var dataType = getTypeDeclarationForProperty(target, property);
             property.dataType = dataType;
             if (!property.isEnum) {
-                property.datatypeWithEnum = property.dataType;
+                property.datatypeWithEnum = dataType;
+            }
+        } else if (ModelUtils.isMapSchema(target)) {
+            var dataType = getTypeDeclarationForProperty(p, property);
+            property.dataType = dataType;
+            if (!property.isEnum) {
+                property.datatypeWithEnum = dataType;
             }
         }
         return property;
@@ -2247,7 +2280,7 @@ public class KoraCodegen extends DefaultCodegen {
                 if (formParam.isModel || isEnum) {
                     formParam.vendorExtensions.put("requiresMapper", true);
                     String type;
-                    if(isEnum) {
+                    if (isEnum) {
                         type = allModels.stream()
                             .filter(m -> m.getModel().name.equals(formParam.dataType))
                             .findFirst()
@@ -2257,7 +2290,7 @@ public class KoraCodegen extends DefaultCodegen {
                                 .findFirst()
                                 .map(m -> m.get("importPath") + "." + formParam.datatypeWithEnum))
                             .orElseThrow(() -> new IllegalArgumentException("Unknown form param model: " + formParam));
-                        if(formParam.datatypeWithEnum != null) {
+                        if (formParam.datatypeWithEnum != null) {
                             formParam.dataType = type;
                         }
                     } else {
@@ -2285,12 +2318,12 @@ public class KoraCodegen extends DefaultCodegen {
                             "last", false
                         )));
                     }
-                } else if(formParam.isString
-                          || formParam.isBoolean
-                          || formParam.isDouble
-                          || formParam.isFloat
-                          || formParam.isInteger
-                          || formParam.isLong) {
+                } else if (formParam.isString
+                           || formParam.isBoolean
+                           || formParam.isDouble
+                           || formParam.isFloat
+                           || formParam.isInteger
+                           || formParam.isLong) {
                     formParam.vendorExtensions.put("isPrimitive", true);
                 } else {
                     formParam.vendorExtensions.put("requiresMapper", true);

--- a/openapi/openapi-generator/src/main/java/ru/tinkoff/kora/openapi/generator/KoraCodegen.java
+++ b/openapi/openapi-generator/src/main/java/ru/tinkoff/kora/openapi/generator/KoraCodegen.java
@@ -791,6 +791,8 @@ public class KoraCodegen extends DefaultCodegen {
                             } else {
                                 prop.isOverridden = haveReqVar;
                             }
+                        } else if (model.requiredVars.stream().anyMatch(p -> p.name.equals(prop.name))) {
+                            prop.isOverridden = true;
                         }
                     }
 
@@ -1241,7 +1243,7 @@ public class KoraCodegen extends DefaultCodegen {
 
             final boolean isItemNullable = Boolean.TRUE.equals(items.getNullable())
                                            || (target.getExtensions() != null && Boolean.parseBoolean(String.valueOf(target.getExtensions().get("x-items-nullable"))));
-            if(params.codegenMode.isKotlin() && isItemNullable) {
+            if (params.codegenMode.isKotlin() && isItemNullable) {
                 return getSchemaType(target) + "<" + itemsDataType + "?>";
             } else {
                 return getSchemaType(target) + "<" + itemsDataType + ">";
@@ -1259,7 +1261,7 @@ public class KoraCodegen extends DefaultCodegen {
             final boolean isKeyNullable = target.getExtensions() != null
                                           && Boolean.parseBoolean(String.valueOf(target.getExtensions().get("x-key-nullable")));
             final boolean isValueNullable = target.getExtensions() != null
-                                          && Boolean.parseBoolean(String.valueOf(target.getExtensions().get("x-items-nullable")));
+                                            && Boolean.parseBoolean(String.valueOf(target.getExtensions().get("x-items-nullable")));
 
             String mapType = getSchemaType(target);
             String keyType = (target.getExtensions() == null)

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaEnumClass.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaEnumClass.mustache
@@ -1,6 +1,4 @@
-  /**
-   * {{^description}}Gets or Sets {{{name}}}{{/description}}{{#description}}{{{description}}}{{/description}}
-   */
+  /** {{^description}}Gets or Sets {{{name}}}{{/description}}{{#description}}{{{description}}}{{/description}} */
   @ru.tinkoff.kora.common.annotation.Generated("openapi generator kora")
   {{#additionalEnumTypeAnnotations}}
   {{{.}}}

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaModel.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaModel.mustache
@@ -28,31 +28,25 @@ public sealed interface {{classname}} permits {{#vendorExtensions.x-unique-mappe
 
   /** {{#description}}{{.}}{{/description}}{{^description}}{{name}}{{/description}}{{#example}} (example: {{.}}){{/example}} */
   {{{datatypeWithEnum}}} {{name}}();{{/vendorExtensions.x-discriminator-property}}
-{{#vendorExtensions.x-discriminator-property}}
-
-{{^isContainer}}{{>javaEnumClass}}{{/isContainer}}
-{{#isContainer}}{{#mostInnerItems}}{{>javaEnumClass}}{{/mostInnerItems}}{{/isContainer}}
-{{/vendorExtensions.x-discriminator-property}}
-  {{#allVars}}{{^isDiscriminator}}{{#example}}
+{{#allVars}}{{^isDiscriminator}}{{#example}}
   /** (example: {{.}}) */{{/example}}
   {{{classname}}} with{{#lambda.titlecase}}{{name}}{{/lambda.titlecase}}({{^vendorExtensions.x-json-nullable}}{{^required}}@Nullable {{/required}}{{{datatypeWithEnum}}}{{/vendorExtensions.x-json-nullable}}{{#vendorExtensions.x-json-nullable}}ru.tinkoff.kora.json.common.JsonNullable<{{{datatypeWithEnum}}}>{{/vendorExtensions.x-json-nullable}} {{name}});
 {{/isDiscriminator}}{{/allVars}}
 {{#allVars}}
-  {{^isDiscriminator}}
-        {{#isEnum}}
-        {{^isContainer}}
-    {{>javaEnumClass}}
-        {{/isContainer}}
-        {{#isContainer}}
-        {{#mostInnerItems}}
-    {{>javaEnumClass}}
-        {{/mostInnerItems}}
-        {{/isContainer}}
-        {{/isEnum}}
-
-  /** {{#description}}{{.}}{{/description}}{{^description}}{{name}}{{/description}}{{#example}} (example: {{.}}){{/example}} */
-  {{^vendorExtensions.x-json-nullable}}{{^required}}@Nullable {{/required}}{{{datatypeWithEnum}}}{{/vendorExtensions.x-json-nullable}}{{#vendorExtensions.x-json-nullable}}ru.tinkoff.kora.json.common.JsonNullable<{{{datatypeWithEnum}}}>{{/vendorExtensions.x-json-nullable}} {{name}}();{{/isDiscriminator}}
+{{^isDiscriminator}}{{#isEnum}}{{^isContainer}}
+  {{>javaEnumClass}}
+{{/isContainer}}{{#isContainer}}{{#mostInnerItems}}
+  {{>javaEnumClass}}
+{{/mostInnerItems}}{{/isContainer}}{{/isEnum}}
+  /** {{#description}}{{.}}{{/description}}{{^description}}{{name}}{{/description}}{{#example}} (example: {{.}}){{/example}} */{{^vendorExtensions.x-json-nullable}}{{^required}}
+  @Nullable {{/required}}
+  {{{datatypeWithEnum}}}{{/vendorExtensions.x-json-nullable}}{{#vendorExtensions.x-json-nullable}}ru.tinkoff.kora.json.common.JsonNullable<{{{datatypeWithEnum}}}>{{/vendorExtensions.x-json-nullable}} {{name}}();{{/isDiscriminator}}
 {{/allVars}}
+{{#vendorExtensions.x-discriminator-property}}
+
+  {{^isContainer}}{{>javaEnumClass}}{{/isContainer}}
+  {{#isContainer}}{{#mostInnerItems}}{{>javaEnumClass}}{{/mostInnerItems}}{{/isContainer}}
+{{/vendorExtensions.x-discriminator-property}}
 }
 {{/discriminator}}
 {{^discriminator}}

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaModel.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaModel.mustache
@@ -84,11 +84,13 @@ public record {{classname}}(
   """;
   {{/isArray}}{{#additionalConstructor}}
 
-  public {{classname}}({{#requiredVars}}{{^vendorExtensions.x-discriminator-single}}{{^vendorExtensions.x-json-nullable}}{{^required}}@Nullable {{/required}}{{{datatypeWithEnum}}}{{/vendorExtensions.x-json-nullable}}{{#vendorExtensions.x-json-nullable}}ru.tinkoff.kora.json.common.JsonNullable<{{{datatypeWithEnum}}}>{{/vendorExtensions.x-json-nullable}} {{name}}{{^-last}}, {{/-last}}{{/vendorExtensions.x-discriminator-single}}{{/requiredVars}}) {
+  public {{classname}}({{#requiredVars}}{{^vendorExtensions.x-discriminator-single}}{{^vendorExtensions.x-json-nullable}}{{^required}}@Nullable {{/required}}{{{datatypeWithEnum}}}{{/vendorExtensions.x-json-nullable}}{{#vendorExtensions.x-json-nullable}}ru.tinkoff.kora.json.common.JsonNullable<{{{datatypeWithEnum}}}>{{/vendorExtensions.x-json-nullable}} {{name}}{{^-last}},
+             {{/-last}}{{/vendorExtensions.x-discriminator-single}}{{/requiredVars}}) {
     this({{#allVars}}{{#required}}{{#vendorExtensions.x-discriminator-single}}{{vendorExtensions.x-discriminator-single}}{{/vendorExtensions.x-discriminator-single}}{{^vendorExtensions.x-discriminator-single}}{{name}}{{/vendorExtensions.x-discriminator-single}}{{/required}}{{^required}}null{{/required}}{{^-last}}, {{/-last}}{{/allVars}});
   }{{/additionalConstructor}}{{#vendorExtensions.x-discriminator-single}}
 
-  public {{classname}}({{#allVars}}{{^isDiscriminator}}{{^vendorExtensions.x-json-nullable}}{{^required}}@Nullable {{/required}}{{{datatypeWithEnum}}}{{/vendorExtensions.x-json-nullable}}{{#vendorExtensions.x-json-nullable}}ru.tinkoff.kora.json.common.JsonNullable<{{{datatypeWithEnum}}}>{{/vendorExtensions.x-json-nullable}} {{name}}{{^-last}}, {{/-last}}{{/isDiscriminator}}{{/allVars}}) {
+  public {{classname}}({{#allVars}}{{^isDiscriminator}}{{^vendorExtensions.x-json-nullable}}{{^required}}@Nullable {{/required}}{{{datatypeWithEnum}}}{{/vendorExtensions.x-json-nullable}}{{#vendorExtensions.x-json-nullable}}ru.tinkoff.kora.json.common.JsonNullable<{{{datatypeWithEnum}}}>{{/vendorExtensions.x-json-nullable}} {{name}}{{^-last}},
+             {{/-last}}{{/isDiscriminator}}{{/allVars}}) {
     this({{#allVars}}{{#isDiscriminator}}{{vendorExtensions.x-discriminator-single}}{{/isDiscriminator}}{{^isDiscriminator}}{{name}}{{/isDiscriminator}}{{^-last}}, {{/-last}}{{/allVars}});
   }{{/vendorExtensions.x-discriminator-single}}
 

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinEnumClass.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinEnumClass.mustache
@@ -1,14 +1,11 @@
-  /**
-   * {{^description}}Gets or Sets {{{name}}}{{/description}}{{#description}}{{{description}}}{{/description}}
-   */
+  /** {{^description}}Gets or Sets {{{name}}}{{/description}}{{#description}}{{{description}}}{{/description}} */
   @ru.tinkoff.kora.common.annotation.Generated("openapi generator kora")
   {{#additionalEnumTypeAnnotations}}
   {{{.}}}
   {{/additionalEnumTypeAnnotations}}
   enum class {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}(private val value: {{{dataType}}}) {
 {{#allowableValues}}{{#enumVars}}
-    {{{name}}}(Constants.{{{name}}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
-{{/enumVars}}{{/allowableValues}}
+    {{{name}}}(Constants.{{{name}}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}{{/enumVars}}{{/allowableValues}}
 
     override fun toString(): String = {{#dataType}}{{#isString}}value{{/isString}}{{^isString}}"${value}"{{/isString}}{{/dataType}}
 
@@ -29,13 +26,16 @@
       const val {{{name}}}: {{dataType}} = {{{value}}}{{/enumVarsDeprecated}}{{/allowableValues}}
     }
 
-
     @ru.tinkoff.kora.common.annotation.Generated("openapi generator kora")
     @ru.tinkoff.kora.common.Component
     class JsonWriter(valueWriter: ru.tinkoff.kora.json.common.JsonWriter<{{{dataType}}}>)
         : ru.tinkoff.kora.json.common.JsonWriter<{{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}> {
 
-      private val delegate = ru.tinkoff.kora.json.common.EnumJsonWriter({{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.entries.toTypedArray(), {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}::value, valueWriter)
+      private val delegate = ru.tinkoff.kora.json.common.EnumJsonWriter(
+          {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.entries.toTypedArray(),
+          {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}::value,
+          valueWriter
+      )
 
       override fun write(gen: com.fasterxml.jackson.core.JsonGenerator, value: {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}?) {
         this.delegate.write(gen, value)
@@ -63,7 +63,11 @@
     class NullableJsonWriter(valueWriter: ru.tinkoff.kora.json.common.JsonWriter<{{{dataType}}}>)
         : ru.tinkoff.kora.json.common.JsonWriter<{{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}?> {
 
-      private val delegate = ru.tinkoff.kora.json.common.EnumJsonWriter({{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.entries.toTypedArray(), {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}::value, valueWriter)
+      private val delegate = ru.tinkoff.kora.json.common.EnumJsonWriter(
+          {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.entries.toTypedArray(),
+          {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}::value,
+          valueWriter
+      )
 
       override fun write(gen: com.fasterxml.jackson.core.JsonGenerator, value: {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}?) {
         this.delegate.write(gen, value)

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinModel.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinModel.mustache
@@ -33,11 +33,11 @@ sealed interface {{classname}} {
 {{#vendorExtensions.x-discriminator-property}}
 
         {{^isContainer}}
-    {{>kotlinEnumClass}}
+{{>kotlinEnumClass}}
         {{/isContainer}}
         {{#isContainer}}
         {{#mostInnerItems}}
-    {{>kotlinEnumClass}}
+{{>kotlinEnumClass}}
         {{/mostInnerItems}}
         {{/isContainer}}
 {{/vendorExtensions.x-discriminator-property}}
@@ -96,9 +96,7 @@ sealed interface {{classname}} {
     return true
   }
 
-  override fun hashCode(): Int {
-    return javaClass.hashCode()
-  }
+  override fun hashCode(): Int = javaClass.hashCode()
 {{/hasVars}}
 
   {{#allVars}}

--- a/openapi/openapi-generator/src/test/java/ru/tinkoff/kora/openapi/generator/KoraCodegenTest.java
+++ b/openapi/openapi-generator/src/test/java/ru/tinkoff/kora/openapi/generator/KoraCodegenTest.java
@@ -193,7 +193,7 @@ class KoraCodegenTest {
                 "skipFormModel", "false"
             ))
             .addAdditionalProperty("mode", mode)
-            .addAdditionalProperty("additionalModelTypeAnnotations", "@ru.tinkoff.kora.json.common.annotation.JsonInclude(ru.tinkoff.kora.json.common.annotation.JsonInclude.IncludeType.ALWAYS)")
+            .addAdditionalProperty("additionalModelTypeAnnotations", "@org.jetbrains.annotations.NonBlocking")
             .addAdditionalProperty("interceptors", """
                 {
                   "*": [

--- a/openapi/openapi-generator/src/test/resources/example/petstoreV3_nullable.yaml
+++ b/openapi/openapi-generator/src/test/resources/example/petstoreV3_nullable.yaml
@@ -111,16 +111,22 @@ components:
       type: object
       required:
         - id
-        - fieldRequired
         - fieldRequiredNullable
         - fieldRequiredNonNullable
+        - fieldArrayRequiredNullable
+        - fieldArrayRequiredNonNullable
+        - fieldArrayItemsRequiredNullable
+        - fieldArrayItemsRequiredNonNullable
+        - fieldArrayItemsObjectNullable
+        - fieldArrayItemsObjectNonNullable
+        - fieldArrayItemsMapNullable
+        - fieldArrayItemsMapNullableKey
+        - fieldArrayItemsMapNullableValue
+        - fieldArrayItemsMapNonNullable
       properties:
         id:
           type: integer
           format: int64
-        fieldRequired:
-          type: string
-          example: 123
         fieldNullable:
           type: string
           nullable: true
@@ -132,6 +138,74 @@ components:
         fieldRequiredNonNullable:
           type: string
           example: 123
+        fieldArrayNullable:
+          nullable: true
+          items:
+            type: string
+        fieldArrayRequiredNullable:
+          nullable: true
+          items:
+            type: string
+        fieldArrayRequiredNonNullable:
+          items:
+            type: string
+        fieldArrayItemsNullable:
+          type: array
+          nullable: true
+          items:
+            type: string
+            nullable: true
+        fieldArrayItemsRequiredNullable:
+          type: array
+          items:
+            type: string
+            nullable: true
+        fieldArrayItemsRequiredNonNullable:
+          type: array
+          items:
+            type: string
+        fieldArrayItemsObjectNullable:
+          type: array
+          x-items-nullable: true
+          items:
+            $ref: '#/components/schemas/Simple'
+        fieldArrayItemsObjectNonNullable:
+          type: array
+          items:
+            $ref: '#/components/schemas/Simple'
+        fieldArrayItemsMapNullable:
+          type: array
+          items:
+            type: object
+            nullable: true
+            additionalProperties:
+              $ref: '#/components/schemas/Simple'
+        fieldArrayItemsMapNullableKey:
+          type: array
+          items:
+            type: object
+            x-key-type: Long
+            x-key-nullable: true
+            additionalProperties:
+              $ref: '#/components/schemas/Simple'
+        fieldArrayItemsMapNullableValue:
+          type: array
+          items:
+            type: object
+            x-items-nullable: true
+            additionalProperties:
+              $ref: '#/components/schemas/Simple'
+        fieldArrayItemsMapNonNullable:
+          type: array
+          items:
+            type: object
+            additionalProperties:
+              $ref: '#/components/schemas/Simple'
+    Simple:
+      type: object
+      properties:
+        type:
+          type: string
     Pets:
       type: array
       items:

--- a/openapi/openapi-generator/src/test/resources/example/petstoreV3_nullable.yaml
+++ b/openapi/openapi-generator/src/test/resources/example/petstoreV3_nullable.yaml
@@ -7,6 +7,22 @@ info:
 servers:
   - url: http://petstore.swagger.io/v1
 paths:
+  /animals:
+    get:
+      operationId: listAnimals
+      responses:
+        '200':
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Animals"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   /pets:
     get:
       summary: List all pets
@@ -206,10 +222,37 @@ components:
       properties:
         type:
           type: string
+    Dog:
+      type: object
+      properties:
+        name:
+          type: string
+      allOf:
+        - $ref: "#/components/schemas/Animal"
+    Animal:
+      discriminator:
+        propertyName: type
+        mapping:
+          pet: "#/components/schemas/Pet"
+          dog: "#/components/schemas/Dog"
+      type: object
+      required:
+        - id
+        - type
+      properties:
+        id:
+          type: integer
+          format: int64
+        type:
+          type: string
     Pets:
       type: array
       items:
         $ref: "#/components/schemas/Pet"
+    Animals:
+      type: array
+      items:
+        $ref: "#/components/schemas/Animal"
     Error:
       type: object
       required:


### PR DESCRIPTION
- Added OpenAPI generator `x-items-nullable` option for items to mark them as nullable
- Added OpenAPI generator `x-key-nullable` option for additionalProperties to mark key as nullable (use `x-items-nullable` for value)
- Added OpenAPI generator `x-key-type` option for additionalProperties to mark change key type