### PR TITLE
Downgrade okio to 3.9.1 (cause somehow 3.10.2 is also Kotlin 2 binary)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -84,7 +84,7 @@ undertow-servlet = { module = "io.undertow:undertow-servlet", version.ref = "und
 async-http-client = { module = "org.asynchttpclient:async-http-client", version = "2.12.4" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version = "5.0.0-alpha.14" } # Cant up cause Kotlin 2.0+ in newer versions
 okhttp-jvm = { module = "com.squareup.okhttp3:okhttp-jvm", version = "5.0.0-alpha.12" } # Cant up cause Kotlin 2.0+ in newer versions
-okio = { module = "com.squareup.okio:okio", version = "3.10.2" }
+okio = { module = "com.squareup.okio:okio", version = "3.9.1" }
 
 netty-buffer = { module = "io.netty:netty-buffer", version.ref = "netty" }
 netty-codecs = { module = "io.netty:netty-codec", version.ref = "netty" }


### PR DESCRIPTION
Downgrade okio to 3.9.1 (cause somehow 3.10.2 is also Kotlin 2 binary)