### PR TITLE
Fixed OpenAPI generator `forceIncludeOptional` for Kotlin

### DIFF
--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinModel.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinModel.mustache
@@ -57,7 +57,8 @@ sealed interface {{classname}} {
 @ru.tinkoff.kora.validation.common.annotation.Valid{{/vendorExtensions.x-enable-validation}}
 {{#hasVars}}data {{/hasVars}}class {{classname}} @ru.tinkoff.kora.json.common.annotation.JsonReader constructor (
 {{#requiredVars}}
-  @ru.tinkoff.kora.json.common.annotation.JsonField("{{baseName}}"){{#vendorExtensions.x-has-min-max}}
+  @ru.tinkoff.kora.json.common.annotation.JsonField("{{baseName}}"){{#vendorExtensions.x-json-include-always}}
+  @ru.tinkoff.kora.json.common.annotation.JsonInclude(ru.tinkoff.kora.json.common.annotation.JsonInclude.IncludeType.ALWAYS){{/vendorExtensions.x-json-include-always}}{{#vendorExtensions.x-has-min-max}}
   @ru.tinkoff.kora.validation.common.annotation.Range(from = {{minimum}}.toDouble(), to = {{maximum}}.toDouble(), boundary = ru.tinkoff.kora.validation.common.annotation.Range.Boundary.{{#exclusiveMinimum}}EXCLUSIVE{{/exclusiveMinimum}}{{^exclusiveMinimum}}INCLUSIVE{{/exclusiveMinimum}}_{{#exclusiveMaximum}}EXCLUSIVE{{/exclusiveMaximum}}{{^exclusiveMaximum}}INCLUSIVE{{/exclusiveMaximum}}){{/vendorExtensions.x-has-min-max}}{{#vendorExtensions.x-has-min-max-items}}
   @ru.tinkoff.kora.validation.common.annotation.Size(min = {{minItems}}, max = {{maxItems}}){{/vendorExtensions.x-has-min-max-items}}{{#vendorExtensions.x-has-min-max-length}}
   @ru.tinkoff.kora.validation.common.annotation.Size(min = {{minLength}}, max = {{maxLength}}){{/vendorExtensions.x-has-min-max-length}}{{#vendorExtensions.x-has-pattern}}
@@ -66,7 +67,8 @@ sealed interface {{classname}} {
   {{#isOverridden}}override {{/isOverridden}}val {{name}}: {{^vendorExtensions.x-json-nullable}}{{#isDiscriminator}}{{parent}}.{{/isDiscriminator}}{{{datatypeWithEnum}}}{{/vendorExtensions.x-json-nullable}}{{#vendorExtensions.x-json-nullable}}ru.tinkoff.kora.json.common.JsonNullable<{{#isDiscriminator}}{{parent}}.{{/isDiscriminator}}{{{datatypeWithEnum}}}>{{/vendorExtensions.x-json-nullable}},
 {{/requiredVars}}
 {{#optionalVars}}
-  @ru.tinkoff.kora.json.common.annotation.JsonField("{{baseName}}"){{#vendorExtensions.x-has-min-max}}
+  @ru.tinkoff.kora.json.common.annotation.JsonField("{{baseName}}"){{#vendorExtensions.x-json-include-always}}
+  @ru.tinkoff.kora.json.common.annotation.JsonInclude(ru.tinkoff.kora.json.common.annotation.JsonInclude.IncludeType.ALWAYS){{/vendorExtensions.x-json-include-always}}{{#vendorExtensions.x-has-min-max}}
   @ru.tinkoff.kora.validation.common.annotation.Range(from = {{minimum}}.toDouble(), to = {{maximum}}.toDouble(), boundary = ru.tinkoff.kora.validation.common.annotation.Range.Boundary.{{#exclusiveMinimum}}EXCLUSIVE{{/exclusiveMinimum}}{{^exclusiveMinimum}}INCLUSIVE{{/exclusiveMinimum}}_{{#exclusiveMaximum}}EXCLUSIVE{{/exclusiveMaximum}}{{^exclusiveMaximum}}INCLUSIVE{{/exclusiveMaximum}}){{/vendorExtensions.x-has-min-max}}{{#vendorExtensions.x-has-min-max-items}}
   @ru.tinkoff.kora.validation.common.annotation.Size(min = {{minItems}}, max = {{maxItems}}){{/vendorExtensions.x-has-min-max-items}}{{#vendorExtensions.x-has-min-max-length}}
   @ru.tinkoff.kora.validation.common.annotation.Size(min = {{minLength}}, max = {{maxLength}}){{/vendorExtensions.x-has-min-max-length}}{{#vendorExtensions.x-has-pattern}}


### PR DESCRIPTION
Added OpenAPI generator option `forceIncludeNonRequired`