### PR TITLE
Added protected access modifiers to LettuceClusterRedisCacheClient

### DIFF
--- a/cache/cache-redis/src/main/java/ru/tinkoff/kora/cache/redis/lettuce/LettuceClusterRedisCacheClient.java
+++ b/cache/cache-redis/src/main/java/ru/tinkoff/kora/cache/redis/lettuce/LettuceClusterRedisCacheClient.java
@@ -24,14 +24,14 @@ public class LettuceClusterRedisCacheClient implements RedisCacheClient, Lifecyc
 
     private static final Logger logger = LoggerFactory.getLogger(LettuceClusterRedisCacheClient.class);
 
-    private final RedisClusterClient redisClient;
+    protected final RedisClusterClient redisClient;
 
     // use for pipeline commands only cause lettuce have bad performance when using pool
-    private BoundedAsyncPool<StatefulRedisClusterConnection<byte[], byte[]>> pool;
-    private StatefulRedisClusterConnection<byte[], byte[]> connection;
+    protected BoundedAsyncPool<StatefulRedisClusterConnection<byte[], byte[]>> pool;
+    protected StatefulRedisClusterConnection<byte[], byte[]> connection;
 
     // always use async cause sync uses JDK Proxy wrapped async impl
-    private RedisAdvancedClusterAsyncCommands<byte[], byte[]> commands;
+    protected RedisAdvancedClusterAsyncCommands<byte[], byte[]> commands;
 
     public LettuceClusterRedisCacheClient(RedisClusterClient redisClient) {
         this.redisClient = redisClient;


### PR DESCRIPTION
Replaced the access modifiers in the LettuceClusterRedisCacheClient class for the redisClient, pool, connection, and commands fields to allow inheritance from this class and full access to the redis client.
Because now, to add a new operation to the client, you have to duplicate the client's logic without inheriting it, because there is no access to the Redis client.