### PR TITLE
Make GraphInterceptor work with interfaces

### DIFF
--- a/application-graph/src/main/java/ru/tinkoff/kora/application/graph/ApplicationGraphDraw.java
+++ b/application-graph/src/main/java/ru/tinkoff/kora/application/graph/ApplicationGraphDraw.java
@@ -25,11 +25,12 @@ public class ApplicationGraphDraw {
         return this.addNode0(type, tags, factory, List.of(), dependencies);
     }
 
-    public <T> Node<T> addNode0(Type type, Class<?>[] tags, Graph.Factory<? extends T> factory, List<? extends Node<? extends GraphInterceptor<T>>> interceptors, Node<?>... dependencies) {
+    public <T> Node<T> addNode0(Type type, Class<?>[] tags, Graph.Factory<? extends T> factory, List<? extends Node<? extends GraphInterceptor<? super T>>> interceptors, Node<?>... dependencies) {
         var dependenciesList = new ArrayList<NodeImpl<?>>();
         for (var dependency : dependencies) {
             dependenciesList.add((NodeImpl<?>) dependency);
         }
+        @SuppressWarnings("unchecked")
         var interceptorsList = new ArrayList<NodeImpl<? extends GraphInterceptor<T>>>();
         for (var interceptor : interceptors) {
             interceptorsList.add((NodeImpl<? extends GraphInterceptor<T>>) interceptor);

--- a/kora-app-annotation-processor/src/main/java/ru/tinkoff/kora/kora/app/annotation/processor/ServiceTypesHelper.java
+++ b/kora-app-annotation-processor/src/main/java/ru/tinkoff/kora/kora/app/annotation/processor/ServiceTypesHelper.java
@@ -70,15 +70,7 @@ public class ServiceTypesHelper {
         if (this.types.isSameType(interceptedType, targetType)) {
             return true;
         } else if (this.types.isAssignable(targetType, interceptedType)) {
-            // Check if is AopProxy
-            var typeMirrorElement = types.asElement(targetType);
-            var annotation = AnnotationUtils.findAnnotation(typeMirrorElement, CommonClassNames.aopProxy);
-            if (annotation != null) {
-                var interceptedTypeElement = types.asElement(interceptedType);
-                var aopProxyName = NameUtils.generatedType(interceptedTypeElement, "_AopProxy");
-                var expectedAopProxyCanonicalName = elements.getPackageOf(interceptedTypeElement).toString() + "." + aopProxyName;
-                return expectedAopProxyCanonicalName.equals(typeMirrorElement.toString());
-            }
+            return true;
         }
 
         return false;

--- a/kora-app-symbol-processor/src/main/kotlin/ru/tinkoff/kora/kora/app/ksp/ServiceTypesHelper.kt
+++ b/kora-app-symbol-processor/src/main/kotlin/ru/tinkoff/kora/kora/app/ksp/ServiceTypesHelper.kt
@@ -93,13 +93,7 @@ class ServiceTypesHelper(val resolver: Resolver) {
         if (targetType == interceptedType.makeNotNullable()) {
             return true
         } else if (interceptedType.isAssignableFrom(targetType)) {
-            val aopProxyAnnotation = targetType.declaration.findAnnotation(CommonClassNames.aopProxy)
-            val proxyDeclaration = interceptedType.declaration
-            if (aopProxyAnnotation != null && proxyDeclaration.parentDeclaration != null) {
-                val aopProxyName = proxyDeclaration.getOuterClassesAsPrefix() + proxyDeclaration.simpleName.asString() + "__AopProxy"
-                val aopProxyCanonical = proxyDeclaration.packageName.asString() + "." + aopProxyName
-                return aopProxyCanonical == targetType.declaration.qualifiedName!!.asString()
-            }
+            return true
         }
 
         return false

--- a/kora-app-symbol-processor/src/test/kotlin/ru/tinkoff/kora/kora/app/ksp/GraphInterceptorTests.kt
+++ b/kora-app-symbol-processor/src/test/kotlin/ru/tinkoff/kora/kora/app/ksp/GraphInterceptorTests.kt
@@ -4,7 +4,7 @@ import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
 import ru.tinkoff.kora.application.graph.internal.NodeImpl
 
-class GraphInterceptorTests :AbstractKoraAppProcessorTest() {
+class GraphInterceptorTests : AbstractKoraAppProcessorTest() {
 
     @Test
     fun interceptor() {
@@ -103,6 +103,39 @@ class GraphInterceptorTests :AbstractKoraAppProcessorTest() {
                 """.trimIndent(),
         )
         Assertions.assertThat(draw.nodes).hasSize(2)
+        draw.init()
+        Assertions.assertThat((draw.nodes[1] as NodeImpl<*>).interceptors).hasSize(1)
+    }
+
+    @Test
+    fun interceptorForInterface() {
+        val draw = compile(
+            """
+                import ru.tinkoff.kora.application.graph.GraphInterceptor
+
+                @KoraApp
+                interface ExampleApplication {
+                            
+                    interface TestInterface
+
+                    class TestClass : TestInterface
+                            
+                    class TestRoot
+                    
+                    class TestInterceptor : GraphInterceptor<TestInterface> {
+                        override fun init(value: TestInterface) = value
+
+                        override fun release(value: TestInterface) = value
+                    }
+
+                    @Root
+                    fun root(testClass: TestClass) = TestRoot()
+                    
+                    fun interceptor(): TestInterceptor = TestInterceptor()
+                }
+                """.trimIndent(),
+        )
+        Assertions.assertThat(draw.nodes).hasSize(3)
         draw.init()
         Assertions.assertThat((draw.nodes[1] as NodeImpl<*>).interceptors).hasSize(1)
     }


### PR DESCRIPTION
Problem

`GraphInterceptor<TestInterface>` doesn't intercept `TestClass : TestInterface` because:

1. `isInterceptable` only returns true for exact type match or AOP proxy — but not for general interface-to-implementation relationships
2. Simply making it return true for `isAssignableFrom` causes a compile-time type mismatch in the generated code: `addNode0<T>` expects `List<Node<GraphInterceptor<T>>>` for interceptors, but when `T = TestClass`, a `Node<GraphInterceptor<TestInterface>>` doesn't satisfy `GraphInterceptor<TestClass>` (invariant generics)

Solution

Two-pronged fix:
1. Relax `isInterceptable` — return true when `interceptedType.isAssignableFrom(targetType)`
2. Add `? super T` to `addNode0` interceptors parameter — `GraphInterceptor<TestInterface>` IS a `GraphInterceptor<? super TestClass>` because `TestInterface` is a supertype of `TestClass`

At runtime this is all erased and already uses unchecked casts (lines 442-443 in `GraphImpl.java`), so this is purely a compile-time correctness fix.