### PR TITLE
Add response=sealed|plain mode for OpenAPI client generation

### DIFF
--- a/http/http-client-common/src/main/java/io/koraframework/http/client/common/exception/HttpClientDecodedResponseException.java
+++ b/http/http-client-common/src/main/java/io/koraframework/http/client/common/exception/HttpClientDecodedResponseException.java
@@ -1,0 +1,26 @@
+package io.koraframework.http.client.common.exception;
+
+import io.koraframework.http.common.header.HttpHeaders;
+import org.jspecify.annotations.Nullable;
+
+public class HttpClientDecodedResponseException extends HttpClientResponseException {
+
+    private final @Nullable Object body;
+
+    public HttpClientDecodedResponseException(int code, HttpHeaders headers, @Nullable Object body) {
+        super("HTTP response with status code %d".formatted(code), code, headers, new byte[0]);
+        this.body = body;
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> T body() {
+        return (T) body;
+    }
+
+    public <T> @Nullable T body(Class<T> type) {
+        if (type.isInstance(body)) {
+            return type.cast(body);
+        }
+        return null;
+    }
+}

--- a/http/http-client-common/src/main/java/io/koraframework/http/client/common/exception/HttpClientResponseException.java
+++ b/http/http-client-common/src/main/java/io/koraframework/http/client/common/exception/HttpClientResponseException.java
@@ -18,6 +18,12 @@ public class HttpClientResponseException extends HttpClientException {
         this.bytes = bytes;
     }
 
+    protected HttpClientResponseException(String message, int code, HttpHeaders headers, byte[] bytes) {
+        super(message);
+        this.code = code;
+        this.headers = headers;
+        this.bytes = bytes;
+    }
 
     public static HttpClientResponseException fromResponse(HttpClientResponse response) throws IOException {
         try (var body = response.body()) {

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/CodegenParams.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/CodegenParams.java
@@ -28,7 +28,8 @@ public class CodegenParams {
     public static final String IMPLICIT_HEADERS = "implicitHeaders";
     public static final String IMPLICIT_HEADERS_REGEX = "implicitHeadersRegex";
     public static final String FORCE_INCLUDE_OPTIONAL = "forceIncludeOptional";
-    
+    public static final String RESPONSE_STYLE = "response";
+
     public CodegenMode codegenMode = CodegenMode.JAVA_CLIENT;
     public boolean enableValidation = false;
     public boolean authAsMethodArgument = false;
@@ -45,6 +46,7 @@ public class CodegenParams {
     public boolean implicitHeaders = false;
     public @Nullable Pattern implicitHeadersRegex = null;
     public boolean forceIncludeOptional = false;
+    public ResponseStyle responseStyle = ResponseStyle.SEALED;
 
     static List<CliOption> cliOptions() {
         var cliOptions = new ArrayList<CliOption>();
@@ -62,6 +64,7 @@ public class CodegenParams {
         cliOptions.add(CliOption.newString(PREFIX_PATH, "Path prefix for HTTP Server controllers"));
         cliOptions.add(CliOption.newString(DELEGATE_METHOD_BODY_MODE, "Delegate method generation mode"));
         cliOptions.add(CliOption.newString(FORCE_INCLUDE_OPTIONAL, "If enabled forces Nullable and NonRequired fields to be included ALWAYS even if null, can't be enabled with enableJsonNullable simultaneously"));
+        cliOptions.add(CliOption.newString(RESPONSE_STYLE, "Response handling style: 'sealed' (default) wraps all responses in sealed interface, 'plain' returns success type directly and throws exception for errors. Only applies to client modes."));
         return cliOptions;
     }
 
@@ -136,6 +139,11 @@ public class CodegenParams {
         }
         if (additionalProperties.containsKey(FORCE_INCLUDE_OPTIONAL)) {
             params.forceIncludeOptional = Boolean.parseBoolean(additionalProperties.get(FORCE_INCLUDE_OPTIONAL).toString());
+        }
+        if (additionalProperties.containsKey(RESPONSE_STYLE)) {
+            if (params.codegenMode.isClient()) {
+                params.responseStyle = ResponseStyle.of(additionalProperties.get(RESPONSE_STYLE).toString());
+            }
         }
         return params;
     }

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/KoraCodegen.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/KoraCodegen.java
@@ -1307,9 +1307,46 @@ public class KoraCodegen extends DefaultCodegen {
         var operationList = operations.getOperation();
         for (var op : operationList) {
             handleImplicitHeaders(op);
+            handlePlainResponseMode(op);
         }
         this.operationsByClassName.put(objs.getOperations().getClassname(), objs);
         return objs;
+    }
+
+    private void handlePlainResponseMode(CodegenOperation op) {
+        if (params.responseStyle != ResponseStyle.PLAIN || !params.codegenMode.isClient()) {
+            op.vendorExtensions.put("plainResponse", false);
+            return;
+        }
+
+        var successDataTypes = op.responses.stream()
+            .filter(r -> !r.isDefault && r.code != null && r.code.startsWith("2"))
+            .map(r -> r.dataType)
+            .filter(Objects::nonNull)
+            .distinct()
+            .toList();
+
+        if (successDataTypes.size() > 1) {
+            op.vendorExtensions.put("plainResponse", false);
+            return;
+        }
+
+        op.vendorExtensions.put("plainResponse", true);
+
+        var successResponse = op.responses.stream()
+            .filter(r -> !r.isDefault && r.code != null && r.code.startsWith("2") && r.dataType != null)
+            .findFirst()
+            .orElse(null);
+
+        if (successResponse != null) {
+            op.vendorExtensions.put("plainResponseDataType", successResponse.dataType);
+        }
+
+        var errorResponses = op.responses.stream()
+            .filter(r -> r.isDefault || (r.code != null && !r.code.startsWith("2")))
+            .filter(r -> r.dataType != null)
+            .toList();
+        op.vendorExtensions.put("plainErrorResponses", errorResponses);
     }
 
     public static boolean isContentJson(CodegenParameter parameter) {

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/ResponseStyle.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/ResponseStyle.java
@@ -1,0 +1,13 @@
+package io.koraframework.openapi.generator;
+
+public enum ResponseStyle {
+    SEALED,
+    PLAIN;
+
+    static ResponseStyle of(String value) {
+        return switch (value.toLowerCase()) {
+            case "plain" -> PLAIN;
+            default -> SEALED;
+        };
+    }
+}

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ApiResponseGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ApiResponseGenerator.java
@@ -14,6 +14,9 @@ public class ApiResponseGenerator extends AbstractJavaGenerator<OperationsMap> {
             .addAnnotation(generated())
             .addModifiers(Modifier.PUBLIC);
         for (var operation : ctx.getOperations().getOperation()) {
+            if (Boolean.TRUE.equals(operation.vendorExtensions.get("plainResponse"))) {
+                continue;
+            }
             var responseClassName = className.nestedClass(capitalize(operation.operationId) + "ApiResponse");
             if (operation.responses.size() == 1) {
                 b.addType(response(ctx, responseClassName, operation.responses.getFirst()));

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientApiGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientApiGenerator.java
@@ -38,7 +38,7 @@ public class ClientApiGenerator extends AbstractJavaGenerator<OperationsMap> {
     }
 
     private MethodSpec buildRequiredArgsCall(OperationsMap ctx, CodegenOperation operation, List<CodegenParameter> optionalParams) {
-        var returnType = ClassName.get(apiPackage, ctx.get("classname") + "Responses", StringUtils.capitalize(operation.operationId) + "ApiResponse");
+        var returnType = resolveReturnType(ctx, operation);
         var b = MethodSpec.methodBuilder(operation.operationId)
             .addModifiers(Modifier.PUBLIC, Modifier.DEFAULT)
             .returns(returnType)
@@ -89,7 +89,7 @@ public class ClientApiGenerator extends AbstractJavaGenerator<OperationsMap> {
     }
 
     private MethodSpec buildRequiredArgsWithArgsCall(OperationsMap ctx, CodegenOperation operation, List<CodegenParameter> optionalParams) {
-        var returnType = ClassName.get(apiPackage, ctx.get("classname") + "Responses", StringUtils.capitalize(operation.operationId) + "ApiResponse");
+        var returnType = resolveReturnType(ctx, operation);
         var b = MethodSpec.methodBuilder(operation.operationId)
             .addModifiers(Modifier.PUBLIC, Modifier.DEFAULT)
             .returns(returnType)
@@ -211,7 +211,22 @@ public class ClientApiGenerator extends AbstractJavaGenerator<OperationsMap> {
     }
 
 
+    private TypeName resolveReturnType(OperationsMap ctx, CodegenOperation operation) {
+        if (Boolean.TRUE.equals(operation.vendorExtensions.get("plainResponse"))) {
+            var plainDataType = (String) operation.vendorExtensions.get("plainResponseDataType");
+            if (plainDataType != null) {
+                return asType(operation.responses.stream()
+                    .filter(r -> !r.isDefault && r.code != null && r.code.startsWith("2") && r.dataType != null)
+                    .findFirst()
+                    .orElseThrow());
+            }
+            return TypeName.VOID;
+        }
+        return ClassName.get(apiPackage, ctx.get("classname") + "Responses", StringUtils.capitalize(operation.operationId) + "ApiResponse");
+    }
+
     private MethodSpec buildMethod(OperationsMap ctx, CodegenOperation operation) {
+        var isPlain = Boolean.TRUE.equals(operation.vendorExtensions.get("plainResponse"));
         var tag = ctx.get("baseName").toString();
         var b = MethodSpec.methodBuilder(operation.operationId)
             .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
@@ -222,12 +237,23 @@ public class ClientApiGenerator extends AbstractJavaGenerator<OperationsMap> {
         this.buildAdditionalAnnotations(tag).forEach(b::addAnnotation);
         this.buildImplicitHeaders(operation).forEach(b::addAnnotation);
         b.addAnnotation(this.buildHttpRoute(operation));
-        for (var response : operation.responses) {
-            b.addAnnotation(AnnotationSpec.builder(Classes.responseCodeMapper)
-                .addMember("code", "$L", response.isDefault ? "-1" : response.code)
-                .addMember("mapper", "$T.class", ClassName.get(apiPackage, ctx.get("classname") + "ClientResponseMappers", StringUtils.capitalize(operation.operationId) + response.code + "ApiResponseMapper"))
-                .build()
-            );
+        if (isPlain) {
+            var plainDataType = operation.vendorExtensions.get("plainResponseDataType");
+            if (plainDataType != null) {
+                b.addAnnotation(AnnotationSpec.builder(Classes.responseCodeMapper)
+                    .addMember("code", "$L", "-1")
+                    .addMember("mapper", "$T.class", ClassName.get(apiPackage, ctx.get("classname") + "ClientResponseMappers", StringUtils.capitalize(operation.operationId) + "PlainResponseMapper"))
+                    .build()
+                );
+            }
+        } else {
+            for (var response : operation.responses) {
+                b.addAnnotation(AnnotationSpec.builder(Classes.responseCodeMapper)
+                    .addMember("code", "$L", response.isDefault ? "-1" : response.code)
+                    .addMember("mapper", "$T.class", ClassName.get(apiPackage, ctx.get("classname") + "ClientResponseMappers", StringUtils.capitalize(operation.operationId) + response.code + "ApiResponseMapper"))
+                    .build()
+                );
+            }
         }
         if (!params.authAsMethodArgument) {
             var requirement = this.security.securityRequirementByOperation.get(operation.operationId);
@@ -242,7 +268,19 @@ public class ClientApiGenerator extends AbstractJavaGenerator<OperationsMap> {
         }
 
         this.buildInterceptors(tag, Classes.httpClientInterceptor).forEach(b::addAnnotation);
-        b.returns(ClassName.get(apiPackage, ctx.get("classname") + "Responses", StringUtils.capitalize(operation.operationId) + "ApiResponse"));
+        if (isPlain) {
+            var plainDataType = (String) operation.vendorExtensions.get("plainResponseDataType");
+            if (plainDataType != null) {
+                b.returns(asType(operation.responses.stream()
+                    .filter(r -> !r.isDefault && r.code != null && r.code.startsWith("2") && r.dataType != null)
+                    .findFirst()
+                    .orElseThrow()));
+            } else {
+                b.returns(TypeName.VOID);
+            }
+        } else {
+            b.returns(ClassName.get(apiPackage, ctx.get("classname") + "Responses", StringUtils.capitalize(operation.operationId) + "ApiResponse"));
+        }
         if (operation.hasAuthMethods && params.authAsMethodArgument) {
             for (var param : this.buildAuthParameters(operation)) {
                 b.addParameter(param);

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientResponseMapperGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientResponseMapperGenerator.java
@@ -11,6 +11,12 @@ import java.io.IOException;
 import static io.koraframework.openapi.generator.KoraCodegen.isContentJson;
 
 public class ClientResponseMapperGenerator extends AbstractJavaGenerator<OperationsMap> {
+
+    private static final ClassName HTTP_CLIENT_RESPONSE_EXCEPTION = ClassName.get(
+        "io.koraframework.http.client.common.exception", "HttpClientResponseException");
+    private static final ClassName HTTP_CLIENT_DECODED_RESPONSE_EXCEPTION = ClassName.get(
+        "io.koraframework.http.client.common.exception", "HttpClientDecodedResponseException");
+
     @Override
     public JavaFile generate(OperationsMap ctx) {
         var className = ClassName.get(apiPackage, ctx.get("classname") + "ClientResponseMappers");
@@ -18,12 +24,99 @@ public class ClientResponseMapperGenerator extends AbstractJavaGenerator<Operati
             .addAnnotation(generated())
             .addModifiers(Modifier.PUBLIC, Modifier.STATIC);
         for (var operation : ctx.getOperations().getOperation()) {
-            for (var response : operation.responses) {
-                b.addType(responseMapper(ctx, className, operation, response));
+            if (Boolean.TRUE.equals(operation.vendorExtensions.get("plainResponse"))) {
+                var plainDataType = operation.vendorExtensions.get("plainResponseDataType");
+                if (plainDataType != null) {
+                    b.addType(plainResponseMapper(ctx, className, operation));
+                }
+            } else {
+                for (var response : operation.responses) {
+                    b.addType(responseMapper(ctx, className, operation, response));
+                }
             }
         }
 
         return JavaFile.builder(apiPackage, b.build()).build();
+    }
+
+    @SuppressWarnings("unchecked")
+    private TypeSpec plainResponseMapper(OperationsMap ctx, ClassName mappers, CodegenOperation operation) {
+        var successResponse = operation.responses.stream()
+            .filter(r -> !r.isDefault && r.code != null && r.code.startsWith("2") && r.dataType != null)
+            .findFirst()
+            .orElseThrow();
+        var successType = asType(successResponse);
+        var className = mappers.nestedClass(capitalize(operation.operationId) + "PlainResponseMapper");
+        var b = TypeSpec.classBuilder(className)
+            .addAnnotation(generated())
+            .addAnnotation(Classes.component)
+            .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
+            .addSuperinterface(ParameterizedTypeName.get(Classes.httpClientResponseMapper, successType));
+
+        var constructor = MethodSpec.constructorBuilder().addModifiers(Modifier.PUBLIC);
+
+        // Success mapper field
+        var successMapperType = ParameterizedTypeName.get(Classes.httpClientResponseMapper, successType);
+        b.addField(successMapperType, "successMapper", Modifier.PRIVATE, Modifier.FINAL);
+        var successParam = ParameterSpec.builder(successMapperType, "successMapper");
+        if (isContentJson(successResponse.getContent())) {
+            successParam.addAnnotation(jsonAnnotation());
+        }
+        constructor.addParameter(successParam.build()).addStatement("this.successMapper = successMapper");
+
+        // Error mapper fields
+        var errorResponses = (java.util.List<CodegenResponse>) operation.vendorExtensions.getOrDefault("plainErrorResponses", java.util.List.of());
+        for (var error : errorResponses) {
+            var errorType = asType(error);
+            var errorMapperType = ParameterizedTypeName.get(Classes.httpClientResponseMapper, errorType);
+            var fieldName = errorMapperFieldName(error);
+            b.addField(errorMapperType, fieldName, Modifier.PRIVATE, Modifier.FINAL);
+            var errorParam = ParameterSpec.builder(errorMapperType, fieldName);
+            if (isContentJson(error.getContent())) {
+                errorParam.addAnnotation(jsonAnnotation());
+            }
+            constructor.addParameter(errorParam.build()).addStatement("this.$N = $N", fieldName, fieldName);
+        }
+
+        // apply() method
+        var apply = MethodSpec.methodBuilder("apply")
+            .addModifiers(Modifier.PUBLIC)
+            .addAnnotation(Override.class)
+            .returns(successType)
+            .addParameter(Classes.httpClientResponse, "response")
+            .addException(IOException.class);
+
+        apply.addStatement("var code = response.code()");
+        apply.beginControlFlow("if (code >= 200 && code < 300)")
+            .addStatement("return successMapper.apply(response)")
+            .endControlFlow();
+
+        for (var error : errorResponses) {
+            if (!error.isDefault) {
+                var fieldName = errorMapperFieldName(error);
+                apply.beginControlFlow("if (code == $L)", error.code)
+                    .addStatement("var body = this.$N.apply(response)", fieldName)
+                    .addStatement("throw new $T(code, response.headers(), body)", HTTP_CLIENT_DECODED_RESPONSE_EXCEPTION)
+                    .endControlFlow();
+            }
+        }
+
+        // Default error handler
+        var hasDefaultError = errorResponses.stream().anyMatch(r -> r.isDefault);
+        if (hasDefaultError) {
+            var defaultError = errorResponses.stream().filter(r -> r.isDefault).findFirst().orElseThrow();
+            var fieldName = errorMapperFieldName(defaultError);
+            apply.addStatement("var body = this.$N.apply(response)", fieldName)
+                .addStatement("throw new $T(code, response.headers(), body)", HTTP_CLIENT_DECODED_RESPONSE_EXCEPTION);
+        } else {
+            apply.addStatement("throw $T.fromResponse(response)", HTTP_CLIENT_RESPONSE_EXCEPTION);
+        }
+
+        return b.addMethod(constructor.build()).addMethod(apply.build()).build();
+    }
+
+    private static String errorMapperFieldName(CodegenResponse error) {
+        return error.isDefault ? "errorDefaultMapper" : "error" + error.code + "Mapper";
     }
 
     private TypeSpec responseMapper(OperationsMap ctx, ClassName mappers, CodegenOperation operation, CodegenResponse response) {

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ApiResponseGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ApiResponseGenerator.kt
@@ -10,6 +10,9 @@ class ApiResponseGenerator : AbstractKotlinGenerator<OperationsMap>() {
         val b = TypeSpec.interfaceBuilder(className)
             .addAnnotation(generated())
         for (operation in ctx.operations.operation) {
+            if (operation.vendorExtensions["plainResponse"] == true) {
+                continue
+            }
             val responseClassName = className.nestedClass(capitalize(operation.operationId) + "ApiResponse")
             if (operation.responses.size == 1) {
                 b.addType(response(ctx, responseClassName, operation.responses.single()))

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ClientApiGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ClientApiGenerator.kt
@@ -22,6 +22,7 @@ class ClientApiGenerator() : AbstractKotlinGenerator<OperationsMap>() {
     }
 
     private fun buildFunction(ctx: OperationsMap, operation: CodegenOperation): FunSpec {
+        val isPlain = operation.vendorExtensions["plainResponse"] == true
         val tag = ctx.get("baseName").toString()
         val b = FunSpec.builder(operation.operationId)
             .addModifiers(KModifier.ABSTRACT)
@@ -29,16 +30,31 @@ class ClientApiGenerator() : AbstractKotlinGenerator<OperationsMap>() {
         buildAdditionalAnnotations(tag).forEach { b.addAnnotation(it) }
         b.addAnnotations(this.buildImplicitHeaders(operation))
         b.addAnnotation(buildRouteAnnotation(operation))
-        for (response in operation.responses) {
-            b.addAnnotation(
-                AnnotationSpec.builder(Classes.responseCodeMapper.asKt())
-                    .addMember("code = %L", if (response.isDefault) "-1" else response.code)
-                    .addMember(
-                        "mapper = %T::class",
-                        ClassName(apiPackage, ctx.get("classname").toString() + "ClientResponseMappers", (StringUtils.capitalize(operation.operationId) + response.code) + "ApiResponseMapper")
-                    )
-                    .build()
-            )
+        if (isPlain) {
+            val plainDataType = operation.vendorExtensions["plainResponseDataType"]
+            if (plainDataType != null) {
+                b.addAnnotation(
+                    AnnotationSpec.builder(Classes.responseCodeMapper.asKt())
+                        .addMember("code = %L", "-1")
+                        .addMember(
+                            "mapper = %T::class",
+                            ClassName(apiPackage, ctx.get("classname").toString() + "ClientResponseMappers", StringUtils.capitalize(operation.operationId) + "PlainResponseMapper")
+                        )
+                        .build()
+                )
+            }
+        } else {
+            for (response in operation.responses) {
+                b.addAnnotation(
+                    AnnotationSpec.builder(Classes.responseCodeMapper.asKt())
+                        .addMember("code = %L", if (response.isDefault) "-1" else response.code)
+                        .addMember(
+                            "mapper = %T::class",
+                            ClassName(apiPackage, ctx.get("classname").toString() + "ClientResponseMappers", (StringUtils.capitalize(operation.operationId) + response.code) + "ApiResponseMapper")
+                        )
+                        .build()
+                )
+            }
         }
 //        this.buildMethodAuth(operation, Classes.httpClientInterceptor.asKt())?.let {
 //            b.addAnnotation(it)
@@ -47,7 +63,17 @@ class ClientApiGenerator() : AbstractKotlinGenerator<OperationsMap>() {
         if (operation.isDeprecated) {
             b.addAnnotation(AnnotationSpec.builder(Deprecated::class.asClassName()).addMember("%S", "deprecated").build())
         }
-        b.returns(ClassName(apiPackage, ctx.get("classname").toString() + "Responses", StringUtils.capitalize(operation.operationId) + "ApiResponse"))
+        if (isPlain) {
+            val plainDataType = operation.vendorExtensions["plainResponseDataType"] as? String
+            if (plainDataType != null) {
+                val successResponse = operation.responses.first { r -> !r.isDefault && r.code != null && r.code.startsWith("2") && r.dataType != null }
+                b.returns(asType(successResponse).asKt())
+            } else {
+                b.returns(UNIT)
+            }
+        } else {
+            b.returns(ClassName(apiPackage, ctx.get("classname").toString() + "Responses", StringUtils.capitalize(operation.operationId) + "ApiResponse"))
+        }
         if (operation.hasAuthMethods && params.authAsMethodArgument) {
             b.addParameter(this.buildAuthParameter(operation));
         }

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ClientResponseMapperGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ClientResponseMapperGenerator.kt
@@ -8,17 +8,107 @@ import org.openapitools.codegen.model.OperationsMap
 import io.koraframework.openapi.generator.KoraCodegen
 
 class ClientResponseMapperGenerator : AbstractKotlinGenerator<OperationsMap>() {
+
+    companion object {
+        private val HTTP_CLIENT_RESPONSE_EXCEPTION = com.palantir.javapoet.ClassName.get(
+            "io.koraframework.http.client.common.exception", "HttpClientResponseException")
+        private val HTTP_CLIENT_DECODED_RESPONSE_EXCEPTION = com.palantir.javapoet.ClassName.get(
+            "io.koraframework.http.client.common.exception", "HttpClientDecodedResponseException")
+    }
+
+    private fun errorMapperFieldName(error: CodegenResponse): String {
+        return if (error.isDefault) "errorDefaultMapper" else "error${error.code}Mapper"
+    }
+
     override fun generate(ctx: OperationsMap): FileSpec {
         val className = ClassName(apiPackage, ctx["classname"].toString() + "ClientResponseMappers")
         val b = TypeSpec.interfaceBuilder(className)
             .addAnnotation(generated())
         for (operation in ctx.operations.operation) {
-            for (response in operation.responses) {
-                b.addType(responseMapper(ctx, className, operation, response))
+            if (operation.vendorExtensions["plainResponse"] == true) {
+                val plainDataType = operation.vendorExtensions["plainResponseDataType"]
+                if (plainDataType != null) {
+                    b.addType(plainResponseMapper(ctx, className, operation))
+                }
+            } else {
+                for (response in operation.responses) {
+                    b.addType(responseMapper(ctx, className, operation, response))
+                }
             }
         }
 
         return FileSpec.get(apiPackage, b.build())
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun plainResponseMapper(ctx: OperationsMap, mappers: ClassName, operation: CodegenOperation): TypeSpec {
+        val successResponse = operation.responses.first { r -> !r.isDefault && r.code != null && r.code.startsWith("2") && r.dataType != null }
+        val successType = asType(successResponse).asKt()
+        val className = mappers.nestedClass(capitalize(operation.operationId) + "PlainResponseMapper")
+        val b = TypeSpec.classBuilder(className)
+            .addAnnotation(generated())
+            .addAnnotation(Classes.component.asKt())
+            .addSuperinterface(Classes.httpClientResponseMapper.asKt().parameterizedBy(successType))
+
+        val constructor = FunSpec.constructorBuilder()
+
+        // Success mapper
+        val successMapperType = Classes.httpClientResponseMapper.asKt().parameterizedBy(successType)
+        b.addProperty(PropertySpec.builder("successMapper", successMapperType).initializer("successMapper").build())
+        val successParam = ParameterSpec.builder("successMapper", successMapperType)
+        if (KoraCodegen.isContentJson(successResponse.content)) {
+            successParam.addAnnotation(jsonAnnotation())
+        }
+        constructor.addParameter(successParam.build())
+
+        // Error mappers
+        val errorResponses = operation.vendorExtensions.getOrDefault("plainErrorResponses", emptyList<CodegenResponse>()) as List<CodegenResponse>
+        for (error in errorResponses) {
+            val errorType = asType(error).asKt()
+            val errorMapperType = Classes.httpClientResponseMapper.asKt().parameterizedBy(errorType)
+            val fieldName = errorMapperFieldName(error)
+            b.addProperty(PropertySpec.builder(fieldName, errorMapperType).initializer(fieldName).build())
+            val errorParam = ParameterSpec.builder(fieldName, errorMapperType)
+            if (KoraCodegen.isContentJson(error.content)) {
+                errorParam.addAnnotation(jsonAnnotation())
+            }
+            constructor.addParameter(errorParam.build())
+        }
+
+        // apply()
+        val apply = FunSpec.builder("apply")
+            .addModifiers(KModifier.OVERRIDE)
+            .returns(successType)
+            .addParameter("response", Classes.httpClientResponse.asKt())
+
+        apply.addStatement("val code = response.code()")
+        apply.beginControlFlow("if (code in 200..299)")
+        apply.addStatement("return successMapper.apply(response)!!")
+        apply.endControlFlow()
+
+        for (error in errorResponses) {
+            if (!error.isDefault) {
+                val fieldName = errorMapperFieldName(error)
+                apply.beginControlFlow("if (code == %L)", error.code)
+                apply.addStatement("val body = this.%N.apply(response)", fieldName)
+                apply.addStatement("throw %T(code, response.headers(), body)", HTTP_CLIENT_DECODED_RESPONSE_EXCEPTION.asKt())
+                apply.endControlFlow()
+            }
+        }
+
+        val hasDefaultError = errorResponses.any { it.isDefault }
+        if (hasDefaultError) {
+            val defaultError = errorResponses.first { it.isDefault }
+            val fieldName = errorMapperFieldName(defaultError)
+            apply.addStatement("val body = this.%N.apply(response)", fieldName)
+            apply.addStatement("throw %T(code, response.headers(), body)", HTTP_CLIENT_DECODED_RESPONSE_EXCEPTION.asKt())
+        } else {
+            apply.addStatement("throw %T.fromResponse(response)", HTTP_CLIENT_RESPONSE_EXCEPTION.asKt())
+        }
+
+        b.primaryConstructor(constructor.build())
+        b.addFunction(apply.build())
+        return b.build()
     }
 
     private fun responseMapper(ctx: OperationsMap, mappers: ClassName, operation: CodegenOperation, response: CodegenResponse): TypeSpec {

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/BaseOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/BaseOpenapiTest.java
@@ -23,6 +23,7 @@ public abstract class BaseOpenapiTest {
             @Nullable
             public String implicitHeadersRegex;
             public boolean defaultDelegate;
+            public boolean plainResponse;
 
             public Options setAuthAsArg(boolean authAsArg) {
                 this.authAsArg = authAsArg;
@@ -46,6 +47,11 @@ public abstract class BaseOpenapiTest {
 
             public Options setDefaultDelegate(boolean defaultDelegate) {
                 this.defaultDelegate = defaultDelegate;
+                return this;
+            }
+
+            public Options setPlainResponse(boolean plainResponse) {
+                this.plainResponse = plainResponse;
                 return this;
             }
         }
@@ -76,6 +82,7 @@ public abstract class BaseOpenapiTest {
             "/example/petstoreV3_responses.yaml",
             "/example/petstoreV3_types.yaml",
             "/example/petstoreV3_validation.yaml",
+            "/example/petstoreV3_plain_response.yaml",
         };
 
         for (var fileName : files) {
@@ -97,6 +104,10 @@ public abstract class BaseOpenapiTest {
 
             if (name.equals("petstoreV3")) {
                 result.add(new SwaggerParams(fileName, name + "_default_delegate", new SwaggerParams.Options().setDefaultDelegate(true)));
+            }
+
+            if (name.equals("petstoreV3_plain_response")) {
+                result.add(new SwaggerParams(fileName, name + "_plain", new SwaggerParams.Options().setPlainResponse(true)));
             }
         }
 
@@ -149,6 +160,10 @@ public abstract class BaseOpenapiTest {
 
         if (options.implicitHeadersRegex != null) {
             configurator.addAdditionalProperty("implicitHeadersRegex", options.implicitHeadersRegex);
+        }
+
+        if (options.plainResponse) {
+            configurator.addAdditionalProperty("response", "plain");
         }
 
         if (spec.contains("_filter")) {

--- a/openapi/openapi-generator/src/test/resources/example/petstoreV3_plain_response.yaml
+++ b/openapi/openapi-generator/src/test/resources/example/petstoreV3_plain_response.yaml
@@ -1,0 +1,147 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore Plain
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: A list of pets
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pets"
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /pets/{petId}:
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Expected response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+        '404':
+          description: Pet not found
+    delete:
+      summary: Delete a pet
+      operationId: deletePet
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Pet deleted
+        '404':
+          description: Pet not found
+  /pets/search:
+    get:
+      summary: Search pets (multiple 2xx same type)
+      operationId: searchPets
+      parameters:
+        - name: q
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Full results
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pets"
+        '206':
+          description: Partial results
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pets"
+  /pets/multi:
+    get:
+      summary: Multi response (different 2xx types - fallback to sealed)
+      operationId: multiResponse
+      responses:
+        '200':
+          description: Full pet
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+        '202':
+          description: Accepted with status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Status"
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+    Pets:
+      type: array
+      items:
+        $ref: "#/components/schemas/Pet"
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string
+    Status:
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          type: string


### PR DESCRIPTION
## Summary

- When `response=plain`, client methods return success type directly instead of sealed interface
- Error responses throw `HttpClientDecodedResponseException` (typed body) or `HttpClientResponseException` (raw)
- Falls back to sealed mode when 2xx responses have different data types
- Reimplemented from scratch for 2.0.0 architecture (JavaPoet/KotlinPoet code generators)

## Changes

- **http-client-common**: `HttpClientDecodedResponseException` + protected constructor in `HttpClientResponseException`
- **openapi-generator**: `ResponseStyle` enum, `response` CLI option, plain response vendor extensions
- **Java generators**: `ApiResponseGenerator`, `ClientApiGenerator`, `ClientResponseMapperGenerator`
- **Kotlin generators**: Same as Java
- **Tests**: `petstoreV3_plain_response.yaml` spec + `plainResponse` option

Supersedes #615 (was targeting 1.0, rewritten for master/2.0.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)