### PR TITLE
Fixed JUnit test extension graph cleanup in afterAll for `@Nested` test classes `PER_METHOD`

### DIFF
--- a/test/test-junit5/src/main/java/ru/tinkoff/kora/test/extension/junit5/KoraJUnit5Extension.java
+++ b/test/test-junit5/src/main/java/ru/tinkoff/kora/test/extension/junit5/KoraJUnit5Extension.java
@@ -391,7 +391,7 @@ final class KoraJUnit5Extension implements BeforeAllCallback, BeforeEachCallback
 
                 if (!fieldsForInjection.isEmpty()) {
                     throw new ExtensionConfigurationException("@KoraAppTest can't use @Nested class field injection when outer class lifecycle is 'PER_CLASS', " +
-                                                              "cause graph is already initialized on the top level");
+                                                              "cause graph is already initialized on the top level test class and initialization context is sources from top level test class only, use 'PER_METHOD' lifecycle instead");
                 }
             }
         }
@@ -448,7 +448,9 @@ final class KoraJUnit5Extension implements BeforeAllCallback, BeforeEachCallback
         var koraTestContext = getKoraTestContext(context);
         if (koraTestContext.lifecycle == TestInstance.Lifecycle.PER_CLASS) {
             // check if created graph test class equal current test class (so nested class won't close upper class lifecycle graph)
-            if (koraTestContext.graph != null && koraTestContext.metadata.testClass().equals(context.getRequiredTestClass())) {
+            if (koraTestContext.graph != null
+                && (koraTestContext.metadata.outerTestClass == null && !context.getRequiredTestClass().isAnnotationPresent(Nested.class))
+                && koraTestContext.metadata.testClass().equals(context.getRequiredTestClass())) {
                 var lock = koraTestContext.graph;
                 synchronized (lock) {
                     if (koraTestContext.graph.status() == TestGraph.Status.INITIALIZED) {

--- a/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/initializemode/AbstractNestedPerClassTests.java
+++ b/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/initializemode/AbstractNestedPerClassTests.java
@@ -62,5 +62,11 @@ abstract class AbstractNestedPerClassTests {
             assertSame(prevComponent12, component12);
         }
     }
+
+    @AfterAll
+    static void cleanup() {
+        prevComponent1 = null;
+        prevComponent12 = null;
+    }
 }
 

--- a/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/initializemode/AbstractNestedPerClassTests.java
+++ b/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/initializemode/AbstractNestedPerClassTests.java
@@ -1,0 +1,66 @@
+package ru.tinkoff.kora.test.extension.junit5.initializemode;
+
+import org.junit.jupiter.api.*;
+import ru.tinkoff.kora.test.extension.junit5.KoraAppTest;
+import ru.tinkoff.kora.test.extension.junit5.TestComponent;
+import ru.tinkoff.kora.test.extension.junit5.testdata.TestApplication;
+import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent1;
+import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent12;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+@KoraAppTest(value = TestApplication.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+abstract class AbstractNestedPerClassTests {
+
+    static volatile TestComponent1 prevComponent1;
+    static volatile TestComponent12 prevComponent12;
+
+    @TestComponent
+    TestComponent1 component1;
+    @TestComponent
+    TestComponent12 component12;
+
+    @Nested
+    class Nested1 {
+
+        @Test
+        void test1() {
+            assertNotNull(component1);
+            assertNotNull(component12);
+            assertSame(prevComponent1, component1);
+            assertSame(prevComponent12, component12);
+        }
+
+        @Test
+        void test2() {
+            assertNotNull(component1);
+            assertNotNull(component12);
+            assertSame(prevComponent1, component1);
+            assertSame(prevComponent12, component12);
+        }
+    }
+
+    @Nested
+    class Nested2 {
+
+        @Test
+        void test3() {
+            assertNotNull(component1);
+            assertNotNull(component12);
+            assertSame(prevComponent1, component1);
+            assertSame(prevComponent12, component12);
+        }
+
+        @Test
+        void test4() {
+            assertNotNull(component1);
+            assertNotNull(component12);
+            assertSame(prevComponent1, component1);
+            assertSame(prevComponent12, component12);
+        }
+    }
+}
+

--- a/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/initializemode/AbstractNestedPerMethodTests.java
+++ b/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/initializemode/AbstractNestedPerMethodTests.java
@@ -13,35 +13,16 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
 @KoraAppTest(value = TestApplication.class)
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-class NestedFieldPerMethodTests {
+abstract class AbstractNestedPerMethodTests {
 
     static volatile TestComponent1 prevComponent1;
     static volatile TestComponent12 prevComponent12;
 
     @TestComponent
-    private TestComponent1 component1;
+    TestComponent1 component1;
     @TestComponent
-    private TestComponent12 component12;
+    TestComponent12 component12;
 
-    @Test
-    @Order(1)
-    void test1() {
-        assertNotNull(component1);
-        assertNotNull(component12);
-        prevComponent1 = component1;
-        prevComponent12 = component12;
-    }
-
-    @Test
-    @Order(2)
-    void test2() {
-        assertNotNull(component1);
-        assertNotNull(component12);
-        assertNotSame(prevComponent1, component1);
-        assertNotSame(prevComponent12, component12);
-    }
-
-    @Order(3)
     @Nested
     class Nested1 {
 
@@ -49,12 +30,33 @@ class NestedFieldPerMethodTests {
         private TestComponent12 componentNested12;
 
         @Test
-        void test3() {
+        void test1() {
             assertNotNull(component1);
             assertNotNull(component12);
             assertNotSame(prevComponent1, component1);
             assertNotSame(prevComponent12, component12);
             assertNotSame(prevComponent12, componentNested12);
+        }
+
+        @Test
+        void test2() {
+            assertNotNull(component1);
+            assertNotNull(component12);
+            assertNotSame(prevComponent1, component1);
+            assertNotSame(prevComponent12, component12);
+            assertNotSame(prevComponent12, componentNested12);
+        }
+    }
+
+    @Nested
+    class Nested2 {
+
+        @Test
+        void test3() {
+            assertNotNull(component1);
+            assertNotNull(component12);
+            assertNotSame(prevComponent1, component1);
+            assertNotSame(prevComponent12, component12);
         }
 
         @Test
@@ -63,28 +65,7 @@ class NestedFieldPerMethodTests {
             assertNotNull(component12);
             assertNotSame(prevComponent1, component1);
             assertNotSame(prevComponent12, component12);
-            assertNotSame(prevComponent12, componentNested12);
-        }
-    }
-
-    @Order(4)
-    @Nested
-    class Nested2 {
-
-        @Test
-        void test5() {
-            assertNotNull(component1);
-            assertNotNull(component12);
-            assertNotSame(prevComponent1, component1);
-            assertNotSame(prevComponent12, component12);
-        }
-
-        @Test
-        void test6() {
-            assertNotNull(component1);
-            assertNotNull(component12);
-            assertNotSame(prevComponent1, component1);
-            assertNotSame(prevComponent12, component12);
         }
     }
 }
+

--- a/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/initializemode/AbstractNestedPerMethodTests.java
+++ b/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/initializemode/AbstractNestedPerMethodTests.java
@@ -67,5 +67,11 @@ abstract class AbstractNestedPerMethodTests {
             assertNotSame(prevComponent12, component12);
         }
     }
+
+    @AfterAll
+    static void cleanup() {
+        prevComponent1 = null;
+        prevComponent12 = null;
+    }
 }
 

--- a/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/initializemode/AbstractPerClassTests.java
+++ b/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/initializemode/AbstractPerClassTests.java
@@ -12,6 +12,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @KoraAppTest(value = TestApplication.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 abstract class AbstractPerClassTests {
 
     static volatile KoraAppGraph prevGraph = null;

--- a/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/initializemode/AbstractPerMethodTests.java
+++ b/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/initializemode/AbstractPerMethodTests.java
@@ -12,6 +12,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @KoraAppTest(value = TestApplication.class)
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 abstract class AbstractPerMethodTests {
 
     static volatile KoraAppGraph prevGraph = null;

--- a/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/initializemode/NestedFieldPerClassExtendedTests.java
+++ b/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/initializemode/NestedFieldPerClassExtendedTests.java
@@ -1,0 +1,66 @@
+package ru.tinkoff.kora.test.extension.junit5.initializemode;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class NestedFieldPerClassExtendedTests extends AbstractNestedPerClassTests {
+
+    @Test
+    void test3() {
+        assertNotNull(component1);
+        assertNotNull(component12);
+        prevComponent1 = component1;
+        prevComponent12 = component12;
+    }
+
+    @Test
+    void test4() {
+        assertNotNull(component1);
+        assertNotNull(component12);
+        assertSame(prevComponent1, component1);
+        assertSame(prevComponent12, component12);
+    }
+
+    @Nested
+    class Nested5 {
+
+        @Test
+        void test5() {
+            assertNotNull(component1);
+            assertNotNull(component12);
+            assertSame(prevComponent1, component1);
+            assertSame(prevComponent12, component12);
+        }
+
+        @Test
+        void test6() {
+            assertNotNull(component1);
+            assertNotNull(component12);
+            assertSame(prevComponent1, component1);
+            assertSame(prevComponent12, component12);
+        }
+    }
+
+    @Nested
+    class Nested6 {
+
+        @Test
+        void test7() {
+            assertNotNull(component1);
+            assertNotNull(component12);
+            assertSame(prevComponent1, component1);
+            assertSame(prevComponent12, component12);
+        }
+
+        @Test
+        void test8() {
+            assertNotNull(component1);
+            assertNotNull(component12);
+            assertSame(prevComponent1, component1);
+            assertSame(prevComponent12, component12);
+        }
+    }
+}

--- a/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/initializemode/NestedFieldPerMethodExtendedTests.java
+++ b/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/initializemode/NestedFieldPerMethodExtendedTests.java
@@ -1,31 +1,19 @@
 package ru.tinkoff.kora.test.extension.junit5.initializemode;
 
-import org.junit.jupiter.api.*;
-import ru.tinkoff.kora.test.extension.junit5.KoraAppTest;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
 import ru.tinkoff.kora.test.extension.junit5.TestComponent;
-import ru.tinkoff.kora.test.extension.junit5.testdata.TestApplication;
-import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent1;
 import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent12;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 
-@KoraAppTest(value = TestApplication.class)
-@TestInstance(TestInstance.Lifecycle.PER_METHOD)
-@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-class NestedFieldPerMethodTests {
-
-    static volatile TestComponent1 prevComponent1;
-    static volatile TestComponent12 prevComponent12;
-
-    @TestComponent
-    private TestComponent1 component1;
-    @TestComponent
-    private TestComponent12 component12;
+class NestedFieldPerMethodExtendedTests extends AbstractNestedPerMethodTests {
 
     @Test
-    @Order(1)
-    void test1() {
+    @Order(3)
+    void test7() {
         assertNotNull(component1);
         assertNotNull(component12);
         prevComponent1 = component1;
@@ -33,17 +21,17 @@ class NestedFieldPerMethodTests {
     }
 
     @Test
-    @Order(2)
-    void test2() {
+    @Order(4)
+    void test8() {
         assertNotNull(component1);
         assertNotNull(component12);
         assertNotSame(prevComponent1, component1);
         assertNotSame(prevComponent12, component12);
     }
 
-    @Order(3)
+    @Order(5)
     @Nested
-    class Nested1 {
+    class Nested5 {
 
         @TestComponent
         private TestComponent12 componentNested12;
@@ -67,9 +55,9 @@ class NestedFieldPerMethodTests {
         }
     }
 
-    @Order(4)
+    @Order(6)
     @Nested
-    class Nested2 {
+    class Nested6 {
 
         @Test
         void test5() {

--- a/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/initializemode/NestedOnlyFieldPerClassExtendedTests.java
+++ b/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/initializemode/NestedOnlyFieldPerClassExtendedTests.java
@@ -1,0 +1,66 @@
+package ru.tinkoff.kora.test.extension.junit5.initializemode;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class NestedOnlyFieldPerClassExtendedTests extends AbstractNestedPerClassTests {
+
+    @Nested
+    class Nested3 {
+
+        @Test
+        void test3() {
+            assertNotNull(component1);
+            assertNotNull(component12);
+            if (prevComponent1 == null) {
+                prevComponent1 = component1;
+            } else {
+                assertSame(prevComponent1, component1);
+            }
+            if (prevComponent12 == null) {
+                prevComponent12 = component12;
+            } else {
+                assertSame(prevComponent12, component12);
+            }
+        }
+
+        @Test
+        void test4() {
+            assertNotNull(component1);
+            assertNotNull(component12);
+            assertSame(prevComponent1, component1);
+            assertSame(prevComponent12, component12);
+        }
+    }
+
+    @Nested
+    class Nested4 {
+
+        @Test
+        void test5() {
+            assertNotNull(component1);
+            assertNotNull(component12);
+            if (prevComponent1 == null) {
+                prevComponent1 = component1;
+            } else {
+                assertSame(prevComponent1, component1);
+            }
+            if (prevComponent12 == null) {
+                prevComponent12 = component12;
+            } else {
+                assertSame(prevComponent12, component12);
+            }
+        }
+
+        @Test
+        void test6() {
+            assertNotNull(component1);
+            assertNotNull(component12);
+            assertSame(prevComponent1, component1);
+            assertSame(prevComponent12, component12);
+        }
+    }
+}

--- a/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/initializemode/NestedOnlyFieldPerClassTests.java
+++ b/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/initializemode/NestedOnlyFieldPerClassTests.java
@@ -1,0 +1,85 @@
+package ru.tinkoff.kora.test.extension.junit5.initializemode;
+
+import org.junit.jupiter.api.*;
+import ru.tinkoff.kora.test.extension.junit5.KoraAppTest;
+import ru.tinkoff.kora.test.extension.junit5.TestComponent;
+import ru.tinkoff.kora.test.extension.junit5.testdata.TestApplication;
+import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent1;
+import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent12;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+@KoraAppTest(value = TestApplication.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.MethodName.class)
+class NestedOnlyFieldPerClassTests {
+
+    static volatile TestComponent1 prevComponent1;
+    static volatile TestComponent12 prevComponent12;
+
+    @TestComponent
+    private TestComponent1 component1;
+    @TestComponent
+    private TestComponent12 component12;
+
+    @Nested
+    class Nested1 {
+
+        @Order(1)
+        @Test
+        void test1() {
+            assertNotNull(component1);
+            assertNotNull(component12);
+            if (prevComponent1 == null) {
+                prevComponent1 = component1;
+            } else {
+                assertSame(prevComponent1, component1);
+            }
+            if (prevComponent12 == null) {
+                prevComponent12 = component12;
+            } else {
+                assertSame(prevComponent12, component12);
+            }
+        }
+
+        @Order(2)
+        @Test
+        void test2() {
+            assertNotNull(component1);
+            assertNotNull(component12);
+            assertSame(prevComponent1, component1);
+            assertSame(prevComponent12, component12);
+        }
+    }
+
+    @Nested
+    class Nested2 {
+
+        @Order(3)
+        @Test
+        void test3() {
+            assertNotNull(component1);
+            assertNotNull(component12);
+            if (prevComponent1 == null) {
+                prevComponent1 = component1;
+            } else {
+                assertSame(prevComponent1, component1);
+            }
+            if (prevComponent12 == null) {
+                prevComponent12 = component12;
+            } else {
+                assertSame(prevComponent12, component12);
+            }
+        }
+
+        @Order(4)
+        @Test
+        void test4() {
+            assertNotNull(component1);
+            assertNotNull(component12);
+            assertSame(prevComponent1, component1);
+            assertSame(prevComponent12, component12);
+        }
+    }
+}

--- a/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/initializemode/NestedOnlyFieldPerMethodExtendedTests.java
+++ b/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/initializemode/NestedOnlyFieldPerMethodExtendedTests.java
@@ -22,7 +22,14 @@ class NestedOnlyFieldPerMethodExtendedTests extends AbstractNestedPerMethodTests
         void test3() {
             assertNotNull(component1);
             assertNotNull(component12);
+            if (prevComponent1 != null) {
+                assertNotSame(prevComponent1, component1);
+            }
             prevComponent1 = component1;
+            if (prevComponent12 != null) {
+                assertNotSame(prevComponent12, component12);
+                assertNotSame(prevComponent12, componentNested12);
+            }
             prevComponent12 = component12;
         }
 
@@ -44,8 +51,14 @@ class NestedOnlyFieldPerMethodExtendedTests extends AbstractNestedPerMethodTests
         void test5() {
             assertNotNull(component1);
             assertNotNull(component12);
-            assertNotSame(prevComponent1, component1);
-            assertNotSame(prevComponent12, component12);
+            if (prevComponent1 != null) {
+                assertNotSame(prevComponent1, component1);
+            }
+            prevComponent1 = component1;
+            if (prevComponent12 != null) {
+                assertNotSame(prevComponent12, component12);
+            }
+            prevComponent12 = component12;
         }
 
         @Test

--- a/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/initializemode/NestedOnlyFieldPerMethodExtendedTests.java
+++ b/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/initializemode/NestedOnlyFieldPerMethodExtendedTests.java
@@ -1,49 +1,19 @@
 package ru.tinkoff.kora.test.extension.junit5.initializemode;
 
-import org.junit.jupiter.api.*;
-import ru.tinkoff.kora.test.extension.junit5.KoraAppTest;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
 import ru.tinkoff.kora.test.extension.junit5.TestComponent;
-import ru.tinkoff.kora.test.extension.junit5.testdata.TestApplication;
-import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent1;
 import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent12;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 
-@KoraAppTest(value = TestApplication.class)
-@TestInstance(TestInstance.Lifecycle.PER_METHOD)
-@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-class NestedFieldPerMethodTests {
-
-    static volatile TestComponent1 prevComponent1;
-    static volatile TestComponent12 prevComponent12;
-
-    @TestComponent
-    private TestComponent1 component1;
-    @TestComponent
-    private TestComponent12 component12;
-
-    @Test
-    @Order(1)
-    void test1() {
-        assertNotNull(component1);
-        assertNotNull(component12);
-        prevComponent1 = component1;
-        prevComponent12 = component12;
-    }
-
-    @Test
-    @Order(2)
-    void test2() {
-        assertNotNull(component1);
-        assertNotNull(component12);
-        assertNotSame(prevComponent1, component1);
-        assertNotSame(prevComponent12, component12);
-    }
+class NestedOnlyFieldPerMethodExtendedTests extends AbstractNestedPerMethodTests {
 
     @Order(3)
     @Nested
-    class Nested1 {
+    class Nested3 {
 
         @TestComponent
         private TestComponent12 componentNested12;
@@ -52,9 +22,8 @@ class NestedFieldPerMethodTests {
         void test3() {
             assertNotNull(component1);
             assertNotNull(component12);
-            assertNotSame(prevComponent1, component1);
-            assertNotSame(prevComponent12, component12);
-            assertNotSame(prevComponent12, componentNested12);
+            prevComponent1 = component1;
+            prevComponent12 = component12;
         }
 
         @Test
@@ -69,7 +38,7 @@ class NestedFieldPerMethodTests {
 
     @Order(4)
     @Nested
-    class Nested2 {
+    class Nested4 {
 
         @Test
         void test5() {

--- a/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/initializemode/NestedOnlyFieldPerMethodTests.java
+++ b/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/initializemode/NestedOnlyFieldPerMethodTests.java
@@ -13,7 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
 @KoraAppTest(value = TestApplication.class)
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-class NestedFieldPerMethodTests {
+class NestedOnlyFieldPerMethodTests {
 
     static volatile TestComponent1 prevComponent1;
     static volatile TestComponent12 prevComponent12;
@@ -23,25 +23,7 @@ class NestedFieldPerMethodTests {
     @TestComponent
     private TestComponent12 component12;
 
-    @Test
     @Order(1)
-    void test1() {
-        assertNotNull(component1);
-        assertNotNull(component12);
-        prevComponent1 = component1;
-        prevComponent12 = component12;
-    }
-
-    @Test
-    @Order(2)
-    void test2() {
-        assertNotNull(component1);
-        assertNotNull(component12);
-        assertNotSame(prevComponent1, component1);
-        assertNotSame(prevComponent12, component12);
-    }
-
-    @Order(3)
     @Nested
     class Nested1 {
 
@@ -52,9 +34,8 @@ class NestedFieldPerMethodTests {
         void test3() {
             assertNotNull(component1);
             assertNotNull(component12);
-            assertNotSame(prevComponent1, component1);
-            assertNotSame(prevComponent12, component12);
-            assertNotSame(prevComponent12, componentNested12);
+            prevComponent1 = component1;
+            prevComponent12 = component12;
         }
 
         @Test
@@ -67,7 +48,7 @@ class NestedFieldPerMethodTests {
         }
     }
 
-    @Order(4)
+    @Order(2)
     @Nested
     class Nested2 {
 

--- a/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/initializemode/NestedOnlyFieldPerMethodTests.java
+++ b/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/initializemode/NestedOnlyFieldPerMethodTests.java
@@ -34,7 +34,14 @@ class NestedOnlyFieldPerMethodTests {
         void test3() {
             assertNotNull(component1);
             assertNotNull(component12);
+            if (prevComponent1 != null) {
+                assertNotSame(prevComponent1, component1);
+            }
             prevComponent1 = component1;
+            if (prevComponent12 != null) {
+                assertNotSame(prevComponent12, component12);
+                assertNotSame(prevComponent12, componentNested12);
+            }
             prevComponent12 = component12;
         }
 
@@ -56,8 +63,14 @@ class NestedOnlyFieldPerMethodTests {
         void test5() {
             assertNotNull(component1);
             assertNotNull(component12);
-            assertNotSame(prevComponent1, component1);
-            assertNotSame(prevComponent12, component12);
+            if (prevComponent1 != null) {
+                assertNotSame(prevComponent1, component1);
+            }
+            prevComponent1 = component1;
+            if (prevComponent12 != null) {
+                assertNotSame(prevComponent12, component12);
+            }
+            prevComponent12 = component12;
         }
 
         @Test

--- a/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/initializemode/NestedOnlyFieldPerNestedClassTests.java
+++ b/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/initializemode/NestedOnlyFieldPerNestedClassTests.java
@@ -7,12 +7,11 @@ import ru.tinkoff.kora.test.extension.junit5.testdata.TestApplication;
 import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent1;
 import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent12;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.*;
 
 @KoraAppTest(value = TestApplication.class)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-class NestedFieldPerClassNestedTests {
+class NestedOnlyFieldPerNestedClassTests {
 
     static volatile TestComponent1 prevComponent1;
     static volatile TestComponent12 prevComponent12;
@@ -23,60 +22,67 @@ class NestedFieldPerClassNestedTests {
     private TestComponent12 component12;
 
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-    @Order(3)
+    @Order(1)
     @Nested
     class Nested1 {
 
         @TestComponent
-        private TestComponent12 componentNested;
+        private TestComponent12 componentNested12;
 
-        @Order(4)
+        @Test
+        void test1() {
+            assertNotNull(component1);
+            assertNotNull(component12);
+            if (prevComponent1 != null) {
+                assertNotSame(prevComponent1, component1);
+            }
+            prevComponent1 = component1;
+            if (prevComponent12 != null) {
+                assertNotSame(prevComponent12, component12);
+                assertNotSame(prevComponent12, componentNested12);
+            }
+            prevComponent12 = component12;
+        }
+
+        @Test
+        void test2() {
+            assertNotNull(component1);
+            assertNotNull(component12);
+            assertSame(prevComponent1, component1);
+            assertSame(prevComponent12, component12);
+            assertSame(prevComponent12, componentNested12);
+        }
+    }
+
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    @Order(4)
+    @Nested
+    class Nested2 {
+
+        @TestComponent
+        private TestComponent12 componentNested12;
+
         @Test
         void test3() {
             assertNotNull(component1);
             assertNotNull(component12);
+            if (prevComponent1 != null) {
+                assertNotSame(prevComponent1, component1);
+            }
             prevComponent1 = component1;
+            if (prevComponent12 != null) {
+                assertNotSame(prevComponent12, component12);
+                assertNotSame(prevComponent12, componentNested12);
+            }
             prevComponent12 = component12;
-            componentNested = component12;
         }
 
-        @Order(5)
         @Test
         void test4() {
             assertNotNull(component1);
             assertNotNull(component12);
             assertSame(prevComponent1, component1);
             assertSame(prevComponent12, component12);
-            assertSame(prevComponent12, componentNested);
-        }
-    }
-
-    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-    @Order(6)
-    @Nested
-    class Nested2 {
-
-        @TestComponent
-        private TestComponent12 componentNested;
-
-        @Order(7)
-        @Test
-        void test5() {
-            assertNotNull(component1);
-            assertNotNull(component12);
-            prevComponent1 = component1;
-            prevComponent12 = component12;
-            componentNested = component12;
-        }
-
-        @Order(8)
-        @Test
-        void test6() {
-            assertNotNull(component1);
-            assertNotNull(component12);
-            assertSame(prevComponent1, component1);
-            assertSame(prevComponent12, component12);
-            assertSame(prevComponent12, componentNested);
         }
     }
 }

--- a/test/test-junit5/src/test/kotlin/ru/tinkoff/kora/test/extension/junit5/kotlin/initializemode/AbstractNestedPerClassTests.kt
+++ b/test/test-junit5/src/test/kotlin/ru/tinkoff/kora/test/extension/junit5/kotlin/initializemode/AbstractNestedPerClassTests.kt
@@ -1,0 +1,73 @@
+package ru.tinkoff.kora.test.extension.junit5.kotlin.initializemode
+
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertSame
+import ru.tinkoff.kora.test.extension.junit5.KoraAppTest
+import ru.tinkoff.kora.test.extension.junit5.TestComponent
+import ru.tinkoff.kora.test.extension.junit5.testdata.TestApplication
+import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent1
+import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent12
+
+@KoraAppTest(value = TestApplication::class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+abstract class AbstractNestedPerClassTests {
+
+    companion object {
+        @Volatile
+        var prevComponent1: TestComponent1? = null
+
+        @Volatile
+        var prevComponent12: TestComponent12? = null
+    }
+
+    @TestComponent
+    lateinit var component1: TestComponent1
+
+    @TestComponent
+    lateinit var component12: TestComponent12
+
+    @Order(1)
+    @Nested
+    inner class Nested1 {
+
+        @Test
+        fun test1() {
+            assertNotNull(component1)
+            assertNotNull(component12)
+            assertSame(prevComponent1, component1)
+            assertSame(prevComponent12, component12)
+        }
+
+        @Test
+        fun test2() {
+            assertNotNull(component1)
+            assertNotNull(component12)
+            assertSame(prevComponent1, component1)
+            assertSame(prevComponent12, component12)
+        }
+    }
+
+    @Order(2)
+    @Nested
+    inner class Nested2 {
+
+        @Test
+        fun test3() {
+            assertNotNull(component1)
+            assertNotNull(component12)
+            assertSame(prevComponent1, component1)
+            assertSame(prevComponent12, component12)
+        }
+
+        @Test
+        fun test4() {
+            assertNotNull(component1)
+            assertNotNull(component12)
+            assertSame(prevComponent1, component1)
+            assertSame(prevComponent12, component12)
+        }
+    }
+}
+

--- a/test/test-junit5/src/test/kotlin/ru/tinkoff/kora/test/extension/junit5/kotlin/initializemode/AbstractNestedPerClassTests.kt
+++ b/test/test-junit5/src/test/kotlin/ru/tinkoff/kora/test/extension/junit5/kotlin/initializemode/AbstractNestedPerClassTests.kt
@@ -15,16 +15,22 @@ import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent12
 abstract class AbstractNestedPerClassTests {
 
     companion object {
-        @Volatile
-        var prevComponent1: TestComponent1? = null
 
         @Volatile
+        var prevComponent1: TestComponent1? = null
+        @Volatile
         var prevComponent12: TestComponent12? = null
+
+        @JvmStatic
+        @AfterAll
+        fun cleanup() {
+            prevComponent1 = null
+            prevComponent12 = null
+        }
     }
 
     @TestComponent
     lateinit var component1: TestComponent1
-
     @TestComponent
     lateinit var component12: TestComponent12
 

--- a/test/test-junit5/src/test/kotlin/ru/tinkoff/kora/test/extension/junit5/kotlin/initializemode/AbstractNestedPerMethodTests.kt
+++ b/test/test-junit5/src/test/kotlin/ru/tinkoff/kora/test/extension/junit5/kotlin/initializemode/AbstractNestedPerMethodTests.kt
@@ -15,16 +15,22 @@ import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent12
 abstract class AbstractNestedPerMethodTests {
 
     companion object {
-        @Volatile
-        var prevComponent1: TestComponent1? = null
 
         @Volatile
+        var prevComponent1: TestComponent1? = null
+        @Volatile
         var prevComponent12: TestComponent12? = null
+
+        @JvmStatic
+        @AfterAll
+        fun cleanup() {
+            prevComponent1 = null
+            prevComponent12 = null
+        }
     }
 
     @TestComponent
     lateinit var component1: TestComponent1
-
     @TestComponent
     lateinit var component12: TestComponent12
 
@@ -39,8 +45,8 @@ abstract class AbstractNestedPerMethodTests {
         fun test1() {
             assertNotNull(component1)
             assertNotNull(component12)
-            prevComponent1 = component1
-            prevComponent12 = component12
+            assertNotSame(prevComponent1, component1)
+            assertNotSame(prevComponent12, component12)
         }
 
         @Test

--- a/test/test-junit5/src/test/kotlin/ru/tinkoff/kora/test/extension/junit5/kotlin/initializemode/AbstractNestedPerMethodTests.kt
+++ b/test/test-junit5/src/test/kotlin/ru/tinkoff/kora/test/extension/junit5/kotlin/initializemode/AbstractNestedPerMethodTests.kt
@@ -1,0 +1,77 @@
+package ru.tinkoff.kora.test.extension.junit5.kotlin.initializemode
+
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNotSame
+import ru.tinkoff.kora.test.extension.junit5.KoraAppTest
+import ru.tinkoff.kora.test.extension.junit5.TestComponent
+import ru.tinkoff.kora.test.extension.junit5.testdata.TestApplication
+import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent1
+import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent12
+
+@KoraAppTest(value = TestApplication::class)
+@TestInstance(TestInstance.Lifecycle.PER_METHOD)
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+abstract class AbstractNestedPerMethodTests {
+
+    companion object {
+        @Volatile
+        var prevComponent1: TestComponent1? = null
+
+        @Volatile
+        var prevComponent12: TestComponent12? = null
+    }
+
+    @TestComponent
+    lateinit var component1: TestComponent1
+
+    @TestComponent
+    lateinit var component12: TestComponent12
+
+    @Order(1)
+    @Nested
+    inner class Nested1 {
+
+        @TestComponent
+        lateinit var componentNested12: TestComponent12
+
+        @Test
+        fun test1() {
+            assertNotNull(component1)
+            assertNotNull(component12)
+            prevComponent1 = component1
+            prevComponent12 = component12
+        }
+
+        @Test
+        fun test2() {
+            assertNotNull(component1)
+            assertNotNull(component12)
+            assertNotSame(prevComponent1, component1)
+            assertNotSame(prevComponent12, component12)
+            assertNotSame(prevComponent12, componentNested12)
+        }
+    }
+
+    @Order(2)
+    @Nested
+    inner class Nested2 {
+
+        @Test
+        fun test3() {
+            assertNotNull(component1)
+            assertNotNull(component12)
+            assertNotSame(prevComponent1, component1)
+            assertNotSame(prevComponent12, component12)
+        }
+
+        @Test
+        fun test4() {
+            assertNotNull(component1)
+            assertNotNull(component12)
+            assertNotSame(prevComponent1, component1)
+            assertNotSame(prevComponent12, component12)
+        }
+    }
+}
+

--- a/test/test-junit5/src/test/kotlin/ru/tinkoff/kora/test/extension/junit5/kotlin/initializemode/AbstractPerClassTests.kt
+++ b/test/test-junit5/src/test/kotlin/ru/tinkoff/kora/test/extension/junit5/kotlin/initializemode/AbstractPerClassTests.kt
@@ -8,10 +8,10 @@ import ru.tinkoff.kora.test.extension.junit5.TestComponent
 import ru.tinkoff.kora.test.extension.junit5.testdata.TestApplication
 import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent1
 import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent12
-import kotlin.concurrent.Volatile
 
 @KoraAppTest(value = TestApplication::class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
 abstract class AbstractPerClassTests {
 
     @TestComponent

--- a/test/test-junit5/src/test/kotlin/ru/tinkoff/kora/test/extension/junit5/kotlin/initializemode/AbstractPerMethodTests.kt
+++ b/test/test-junit5/src/test/kotlin/ru/tinkoff/kora/test/extension/junit5/kotlin/initializemode/AbstractPerMethodTests.kt
@@ -8,10 +8,10 @@ import ru.tinkoff.kora.test.extension.junit5.TestComponent
 import ru.tinkoff.kora.test.extension.junit5.testdata.TestApplication
 import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent1
 import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent12
-import kotlin.concurrent.Volatile
 
 @KoraAppTest(value = TestApplication::class)
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
 abstract class AbstractPerMethodTests {
 
     @TestComponent

--- a/test/test-junit5/src/test/kotlin/ru/tinkoff/kora/test/extension/junit5/kotlin/initializemode/ConstructorPerClassTests.kt
+++ b/test/test-junit5/src/test/kotlin/ru/tinkoff/kora/test/extension/junit5/kotlin/initializemode/ConstructorPerClassTests.kt
@@ -8,7 +8,6 @@ import ru.tinkoff.kora.test.extension.junit5.TestComponent
 import ru.tinkoff.kora.test.extension.junit5.testdata.TestApplication
 import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent1
 import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent12
-import kotlin.concurrent.Volatile
 
 @KoraAppTest(value = TestApplication::class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)

--- a/test/test-junit5/src/test/kotlin/ru/tinkoff/kora/test/extension/junit5/kotlin/initializemode/ConstructorPerMethodTests.kt
+++ b/test/test-junit5/src/test/kotlin/ru/tinkoff/kora/test/extension/junit5/kotlin/initializemode/ConstructorPerMethodTests.kt
@@ -8,7 +8,6 @@ import ru.tinkoff.kora.test.extension.junit5.TestComponent
 import ru.tinkoff.kora.test.extension.junit5.testdata.TestApplication
 import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent1
 import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent12
-import kotlin.concurrent.Volatile
 
 @KoraAppTest(value = TestApplication::class)
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)

--- a/test/test-junit5/src/test/kotlin/ru/tinkoff/kora/test/extension/junit5/kotlin/initializemode/FieldPerClassTests.kt
+++ b/test/test-junit5/src/test/kotlin/ru/tinkoff/kora/test/extension/junit5/kotlin/initializemode/FieldPerClassTests.kt
@@ -8,7 +8,6 @@ import ru.tinkoff.kora.test.extension.junit5.TestComponent
 import ru.tinkoff.kora.test.extension.junit5.testdata.TestApplication
 import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent1
 import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent12
-import kotlin.concurrent.Volatile
 
 @KoraAppTest(value = TestApplication::class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)

--- a/test/test-junit5/src/test/kotlin/ru/tinkoff/kora/test/extension/junit5/kotlin/initializemode/MethodPerClassTests.kt
+++ b/test/test-junit5/src/test/kotlin/ru/tinkoff/kora/test/extension/junit5/kotlin/initializemode/MethodPerClassTests.kt
@@ -8,7 +8,6 @@ import ru.tinkoff.kora.test.extension.junit5.TestComponent
 import ru.tinkoff.kora.test.extension.junit5.testdata.TestApplication
 import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent1
 import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent12
-import kotlin.concurrent.Volatile
 
 @KoraAppTest(value = TestApplication::class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)

--- a/test/test-junit5/src/test/kotlin/ru/tinkoff/kora/test/extension/junit5/kotlin/initializemode/NestedFieldPerClassExtendedTests.kt
+++ b/test/test-junit5/src/test/kotlin/ru/tinkoff/kora/test/extension/junit5/kotlin/initializemode/NestedFieldPerClassExtendedTests.kt
@@ -1,0 +1,80 @@
+package ru.tinkoff.kora.test.extension.junit5.kotlin.initializemode
+
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
+import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent1
+import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent12
+
+internal class NestedFieldPerClassExtendedTests : AbstractPerClassTests() {
+
+    companion object {
+        @Volatile
+        var prevComponent1: TestComponent1? = null
+
+        @Volatile
+        var prevComponent12: TestComponent12? = null
+    }
+
+    @Test
+    @Order(3)
+    fun test3() {
+        assertNotNull(component1)
+        assertNotNull(component12)
+        prevComponent1 = component1
+        prevComponent12 = component12
+    }
+
+    @Test
+    @Order(4)
+    fun test4() {
+        assertNotNull(component1)
+        assertNotNull(component12)
+        assertSame(prevComponent1, component1)
+        assertSame(prevComponent12, component12)
+    }
+
+    @Order(5)
+    @Nested
+    inner class Nested5 {
+
+        @Test
+        fun test5() {
+            assertNotNull(component1)
+            assertNotNull(component12)
+            assertSame(prevComponent1, component1)
+            assertSame(prevComponent12, component12)
+        }
+
+        @Test
+        fun test6() {
+            assertNotNull(component1)
+            assertNotNull(component12)
+            assertSame(prevComponent1, component1)
+            assertSame(prevComponent12, component12)
+        }
+    }
+
+    @Order(6)
+    @Nested
+    inner class Nested6 {
+
+        @Test
+        fun test7() {
+            assertNotNull(component1)
+            assertNotNull(component12)
+            assertSame(prevComponent1, component1)
+            assertSame(prevComponent12, component12)
+        }
+
+        @Test
+        fun test8() {
+            assertNotNull(component1)
+            assertNotNull(component12)
+            assertSame(prevComponent1, component1)
+            assertSame(prevComponent12, component12)
+        }
+    }
+}

--- a/test/test-junit5/src/test/kotlin/ru/tinkoff/kora/test/extension/junit5/kotlin/initializemode/NestedFieldPerMethodExtendedTests.kt
+++ b/test/test-junit5/src/test/kotlin/ru/tinkoff/kora/test/extension/junit5/kotlin/initializemode/NestedFieldPerMethodExtendedTests.kt
@@ -1,0 +1,85 @@
+package ru.tinkoff.kora.test.extension.junit5.kotlin.initializemode
+
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNotSame
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
+import ru.tinkoff.kora.test.extension.junit5.TestComponent
+import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent1
+import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent12
+
+internal class NestedFieldPerMethodExtendedTests : AbstractPerMethodTests() {
+
+    companion object {
+        @Volatile
+        var prevComponent1: TestComponent1? = null
+
+        @Volatile
+        var prevComponent12: TestComponent12? = null
+    }
+
+    @Test
+    @Order(3)
+    fun test3() {
+        assertNotNull(component1)
+        assertNotNull(component12)
+        prevComponent1 = component1
+        prevComponent12 = component12
+    }
+
+    @Test
+    @Order(4)
+    fun test4() {
+        assertNotNull(component1)
+        assertNotNull(component12)
+        assertNotSame(prevComponent1, component1)
+        assertNotSame(prevComponent12, component12)
+    }
+
+    @Order(5)
+    @Nested
+    inner class Nested5 {
+
+        @TestComponent
+        lateinit var componentNested12: TestComponent12
+
+        @Test
+        fun test5() {
+            assertNotNull(component1)
+            assertNotNull(component12)
+            assertNotSame(prevComponent1, component1)
+            assertNotSame(prevComponent12, component12)
+            assertNotSame(prevComponent12, componentNested12)
+        }
+
+        @Test
+        fun test6() {
+            assertNotNull(component1)
+            assertNotNull(component12)
+            assertNotSame(prevComponent1, component1)
+            assertNotSame(prevComponent12, component12)
+        }
+    }
+
+    @Order(6)
+    @Nested
+    inner class Nested6 {
+
+        @Test
+        fun test7() {
+            assertNotNull(component1)
+            assertNotNull(component12)
+            assertNotSame(prevComponent1, component1)
+            assertNotSame(prevComponent12, component12)
+        }
+
+        @Test
+        fun test8() {
+            assertNotNull(component1)
+            assertNotNull(component12)
+            assertNotSame(prevComponent1, component1)
+            assertNotSame(prevComponent12, component12)
+        }
+    }
+}

--- a/test/test-junit5/src/test/kotlin/ru/tinkoff/kora/test/extension/junit5/kotlin/initializemode/NestedOnlyFieldPerClassExtendedTests.kt
+++ b/test/test-junit5/src/test/kotlin/ru/tinkoff/kora/test/extension/junit5/kotlin/initializemode/NestedOnlyFieldPerClassExtendedTests.kt
@@ -1,0 +1,68 @@
+package ru.tinkoff.kora.test.extension.junit5.kotlin.initializemode
+
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
+
+internal class NestedOnlyFieldPerClassExtendedTests : AbstractNestedPerClassTests() {
+
+    @Order(3)
+    @Nested
+    inner class Nested3 {
+
+        @Test
+        fun test3() {
+            assertNotNull(component1)
+            assertNotNull(component12)
+            if (prevComponent1 == null) {
+                prevComponent1 = component1
+            } else {
+                assertSame(prevComponent1, component1)
+            }
+            if (prevComponent12 == null) {
+                prevComponent12 = component12
+            } else {
+                assertSame(prevComponent12, component12)
+            }
+        }
+
+        @Test
+        fun test4() {
+            assertNotNull(component1)
+            assertNotNull(component12)
+            assertSame(prevComponent1, component1)
+            assertSame(prevComponent12, component12)
+        }
+    }
+
+    @Order(4)
+    @Nested
+    inner class Nested4 {
+
+        @Test
+        fun test5() {
+            assertNotNull(component1)
+            assertNotNull(component12)
+            if (prevComponent1 == null) {
+                prevComponent1 = component1
+            } else {
+                assertSame(prevComponent1, component1)
+            }
+            if (prevComponent12 == null) {
+                prevComponent12 = component12
+            } else {
+                assertSame(prevComponent12, component12)
+            }
+        }
+
+        @Test
+        fun test6() {
+            assertNotNull(component1)
+            assertNotNull(component12)
+            assertSame(prevComponent1, component1)
+            assertSame(prevComponent12, component12)
+        }
+    }
+}

--- a/test/test-junit5/src/test/kotlin/ru/tinkoff/kora/test/extension/junit5/kotlin/initializemode/NestedOnlyFieldPerClassTests.kt
+++ b/test/test-junit5/src/test/kotlin/ru/tinkoff/kora/test/extension/junit5/kotlin/initializemode/NestedOnlyFieldPerClassTests.kt
@@ -1,0 +1,88 @@
+package ru.tinkoff.kora.test.extension.junit5.kotlin.initializemode
+
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertSame
+import ru.tinkoff.kora.test.extension.junit5.KoraAppTest
+import ru.tinkoff.kora.test.extension.junit5.TestComponent
+import ru.tinkoff.kora.test.extension.junit5.testdata.TestApplication
+import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent1
+import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent12
+
+@KoraAppTest(value = TestApplication::class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+internal class NestedOnlyFieldPerClassTests {
+
+    companion object {
+        @Volatile
+        var prevComponent1: TestComponent1? = null
+
+        @Volatile
+        var prevComponent12: TestComponent12? = null
+    }
+
+    @TestComponent
+    private lateinit var component1: TestComponent1
+
+    @TestComponent
+    private lateinit var component12: TestComponent12
+
+    @Order(1)
+    @Nested
+    inner class Nested1 {
+
+        @Test
+        fun test1() {
+            assertNotNull(component1)
+            assertNotNull(component12)
+            if (prevComponent1 == null) {
+                prevComponent1 = component1
+            } else {
+                assertSame(prevComponent1, component1)
+            }
+            if (prevComponent12 == null) {
+                prevComponent12 = component12
+            } else {
+                assertSame(prevComponent12, component12)
+            }
+        }
+
+        @Test
+        fun test2() {
+            assertNotNull(component1)
+            assertNotNull(component12)
+            assertSame(prevComponent1, component1)
+            assertSame(prevComponent12, component12)
+        }
+    }
+
+    @Order(2)
+    @Nested
+    inner class Nested2 {
+
+        @Test
+        fun test3() {
+            assertNotNull(component1)
+            assertNotNull(component12)
+            if (prevComponent1 == null) {
+                prevComponent1 = component1
+            } else {
+                assertSame(prevComponent1, component1)
+            }
+            if (prevComponent12 == null) {
+                prevComponent12 = component12
+            } else {
+                assertSame(prevComponent12, component12)
+            }
+        }
+
+        @Test
+        fun test4() {
+            assertNotNull(component1)
+            assertNotNull(component12)
+            assertSame(prevComponent1, component1)
+            assertSame(prevComponent12, component12)
+        }
+    }
+}

--- a/test/test-junit5/src/test/kotlin/ru/tinkoff/kora/test/extension/junit5/kotlin/initializemode/NestedOnlyFieldPerMethodExtendedTests.kt
+++ b/test/test-junit5/src/test/kotlin/ru/tinkoff/kora/test/extension/junit5/kotlin/initializemode/NestedOnlyFieldPerMethodExtendedTests.kt
@@ -23,12 +23,12 @@ internal class NestedOnlyFieldPerMethodExtendedTests : AbstractNestedPerMethodTe
             if (prevComponent1 == null) {
                 prevComponent1 = component1
             } else {
-                assertSame(prevComponent1, component1)
+                assertNotSame(prevComponent1, component1)
             }
             if (prevComponent12 == null) {
                 prevComponent12 = component12
             } else {
-                assertSame(prevComponent12, component12)
+                assertNotSame(prevComponent12, component12)
             }
         }
 
@@ -53,12 +53,12 @@ internal class NestedOnlyFieldPerMethodExtendedTests : AbstractNestedPerMethodTe
             if (prevComponent1 == null) {
                 prevComponent1 = component1
             } else {
-                assertSame(prevComponent1, component1)
+                assertNotSame(prevComponent1, component1)
             }
             if (prevComponent12 == null) {
                 prevComponent12 = component12
             } else {
-                assertSame(prevComponent12, component12)
+                assertNotSame(prevComponent12, component12)
             }
         }
 

--- a/test/test-junit5/src/test/kotlin/ru/tinkoff/kora/test/extension/junit5/kotlin/initializemode/NestedOnlyFieldPerMethodExtendedTests.kt
+++ b/test/test-junit5/src/test/kotlin/ru/tinkoff/kora/test/extension/junit5/kotlin/initializemode/NestedOnlyFieldPerMethodExtendedTests.kt
@@ -1,0 +1,58 @@
+package ru.tinkoff.kora.test.extension.junit5.kotlin.initializemode
+
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNotSame
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
+import ru.tinkoff.kora.test.extension.junit5.TestComponent
+import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent12
+
+internal class NestedOnlyFieldPerMethodExtendedTests : AbstractNestedPerMethodTests() {
+
+    @Order(3)
+    @Nested
+    inner class Nested3 {
+
+        @TestComponent
+        lateinit var componentNested12: TestComponent12
+
+        @Test
+        fun test3() {
+            assertNotNull(component1)
+            assertNotNull(component12)
+            prevComponent1 = component1
+            prevComponent12 = component12
+        }
+
+        @Test
+        fun test4() {
+            assertNotNull(component1)
+            assertNotNull(component12)
+            assertNotSame(prevComponent1, component1)
+            assertNotSame(prevComponent12, component12)
+            assertNotSame(prevComponent12, componentNested12)
+        }
+    }
+
+    @Order(4)
+    @Nested
+    inner class Nested4 {
+
+        @Test
+        fun test5() {
+            assertNotNull(component1)
+            assertNotNull(component12)
+            assertNotSame(prevComponent1, component1)
+            assertNotSame(prevComponent12, component12)
+        }
+
+        @Test
+        fun test6() {
+            assertNotNull(component1)
+            assertNotNull(component12)
+            assertNotSame(prevComponent1, component1)
+            assertNotSame(prevComponent12, component12)
+        }
+    }
+}

--- a/test/test-junit5/src/test/kotlin/ru/tinkoff/kora/test/extension/junit5/kotlin/initializemode/NestedOnlyFieldPerMethodExtendedTests.kt
+++ b/test/test-junit5/src/test/kotlin/ru/tinkoff/kora/test/extension/junit5/kotlin/initializemode/NestedOnlyFieldPerMethodExtendedTests.kt
@@ -1,7 +1,6 @@
 package ru.tinkoff.kora.test.extension.junit5.kotlin.initializemode
 
-import org.junit.jupiter.api.Assertions.assertNotNull
-import org.junit.jupiter.api.Assertions.assertNotSame
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
@@ -21,8 +20,16 @@ internal class NestedOnlyFieldPerMethodExtendedTests : AbstractNestedPerMethodTe
         fun test3() {
             assertNotNull(component1)
             assertNotNull(component12)
-            prevComponent1 = component1
-            prevComponent12 = component12
+            if (prevComponent1 == null) {
+                prevComponent1 = component1
+            } else {
+                assertSame(prevComponent1, component1)
+            }
+            if (prevComponent12 == null) {
+                prevComponent12 = component12
+            } else {
+                assertSame(prevComponent12, component12)
+            }
         }
 
         @Test
@@ -43,8 +50,16 @@ internal class NestedOnlyFieldPerMethodExtendedTests : AbstractNestedPerMethodTe
         fun test5() {
             assertNotNull(component1)
             assertNotNull(component12)
-            assertNotSame(prevComponent1, component1)
-            assertNotSame(prevComponent12, component12)
+            if (prevComponent1 == null) {
+                prevComponent1 = component1
+            } else {
+                assertSame(prevComponent1, component1)
+            }
+            if (prevComponent12 == null) {
+                prevComponent12 = component12
+            } else {
+                assertSame(prevComponent12, component12)
+            }
         }
 
         @Test

--- a/test/test-junit5/src/test/kotlin/ru/tinkoff/kora/test/extension/junit5/kotlin/initializemode/NestedOnlyFieldPerMethodTests.kt
+++ b/test/test-junit5/src/test/kotlin/ru/tinkoff/kora/test/extension/junit5/kotlin/initializemode/NestedOnlyFieldPerMethodTests.kt
@@ -1,0 +1,76 @@
+package ru.tinkoff.kora.test.extension.junit5.kotlin.initializemode
+
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNotSame
+import ru.tinkoff.kora.test.extension.junit5.KoraAppTest
+import ru.tinkoff.kora.test.extension.junit5.TestComponent
+import ru.tinkoff.kora.test.extension.junit5.testdata.TestApplication
+import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent1
+import ru.tinkoff.kora.test.extension.junit5.testdata.TestComponent12
+
+@KoraAppTest(value = TestApplication::class)
+@TestInstance(TestInstance.Lifecycle.PER_METHOD)
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+internal class NestedOnlyFieldPerMethodTests {
+
+    companion object {
+        @Volatile
+        var prevComponent1: TestComponent1? = null
+
+        @Volatile
+        var prevComponent12: TestComponent12? = null
+    }
+
+    @TestComponent
+    private lateinit var component1: TestComponent1
+
+    @TestComponent
+    private lateinit var component12: TestComponent12
+
+    @Order(1)
+    @Nested
+    inner class Nested1 {
+
+        @TestComponent
+        lateinit var componentNested12: TestComponent12
+
+        @Test
+        fun test3() {
+            assertNotNull(component1)
+            assertNotNull(component12)
+            prevComponent1 = component1
+            prevComponent12 = component12
+        }
+
+        @Test
+        fun test4() {
+            assertNotNull(component1)
+            assertNotNull(component12)
+            assertNotSame(prevComponent1, component1)
+            assertNotSame(prevComponent12, component12)
+            assertNotSame(prevComponent12, componentNested12)
+        }
+    }
+
+    @Order(2)
+    @Nested
+    inner class Nested2 {
+
+        @Test
+        fun test5() {
+            assertNotNull(component1)
+            assertNotNull(component12)
+            assertNotSame(prevComponent1, component1)
+            assertNotSame(prevComponent12, component12)
+        }
+
+        @Test
+        fun test6() {
+            assertNotNull(component1)
+            assertNotNull(component12)
+            assertNotSame(prevComponent1, component1)
+            assertNotSame(prevComponent12, component12)
+        }
+    }
+}

--- a/test/test-junit5/src/test/kotlin/ru/tinkoff/kora/test/extension/junit5/kotlin/initializemode/NestedOnlyFieldPerMethodTests.kt
+++ b/test/test-junit5/src/test/kotlin/ru/tinkoff/kora/test/extension/junit5/kotlin/initializemode/NestedOnlyFieldPerMethodTests.kt
@@ -39,8 +39,16 @@ internal class NestedOnlyFieldPerMethodTests {
         fun test3() {
             assertNotNull(component1)
             assertNotNull(component12)
-            prevComponent1 = component1
-            prevComponent12 = component12
+            if (prevComponent1 == null) {
+                prevComponent1 = component1
+            } else {
+                assertNotSame(prevComponent1, component1)
+            }
+            if (prevComponent12 == null) {
+                prevComponent12 = component12
+            } else {
+                assertNotSame(prevComponent12, component12)
+            }
         }
 
         @Test
@@ -61,8 +69,16 @@ internal class NestedOnlyFieldPerMethodTests {
         fun test5() {
             assertNotNull(component1)
             assertNotNull(component12)
-            assertNotSame(prevComponent1, component1)
-            assertNotSame(prevComponent12, component12)
+            if (prevComponent1 == null) {
+                prevComponent1 = component1
+            } else {
+                assertNotSame(prevComponent1, component1)
+            }
+            if (prevComponent12 == null) {
+                prevComponent12 = component12
+            } else {
+                assertNotSame(prevComponent12, component12)
+            }
         }
 
         @Test


### PR DESCRIPTION
Fixed JUnit test extension graph cleanup in afterAll for `@Nested` test classes