### PR TITLE
Improved JUnit support for `Wrapped` components finding in TestGraph (backport)

### DIFF
--- a/test/test-junit5/src/main/java/io/koraframework/test/extension/junit5/DefaultKoraAppGraph.java
+++ b/test/test-junit5/src/main/java/io/koraframework/test/extension/junit5/DefaultKoraAppGraph.java
@@ -1,9 +1,11 @@
 package io.koraframework.test.extension.junit5;
 
-import org.jspecify.annotations.Nullable;
 import io.koraframework.application.graph.ApplicationGraphDraw;
 import io.koraframework.application.graph.Graph;
+import io.koraframework.application.graph.ValueOf;
+import io.koraframework.application.graph.Wrapped;
 import io.koraframework.common.Tag;
+import org.jspecify.annotations.Nullable;
 
 import java.lang.reflect.Type;
 import java.util.List;
@@ -23,26 +25,40 @@ final class DefaultKoraAppGraph implements KoraAppGraph {
     @Nullable
     @Override
     public Object getFirst(Type type) {
-        var node = graphDraw.findNodeByType(type);
-        return (node == null)
-            ? null
-            : graph.get(node);
+        return getFirst(type, null);
     }
 
     @Nullable
     @Override
     public <T> T getFirst(Class<T> type) {
-        return type.cast(getFirst(((Type) type)));
+        var value = getFirst(((Type) type));
+        return type.cast(value);
     }
 
     @Nullable
     @Override
     public Object getFirst(Type type, @Nullable Class<?> tag) {
-        var nodes = GraphUtils.findNodeByType(graphDraw, new GraphCandidate(type, tag));
-        return nodes.stream()
-            .map(graph::get)
-            .findFirst()
-            .orElse(null);
+        if (tag == null) {
+            var node = graphDraw.findNodeByType(type);
+            if (node != null) {
+                var value = graph.get(node);
+                return unwrap(type, value);
+            }
+        } else {
+            var nodesByType = graphDraw.findNodesByType(type, tag);
+            if (!nodesByType.isEmpty()) {
+                var value = graph.get(nodesByType.iterator().next());
+                return unwrap(type, value);
+            }
+        }
+
+        var nodes = GraphUtils.findNodeByTypeOrAssignable(graphDraw, type, tag);
+        if (nodes.isEmpty()) {
+            return null;
+        } else {
+            var value = graph.get(nodes.iterator().next());
+            return unwrap(type, value);
+        }
     }
 
     @Nullable
@@ -58,10 +74,33 @@ final class DefaultKoraAppGraph implements KoraAppGraph {
 
     @Override
     public List<Object> getAll(Type type, @Nullable Class<?> tag) {
-        var nodes = GraphUtils.findNodeByType(graphDraw, new GraphCandidate(type, tag));
+        var nodesByType = graphDraw.findNodesByType(type, tag);
+        if (!nodesByType.isEmpty()) {
+            return nodesByType.stream()
+                .map(n -> {
+                    var value = graph.get(n);
+                    return unwrap(type, value);
+                })
+                .toList();
+        }
+
+        var nodes = GraphUtils.findNodeByTypeOrAssignable(graphDraw, type, tag);
         return nodes.stream()
-            .map(graph::get)
+            .map(n -> {
+                var value = graph.get(n);
+                return unwrap(type, value);
+            })
             .toList();
+    }
+
+    private static Object unwrap(Type type, Object value) {
+        if (value instanceof Wrapped<?> wrapped && !GraphUtils.isTypeAssignable(type, Wrapped.class)) {
+            return wrapped.value();
+        } else if (value instanceof ValueOf<?> valOf && !GraphUtils.isTypeAssignable(type, ValueOf.class)) {
+            return valOf.get();
+        } else {
+            return value;
+        }
     }
 
     @Override

--- a/test/test-junit5/src/main/java/io/koraframework/test/extension/junit5/GraphUtils.java
+++ b/test/test-junit5/src/main/java/io/koraframework/test/extension/junit5/GraphUtils.java
@@ -1,6 +1,5 @@
 package io.koraframework.test.extension.junit5;
 
-import jakarta.annotation.Nullable;
 import org.jspecify.annotations.Nullable;
 import io.koraframework.application.graph.ApplicationGraphDraw;
 import io.koraframework.application.graph.Node;

--- a/test/test-junit5/src/main/java/io/koraframework/test/extension/junit5/GraphUtils.java
+++ b/test/test-junit5/src/main/java/io/koraframework/test/extension/junit5/GraphUtils.java
@@ -1,5 +1,6 @@
 package io.koraframework.test.extension.junit5;
 
+import jakarta.annotation.Nullable;
 import org.jspecify.annotations.Nullable;
 import io.koraframework.application.graph.ApplicationGraphDraw;
 import io.koraframework.application.graph.Node;
@@ -59,7 +60,7 @@ final class GraphUtils {
         return findNodeByTypeOrAssignable(graph, candidate.type(), candidate.tag());
     }
 
-    static Set<Node<?>> findNodeByTypeOrAssignable(ApplicationGraphDraw graph, Type type, Class<?> tag) {
+    static Set<Node<?>> findNodeByTypeOrAssignable(ApplicationGraphDraw graph, Type type, @Nullable Class<?> tag) {
         if (tag == null || Objects.equals(Tag.Any.class, tag)) {
             final Set<Node<?>> nodes = new HashSet<>();
             for (var graphNode : graph.getNodes()) {

--- a/test/test-junit5/src/test/java/io/koraframework/test/extension/junit5/inject/InjectGraphWrapperTests.java
+++ b/test/test-junit5/src/test/java/io/koraframework/test/extension/junit5/inject/InjectGraphWrapperTests.java
@@ -1,0 +1,19 @@
+package io.koraframework.test.extension.junit5.inject;
+
+import io.koraframework.test.extension.junit5.KoraAppGraph;
+import io.koraframework.test.extension.junit5.KoraAppTest;
+import io.koraframework.test.extension.junit5.testdata.TestApplication;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@KoraAppTest(TestApplication.class)
+public class InjectGraphWrapperTests {
+
+    @Test
+    void testWrapped(KoraAppGraph graph) {
+        assertNotNull(graph.getFirst(TestApplication.SomeChild.class));
+        assertNotNull(graph.getFirst(TestApplication.ComplexWrapped.class));
+        assertNotNull(graph.getFirst(Integer.class));
+    }
+}

--- a/test/test-junit5/src/test/java/io/koraframework/test/extension/junit5/inject/InjectWrapperTests.java
+++ b/test/test-junit5/src/test/java/io/koraframework/test/extension/junit5/inject/InjectWrapperTests.java
@@ -13,16 +13,14 @@ public class InjectWrapperTests {
     @TestComponent
     private TestApplication.SomeChild someChild;
     @TestComponent
+    private TestApplication.ComplexWrapped someWrapped;
+    @TestComponent
     private Integer someInt;
 
     @Test
-    void emptyTest() {
-        // do nothing
-    }
-
-    @Test
-    void testBean() {
+    void testWrapped() {
         assertNotNull(someInt);
         assertNotNull(someChild);
+        assertNotNull(someWrapped);
     }
 }

--- a/test/test-junit5/src/test/java/io/koraframework/test/extension/junit5/mockito/MockOnlyTests.java
+++ b/test/test-junit5/src/test/java/io/koraframework/test/extension/junit5/mockito/MockOnlyTests.java
@@ -1,5 +1,6 @@
 package io.koraframework.test.extension.junit5.mockito;
 
+import io.koraframework.test.extension.junit5.testdata.TestApplicationOps;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;

--- a/test/test-junit5/src/test/java/io/koraframework/test/extension/junit5/mockito/MockOnlyTests.java
+++ b/test/test-junit5/src/test/java/io/koraframework/test/extension/junit5/mockito/MockOnlyTests.java
@@ -11,7 +11,7 @@ import io.koraframework.test.extension.junit5.testdata.TestComponent3;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@KoraAppTest(TestApplication.class)
+@KoraAppTest(TestApplicationOps.class)
 public class MockOnlyTests {
 
     @Mock

--- a/test/test-junit5/src/test/java/io/koraframework/test/extension/junit5/testdata/TestApplication.java
+++ b/test/test-junit5/src/test/java/io/koraframework/test/extension/junit5/testdata/TestApplication.java
@@ -3,6 +3,7 @@ package io.koraframework.test.extension.junit5.testdata;
 import io.koraframework.application.graph.Lifecycle;
 import io.koraframework.application.graph.LifecycleWrapper;
 import io.koraframework.application.graph.Wrapped;
+import io.koraframework.common.DefaultComponent;
 import io.koraframework.common.KoraApp;
 import io.koraframework.common.Tag;
 import io.koraframework.common.annotation.Root;
@@ -12,10 +13,6 @@ import java.util.function.Supplier;
 
 @KoraApp
 public interface TestApplication extends TestExtendModule {
-
-    default TestComponent3 testComponent3() {
-        return new TestComponent3();
-    }
 
     @Root
     default GenericComponent<String> genericComponent1() {

--- a/test/test-junit5/src/test/java/io/koraframework/test/extension/junit5/testdata/TestApplication.java
+++ b/test/test-junit5/src/test/java/io/koraframework/test/extension/junit5/testdata/TestApplication.java
@@ -13,6 +13,10 @@ import java.util.function.Supplier;
 @KoraApp
 public interface TestApplication extends TestExtendModule {
 
+    default TestComponent3 testComponent3() {
+        return new TestComponent3();
+    }
+
     @Root
     default GenericComponent<String> genericComponent1() {
         return new GenericComponent.StringGenericComponent();
@@ -75,12 +79,7 @@ public interface TestApplication extends TestExtendModule {
             public void release() {}
 
             @Override
-            public String generic() {
-                return "1";
-            }
-
-            @Override
-            public ComplexWrapped value() {
+            public ComplexWrappedGeneric<String> value() {
                 return () -> "1";
             }
 
@@ -146,13 +145,17 @@ public interface TestApplication extends TestExtendModule {
         }
     }
 
-    interface ComplexInterfaceHolder<T> extends Wrapped<ComplexWrapped>, Lifecycle, ComplexOther {
+    interface ComplexInterfaceHolder<T> extends Wrapped<ComplexWrappedGeneric<T>>, Lifecycle, ComplexOther {
 
-        T generic();
     }
 
     interface ComplexWrapped {
         String wrapped();
+    }
+
+    interface ComplexWrappedGeneric<T> {
+
+        T generic();
     }
 
     interface ComplexOther {

--- a/test/test-junit5/src/test/java/io/koraframework/test/extension/junit5/testdata/TestApplication.java
+++ b/test/test-junit5/src/test/java/io/koraframework/test/extension/junit5/testdata/TestApplication.java
@@ -3,7 +3,6 @@ package io.koraframework.test.extension.junit5.testdata;
 import io.koraframework.application.graph.Lifecycle;
 import io.koraframework.application.graph.LifecycleWrapper;
 import io.koraframework.application.graph.Wrapped;
-import io.koraframework.common.DefaultComponent;
 import io.koraframework.common.KoraApp;
 import io.koraframework.common.Tag;
 import io.koraframework.common.annotation.Root;
@@ -13,6 +12,10 @@ import java.util.function.Supplier;
 
 @KoraApp
 public interface TestApplication extends TestExtendModule {
+
+    default TestComponent3 testComponent3() {
+        return new TestComponent3();
+    }
 
     @Root
     default GenericComponent<String> genericComponent1() {

--- a/test/test-junit5/src/test/java/io/koraframework/test/extension/junit5/testdata/TestApplicationOps.java
+++ b/test/test-junit5/src/test/java/io/koraframework/test/extension/junit5/testdata/TestApplicationOps.java
@@ -1,0 +1,18 @@
+package io.koraframework.test.extension.junit5.testdata;
+
+import io.koraframework.common.DefaultComponent;
+import io.koraframework.common.KoraApp;
+
+@KoraApp
+public interface TestApplicationOps {
+
+    @DefaultComponent
+    default TestComponent3 testComponent3() {
+        return new TestComponent3() {
+            @Override
+            public void init() {
+                throw new IllegalStateException("OPS");
+            }
+        };
+    }
+}

--- a/test/test-junit5/src/test/java/io/koraframework/test/extension/junit5/testdata/TestComponent3.java
+++ b/test/test-junit5/src/test/java/io/koraframework/test/extension/junit5/testdata/TestComponent3.java
@@ -13,6 +13,6 @@ public class TestComponent3 implements LifecycleComponent {
 
     @Override
     public void init() {
-        throw new IllegalStateException("OPS");
+        // do nothing
     }
 }

--- a/test/test-junit5/src/test/java/io/koraframework/test/extension/junit5/testdata/TestComponent3.java
+++ b/test/test-junit5/src/test/java/io/koraframework/test/extension/junit5/testdata/TestComponent3.java
@@ -1,10 +1,5 @@
 package io.koraframework.test.extension.junit5.testdata;
 
-import io.koraframework.common.Component;
-import io.koraframework.common.annotation.Root;
-
-@Root
-@Component
 public class TestComponent3 implements LifecycleComponent {
 
     public String get() {

--- a/test/test-junit5/src/test/java/io/koraframework/test/extension/junit5/testdata/TestConfigApplication.java
+++ b/test/test-junit5/src/test/java/io/koraframework/test/extension/junit5/testdata/TestConfigApplication.java
@@ -11,4 +11,8 @@ public interface TestConfigApplication extends HoconConfigModule {
     default Object root(Config config) {
         return config;
     }
+
+    default TestComponent3 testComponent3() {
+        return new TestComponent3();
+    }
 }


### PR DESCRIPTION
Added support for wrapped components and improved graph handling:
- Added processing of Wrapped and ValueOf in the application graph
- Improved node search logic in the graph considering type inheritance

(cherry picked from commit 4efea91d7976c5f2813504c1cccd36c473ed7517)

Backport (https://github.com/kora-projects/kora/pull/576)