### PR TITLE
Fixed `@Log` mark `AopAnnotation` only for supported

### DIFF
--- a/annotation-processor-common/src/main/java/ru/tinkoff/kora/annotation/processor/common/CommonClassNames.java
+++ b/annotation-processor-common/src/main/java/ru/tinkoff/kora/annotation/processor/common/CommonClassNames.java
@@ -15,6 +15,9 @@ public class CommonClassNames {
     public static final ClassName flux = ClassName.get("reactor.core.publisher", "Flux");
     public static final ClassName synchronousSink = ClassName.get("reactor.core.publisher", "SynchronousSink");
 
+    public static final ClassName logOff = ClassName.get("ru.tinkoff.kora.logging.common.annotation", "Log", "result");
+    public static final ClassName logResult = ClassName.get("ru.tinkoff.kora.logging.common.annotation", "Log", "off");
+
     public static final ClassName root = ClassName.get("ru.tinkoff.kora.common.annotation", "Root");
     public static final ClassName aopAnnotation = ClassName.get("ru.tinkoff.kora.common", "AopAnnotation");
     public static final ClassName aopProxy = ClassName.get("ru.tinkoff.kora.common", "AopProxy");

--- a/annotation-processor-common/src/main/java/ru/tinkoff/kora/annotation/processor/common/CommonUtils.java
+++ b/annotation-processor-common/src/main/java/ru/tinkoff/kora/annotation/processor/common/CommonUtils.java
@@ -492,7 +492,9 @@ public class CommonUtils {
     }
 
     private static boolean isAopAnnotation(AnnotationMirror am) {
-        return AnnotationUtils.isAnnotationPresent(am.getAnnotationType().asElement(), CommonClassNames.aopAnnotation);
+        return AnnotationUtils.isAnnotationPresent(am.getAnnotationType().asElement(), CommonClassNames.aopAnnotation)
+               || ClassName.get(am.getAnnotationType()).equals(CommonClassNames.logOff)
+               || ClassName.get(am.getAnnotationType()).equals(CommonClassNames.logResult);
     }
 
     public static boolean isVoid(TypeMirror returnType) {

--- a/logging/logging-common/src/main/java/ru/tinkoff/kora/logging/common/annotation/Log.java
+++ b/logging/logging-common/src/main/java/ru/tinkoff/kora/logging/common/annotation/Log.java
@@ -30,14 +30,12 @@ public @interface Log {
         Level value() default Level.INFO;
     }
 
-    @AopAnnotation
     @Target(METHOD)
     @Retention(RetentionPolicy.RUNTIME)
     @interface result {
         Level value() default Level.DEBUG;
     }
 
-    @AopAnnotation
     @Target({PARAMETER, METHOD})
     @Retention(RetentionPolicy.RUNTIME)
     @interface off {}

--- a/logging/logging-common/src/main/java/ru/tinkoff/kora/logging/common/annotation/Mdc.java
+++ b/logging/logging-common/src/main/java/ru/tinkoff/kora/logging/common/annotation/Mdc.java
@@ -20,6 +20,8 @@ public @interface Mdc {
 
     String value() default "";
 
+
+
     boolean global() default false;
 
     @AopAnnotation

--- a/logging/logging-common/src/main/java/ru/tinkoff/kora/logging/common/annotation/Mdc.java
+++ b/logging/logging-common/src/main/java/ru/tinkoff/kora/logging/common/annotation/Mdc.java
@@ -20,8 +20,6 @@ public @interface Mdc {
 
     String value() default "";
 
-
-
     boolean global() default false;
 
     @AopAnnotation

--- a/symbol-processor-common/src/main/kotlin/ru/tinkoff/kora/ksp/common/CommonAopUtils.kt
+++ b/symbol-processor-common/src/main/kotlin/ru/tinkoff/kora/ksp/common/CommonAopUtils.kt
@@ -161,10 +161,15 @@ object CommonAopUtils {
     }
 
     fun isAopAnnotation(annotation: KSAnnotation): Boolean {
-        return annotation.annotationType.resolveToUnderlying().declaration.isAnnotationPresent(aopAnnotation)
+        val resolved = annotation.annotationType.resolveToUnderlying()
+        return resolved.declaration.isAnnotationPresent(aopAnnotation)
+            || resolved.toClassName() == CommonClassNames.logOff
+            || resolved.toClassName() == CommonClassNames.logResult
     }
 
     fun isAopAnnotation(annotation: KSType): Boolean {
         return annotation.declaration.isAnnotationPresent(aopAnnotation)
+            || annotation.toClassName() == CommonClassNames.logOff
+            || annotation.toClassName() == CommonClassNames.logResult
     }
 }

--- a/symbol-processor-common/src/main/kotlin/ru/tinkoff/kora/ksp/common/CommonClassNames.kt
+++ b/symbol-processor-common/src/main/kotlin/ru/tinkoff/kora/ksp/common/CommonClassNames.kt
@@ -23,6 +23,9 @@ object CommonClassNames {
     val await = MemberName("kotlinx.coroutines.future", "await")
     val flowBuilder = MemberName("kotlinx.coroutines.flow", "flow")
 
+    val logOff = ClassName("ru.tinkoff.kora.logging.common.annotation", "Log", "off")
+    val logResult = ClassName("ru.tinkoff.kora.logging.common.annotation", "Log", "result")
+
     val context = ClassName("ru.tinkoff.kora.common", "Context")
     val contextReactor = ClassName("ru.tinkoff.kora.common", "Context", "Reactor")
     val aopAnnotation = ClassName("ru.tinkoff.kora.common", "AopAnnotation")


### PR DESCRIPTION
Fixed proper Log annotation `AopAnnotation` mark only for supported annotations