### PR TITLE
Fix config value extractors for interfaces with default methods (#586)

### DIFF
--- a/config/config-symbol-processor/src/main/kotlin/io/koraframework/config/ksp/ConfigParserGenerator.kt
+++ b/config/config-symbol-processor/src/main/kotlin/io/koraframework/config/ksp/ConfigParserGenerator.kt
@@ -394,9 +394,14 @@ class ConfigParserGenerator(private val resolver: Resolver) {
             }
             parse.addStatement("return %N.extract(value)", "${field.name}_parser")
         } else {
+            if (field.hasDefault) {
+                parse.controlFlow("if (value is %T.NullValue)", ConfigClassNames.configValue) {
+                    addCode(returnDefaultOrThrow)
+                }
+            }
             parse.addStatement("val parsed = %N.extract(value)", "${field.name}_parser")
             parse.controlFlow("if (parsed == null)") {
-                addCode(returnDefaultOrThrow)
+                addStatement("throw %T.missingValueAfterParse(value)", ConfigClassNames.configValueExtractionException)
             }
             parse.addStatement("return parsed")
         }


### PR DESCRIPTION
(cherry picked from commit 133fc1915172db7dfd81c025859afaa303b8d544)

Backport (https://github.com/kora-projects/kora/pull/582)