### PR TITLE
fix: propagate meta-annotation tags (@Json) through @KoraSubmodule, HTTP routes and @KoraAppTest

### DIFF
--- a/http/http-server-symbol-processor/src/main/kotlin/ru/tinkoff/kora/http/server/symbol/procesor/RouteProcessor.kt
+++ b/http/http-server-symbol-processor/src/main/kotlin/ru/tinkoff/kora/http/server/symbol/procesor/RouteProcessor.kt
@@ -32,7 +32,8 @@ import ru.tinkoff.kora.ksp.common.KotlinPoetUtils.controlFlow
 import ru.tinkoff.kora.ksp.common.KspCommonUtils.findRepeatableAnnotation
 import ru.tinkoff.kora.ksp.common.makeTagAnnotationSpec
 import ru.tinkoff.kora.ksp.common.parseMappingData
-import ru.tinkoff.kora.ksp.common.parseTags
+import ru.tinkoff.kora.ksp.common.TagUtils.makeAnnotationSpecForTypes
+import ru.tinkoff.kora.ksp.common.TagUtils.parseTagValue
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionException
 import java.util.concurrent.CompletionStage
@@ -58,17 +59,17 @@ class RouteProcessor {
             .distinct()
             .toList()
 
-        val tags = declaration.parseTags()
+        val tags = parseTagValue(declaration)
         val paramSpecBuilder = ParameterSpec.builder("_controller", parent.toClassName())
         if (tags.isNotEmpty()) {
-            paramSpecBuilder.addAnnotation(tags.makeTagAnnotationSpec())
+            paramSpecBuilder.addAnnotation(tags.makeAnnotationSpecForTypes())
         }
 
         val funBuilder = FunSpec.builder(funName)
             .returns(httpServerRequestHandler)
             .addParameter(paramSpecBuilder.build())
         if (tags.isNotEmpty()) {
-            funBuilder.addAnnotation(tags.makeTagAnnotationSpec())
+            funBuilder.addAnnotation(tags.makeAnnotationSpecForTypes())
         }
 
         val isSuspend = function.modifiers.contains(Modifier.SUSPEND)

--- a/json/json-common/src/main/java/ru/tinkoff/kora/json/common/annotation/Json.java
+++ b/json/json-common/src/main/java/ru/tinkoff/kora/json/common/annotation/Json.java
@@ -13,6 +13,6 @@ import java.lang.annotation.Target;
  * <b>English</b>: Annotation specifies that for the type is represented in JSON format. If specified for a type, a JSON reader and writer will be created for that type and embedded in the dependency container.
  */
 @Tag(Json.class)
-@Target({ElementType.TYPE, ElementType.PARAMETER, ElementType.METHOD, ElementType.TYPE_USE})
+@Target({ElementType.TYPE, ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD, ElementType.TYPE_USE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Json { }

--- a/kora-app-symbol-processor/src/main/kotlin/ru/tinkoff/kora/kora/app/ksp/KoraSubmoduleProcessor.kt
+++ b/kora-app-symbol-processor/src/main/kotlin/ru/tinkoff/kora/kora/app/ksp/KoraSubmoduleProcessor.kt
@@ -20,8 +20,8 @@ import ru.tinkoff.kora.ksp.common.AnnotationUtils.findAnnotation
 import ru.tinkoff.kora.ksp.common.CommonAopUtils.hasAopAnnotations
 import ru.tinkoff.kora.ksp.common.CommonClassNames
 import ru.tinkoff.kora.ksp.common.KspCommonUtils.generated
-import ru.tinkoff.kora.ksp.common.makeTagAnnotationSpec
-import ru.tinkoff.kora.ksp.common.parseTags
+import ru.tinkoff.kora.ksp.common.TagUtils.makeAnnotationSpecForTypes
+import ru.tinkoff.kora.ksp.common.TagUtils.parseTagValue
 
 class KoraSubmoduleProcessor(val environment: SymbolProcessorEnvironment) : SymbolProcessor {
     companion object {
@@ -127,10 +127,10 @@ class KoraSubmoduleProcessor(val environment: SymbolProcessorEnvironment) : Symb
             mb.addCode("return %T(", component.toClassName())
             for (i in constructor.parameters.indices) {
                 val parameter = constructor.parameters[i]
-                val tag = parameter.parseTags()
+                val tag = parseTagValue(parameter)
                 val ps = ParameterSpec.builder(parameter.name!!.asString(), parameter.type.toTypeName())
                 if (tag.isNotEmpty()) {
-                    ps.addAnnotation(tag.makeTagAnnotationSpec())
+                    ps.addAnnotation(tag.makeAnnotationSpecForTypes())
                 }
                 mb.addParameter(ps.build())
                 if (i > 0) {
@@ -138,9 +138,9 @@ class KoraSubmoduleProcessor(val environment: SymbolProcessorEnvironment) : Symb
                 }
                 mb.addCode("%N", parameter.name?.asString())
             }
-            val tag = component.parseTags()
+            val tag = parseTagValue(component)
             if (tag.isNotEmpty()) {
-                mb.addAnnotation(tag.makeTagAnnotationSpec())
+                mb.addAnnotation(tag.makeAnnotationSpecForTypes())
             }
             if (component.findAnnotation(CommonClassNames.root) != null) {
                 mb.addAnnotation(CommonClassNames.root)
@@ -162,10 +162,10 @@ class KoraSubmoduleProcessor(val environment: SymbolProcessorEnvironment) : Symb
                 mb.addCode("return %N.%N(", moduleName, component.simpleName.asString())
                 for (i in component.parameters.indices) {
                     val parameter = component.parameters[i]
-                    val tag = parameter.parseTags()
+                    val tag = parseTagValue(parameter)
                     val ps = ParameterSpec.builder(parameter.name!!.asString(), parameter.type.toTypeName())
                     if (tag.isNotEmpty()) {
-                        ps.addAnnotation(tag.makeTagAnnotationSpec())
+                        ps.addAnnotation(tag.makeAnnotationSpecForTypes())
                     }
                     mb.addParameter(ps.build())
                     if (i > 0) {
@@ -173,9 +173,9 @@ class KoraSubmoduleProcessor(val environment: SymbolProcessorEnvironment) : Symb
                     }
                     mb.addCode("%N", parameter.name?.asString())
                 }
-                val tag = component.parseTags()
+                val tag = parseTagValue(component)
                 if (tag.isNotEmpty()) {
-                    mb.addAnnotation(tag.makeTagAnnotationSpec())
+                    mb.addAnnotation(tag.makeAnnotationSpecForTypes())
                 }
                 if (component.findAnnotation(CommonClassNames.defaultComponent) != null) {
                     mb.addAnnotation(CommonClassNames.defaultComponent)

--- a/kora-app-symbol-processor/src/test/kotlin/ru/tinkoff/kora/kora/app/ksp/KoraAppKspTest.kt
+++ b/kora-app-symbol-processor/src/test/kotlin/ru/tinkoff/kora/kora/app/ksp/KoraAppKspTest.kt
@@ -495,6 +495,23 @@ class KoraAppKspTest {
             throw e
         }
     }
+
+    @Test
+    fun appPartWithMetaTaggedDependency() {
+        val classLoader: ClassLoader = symbolProcess(AppWithMetaTagComponent::class, KoraAppProcessorProvider())
+        val clazz = classLoader.loadClass(AppWithMetaTagComponent::class.java.name + "SubmoduleImpl")
+        assertThat(clazz).isNotNull
+            .isInterface
+
+        val targetFile1 = "build/in-test-generated-ksp/sources/" + AppWithMetaTagComponent::class.java.name.replace(
+            '.',
+            '/'
+        ) + "SubmoduleImpl.kt"
+        val targetFile2 = "src/test/kotlin/" + AppWithMetaTagComponentApp::class.java.name.replace('.', '/') + ".kt"
+        val classLoaderApp = symbolProcessFiles(listOf(targetFile1, targetFile2))
+        val appClazz = classLoaderApp.loadClass(AppWithMetaTagComponentApp::class.java.name + "Graph")
+        assertThat(appClazz).isNotNull
+    }
 }
 
 

--- a/kora-app-symbol-processor/src/test/kotlin/ru/tinkoff/kora/kora/app/ksp/app/AppWithMetaTagComponent.kt
+++ b/kora-app-symbol-processor/src/test/kotlin/ru/tinkoff/kora/kora/app/ksp/app/AppWithMetaTagComponent.kt
@@ -1,0 +1,33 @@
+package ru.tinkoff.kora.kora.app.ksp.app
+
+import ru.tinkoff.kora.common.Component
+import ru.tinkoff.kora.common.KoraSubmodule
+import ru.tinkoff.kora.common.Module
+import ru.tinkoff.kora.common.Tag
+import ru.tinkoff.kora.common.annotation.Root
+
+@KoraSubmodule
+interface AppWithMetaTagComponent {
+
+    @Tag(MetaTag::class)
+    @Target(
+        AnnotationTarget.VALUE_PARAMETER,
+        AnnotationTarget.FIELD,
+        AnnotationTarget.PROPERTY,
+        AnnotationTarget.FUNCTION,
+    )
+    @Retention(AnnotationRetention.RUNTIME)
+    annotation class MetaTag
+
+    interface MetaTaggedDependency
+
+    @Module
+    interface MetaTagModule {
+        @Tag(MetaTag::class)
+        fun taggedDependency(): MetaTaggedDependency = object : MetaTaggedDependency {}
+    }
+
+    @Component
+    @Root
+    class MetaTagConsumer(@MetaTag val dependency: MetaTaggedDependency)
+}

--- a/kora-app-symbol-processor/src/test/kotlin/ru/tinkoff/kora/kora/app/ksp/app/AppWithMetaTagComponentApp.kt
+++ b/kora-app-symbol-processor/src/test/kotlin/ru/tinkoff/kora/kora/app/ksp/app/AppWithMetaTagComponentApp.kt
@@ -1,0 +1,6 @@
+package ru.tinkoff.kora.kora.app.ksp.app
+
+import ru.tinkoff.kora.common.KoraApp
+
+@KoraApp
+interface AppWithMetaTagComponentApp : AppWithMetaTagComponent

--- a/symbol-processor-common/src/main/kotlin/ru/tinkoff/kora/ksp/common/KspCommonUtils.kt
+++ b/symbol-processor-common/src/main/kotlin/ru/tinkoff/kora/ksp/common/KspCommonUtils.kt
@@ -275,7 +275,21 @@ fun parseAnnotationClassValue(target: KSAnnotated, annotationName: String): List
 inline fun <reified T> parseAnnotationValue(target: KSAnnotation, name: String) = target.findValue<T>(name)
 
 fun parseTags(target: KSAnnotated): List<KSType> {
-    return parseAnnotationClassValue(target, CommonClassNames.tag.canonicalName)
+    val direct = parseAnnotationClassValue(target, CommonClassNames.tag.canonicalName)
+    if (direct.isNotEmpty()) {
+        return direct
+    }
+
+    for (annotation in target.annotations) {
+        val metaTag = parseAnnotationClassValue(
+            annotation.annotationType.resolve().declaration,
+            CommonClassNames.tag.canonicalName
+        )
+        if (metaTag.isNotEmpty()) {
+            return metaTag
+        }
+    }
+    return emptyList()
 }
 
 fun findMethods(ksAnnotated: KSAnnotated, functionFilter: (KSFunctionDeclaration) -> Boolean): List<KSFunctionDeclaration> {

--- a/symbol-processor-common/src/main/kotlin/ru/tinkoff/kora/ksp/common/KspCommonUtils.kt
+++ b/symbol-processor-common/src/main/kotlin/ru/tinkoff/kora/ksp/common/KspCommonUtils.kt
@@ -275,21 +275,7 @@ fun parseAnnotationClassValue(target: KSAnnotated, annotationName: String): List
 inline fun <reified T> parseAnnotationValue(target: KSAnnotation, name: String) = target.findValue<T>(name)
 
 fun parseTags(target: KSAnnotated): List<KSType> {
-    val direct = parseAnnotationClassValue(target, CommonClassNames.tag.canonicalName)
-    if (direct.isNotEmpty()) {
-        return direct
-    }
-
-    for (annotation in target.annotations) {
-        val metaTag = parseAnnotationClassValue(
-            annotation.annotationType.resolve().declaration,
-            CommonClassNames.tag.canonicalName
-        )
-        if (metaTag.isNotEmpty()) {
-            return metaTag
-        }
-    }
-    return emptyList()
+    return parseAnnotationClassValue(target, CommonClassNames.tag.canonicalName)
 }
 
 fun findMethods(ksAnnotated: KSAnnotated, functionFilter: (KSFunctionDeclaration) -> Boolean): List<KSFunctionDeclaration> {

--- a/symbol-processor-common/src/main/kotlin/ru/tinkoff/kora/ksp/common/TagUtils.kt
+++ b/symbol-processor-common/src/main/kotlin/ru/tinkoff/kora/ksp/common/TagUtils.kt
@@ -171,4 +171,16 @@ object TagUtils {
         }
         return true
     }
+
+    fun Collection<String>.makeAnnotationSpecForTypes(): AnnotationSpec {
+        val codeBlock = CodeBlock.builder().add("value = [")
+        forEachIndexed { i, type ->
+            if (i > 0) {
+                codeBlock.add(", ")
+            }
+            codeBlock.add("%T::class", ClassName.bestGuess(type))
+        }
+        val value = codeBlock.add("]").build()
+        return AnnotationSpec.builder(CommonClassNames.tag).addMember(value).build()
+    }
 }

--- a/test/test-junit5/src/main/java/ru/tinkoff/kora/test/extension/junit5/KoraJUnit5Extension.java
+++ b/test/test-junit5/src/main/java/ru/tinkoff/kora/test/extension/junit5/KoraJUnit5Extension.java
@@ -766,11 +766,20 @@ final class KoraJUnit5Extension implements BeforeAllCallback, BeforeEachCallback
     }
 
     private static Class<?>[] parseTags(AnnotatedElement object) {
-        return Arrays.stream(object.getDeclaredAnnotations())
-            .filter(a -> a.annotationType().equals(Tag.class))
-            .map(a -> ((Tag) a).value())
-            .findFirst()
-            .orElse(null);
+        final Annotation[] annotations = object.getDeclaredAnnotations();
+        for (Annotation annotation : annotations) {
+            if (annotation.annotationType().equals(Tag.class)) {
+                return ((Tag) annotation).value();
+            }
+        }
+
+        for (Annotation annotation : annotations) {
+            final Tag metaTag = annotation.annotationType().getAnnotation(Tag.class);
+            if (metaTag != null) {
+                return metaTag.value();
+            }
+        }
+        return null;
     }
 
     private static Object getComponentFromGraph(TestGraphContext graph, GraphCandidate candidate) {

--- a/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/testdata/ComplexOtherMetaTag.java
+++ b/test/test-junit5/src/test/java/ru/tinkoff/kora/test/extension/junit5/testdata/ComplexOtherMetaTag.java
@@ -1,0 +1,14 @@
+package ru.tinkoff.kora.test.extension.junit5.testdata;
+
+import ru.tinkoff.kora.common.Tag;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Tag(TestApplication.ComplexOther.class)
+@Target({ElementType.TYPE, ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD, ElementType.TYPE_USE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ComplexOtherMetaTag {
+}

--- a/test/test-junit5/src/test/kotlin/ru/tinkoff/kora/test/extension/junit5/kotlin/MetaTagFieldInjectionTest.kt
+++ b/test/test-junit5/src/test/kotlin/ru/tinkoff/kora/test/extension/junit5/kotlin/MetaTagFieldInjectionTest.kt
@@ -1,0 +1,21 @@
+package ru.tinkoff.kora.test.extension.junit5.kotlin
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import ru.tinkoff.kora.test.extension.junit5.KoraAppTest
+import ru.tinkoff.kora.test.extension.junit5.TestComponent
+import ru.tinkoff.kora.test.extension.junit5.testdata.ComplexOtherMetaTag
+import ru.tinkoff.kora.test.extension.junit5.testdata.TestApplication
+
+@KoraAppTest(TestApplication::class)
+class MetaTagFieldInjectionTest {
+
+    @ComplexOtherMetaTag
+    @TestComponent
+    lateinit var dep: String
+
+    @Test
+    fun metaTaggedFieldInjected() {
+        assertEquals("other-1", dep)
+    }
+}

--- a/test/test-junit5/src/test/kotlin/ru/tinkoff/kora/test/extension/junit5/kotlin/MetaTagParameterInjectionTest.kt
+++ b/test/test-junit5/src/test/kotlin/ru/tinkoff/kora/test/extension/junit5/kotlin/MetaTagParameterInjectionTest.kt
@@ -1,0 +1,28 @@
+package ru.tinkoff.kora.test.extension.junit5.kotlin
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import ru.tinkoff.kora.test.extension.junit5.KoraAppTest
+import ru.tinkoff.kora.test.extension.junit5.TestComponent
+import ru.tinkoff.kora.test.extension.junit5.testdata.ComplexOtherMetaTag
+import ru.tinkoff.kora.test.extension.junit5.testdata.TestApplication
+
+@KoraAppTest(TestApplication::class)
+class MetaTagConstructorInjectionTest(
+    @ComplexOtherMetaTag @TestComponent val dep: String,
+) {
+
+    @Test
+    fun metaTaggedConstructorParamInjected() {
+        assertEquals("other-1", dep)
+    }
+}
+
+@KoraAppTest(TestApplication::class)
+class MetaTagMethodInjectionTest {
+
+    @Test
+    fun metaTaggedMethodParamInjected(@ComplexOtherMetaTag @TestComponent dep: String) {
+        assertEquals("other-1", dep)
+    }
+}


### PR DESCRIPTION
## Problem

Meta-annotation tags — an annotation that is itself annotated with `@Tag` (e.g. `@Json` = `@Tag(Json.class)`) — were silently dropped in several code paths, while a literal `@Tag(...)` worked. A `@Component` with a `@Json`-tagged constructor parameter routed through a `@KoraSubmodule` produced a generated factory whose parameter lost the tag, breaking graph resolution:

```
Required dependency type wasn't found in graph and can't be auto created: ... (no tags)
Required dependency claim: DependencyClaim(type=..., tags=[], claimType=ONE_REQUIRED)
```

## Root cause

There are two `parseTags` helpers in `symbol-processor-common`:

- `TagUtils.parseTags` — used by the main `@KoraApp` graph (`ComponentDependencyHelper`), **unwraps** meta-annotations.
- `parseTags` in `tags.kt` / `KspCommonUtils` — used by `KoraSubmoduleProcessor` and `RouteProcessor`, only matched a **literal** `@Tag`.

So `@Json` resolved everywhere except submodule / HTTP-route codegen. The runtime `@KoraAppTest` extension (`KoraJUnit5Extension.parseTags`) had the same literal-only limitation. Additionally `@Json` lacked `ElementType.FIELD`, so a bare `@Json` could not be placed on a Kotlin property field at all.

## Changes

- **`KspCommonUtils.parseTags`** is now meta-annotation aware (direct `@Tag` first, then a meta `@Tag`), reusing `parseAnnotationClassValue`. Fixes `@KoraSubmodule` and HTTP route code generation. The generic `parseAnnotationClassValue` (also used for `@Mapping` / `@NamingStrategy`) is left untouched.
- **`KoraJUnit5Extension.parseTags`** is now meta-annotation aware, so `@TestComponent` can be injected by a meta-tag (`@Json`) on constructor / method parameters.
- **`@Json`** gains `ElementType.FIELD`, aligning its targets with `@Tag` (its own meta-annotation already has `FIELD`). This lets a bare `@Json` be used on `@TestComponent` fields. Placement on constructor `val` parameters is unchanged (`param` keeps priority over `field`).

## Tests

- `kora-app-symbol-processor`: submodule meta-tagged dependency resolves end-to-end (generate submodule → build final graph).
- `test-junit5`: meta-tag injection via constructor parameter, method parameter and field.

All affected module suites pass: `symbol-processor-common`, `kora-app-symbol-processor`, `http-server-symbol-processor`, `test-junit5`, `json-annotation-processor`, `json-symbol-processor`, `json-common`, `jackson-module`.
