### PR TITLE
fix: render OpenAPI additionalContractAnnotations verbatim without HTML-escaping

### DIFF
--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaClientApi.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaClientApi.mustache
@@ -44,7 +44,7 @@ public interface {{classname}} {
     {{/externalDocs}}
     */
     {{#koraAdditionalContractAnnotations}}
-    {{.}}
+    {{{.}}}
     {{/koraAdditionalContractAnnotations}}
     @ru.tinkoff.kora.http.common.annotation.HttpRoute(method = "{{httpMethod}}", path = "{{path}}"){{#vendorExtensions.x-has-implicit-headers}}
     @io.swagger.v3.oas.annotations.Parameters({

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaServerApi.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaServerApi.mustache
@@ -53,7 +53,7 @@ public{{^vendorExtensions.allowAspects}} final{{/vendorExtensions.allowAspects}}
     {{/externalDocs}}
     */
     {{#koraAdditionalContractAnnotations}}
-    {{.}}
+    {{{.}}}
     {{/koraAdditionalContractAnnotations}}
     @ru.tinkoff.kora.http.common.annotation.HttpRoute(method = "{{httpMethod}}", path = "{{path}}"){{#vendorExtensions.x-has-implicit-headers}}
     @io.swagger.v3.oas.annotations.Parameters({

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinClientApi.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinClientApi.mustache
@@ -35,7 +35,7 @@ interface {{classname}} {
     {{/externalDocs}}
     */
     {{#koraAdditionalContractAnnotations}}
-    {{.}}
+    {{{.}}}
     {{/koraAdditionalContractAnnotations}}
     @ru.tinkoff.kora.http.common.annotation.HttpRoute(method = "{{httpMethod}}", path = "{{path}}"){{#vendorExtensions.x-has-implicit-headers}}
     @io.swagger.v3.oas.annotations.Parameters(value = [

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinServerApi.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinServerApi.mustache
@@ -40,7 +40,7 @@ import ru.tinkoff.kora.http.server.common.HttpServerRequest
     {{/externalDocs}}
     */
     {{#koraAdditionalContractAnnotations}}
-    {{.}}
+    {{{.}}}
     {{/koraAdditionalContractAnnotations}}
     @ru.tinkoff.kora.http.common.annotation.HttpRoute(method = "{{httpMethod}}", path = "{{path}}"){{#vendorExtensions.x-has-implicit-headers}}
     @io.swagger.v3.oas.annotations.Parameters(value = [

--- a/openapi/openapi-generator/src/test/java/ru/tinkoff/kora/openapi/generator/KoraCodegenTest.java
+++ b/openapi/openapi-generator/src/test/java/ru/tinkoff/kora/openapi/generator/KoraCodegenTest.java
@@ -55,6 +55,7 @@ class KoraCodegenTest {
             @Nullable
             private String implicitHeadersRegex;
             private boolean defaultDelegate;
+            private boolean additionalContractAnnotations;
 
             public boolean authAsArg() {return authAsArg;}
 
@@ -70,6 +71,8 @@ class KoraCodegenTest {
             public String implicitHeadersRegex() {return implicitHeadersRegex;}
 
             public boolean isDefaultDelegate() {return defaultDelegate;}
+
+            public boolean additionalContractAnnotations() {return additionalContractAnnotations;}
 
             public Options setAuthAsArg(boolean authAsArg) {
                 this.authAsArg = authAsArg;
@@ -103,6 +106,11 @@ class KoraCodegenTest {
 
             public Options setDefaultDelegate(boolean defaultDelegate) {
                 this.defaultDelegate = defaultDelegate;
+                return this;
+            }
+
+            public Options setAdditionalContractAnnotations(boolean additionalContractAnnotations) {
+                this.additionalContractAnnotations = additionalContractAnnotations;
                 return this;
             }
         }
@@ -169,6 +177,7 @@ class KoraCodegenTest {
 
                 if (name.equals("petstoreV3")) {
                     result.add(new SwaggerParams(mode, fileName, name + "_default_delegate", new SwaggerParams.Options().setDefaultDelegate(true)));
+                    result.add(new SwaggerParams(mode, fileName, name + "_additional_contract_annotations", new SwaggerParams.Options().setAdditionalContractAnnotations(true)));
                 }
 
                 if (fileName.contains("discriminator")
@@ -234,6 +243,14 @@ class KoraCodegenTest {
 
         if (options.isDefaultDelegate()) {
             configurator.addAdditionalProperty("delegateMethodBodyMode", "throwException");
+        }
+
+        if (options.additionalContractAnnotations()) {
+            configurator.addAdditionalProperty("additionalContractAnnotations", """
+                {
+                  "*": [ { "annotation": "@io.swagger.v3.oas.annotations.tags.Tag(name = \\"additional-contract\\")" } ]
+                }
+                """);
         }
 
         if (options.implicitHeadersRegex() != null) {


### PR DESCRIPTION
## Problem

The OpenAPI codegen option `additionalContractAnnotations` is rendered in the
api templates through the double-mustache tag `{{.}}`, which HTML-escapes its
value. As a result, any annotation that carries a string argument is mangled —
for example:

```groovy
configOptions = [
    additionalContractAnnotations: '{ "*": [ { "annotation": "@ru.tinkoff.kora.resilient.retry.annotation.Retry(\"rest\")" } ] }'
]
```

is generated as:

```java
@ru.tinkoff.kora.resilient.retry.annotation.Retry(&quot;rest&quot;)
```

which does not compile. This affects all four api templates (java/kotlin,
client/server).

## Fix

Render `koraAdditionalContractAnnotations` through the unescaped triple-mustache
`{{{.}}}` in:

- `javaClientApi.mustache`
- `javaServerApi.mustache`
- `kotlinClientApi.mustache`
- `kotlinServerApi.mustache`

The block is conditional on a non-empty `additionalContractAnnotations`, so
generation for every other spec is byte-for-byte unchanged.

## Test

Added a parameterized test
`KoraCodegenTest.additionalContractAnnotationWithStringArgumentIsRenderedVerbatim`
covering `java-client`, `java-server`, `kotlin-client`, `kotlin-server`. For each
mode it generates an additional contract annotation with a string argument
(`@io.swagger.v3.oas.annotations.tags.Tag(name = "additional-contract")`), then:

- asserts the annotation is emitted verbatim (real quotes, no `&quot;`),
- compiles the generated sources (Java APT / Kotlin K2).

Verified red→green: the test fails on the current templates (`AssertionFailedError`,
generated code contains `&quot;`) and passes after the fix. The full
`KoraCodegenTest` suite stays green.
