### PR TITLE
fix(config): track HOCON include files when application config is loaded as a resource

### DIFF
--- a/config/config-hocon/src/main/java/ru/tinkoff/kora/config/hocon/HoconConfigFactory.java
+++ b/config/config-hocon/src/main/java/ru/tinkoff/kora/config/hocon/HoconConfigFactory.java
@@ -14,11 +14,13 @@ import ru.tinkoff.kora.config.common.impl.SimpleConfigValueOrigin;
 import ru.tinkoff.kora.config.common.origin.ConfigOrigin;
 
 import jakarta.annotation.Nullable;
+
 import java.net.URL;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.function.Consumer;
 
 import ru.tinkoff.kora.config.common.origin.FileConfigOrigin;
 
@@ -69,17 +71,21 @@ public class HoconConfigFactory {
     }
 
     static HoconConfigOrigin fileOrigin(Path path) {
+        return new HoconConfigOrigin(path, includedFiles(options -> ConfigFactory.parseFile(path.toFile(), options)));
+    }
+
+    static HoconConfigOrigin resourceOrigin(URL url) {
+        return new HoconConfigOrigin(url, includedFiles(options -> ConfigFactory.parseURL(url, options)));
+    }
+
+    private static List<FileConfigOrigin> includedFiles(Consumer<ConfigParseOptions> parse) {
         var includer = new TrackingConfigIncluder();
         var options = ConfigParseOptions.defaults().setIncluder(includer);
-        ConfigFactory.parseFile(path.toFile(), options);
+        parse.accept(options);
         var includedFiles = new ArrayList<FileConfigOrigin>();
         for (var includedFile : includer.getIncludedFiles()) {
             includedFiles.add(new FileConfigOrigin(includedFile));
         }
-        return new HoconConfigOrigin(path, includedFiles);
-    }
-
-    static HoconConfigOrigin resourceOrigin(URL url) {
-        return new HoconConfigOrigin(url);
+        return includedFiles;
     }
 }

--- a/config/config-hocon/src/main/java/ru/tinkoff/kora/config/hocon/HoconConfigOrigin.java
+++ b/config/config-hocon/src/main/java/ru/tinkoff/kora/config/hocon/HoconConfigOrigin.java
@@ -28,9 +28,11 @@ final class HoconConfigOrigin implements ContainerConfigOrigin {
         this.description = buildDescription();
     }
 
-    HoconConfigOrigin(URL url) {
+    HoconConfigOrigin(URL url, List<FileConfigOrigin> includedFiles) {
         this.primaryOrigin = new ResourceConfigOrigin(url);
-        this.origins = List.of(this.primaryOrigin);
+        this.origins = new ArrayList<>();
+        this.origins.add(this.primaryOrigin);
+        this.origins.addAll(includedFiles);
         this.description = buildDescription();
     }
 

--- a/config/config-hocon/src/test/java/ru/tinkoff/kora/config/hocon/HoconConfigFactoryTest.java
+++ b/config/config-hocon/src/test/java/ru/tinkoff/kora/config/hocon/HoconConfigFactoryTest.java
@@ -4,10 +4,12 @@ import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigParseOptions;
 import org.junit.jupiter.api.Test;
 import ru.tinkoff.kora.config.common.ConfigValue;
+import ru.tinkoff.kora.config.common.origin.FileConfigOrigin;
 import ru.tinkoff.kora.config.common.origin.SimpleConfigOrigin;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.Comparator;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -163,6 +165,38 @@ class HoconConfigFactoryTest {
         } finally {
             Files.walk(tempDir)
                 .sorted(java.util.Comparator.reverseOrder())
+                .forEach(p -> p.toFile().delete());
+        }
+    }
+
+    @Test
+    void resourceOriginTracksFileIncludes() throws Exception {
+        var tempDir = Files.createTempDirectory("hocon-test");
+        try {
+            var overrideFile = tempDir.resolve("override.conf").toAbsolutePath();
+            Files.writeString(overrideFile, """
+                database.pool = 20
+                """);
+
+            var mainFile = tempDir.resolve("application.conf");
+            Files.writeString(mainFile, """
+                include file("%s")
+                database.username = "user"
+                """.formatted(overrideFile));
+
+            // application config loaded as a resource (e.g. packaged inside a jar),
+            // pulling in an external file via include file("...") (e.g. a k8s ConfigMap override)
+            var origin = HoconConfigFactory.resourceOrigin(mainFile.toUri().toURL());
+
+            var includedFilePaths = origin.origins().stream()
+                .filter(o -> o instanceof FileConfigOrigin)
+                .map(o -> ((FileConfigOrigin) o).path())
+                .toList();
+
+            assertThat(includedFilePaths).contains(overrideFile);
+        } finally {
+            Files.walk(tempDir)
+                .sorted(Comparator.reverseOrder())
                 .forEach(p -> p.toFile().delete());
         }
     }


### PR DESCRIPTION
## Problem

`ConfigWatcher` only watched HOCON `include` files when the **application config itself** resolved to a filesystem file — i.e. went through `HoconConfigFactory.fileOrigin()`, which tracks includes via `TrackingConfigIncluder`.

In a typical k8s deployment `application.conf` is packaged **inside the jar**, so `loader.getResource(...)` returns a `jar:` URL and `HoconConfigModule.applicationConfigOrigin()` takes the `resourceOrigin()` branch. That branch built the origin with only the primary `ResourceConfigOrigin` and **no include tracking**, so a file pulled in via `include file("/opt/app/config/override.conf")` (e.g. an override mounted from a ConfigMap) never ended up in `origins()`.

As a result `ConfigWatcher.parseOrigin()` found no `FileConfigOrigin`, the watch loop exited immediately (`origins.isEmpty()`), and changes to the override file did **not** trigger a live reload. The override was only applied on pod restart, when the `include` is re-resolved during config load.

## Fix

`resourceOrigin()` now parses the URL with `TrackingConfigIncluder` and records file includes, exactly mirroring `fileOrigin()`. The shared include-collection logic is extracted into a small `includedFiles(Consumer<ConfigParseOptions>)` helper to remove the duplication between the two.

Classpath/jar includes remain ignored by design (only includes resolving to a regular file on the filesystem are tracked) — which is exactly the case for ConfigMap-mounted overrides referenced via `include file(...)`.

## Tests

- `HoconConfigFactoryTest.resourceOriginTracksFileIncludes` — verifies that, when the application config is loaded as a resource, a `include file("...")` target is present among `origins()` as a `FileConfigOrigin` (the link `ConfigWatcher` relies on). Confirmed RED before the fix, GREEN after.
- Existing `HoconConfigFactoryTest` and `config-common` `ConfigWatcherTest` continue to pass.