### PR TITLE
Added ConfigWatcher tracks HOCON include files

### DIFF
--- a/config/config-common/src/main/java/io/koraframework/config/common/origin/ContainerConfigOrigin.java
+++ b/config/config-common/src/main/java/io/koraframework/config/common/origin/ContainerConfigOrigin.java
@@ -9,16 +9,17 @@ public class ContainerConfigOrigin implements ConfigOrigin {
     private final String description;
 
     public ContainerConfigOrigin(ConfigOrigin origin1, ConfigOrigin origin2) {
+        this(List.of(origin1, origin2));
+    }
+
+    public ContainerConfigOrigin(List<ConfigOrigin> origins) {
         this.origins = new ArrayList<>();
-        if (origin1 instanceof ContainerConfigOrigin container) {
-            this.origins.addAll(container.origins());
-        } else {
-            this.origins.add(origin1);
-        }
-        if (origin2 instanceof ContainerConfigOrigin container) {
-            this.origins.addAll(container.origins());
-        } else {
-            this.origins.add(origin2);
+        for (var origin : origins) {
+            if (origin instanceof ContainerConfigOrigin container) {
+                this.origins.addAll(container.origins());
+            } else {
+                this.origins.add(origin);
+            }
         }
         this.description = this.origins.stream()
             .map(ConfigOrigin::description)

--- a/config/config-hocon/src/main/java/io/koraframework/config/hocon/HoconConfigFactory.java
+++ b/config/config-hocon/src/main/java/io/koraframework/config/hocon/HoconConfigFactory.java
@@ -1,24 +1,32 @@
 package io.koraframework.config.hocon;
 
 import com.typesafe.config.ConfigException;
+import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigList;
 import com.typesafe.config.ConfigObject;
+import com.typesafe.config.ConfigParseOptions;
 import com.typesafe.config.ConfigRenderOptions;
-import org.jspecify.annotations.Nullable;
 import io.koraframework.config.common.Config;
 import io.koraframework.config.common.ConfigValue;
 import io.koraframework.config.common.ConfigValuePath;
 import io.koraframework.config.common.impl.SimpleConfig;
 import io.koraframework.config.common.impl.SimpleConfigValueOrigin;
 import io.koraframework.config.common.origin.ConfigOrigin;
+import io.koraframework.config.common.origin.ContainerConfigOrigin;
+import io.koraframework.config.common.origin.FileConfigOrigin;
+import io.koraframework.config.common.origin.ResourceConfigOrigin;
+import org.jspecify.annotations.Nullable;
 
+import java.net.URL;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.function.Consumer;
 
 public final class HoconConfigFactory {
 
-    private HoconConfigFactory() { }
+    private HoconConfigFactory() {}
 
     public static Config fromHocon(ConfigOrigin origin, com.typesafe.config.Config config) {
         var object = config.root();
@@ -63,5 +71,36 @@ public final class HoconConfigFactory {
             result.add(toValue(origin, configValue, path.child(i)));
         }
         return new ConfigValue.ArrayValue(new SimpleConfigValueOrigin(origin, path), List.copyOf(result));
+    }
+
+    static ConfigOrigin fileOrigin(Path path) {
+        var primary = new FileConfigOrigin(path);
+        return withIncludes(primary, includedFiles(options -> ConfigFactory.parseFile(path.toFile(), options)));
+    }
+
+    static ConfigOrigin resourceOrigin(URL url) {
+        var primary = new ResourceConfigOrigin(url);
+        return withIncludes(primary, includedFiles(options -> ConfigFactory.parseURL(url, options)));
+    }
+
+    private static ConfigOrigin withIncludes(ConfigOrigin primary, List<FileConfigOrigin> includedFiles) {
+        if (includedFiles.isEmpty()) {
+            return primary;
+        }
+        var origins = new ArrayList<ConfigOrigin>();
+        origins.add(primary);
+        origins.addAll(includedFiles);
+        return new ContainerConfigOrigin(origins);
+    }
+
+    private static List<FileConfigOrigin> includedFiles(Consumer<ConfigParseOptions> parse) {
+        var includer = new TrackingConfigIncluder();
+        var options = ConfigParseOptions.defaults().setIncluder(includer);
+        parse.accept(options);
+        var includedFiles = new ArrayList<FileConfigOrigin>();
+        for (var includedFile : includer.getIncludedFiles()) {
+            includedFiles.add(new FileConfigOrigin(includedFile));
+        }
+        return includedFiles;
     }
 }

--- a/config/config-hocon/src/main/java/io/koraframework/config/hocon/HoconConfigModule.java
+++ b/config/config-hocon/src/main/java/io/koraframework/config/hocon/HoconConfigModule.java
@@ -7,6 +7,7 @@ import io.koraframework.config.common.ConfigModule;
 import io.koraframework.config.common.Config;
 import io.koraframework.config.common.annotation.ApplicationConfig;
 import io.koraframework.config.common.origin.ConfigOrigin;
+import io.koraframework.config.common.origin.ContainerConfigOrigin;
 import io.koraframework.config.common.origin.FileConfigOrigin;
 import io.koraframework.config.common.origin.ResourceConfigOrigin;
 import io.koraframework.config.common.origin.SimpleConfigOrigin;
@@ -44,21 +45,22 @@ public interface HoconConfigModule extends ConfigModule {
                 return new SimpleConfigOrigin("empty");
             }
             if (resourceUrl.getProtocol().equals("file")) {
-                return new FileConfigOrigin(Path.of(resourceUrl.toURI()));
+                return HoconConfigFactory.fileOrigin(Path.of(resourceUrl.toURI()));
             }
-            return new ResourceConfigOrigin(resourceUrl);
+            return HoconConfigFactory.resourceOrigin(resourceUrl);
         } else {
-            return new FileConfigOrigin(Path.of(file));
+            return HoconConfigFactory.fileOrigin(Path.of(file));
         }
     }
 
     @ApplicationConfig
     default com.typesafe.config.Config applicationConfigHoconUnresolved(@ApplicationConfig ConfigOrigin origin) throws Exception {
-        if (origin instanceof FileConfigOrigin file) {
+        var source = origin instanceof ContainerConfigOrigin container ? container.origins().get(0) : origin;
+        if (source instanceof FileConfigOrigin file) {
             try (var reader = Files.newBufferedReader(file.path(), StandardCharsets.UTF_8)) {
                 return ConfigFactory.parseReader(reader);
             }
-        } else if (origin instanceof ResourceConfigOrigin resource) {
+        } else if (source instanceof ResourceConfigOrigin resource) {
             var connection = resource.url().openConnection();
             connection.connect();
             try (var reader = new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8)) {

--- a/config/config-hocon/src/main/java/io/koraframework/config/hocon/TrackingConfigIncluder.java
+++ b/config/config-hocon/src/main/java/io/koraframework/config/hocon/TrackingConfigIncluder.java
@@ -1,0 +1,72 @@
+package io.koraframework.config.hocon;
+
+import com.typesafe.config.ConfigIncludeContext;
+import com.typesafe.config.ConfigIncluder;
+import com.typesafe.config.ConfigIncluderFile;
+import com.typesafe.config.ConfigObject;
+import org.jspecify.annotations.Nullable;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * A {@link ConfigIncluder} wrapper that records all file paths encountered
+ * via {@code include file("...")} and {@code include "..."} directives during HOCON parsing.
+ * <p>
+ * Only tracks includes that resolve to actual files on the filesystem.
+ * Classpath resources and URLs are ignored.
+ * <p>
+ * Delegates actual include resolution to the fallback (default) includer.
+ */
+final class TrackingConfigIncluder implements ConfigIncluder, ConfigIncluderFile {
+
+    private @Nullable ConfigIncluder fallback;
+    private final Set<Path> includedFiles = new LinkedHashSet<>();
+
+    @Override
+    public ConfigIncluder withFallback(ConfigIncluder fallback) {
+        if (this.fallback == fallback) {
+            return this;
+        }
+        this.fallback = fallback;
+        return this;
+    }
+
+    @Override
+    public ConfigObject include(ConfigIncludeContext context, String what) {
+        var fallback = Objects.requireNonNull(this.fallback);
+        var parseable = context.relativeTo(what);
+        if (parseable != null) {
+            var filename = parseable.origin().filename();
+            if (filename != null) {
+                var path = Path.of(filename).toAbsolutePath();
+                if (Files.isRegularFile(path)) {
+                    includedFiles.add(path);
+                }
+            }
+        }
+        return fallback.include(context, what);
+    }
+
+    @Override
+    public ConfigObject includeFile(ConfigIncludeContext context, File what) {
+        var fallback = Objects.requireNonNull(this.fallback);
+        var path = what.toPath().toAbsolutePath();
+        if (Files.isRegularFile(path)) {
+            includedFiles.add(path);
+        }
+        if (fallback instanceof ConfigIncluderFile fileIncluder) {
+            return fileIncluder.includeFile(context, what);
+        }
+        return fallback.include(context, what.getPath());
+    }
+
+    Set<Path> getIncludedFiles() {
+        return Collections.unmodifiableSet(includedFiles);
+    }
+}

--- a/config/config-hocon/src/test/java/io/koraframework/config/hocon/HoconConfigFactoryTest.java
+++ b/config/config-hocon/src/test/java/io/koraframework/config/hocon/HoconConfigFactoryTest.java
@@ -1,14 +1,17 @@
 package io.koraframework.config.hocon;
 
 import com.typesafe.config.ConfigFactory;
-import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.Test;
+import com.typesafe.config.ConfigParseOptions;
 import io.koraframework.config.common.ConfigValue;
+import io.koraframework.config.common.origin.ContainerConfigOrigin;
+import io.koraframework.config.common.origin.FileConfigOrigin;
 import io.koraframework.config.common.origin.SimpleConfigOrigin;
+import org.junit.jupiter.api.Test;
 
-import java.math.BigDecimal;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Comparator;
 import java.util.List;
-import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -51,5 +54,152 @@ class HoconConfigFactoryTest {
         assertThat(config.get("testArray")).isInstanceOf(ConfigValue.ArrayValue.class)
             .extracting(v -> v.asArray().value().stream().map(ConfigValue::value).toList())
             .isEqualTo(List.of(1, 2, 3));
+    }
+
+    @Test
+    void testTrackingIncluderRecordsIncludedFile() throws IOException {
+        var tempDir = Files.createTempDirectory("hocon-test");
+        try {
+            var overrideFile = tempDir.resolve("override.conf");
+            Files.writeString(overrideFile, """
+                database.url = "jdbc:postgresql://prod:5432/db"
+                """);
+
+            var mainFile = tempDir.resolve("application.conf");
+            Files.writeString(mainFile, """
+                include file("%s")
+                database.username = "user"
+                """.formatted(overrideFile.toAbsolutePath()));
+
+            var includer = new TrackingConfigIncluder();
+            var options = ConfigParseOptions.defaults().setIncluder(includer);
+            ConfigFactory.parseFile(mainFile.toFile(), options);
+
+            assertThat(includer.getIncludedFiles()).hasSize(1);
+            assertThat(includer.getIncludedFiles()).contains(overrideFile.toAbsolutePath());
+        } finally {
+            Files.walk(tempDir)
+                .sorted(Comparator.reverseOrder())
+                .forEach(p -> p.toFile().delete());
+        }
+    }
+
+    @Test
+    void testTrackingIncluderRecordsNestedIncludes() throws IOException {
+        var tempDir = Files.createTempDirectory("hocon-test");
+        try {
+            var level2File = tempDir.resolve("level2.conf");
+            Files.writeString(level2File, """
+                database.pool = 10
+                """);
+
+            var level1File = tempDir.resolve("level1.conf");
+            Files.writeString(level1File, """
+                include file("%s")
+                database.url = "jdbc:postgresql://prod:5432/db"
+                """.formatted(level2File.toAbsolutePath()));
+
+            var mainFile = tempDir.resolve("application.conf");
+            Files.writeString(mainFile, """
+                include file("%s")
+                database.username = "user"
+                """.formatted(level1File.toAbsolutePath()));
+
+            var includer = new TrackingConfigIncluder();
+            var options = ConfigParseOptions.defaults().setIncluder(includer);
+            ConfigFactory.parseFile(mainFile.toFile(), options);
+
+            assertThat(includer.getIncludedFiles()).hasSize(2);
+            assertThat(includer.getIncludedFiles()).contains(level1File.toAbsolutePath());
+            assertThat(includer.getIncludedFiles()).contains(level2File.toAbsolutePath());
+        } finally {
+            Files.walk(tempDir)
+                .sorted(Comparator.reverseOrder())
+                .forEach(p -> p.toFile().delete());
+        }
+    }
+
+    @Test
+    void testTrackingIncluderRecordsHeuristicInclude() throws IOException {
+        var tempDir = Files.createTempDirectory("hocon-test");
+        try {
+            var overrideFile = tempDir.resolve("override.conf");
+            Files.writeString(overrideFile, """
+                database.url = "jdbc:postgresql://prod:5432/db"
+                """);
+
+            var mainFile = tempDir.resolve("application.conf");
+            Files.writeString(mainFile, """
+                include "override.conf"
+                database.username = "user"
+                """);
+
+            var includer = new TrackingConfigIncluder();
+            var options = ConfigParseOptions.defaults().setIncluder(includer);
+            ConfigFactory.parseFile(mainFile.toFile(), options);
+
+            assertThat(includer.getIncludedFiles()).hasSize(1);
+            assertThat(includer.getIncludedFiles()).contains(overrideFile.toAbsolutePath());
+        } finally {
+            Files.walk(tempDir)
+                .sorted(Comparator.reverseOrder())
+                .forEach(p -> p.toFile().delete());
+        }
+    }
+
+    @Test
+    void testTrackingIncluderIgnoresNonExistentOptionalInclude() throws IOException {
+        var tempDir = Files.createTempDirectory("hocon-test");
+        try {
+            var mainFile = tempDir.resolve("application.conf");
+            Files.writeString(mainFile, """
+                include file("%s")
+                database.username = "user"
+                """.formatted(tempDir.resolve("nonexistent.conf").toAbsolutePath()));
+
+            var includer = new TrackingConfigIncluder();
+            var options = ConfigParseOptions.defaults().setIncluder(includer);
+            ConfigFactory.parseFile(mainFile.toFile(), options);
+
+            // Non-existent files are filtered out by TrackingConfigIncluder
+            assertThat(includer.getIncludedFiles()).isEmpty();
+        } finally {
+            Files.walk(tempDir)
+                .sorted(Comparator.reverseOrder())
+                .forEach(p -> p.toFile().delete());
+        }
+    }
+
+    @Test
+    void resourceOriginTracksFileIncludes() throws Exception {
+        var tempDir = Files.createTempDirectory("hocon-test");
+        try {
+            var overrideFile = tempDir.resolve("override.conf").toAbsolutePath();
+            Files.writeString(overrideFile, """
+                database.pool = 20
+                """);
+
+            var mainFile = tempDir.resolve("application.conf");
+            Files.writeString(mainFile, """
+                include file("%s")
+                database.username = "user"
+                """.formatted(overrideFile));
+
+            // application config loaded as a resource (e.g. packaged inside a jar),
+            // pulling in an external file via include file("...") (e.g. a k8s ConfigMap override)
+            var origin = HoconConfigFactory.resourceOrigin(mainFile.toUri().toURL());
+
+            assertThat(origin).isInstanceOf(ContainerConfigOrigin.class);
+            var includedFilePaths = ((ContainerConfigOrigin) origin).origins().stream()
+                .filter(o -> o instanceof FileConfigOrigin)
+                .map(o -> ((FileConfigOrigin) o).path())
+                .toList();
+
+            assertThat(includedFilePaths).contains(overrideFile);
+        } finally {
+            Files.walk(tempDir)
+                .sorted(Comparator.reverseOrder())
+                .forEach(p -> p.toFile().delete());
+        }
     }
 }


### PR DESCRIPTION
Ports the HOCON include-file tracking to `master` (already present on `1.0` via #610 + #683). On `master` this functionality was entirely absent — `ConfigWatcher` watched only the primary application config file.

## Problem

`ConfigWatcher` already unwraps `ContainerConfigOrigin` into the file origins it watches, but `HoconConfigModule.applicationConfigOrigin()` only ever produced a bare `FileConfigOrigin` / `ResourceConfigOrigin`. So files pulled in via `include file("...")` (e.g. an override mounted from a k8s ConfigMap) were never watched, and live-reload never fired for them — they were only re-read on restart.

This is especially relevant when `application.conf` is packaged **inside a jar**: it resolves as a resource (`ResourceConfigOrigin`), and any `include file("/opt/app/config/override.conf")` pointing at a ConfigMap-mounted file was invisible to the watcher.

## Change

- **`HoconConfigFactory`** — new `fileOrigin(Path)` / `resourceOrigin(URL)` parse the source with a `TrackingConfigIncluder` and, when there are file includes, wrap the primary origin + tracked includes into a `ContainerConfigOrigin` (primary kept first). No includes → primary returned unchanged (previous behaviour).
- **`ContainerConfigOrigin`** — add a `List<ConfigOrigin>` constructor (existing two-arg constructor now delegates to it; behaviour identical).
- **`HoconConfigModule`** — build the origin via the factory; in `applicationConfigHoconUnresolved` read the primary origin out of the container so config reading is unchanged.
- **`TrackingConfigIncluder`** — new; records `include file(...)` / heuristic `include "..."` targets that resolve to real files. Classpath/jar includes are ignored by design (immutable).

The watcher itself is unchanged — it already handles `ContainerConfigOrigin`.

## Tests

`HoconConfigFactoryTest`:
- `testTrackingIncluderRecordsIncludedFile` / `...NestedIncludes` / `...HeuristicInclude` / `...IgnoresNonExistentOptionalInclude` — the includer records the right files.
- `resourceOriginTracksFileIncludes` — when the app config is loaded as a resource (jar case), an `include file("...")` target ends up among the origins so `ConfigWatcher` watches it. Confirmed RED before the change, GREEN after.

`:config:config-hocon:test` and `:config:config-common:test` pass (including `ConfigWatcherTest` and `MergeConfigFactoryTest`, which exercise the refactored `ContainerConfigOrigin`).