### PR TITLE
Fixed `HttpServerResponseException` usage `of` contract (#602)

### DIFF
--- a/http/http-server-common/src/main/java/io/koraframework/http/server/common/response/HttpServerResponseException.java
+++ b/http/http-server-common/src/main/java/io/koraframework/http/server/common/response/HttpServerResponseException.java
@@ -31,7 +31,7 @@ public class HttpServerResponseException extends RuntimeException implements Htt
     }
 
     public static HttpServerResponseException of(int code, Throwable throwable) {
-        return of(throwable, code, Objects.requireNonNull(throwable.getMessage(), "Internal server error"));
+        return of(throwable, code, Objects.requireNonNullElse(throwable.getMessage(), "Internal server error"));
     }
 
     public static HttpServerResponseException of(int code, String text, MutableHttpHeaders headers) {
@@ -39,7 +39,7 @@ public class HttpServerResponseException extends RuntimeException implements Htt
     }
 
     public static HttpServerResponseException of(int code, Throwable throwable, MutableHttpHeaders headers) {
-        return of(throwable, code, Objects.requireNonNull(throwable.getMessage(), "Internal server error"), headers);
+        return of(throwable, code, Objects.requireNonNullElse(throwable.getMessage(), "Internal server error"), headers);
     }
 
     public static HttpServerResponseException of(@Nullable Throwable cause, int code, String text) {


### PR DESCRIPTION
Fixed `HttpServerResponseException` usage `of` contract (#602)

Fixed HttpServerResponseException usage of requireNonNull instead of requireNonNullElse for exception message handling

(cherry picked from commit 2e422ccfb15e09fb95ee30cc7b0538d9c44ed0ef)