### PR TITLE
fix(logging): handle non-native @Mdc parameter types and ${} value expressions in KSP

### DIFF
--- a/logging/declarative-logging/declarative-logging-annotation-processor/src/main/java/ru/tinkoff/kora/logging/aspect/mdc/MdcAspect.java
+++ b/logging/declarative-logging/declarative-logging-annotation-processor/src/main/java/ru/tinkoff/kora/logging/aspect/mdc/MdcAspect.java
@@ -9,7 +9,10 @@ import ru.tinkoff.kora.aop.annotation.processor.KoraAspect;
 
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeMirror;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -26,6 +29,25 @@ import static ru.tinkoff.kora.logging.aspect.mdc.MdcAspectClassNames.mdcContaine
 public class MdcAspect implements KoraAspect {
 
     private static final String MDC_CONTEXT_VAR_NAME = "__mdcContext";
+
+    private static boolean isNativeMdcType(TypeMirror type) {
+        return switch (type.getKind()) {
+            case INT, LONG, BOOLEAN -> true;
+            case DECLARED -> {
+                final var element = ((DeclaredType) type).asElement();
+                if (element instanceof TypeElement typeElement) {
+                    final var qualifiedName = typeElement.getQualifiedName().toString();
+                    yield qualifiedName.equals("java.lang.String")
+                        || qualifiedName.equals("java.lang.Integer")
+                        || qualifiedName.equals("java.lang.Long")
+                        || qualifiedName.equals("java.lang.Boolean")
+                        || qualifiedName.equals("ru.tinkoff.kora.logging.common.arg.StructuredArgumentWriter");
+                }
+                yield false;
+            }
+            default -> false;
+        };
+    }
 
     @Override
     public Set<String> getSupportedAnnotationTypes() {
@@ -105,20 +127,24 @@ public class MdcAspect implements KoraAspect {
         for (VariableElement parameter : parametersWithAnnotation) {
             final String parameterName = parameter.getSimpleName().toString();
             final AnnotationMirror firstAnnotation = findAnnotations(parameter, mdcAnnotation, mdcContainerAnnotation)
-                .get(0);
+                    .get(0);
 
             final String key = extractStringParameter(firstAnnotation, "key")
-                .or(() -> extractStringParameter(firstAnnotation, "value"))
-                .orElse(parameterName);
+                    .or(() -> extractStringParameter(firstAnnotation, "value"))
+                    .orElse(parameterName);
 
             final Boolean global = parseAnnotationValueWithoutDefault(firstAnnotation, "global");
 
-            fillMdcBuilder.addStatement(
-                "$T.put($S, $N)",
-                mdc,
-                key,
-                parameterName
-            );
+            final TypeMirror parameterType = parameter.asType();
+            if (isNativeMdcType(parameterType)) {
+                fillMdcBuilder.addStatement("$T.put($S, $N)", mdc, key, parameterName);
+            } else if (parameterType.getKind().isPrimitive()) {
+                fillMdcBuilder.addStatement("$T.put($S, $T.valueOf($N))", mdc, key, String.class, parameterName);
+            } else {
+                fillMdcBuilder.beginControlFlow("if ($N != null)", parameterName)
+                        .addStatement("$T.put($S, $N.toString())", mdc, key, parameterName)
+                        .endControlFlow();
+            }
 
             if (global == null || !global) {
                 keys.add(key);

--- a/logging/declarative-logging/declarative-logging-annotation-processor/src/main/java/ru/tinkoff/kora/logging/aspect/mdc/MdcAspect.java
+++ b/logging/declarative-logging/declarative-logging-annotation-processor/src/main/java/ru/tinkoff/kora/logging/aspect/mdc/MdcAspect.java
@@ -25,26 +25,25 @@ import static ru.tinkoff.kora.annotation.processor.common.AnnotationUtils.parseA
 import static ru.tinkoff.kora.logging.aspect.mdc.MdcAspectClassNames.mdc;
 import static ru.tinkoff.kora.logging.aspect.mdc.MdcAspectClassNames.mdcAnnotation;
 import static ru.tinkoff.kora.logging.aspect.mdc.MdcAspectClassNames.mdcContainerAnnotation;
+import static ru.tinkoff.kora.logging.aspect.mdc.MdcAspectClassNames.mdcWriter;
 
 public class MdcAspect implements KoraAspect {
 
     private static final String MDC_CONTEXT_VAR_NAME = "__mdcContext";
+    private static final Set<String> NATIVE_MDC_TYPES = Set.of(
+        String.class.getCanonicalName(),
+        Integer.class.getCanonicalName(),
+        Long.class.getCanonicalName(),
+        Boolean.class.getCanonicalName(),
+        mdcWriter.canonicalName()
+    );
 
     private static boolean isNativeMdcType(TypeMirror type) {
         return switch (type.getKind()) {
+            // primitives autobox to their wrappers, which have dedicated MDC.put overloads
             case INT, LONG, BOOLEAN -> true;
-            case DECLARED -> {
-                final var element = ((DeclaredType) type).asElement();
-                if (element instanceof TypeElement typeElement) {
-                    final var qualifiedName = typeElement.getQualifiedName().toString();
-                    yield qualifiedName.equals("java.lang.String")
-                        || qualifiedName.equals("java.lang.Integer")
-                        || qualifiedName.equals("java.lang.Long")
-                        || qualifiedName.equals("java.lang.Boolean")
-                        || qualifiedName.equals("ru.tinkoff.kora.logging.common.arg.StructuredArgumentWriter");
-                }
-                yield false;
-            }
+            case DECLARED -> ((DeclaredType) type).asElement() instanceof TypeElement typeElement
+                && NATIVE_MDC_TYPES.contains(typeElement.getQualifiedName().toString());
             default -> false;
         };
     }
@@ -127,11 +126,11 @@ public class MdcAspect implements KoraAspect {
         for (VariableElement parameter : parametersWithAnnotation) {
             final String parameterName = parameter.getSimpleName().toString();
             final AnnotationMirror firstAnnotation = findAnnotations(parameter, mdcAnnotation, mdcContainerAnnotation)
-                    .get(0);
+                .get(0);
 
             final String key = extractStringParameter(firstAnnotation, "key")
-                    .or(() -> extractStringParameter(firstAnnotation, "value"))
-                    .orElse(parameterName);
+                .or(() -> extractStringParameter(firstAnnotation, "value"))
+                .orElse(parameterName);
 
             final Boolean global = parseAnnotationValueWithoutDefault(firstAnnotation, "global");
 
@@ -142,8 +141,8 @@ public class MdcAspect implements KoraAspect {
                 fillMdcBuilder.addStatement("$T.put($S, $T.valueOf($N))", mdc, key, String.class, parameterName);
             } else {
                 fillMdcBuilder.beginControlFlow("if ($N != null)", parameterName)
-                        .addStatement("$T.put($S, $N.toString())", mdc, key, parameterName)
-                        .endControlFlow();
+                    .addStatement("$T.put($S, $N.toString())", mdc, key, parameterName)
+                    .endControlFlow();
             }
 
             if (global == null || !global) {

--- a/logging/declarative-logging/declarative-logging-annotation-processor/src/main/java/ru/tinkoff/kora/logging/aspect/mdc/MdcAspectClassNames.java
+++ b/logging/declarative-logging/declarative-logging-annotation-processor/src/main/java/ru/tinkoff/kora/logging/aspect/mdc/MdcAspectClassNames.java
@@ -6,4 +6,5 @@ public class MdcAspectClassNames {
     public static final ClassName mdcAnnotation = ClassName.get("ru.tinkoff.kora.logging.common.annotation", "Mdc");
     public static final ClassName mdcContainerAnnotation = ClassName.get("ru.tinkoff.kora.logging.common.annotation", "Mdc", "MdcContainer");
     public static final ClassName mdc = ClassName.get("ru.tinkoff.kora.logging.common", "MDC");
+    public static final ClassName mdcWriter = ClassName.get("ru.tinkoff.kora.logging.common.arg", "StructuredArgumentWriter");
 }

--- a/logging/declarative-logging/declarative-logging-annotation-processor/src/test/java/ru/tinkoff/kora/logging/aspect/mdc/MdcAspectTest.java
+++ b/logging/declarative-logging/declarative-logging-annotation-processor/src/test/java/ru/tinkoff/kora/logging/aspect/mdc/MdcAspectTest.java
@@ -204,4 +204,71 @@ class MdcAspectTest extends AbstractMdcAspectTest {
     private static void clearCurrentContext() {
         MDC.get().values().keySet().forEach(MDC::remove);
     }
+
+    @Test
+    void testMdcNonNativeParameterNonNull() throws Exception {
+        var aopProxy = compile(
+                List.of(new AopAnnotationProcessor()),
+                """
+                        public class TestMdc {
+                        
+                          private final MDCContextHolder mdcContextHolder;
+                        
+                          public TestMdc(MDCContextHolder mdcContextHolder) {
+                              this.mdcContextHolder = mdcContextHolder;
+                          }
+                        
+                          public Integer test(@Mdc(key = "subscriptionId") java.util.UUID subscriptionId) {
+                              mdcContextHolder.set(MDC.get().values());
+                              return null;
+                          }
+                        }
+                        """
+        );
+
+        aopProxy.assertSuccess();
+
+        final UUID subscriptionId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        var generatedClass = aopProxy.loadClass("$TestMdc__AopProxy");
+        var constructor = generatedClass.getConstructors()[0];
+        final TestObject testObject = new TestObject(generatedClass, constructor.newInstance(CONTEXT_HOLDER));
+        testObject.invoke("test", subscriptionId);
+
+        final Map<String, String> context = extractMdcContextFromHolder();
+        assertEquals(Map.of("subscriptionId", "\"" + subscriptionId + "\""), context);
+        assertEquals(emptyMap(), currentMdcContext());
+    }
+
+    @Test
+    void testMdcNonNativeParameterNull() throws Exception {
+        var aopProxy = compile(
+            List.of(new AopAnnotationProcessor()),
+            """
+                public class TestMdc {
+                
+                  private final MDCContextHolder mdcContextHolder;
+                
+                  public TestMdc(MDCContextHolder mdcContextHolder) {
+                      this.mdcContextHolder = mdcContextHolder;
+                  }
+                
+                  public Integer test(@Mdc(key = "subscriptionId") java.util.UUID subscriptionId) {
+                      mdcContextHolder.set(MDC.get().values());
+                      return null;
+                  }
+                }
+                """
+        );
+
+        aopProxy.assertSuccess();
+
+        var generatedClass = aopProxy.loadClass("$TestMdc__AopProxy");
+        var constructor = generatedClass.getConstructors()[0];
+        final TestObject testObject = new TestObject(generatedClass, constructor.newInstance(CONTEXT_HOLDER));
+        testObject.invoke("test", (Object) null);
+
+        final Map<String, String> context = extractMdcContextFromHolder();
+        assertEquals(emptyMap(), context);
+        assertEquals(emptyMap(), currentMdcContext());
+    }
 }

--- a/logging/declarative-logging/declarative-logging-symbol-processor/src/main/kotlin/ru/tinkoff/kora/logging/symbol/processor/aop/mdc/MdcKoraAspect.kt
+++ b/logging/declarative-logging/declarative-logging-symbol-processor/src/main/kotlin/ru/tinkoff/kora/logging/symbol/processor/aop/mdc/MdcKoraAspect.kt
@@ -25,8 +25,18 @@ class MdcKoraAspect : KoraAspect {
     companion object {
         const val MDC_CONTEXT_VAL_NAME = "__mdcContext"
         val mdc = ClassName("ru.tinkoff.kora.logging.common", "MDC")
+        val mdcWriter = ClassName("ru.tinkoff.kora.logging.common.arg", "StructuredArgumentWriter")
         val mdcAnnotation = ClassName("ru.tinkoff.kora.logging.common.annotation", "Mdc")
         val mdcContainerAnnotation = mdcAnnotation.nestedClass("MdcContainer")
+
+        // Parameter types that have a dedicated MDC.put overload and keep their JSON type
+        private val NATIVE_MDC_TYPES = setOf(
+            String::class.qualifiedName!!,
+            Int::class.qualifiedName!!,
+            Long::class.qualifiedName!!,
+            Boolean::class.qualifiedName!!,
+            mdcWriter.canonicalName,
+        )
     }
 
     override fun getSupportedAnnotationTypes(): Set<String> = setOf(mdcAnnotation.canonicalName, mdcContainerAnnotation.canonicalName)
@@ -160,12 +170,6 @@ class MdcKoraAspect : KoraAspect {
             .endControlFlow()
     }
 
-    private fun isNativeMdcType(type: KSType): Boolean {
-        val qualifiedName = type.declaration.qualifiedName?.asString() ?: return false
-        return qualifiedName == "kotlin.String"
-            || qualifiedName == "kotlin.Int"
-            || qualifiedName == "kotlin.Long"
-            || qualifiedName == "kotlin.Boolean"
-            || qualifiedName == "ru.tinkoff.kora.logging.common.arg.StructuredArgumentWriter"
-    }
+    private fun isNativeMdcType(type: KSType): Boolean =
+        type.declaration.qualifiedName?.asString() in NATIVE_MDC_TYPES
 }

--- a/logging/declarative-logging/declarative-logging-symbol-processor/src/main/kotlin/ru/tinkoff/kora/logging/symbol/processor/aop/mdc/MdcKoraAspect.kt
+++ b/logging/declarative-logging/declarative-logging-symbol-processor/src/main/kotlin/ru/tinkoff/kora/logging/symbol/processor/aop/mdc/MdcKoraAspect.kt
@@ -18,6 +18,7 @@ import ru.tinkoff.kora.ksp.common.FunctionUtils.isVoid
 import ru.tinkoff.kora.ksp.common.KspCommonUtils.findRepeatableAnnotation
 import ru.tinkoff.kora.ksp.common.exception.ProcessingErrorException
 import java.util.concurrent.CompletionStage
+import com.google.devtools.ksp.symbol.KSType
 
 class MdcKoraAspect : KoraAspect {
 
@@ -98,12 +99,11 @@ class MdcKoraAspect : KoraAspect {
             } else if (!globalIsSupported) {
                 throw ProcessingErrorException("@Mdc annotation with 'global' attribute is not supported for this function", annotation.annotationType)
             }
-            fillMdcBuilder.addStatement(
-                "%T.put(%S, %S)",
-                mdc,
-                key,
-                value
-            )
+            if (value.startsWith("\${") && value.endsWith("}")) {
+                fillMdcBuilder.addStatement("%T.put(%S, %L)", mdc, key, value.substring(2, value.length - 1))
+            } else {
+                fillMdcBuilder.addStatement("%T.put(%S, %S)", mdc, key, value)
+            }
         }
         return keys
     }
@@ -126,18 +126,25 @@ class MdcKoraAspect : KoraAspect {
 
             val global = annotation.findValue("global") ?: false
 
-            fillMdcBuilder.addStatement(
-                "%T.put(%S, %N)",
-                mdc,
-                key,
-                parameterName
-            )
+            val type = parameter.type.resolve()
+            when {
+                isNativeMdcType(type) -> fillMdcBuilder.addStatement("%T.put(%S, %N)", mdc, key, parameterName)
+                type.isMarkedNullable -> fillMdcBuilder
+                    .beginControlFlow("if (%N != null)", parameterName)
+                    .addStatement("%T.put(%S, %N.toString())", mdc, key, parameterName)
+                    .endControlFlow()
+
+                else -> fillMdcBuilder.addStatement("%T.put(%S, %N.toString())", mdc, key, parameterName)
+            }
 
             if (!global) {
                 keys.add(key)
                 currentContextBuilder.addStatement("val __%L = %N[%S]", key, MDC_CONTEXT_VAL_NAME, key)
             } else if (!globalIsSupported) {
-                throw ProcessingErrorException("@Mdc annotation with 'global' attribute is not supported for this function", annotation.annotationType)
+                throw ProcessingErrorException(
+                    "@Mdc annotation with 'global' attribute is not supported for this function",
+                    annotation.annotationType
+                )
             }
         }
 
@@ -151,5 +158,14 @@ class MdcKoraAspect : KoraAspect {
             .beginControlFlow("else")
             .addStatement("%T.remove(%S)", mdc, it)
             .endControlFlow()
+    }
+
+    private fun isNativeMdcType(type: KSType): Boolean {
+        val qualifiedName = type.declaration.qualifiedName?.asString() ?: return false
+        return qualifiedName == "kotlin.String"
+            || qualifiedName == "kotlin.Int"
+            || qualifiedName == "kotlin.Long"
+            || qualifiedName == "kotlin.Boolean"
+            || qualifiedName == "ru.tinkoff.kora.logging.common.arg.StructuredArgumentWriter"
     }
 }

--- a/logging/declarative-logging/declarative-logging-symbol-processor/src/test/kotlin/ru/tinkoff/kora/logging/symbol/processor/aop/mdc/MdcKoraAspectTest.kt
+++ b/logging/declarative-logging/declarative-logging-symbol-processor/src/test/kotlin/ru/tinkoff/kora/logging/symbol/processor/aop/mdc/MdcKoraAspectTest.kt
@@ -238,4 +238,102 @@ class MdcKoraAspectTest : AbstractMdcAspectTest() {
         """
         )
     }
+
+    @Test
+    fun testMdcNonNativeParameterNonNull() {
+        val aopProxy = compile0(
+            listOf(AopSymbolProcessorProvider()),
+            """
+            import java.util.UUID
+
+            open class TestMdc(
+                private val mdcContextHolder: MDCContextHolder
+            ) {
+                open fun test(@Mdc(key = "subscriptionId") subscriptionId: UUID): Int? {
+                    mdcContextHolder.set(MDC.get().values())
+                    return null
+                }
+            }
+        """.trimIndent()
+        )
+
+        aopProxy.assertSuccess()
+
+        val subscriptionId = UUID.fromString("00000000-0000-0000-0000-000000000001")
+        val generatedClass = aopProxy.loadClass("\$TestMdc__AopProxy")
+        val constructor = generatedClass.constructors.first()
+        val testObject = TestObject(generatedClass.kotlin, constructor.newInstance(contextHolder))
+        testObject.invoke<Int?>("test", subscriptionId)
+
+        val context = contextHolder.get()
+            ?.mapValues { it.value.writeToString() }
+
+        assertEquals(mapOf("subscriptionId" to "\"$subscriptionId\""), context)
+        assertEquals(emptyMap<String, String>(), currentContext())
+    }
+
+    @Test
+    fun testMdcNonNativeNullableParameterNull() {
+        val aopProxy = compile0(
+            listOf(AopSymbolProcessorProvider()),
+            """
+            import java.util.UUID
+
+            open class TestMdc(
+                private val mdcContextHolder: MDCContextHolder
+            ) {
+                open fun test(@Mdc(key = "subscriptionId") subscriptionId: UUID?): Int? {
+                    mdcContextHolder.set(MDC.get().values())
+                    return null
+                }
+            }
+        """.trimIndent()
+        )
+
+        aopProxy.assertSuccess()
+
+        val generatedClass = aopProxy.loadClass("\$TestMdc__AopProxy")
+        val constructor = generatedClass.constructors.first()
+        val testObject = TestObject(generatedClass.kotlin, constructor.newInstance(contextHolder))
+        testObject.invoke<Int?>("test", null)
+
+        val context = contextHolder.get()
+            ?.mapValues { it.value.writeToString() }
+
+        assertEquals(emptyMap<String, String>(), context)
+        assertEquals(emptyMap<String, String>(), currentContext())
+    }
+
+    @Test
+    fun testMdcMethodLevelGeneratedValue() {
+        // single literal dollar; used to emit a non-interpolated `${...}` into the compiled source
+        val dollar = "$"
+        val aopProxy = compile0(
+            listOf(AopSymbolProcessorProvider()),
+            """
+            open class TestMdc(
+                private val mdcContextHolder: MDCContextHolder
+            ) {
+                @Mdc(key = "k", value = "\${dollar}{1 + 1}")
+                open fun test(s: String): Int? {
+                    mdcContextHolder.set(MDC.get().values())
+                    return null
+                }
+            }
+        """.trimIndent()
+        )
+
+        aopProxy.assertSuccess()
+
+        val generatedClass = aopProxy.loadClass("\$TestMdc__AopProxy")
+        val constructor = generatedClass.constructors.first()
+        val testObject = TestObject(generatedClass.kotlin, constructor.newInstance(contextHolder))
+        testObject.invoke<Int?>("test", "x")
+
+        val context = contextHolder.get()
+            ?.mapValues { it.value.writeToString() }
+
+        assertEquals(mapOf("k" to "2"), context)
+        assertEquals(emptyMap<String, String>(), currentContext())
+    }
 }


### PR DESCRIPTION
## What

- `@Mdc` on a parameter of a type without an `MDC.put` overload (UUID, enum, any object) previously generated an uncompilable `MDC.put(key, param)`. Now: non-native types use `param.toString()`, `null` is skipped; native types (String/Int/Long/Boolean/StructuredArgumentWriter) are unchanged. Both Java AP and KSP.
- KSP: method-level `@Mdc(value="${expr}")` is now evaluated as a runtime expression — parity with the Java processor and the documented behaviour (previously written as a literal in Kotlin).

## Tests

- Java + KSP: non-null and null non-native parameter cases.
- KSP: method-level generated `${}` value expression.

All green; existing @Mdc / Log aspect tests unaffected.