### PR TITLE
Added HTTP Client and Repository parent interface `AOP` support (#619)

### DIFF
--- a/annotation-processor-common/src/main/java/io/koraframework/annotation/processor/common/CommonUtils.java
+++ b/annotation-processor-common/src/main/java/io/koraframework/annotation/processor/common/CommonUtils.java
@@ -7,6 +7,7 @@ import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.AnnotatedConstruct;
 import javax.lang.model.element.*;
 import javax.lang.model.type.*;
+import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
@@ -128,6 +129,32 @@ public class CommonUtils {
             }
             result.add((ExecutableElement) element);
         }
+        return result;
+    }
+
+    public static List<ExecutableElement> findAllMethods(Elements elements, TypeElement typeElement, Predicate<Set<Modifier>> modifiersFilter) {
+        var result = new ArrayList<ExecutableElement>();
+        for (var enclosedElement : elements.getAllMembers(typeElement)) {
+            if (enclosedElement.getKind() != ElementKind.METHOD) {
+                continue;
+            }
+
+            var method = (ExecutableElement) enclosedElement;
+            if (method.getModifiers().contains(Modifier.STATIC)) {
+                continue;
+            }
+
+            if (method.getEnclosingElement().toString().equals("java.lang.Object")) {
+                continue;
+            }
+
+            if (!modifiersFilter.test(method.getModifiers())) {
+                continue;
+            }
+
+            result.add(method);
+        }
+
         return result;
     }
 
@@ -292,6 +319,14 @@ public class CommonUtils {
     }
 
     public static TypeSpec.Builder extendsKeepAop(TypeElement type, String newName) {
+        return extendsKeepAopInternal(null, type, newName);
+    }
+
+    public static TypeSpec.Builder extendsKeepAop(Elements elements, TypeElement type, String newName) {
+        return extendsKeepAopInternal(elements, type, newName);
+    }
+
+    private static TypeSpec.Builder extendsKeepAopInternal(@Nullable Elements elements, TypeElement type, String newName) {
         var b = TypeSpec.classBuilder(newName)
             .addModifiers(Modifier.PUBLIC)
             .addOriginatingElement(type);
@@ -313,7 +348,9 @@ public class CommonUtils {
             hasAop = true;
         }
 
-        var methods = CommonUtils.findMethods(type, m -> m.contains(Modifier.PUBLIC) || m.contains(Modifier.PROTECTED));
+        var methods = (elements == null)
+            ? CommonUtils.findMethods(type, m -> m.contains(Modifier.PUBLIC) || m.contains(Modifier.PROTECTED))
+            : CommonUtils.findAllMethods(elements, type, m -> m.contains(Modifier.PUBLIC) || m.contains(Modifier.PROTECTED));
         for (var method : methods) {
             boolean isMethodAop = hasAopAnnotation(method);
             for (var parameter : method.getParameters()) {
@@ -327,8 +364,9 @@ public class CommonUtils {
                     .map(p -> p.getSimpleName().toString())
                     .collect(Collectors.joining(", "));
 
+                var call = MethodUtils.isVoid(method) ? "$T.super.$L($L);" : "return $T.super.$L($L);";
                 b.addMethod(overridingKeepAop(method)
-                    .addCode("return $T.super.$L($L);", type, method.getSimpleName().toString(), superParameters)
+                    .addCode(call, type, method.getSimpleName().toString(), superParameters)
                     .build());
             }
 
@@ -408,6 +446,21 @@ public class CommonUtils {
             return true;
         }
         var methods = CommonUtils.findMethods(typeElement, m -> m.contains(Modifier.PUBLIC) || m.contains(Modifier.PROTECTED));
+        for (var method : methods) {
+            if (hasAopAnnotation(method)) {
+                return true;
+            }
+            for (var parameter : method.getParameters()) {
+                if (hasAopAnnotation(parameter)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    public static boolean hasAopAnnotationsInParents(Elements elements, TypeElement typeElement) {
+        var methods = CommonUtils.findAllMethods(elements, typeElement, m -> m.contains(Modifier.PUBLIC) || m.contains(Modifier.PROTECTED));
         for (var method : methods) {
             if (hasAopAnnotation(method)) {
                 return true;

--- a/database/database-annotation-processor/src/main/java/io/koraframework/database/annotation/processor/RepositoryAnnotationProcessor.java
+++ b/database/database-annotation-processor/src/main/java/io/koraframework/database/annotation/processor/RepositoryAnnotationProcessor.java
@@ -31,7 +31,7 @@ public class RepositoryAnnotationProcessor extends AbstractKoraProcessor {
     @Override
     public synchronized void init(ProcessingEnvironment processingEnv) {
         super.init(processingEnv);
-        this.repositoryBuilder = new RepositoryBuilder(processingEnv);
+        this.repositoryBuilder = new RepositoryBuilder(elements, processingEnv);
     }
 
     @Override

--- a/database/database-annotation-processor/src/main/java/io/koraframework/database/annotation/processor/RepositoryBuilder.java
+++ b/database/database-annotation-processor/src/main/java/io/koraframework/database/annotation/processor/RepositoryBuilder.java
@@ -10,6 +10,7 @@ import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
+import javax.lang.model.util.Elements;
 import java.util.List;
 
 import static io.koraframework.annotation.processor.common.TagUtils.makeAnnotationSpec;
@@ -17,9 +18,11 @@ import static io.koraframework.annotation.processor.common.TagUtils.parseTagValu
 
 public class RepositoryBuilder {
 
+    private final Elements elements;
     private final List<RepositoryGenerator> queryMethodGenerators;
 
-    public RepositoryBuilder(ProcessingEnvironment processingEnv) {
+    public RepositoryBuilder(Elements elements, ProcessingEnvironment processingEnv) {
+        this.elements = elements;
         this.queryMethodGenerators = List.of(
             new JdbcRepositoryGenerator(processingEnv),
             new CassandraRepositoryGenerator(processingEnv)
@@ -29,7 +32,7 @@ public class RepositoryBuilder {
     @Nullable
     public TypeSpec build(TypeElement repositoryElement) throws ProcessingErrorException {
         var name = NameUtils.generatedType(repositoryElement, "Impl");
-        var builder = CommonUtils.extendsKeepAop(repositoryElement, name)
+        var builder = CommonUtils.extendsKeepAop(elements, repositoryElement, name)
             .addAnnotation(AnnotationUtils.generated(RepositoryAnnotationProcessor.class));
 
         if (AnnotationUtils.findAnnotation(repositoryElement, CommonClassNames.root) != null) {

--- a/database/database-symbol-processor/src/main/kotlin/io/koraframework/database/symbol/processor/RepositoryBuilder.kt
+++ b/database/database-symbol-processor/src/main/kotlin/io/koraframework/database/symbol/processor/RepositoryBuilder.kt
@@ -14,7 +14,7 @@ import org.slf4j.LoggerFactory
 import io.koraframework.database.symbol.processor.cassandra.CassandraRepositoryGenerator
 import io.koraframework.database.symbol.processor.jdbc.JdbcRepositoryGenerator
 import io.koraframework.ksp.common.AnnotationUtils.findAnnotation
-import io.koraframework.ksp.common.CommonAopUtils.extendsKeepAop
+import io.koraframework.ksp.common.CommonAopUtils.extendsKeepAopAll
 import io.koraframework.ksp.common.CommonClassNames
 import io.koraframework.ksp.common.KspCommonUtils.addOriginatingKSFile
 import io.koraframework.ksp.common.KspCommonUtils.generated
@@ -35,7 +35,7 @@ class RepositoryBuilder(
     fun build(repositoryDeclaration: KSClassDeclaration): TypeSpec? {
         log.debug("Generating Repository for {}", repositoryDeclaration.simpleName.asString())
         val name = repositoryDeclaration.getOuterClassesAsPrefix() + repositoryDeclaration.simpleName.asString() + "_Impl"
-        val builder = repositoryDeclaration.extendsKeepAop(name, resolver)
+        val builder = repositoryDeclaration.extendsKeepAopAll(name, resolver)
             .generated(RepositoryBuilder::class)
             .addOriginatingKSFile(repositoryDeclaration)
 

--- a/http/http-client-annotation-processor/src/main/java/io/koraframework/http/client/annotation/processor/ClientClassGenerator.java
+++ b/http/http-client-annotation-processor/src/main/java/io/koraframework/http/client/annotation/processor/ClientClassGenerator.java
@@ -40,7 +40,7 @@ public class ClientClassGenerator {
     public TypeSpec generate(TypeElement element) {
         var typeName = HttpClientUtils.clientName(element);
         var methods = this.parseMethods(element);
-        var builder = CommonUtils.extendsKeepAop(element, typeName)
+        var builder = CommonUtils.extendsKeepAop(elements, element, typeName)
             .addAnnotation(AnnotationUtils.generated(ClientClassGenerator.class));
 
         builder.addMethod(this.buildConstructor(builder, element, methods));
@@ -805,7 +805,9 @@ public class ClientClassGenerator {
             var responseCodeMappers = this.parseMapperData(method);
 
             var responseMapper = CommonUtils.parseMapping(method).getMapping(httpClientResponseMapper);
-            result.add(new MethodData(method, returnType, responseMapper, responseCodeMappers, parameters));
+            if (result.stream().noneMatch(n -> n.element().equals(method))) {
+                result.add(new MethodData(method, returnType, responseMapper, responseCodeMappers, parameters));
+            }
         }
         return result;
     }

--- a/http/http-client-annotation-processor/src/test/java/io/koraframework/http/client/annotation/processor/BlockingApiTest.java
+++ b/http/http-client-annotation-processor/src/test/java/io/koraframework/http/client/annotation/processor/BlockingApiTest.java
@@ -417,4 +417,30 @@ public class BlockingApiTest extends AbstractHttpClientTest {
         onRequest("POST", "http://test-url:8080/test1", rs -> rs.withCode(200));
         client.invoke("request1");
     }
+
+    @Test
+    public void testSuperOverridesInterfacesSupported() {
+        var client = compileClient(List.of(), """
+            @HttpClient
+            public interface TestClient extends TestBase {
+              @HttpRoute(method = "POST", path = "/test")
+              void request();
+              @Override
+              @HttpRoute(method = "POST", path = "/test2")
+              void request1();
+            }
+            """, """
+            public interface TestBase {
+              @HttpRoute(method = "POST", path = "/test1")
+              void request1();
+            }
+            """);
+
+        onRequest("POST", "http://test-url:8080/test", rs -> rs.withCode(200));
+        client.invoke("request");
+        reset(httpClient);
+
+        onRequest("POST", "http://test-url:8080/test2", rs -> rs.withCode(200));
+        client.invoke("request1");
+    }
 }

--- a/http/http-client-symbol-processor/src/main/kotlin/io/koraframework/http/client/symbol/processor/ClientClassGenerator.kt
+++ b/http/http-client-symbol-processor/src/main/kotlin/io/koraframework/http/client/symbol/processor/ClientClassGenerator.kt
@@ -34,7 +34,7 @@ import io.koraframework.http.client.symbol.processor.HttpClientClassNames.uriQue
 import io.koraframework.ksp.common.AnnotationUtils.findAnnotation
 import io.koraframework.ksp.common.AnnotationUtils.findValue
 import io.koraframework.ksp.common.AnnotationUtils.findValueNoDefault
-import io.koraframework.ksp.common.CommonAopUtils.extendsKeepAop
+import io.koraframework.ksp.common.CommonAopUtils.extendsKeepAopAll
 import io.koraframework.ksp.common.CommonAopUtils.overridingKeepAop
 import io.koraframework.ksp.common.CommonClassNames
 import io.koraframework.ksp.common.CommonClassNames.isCollection
@@ -64,7 +64,7 @@ class ClientClassGenerator(private val resolver: Resolver) {
     fun generate(declaration: KSClassDeclaration): TypeSpec {
         val typeName = declaration.clientName()
         val methods = this.parseMethods(declaration)
-        val builder = declaration.extendsKeepAop(typeName, resolver)
+        val builder = declaration.extendsKeepAopAll(typeName, resolver)
             .generated(ClientClassGenerator::class)
 
         declaration.findAnnotation(CommonClassNames.root)

--- a/http/http-client-symbol-processor/src/test/kotlin/io/koraframework/http/client/symbol/processor/BlockingApiTest.kt
+++ b/http/http-client-symbol-processor/src/test/kotlin/io/koraframework/http/client/symbol/processor/BlockingApiTest.kt
@@ -445,4 +445,33 @@ class BlockingApiTest : AbstractHttpClientTest() {
         client.invoke<Unit>("request1")
     }
 
+    @Test
+    fun testSuperOverrideInterfacesSupported() {
+        val client = compile(
+            listOf<Any>(), """
+            @HttpClient
+            interface TestClient: TestBase {
+              @HttpRoute(method = "POST", path = "/test")
+              fun request()
+              
+              @HttpRoute(method = "POST", path = "/test2")
+              override fun request1()
+            }
+            
+            """.trimIndent(), """
+            interface TestBase {
+              @HttpRoute(method = "POST", path = "/test1")
+              fun request1()
+            }
+            
+            """.trimIndent()
+        )
+
+        onRequest("POST", "http://test-url:8080/test") { rs -> rs.withCode(200) }
+        client.invoke<Unit>("request")
+        reset(httpClient)
+
+        onRequest("POST", "http://test-url:8080/test2") { rs -> rs.withCode(200) }
+        client.invoke<Unit>("request1")
+    }
 }

--- a/symbol-processor-common/src/main/kotlin/io/koraframework/ksp/common/CommonAopUtils.kt
+++ b/symbol-processor-common/src/main/kotlin/io/koraframework/ksp/common/CommonAopUtils.kt
@@ -15,6 +15,7 @@ import com.squareup.kotlinpoet.ksp.toTypeVariableName
 import io.koraframework.ksp.common.AnnotationUtils.isAnnotationPresent
 import io.koraframework.ksp.common.CommonClassNames.aopAnnotation
 import io.koraframework.ksp.common.CommonClassNames.aopPropagate
+import io.koraframework.ksp.common.FunctionUtils.isVoid
 import io.koraframework.ksp.common.KspCommonUtils.addOriginatingKSFile
 import io.koraframework.ksp.common.KspCommonUtils.resolveToUnderlying
 

--- a/symbol-processor-common/src/main/kotlin/io/koraframework/ksp/common/CommonAopUtils.kt
+++ b/symbol-processor-common/src/main/kotlin/io/koraframework/ksp/common/CommonAopUtils.kt
@@ -21,6 +21,14 @@ import io.koraframework.ksp.common.KspCommonUtils.resolveToUnderlying
 object CommonAopUtils {
 
     fun KSClassDeclaration.extendsKeepAop(newName: String, resolver: Resolver): TypeSpec.Builder {
+        return extendsKeepAopInternal(newName, resolver, false)
+    }
+
+    fun KSClassDeclaration.extendsKeepAopAll(newName: String, resolver: Resolver): TypeSpec.Builder {
+        return extendsKeepAopInternal(newName, resolver, true)
+    }
+
+    private fun KSClassDeclaration.extendsKeepAopInternal(newName: String, resolver: Resolver, allMethods: Boolean): TypeSpec.Builder {
         val type = this
         val b: TypeSpec.Builder = TypeSpec.classBuilder(newName)
             .addOriginatingKSFile(type)
@@ -31,7 +39,11 @@ object CommonAopUtils {
         }
 
         var hasAop = hasAopAnnotation(type)
-        val methods = findMethods(type) { f -> f.isPublic() || f.isProtected() }
+        val methods = if (allMethods)
+            findAllMethods(type) { f -> f.isPublic() || f.isProtected() }
+        else
+            findMethods(type) { f -> f.isPublic() || f.isProtected() }
+
         for (method in methods) {
             var isMethodAop = hasAopAnnotation(method)
 
@@ -43,9 +55,11 @@ object CommonAopUtils {
 
             if (isMethodAop && !method.isAbstract) {
                 val superParameters = method.parameters.joinToString(", ") { p -> p.name!!.asString() }
+
+                val call = if (method.isVoid()) "super.%L(%L)" else "return super.%L(%L)"
                 b.addFunction(
                     method.overridingKeepAop(resolver)
-                        .addCode("return super.%L(%L)", method.simpleName.asString(), superParameters)
+                        .addCode(call, method.simpleName.asString(), superParameters)
                         .build()
                 )
             }
@@ -129,9 +143,7 @@ object CommonAopUtils {
         if (hasAopAnnotation(ksAnnotated)) {
             return true
         }
-        val methods = findMethods(ksAnnotated) { f ->
-            f.isPublic() || f.isProtected()
-        }
+        val methods = findMethods(ksAnnotated) { f -> f.isPublic() || f.isProtected() }
         for (method in methods) {
             if (hasAopAnnotation(method)) {
                 return true

--- a/symbol-processor-common/src/main/kotlin/io/koraframework/ksp/common/KspCommonUtils.kt
+++ b/symbol-processor-common/src/main/kotlin/io/koraframework/ksp/common/KspCommonUtils.kt
@@ -310,6 +310,54 @@ fun findMethods(ksAnnotated: KSAnnotated, functionFilter: (KSFunctionDeclaration
     return result
 }
 
+fun findAllMethods(ksAnnotated: KSAnnotated, functionFilter: (KSFunctionDeclaration) -> Boolean): List<KSFunctionDeclaration> {
+    if (ksAnnotated !is KSClassDeclaration) {
+        return emptyList()
+    }
+    val result = ArrayList<KSFunctionDeclaration>()
+    for (function in ksAnnotated.getAllFunctions().toList()) {
+        if (!functionFilter(function)) {
+            continue
+        }
+        result.add(function)
+    }
+    return result
+}
+
+fun KSClassDeclaration.getNameConverter(default: NameConverter): NameConverter {
+    return getNameConverter() ?: default
+}
+
+fun KSClassDeclaration.getNameConverter(): NameConverter? {
+    val namingStrategy = this.findAnnotation(CommonClassNames.namingStrategy)
+    return if (namingStrategy != null) {
+        val namingStrategyClass = getNamingStrategyConverterClass(this)
+        return if (namingStrategyClass != null) {
+            try {
+                val inst = namingStrategyClass.constructors.firstOrNull()?.call() as NameConverter?
+                inst
+            } catch (e: Exception) {
+                throw ProcessingErrorException("Error on calling name converter constructor $this", this)
+            }
+        } else null
+    } else null
+}
+
+fun getNamingStrategyConverterClass(declaration: KSClassDeclaration): KClass<*>? {
+    val annotationValues = parseAnnotationClassValue(declaration, CommonClassNames.namingStrategy.canonicalName)
+    if (annotationValues.isEmpty()) return null
+    val type = annotationValues[0]
+    if (type.declaration is KSClassDeclaration) {
+        val className = (type.declaration as KSClassDeclaration).qualifiedName!!.asString()
+        return try {
+            Class.forName(className).kotlin
+        } catch (e: ClassNotFoundException) {
+            throw ProcessingErrorException("Class $className not found in classpath", declaration)
+        }
+    }
+    return null
+}
+
 fun KSAnnotated.getOuterClassesAsPrefix(): String {
     val prefix = if(this is KSClassDeclaration && this.simpleName.asString().startsWith("$"))
         StringBuilder()

--- a/symbol-processor-common/src/main/kotlin/io/koraframework/ksp/common/KspCommonUtils.kt
+++ b/symbol-processor-common/src/main/kotlin/io/koraframework/ksp/common/KspCommonUtils.kt
@@ -324,42 +324,8 @@ fun findAllMethods(ksAnnotated: KSAnnotated, functionFilter: (KSFunctionDeclarat
     return result
 }
 
-fun KSClassDeclaration.getNameConverter(default: NameConverter): NameConverter {
-    return getNameConverter() ?: default
-}
-
-fun KSClassDeclaration.getNameConverter(): NameConverter? {
-    val namingStrategy = this.findAnnotation(CommonClassNames.namingStrategy)
-    return if (namingStrategy != null) {
-        val namingStrategyClass = getNamingStrategyConverterClass(this)
-        return if (namingStrategyClass != null) {
-            try {
-                val inst = namingStrategyClass.constructors.firstOrNull()?.call() as NameConverter?
-                inst
-            } catch (e: Exception) {
-                throw ProcessingErrorException("Error on calling name converter constructor $this", this)
-            }
-        } else null
-    } else null
-}
-
-fun getNamingStrategyConverterClass(declaration: KSClassDeclaration): KClass<*>? {
-    val annotationValues = parseAnnotationClassValue(declaration, CommonClassNames.namingStrategy.canonicalName)
-    if (annotationValues.isEmpty()) return null
-    val type = annotationValues[0]
-    if (type.declaration is KSClassDeclaration) {
-        val className = (type.declaration as KSClassDeclaration).qualifiedName!!.asString()
-        return try {
-            Class.forName(className).kotlin
-        } catch (e: ClassNotFoundException) {
-            throw ProcessingErrorException("Class $className not found in classpath", declaration)
-        }
-    }
-    return null
-}
-
 fun KSAnnotated.getOuterClassesAsPrefix(): String {
-    val prefix = if(this is KSClassDeclaration && this.simpleName.asString().startsWith("$"))
+    val prefix = if (this is KSClassDeclaration && this.simpleName.asString().startsWith("$"))
         StringBuilder()
     else
         StringBuilder("$")
@@ -380,7 +346,7 @@ fun KSDeclaration.generatedClass(generatedType: ClassName): String {
 }
 
 fun KSClassDeclaration.generatedClassName(postfix: String): String {
-    val prefix = if(this is KSClassDeclaration && this.simpleName.asString().startsWith("$"))
+    val prefix = if (this is KSClassDeclaration && this.simpleName.asString().startsWith("$"))
         StringBuilder()
     else
         StringBuilder("$")


### PR DESCRIPTION
* Added HTTP Client and Repository parent interface `AOP` support (#619)

* Added ClientClassGenerator parent interface support

* Fixed AOP parent methods correct aspect inspection

* Fixed proper method scan and Void override

(cherry picked from commit 5024a8b6d9bb588687bff240456d14406a5c33ba)