### PR TITLE
Config parser generator should work for empty interfaces with super type (#637)

### DIFF
--- a/config/config-annotation-processor/src/test/java/io/koraframework/config/annotation/processor/AnnotationConfigTest.java
+++ b/config/config-annotation-processor/src/test/java/io/koraframework/config/annotation/processor/AnnotationConfigTest.java
@@ -263,7 +263,7 @@ public class AnnotationConfigTest extends AbstractConfigTest {
     @Test
     public void testInterfaceNoFieldsWithSuper() {
         var extractor = this.compileConfig(List.of(), """
-            @ru.tinkoff.kora.config.common.annotation.ConfigValueExtractor
+            @io.koraframework.config.common.annotation.ConfigValueExtractor
             public interface TestConfig extends SuperTestConfig{
             }
             """, """

--- a/config/config-annotation-processor/src/test/java/io/koraframework/config/annotation/processor/AnnotationConfigTest.java
+++ b/config/config-annotation-processor/src/test/java/io/koraframework/config/annotation/processor/AnnotationConfigTest.java
@@ -251,11 +251,31 @@ public class AnnotationConfigTest extends AbstractConfigTest {
             """, """
             public interface SuperTestConfig {
               default String value2() {  return "default-value"; }
+
+              String value3();
             }
             """);
 
-        assertThat(extractor.extract(MapConfigFactory.fromMap(Map.of("value1", "test1", "value2", "test2")).root()))
-            .isEqualTo(newObject("$TestConfig_ConfigValueExtractor$TestConfig_Impl", "test1", "test2"));
+        assertThat(extractor.extract(MapConfigFactory.fromMap(Map.of("value1", "test1", "value2", "test2", "value3", "test3")).root()))
+            .isEqualTo(newObject("$TestConfig_ConfigValueExtractor$TestConfig_Impl", "test1", "test2", "test3"));
+    }
+
+    @Test
+    public void testInterfaceNoFieldsWithSuper() {
+        var extractor = this.compileConfig(List.of(), """
+            @ru.tinkoff.kora.config.common.annotation.ConfigValueExtractor
+            public interface TestConfig extends SuperTestConfig{
+            }
+            """, """
+            public interface SuperTestConfig {
+              default String value2() {  return "default-value"; }
+    
+              String value3();
+            }
+            """);
+
+        assertThat(extractor.extract(MapConfigFactory.fromMap(Map.of("value2", "test2", "value3", "test3")).root()))
+            .isEqualTo(newObject("$TestConfig_ConfigValueExtractor$TestConfig_Impl",  "test2", "test3"));
     }
 
     @Test


### PR DESCRIPTION
Config parser generator should work for empty interfaces with super type (#637)

(cherry picked from commit ade6dea51fe7c2fcaf2c71593a4f4c409c2f6668)