### PR TITLE
OpenAPI generator Kotlin reserved words reliefs (#652)

### DIFF
--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/KoraCodegen.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/KoraCodegen.java
@@ -8,6 +8,7 @@ import com.ibm.icu.text.Transliterator;
 import com.palantir.javapoet.JavaFile;
 import com.samskivert.mustache.Mustache;
 import com.squareup.kotlinpoet.FileSpec;
+import io.koraframework.openapi.generator.javagen.*;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.examples.Example;
@@ -31,7 +32,6 @@ import org.openapitools.codegen.utils.CamelizeOption;
 import org.openapitools.codegen.utils.ModelUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import io.koraframework.openapi.generator.javagen.*;
 
 import java.io.File;
 import java.io.IOException;
@@ -177,42 +177,49 @@ public class KoraCodegen extends DefaultCodegen {
         final Stream<String> languageReservedWords;
         if (params.codegenMode.isJava()) {
             languageReservedWords = Stream.of(
-                    // Java Reserved Words
-                    "abstract", "assert", "boolean", "break", "byte", "case", "catch", "char",
-                    "class", "const", "continue", "default", "do", "double", "else", "enum",
-                    "extends", "final", "finally", "float", "for", "goto", "if", "implements",
-                    "import", "instanceof", "int", "interface", "long", "native", "new", "package",
-                    "private", "protected", "public", "return", "short", "static", "strictfp",
-                    "super", "switch", "synchronized", "this", "throw", "throws", "transient",
-                    "try", "void", "volatile", "while", "var", "record", "yield", "sealed", "null", "when");
+                // Java Reserved Words
+                "abstract", "assert", "boolean", "break", "byte", "case", "catch", "char",
+                "class", "const", "continue", "default", "do", "double", "else", "enum",
+                "extends", "final", "finally", "float", "for", "goto", "if", "implements",
+                "import", "instanceof", "int", "interface", "long", "native", "new", "package",
+                "private", "protected", "public", "return", "short", "static", "strictfp",
+                "super", "switch", "synchronized", "this", "throw", "throws", "transient",
+                "try", "void", "volatile", "while", "var", "record", "yield", "sealed", "null", "when");
         } else {
             languageReservedWords = Stream.of(
-                    // Kotlin Reserved Words
-                    "abstract", "actual", "annotation", "as", "break", "by", "catch", "class",
-                    "companion", "const", "constructor", "continue", "data", "do", "dynamic",
-                    "else", "enum", "expect", "external", "false", "final", "finally", "for",
-                    "fun", "if", "import", "in", "inline", "interface", "internal", "is", "lateinit",
-                    "native", "null", "object", "open", "operator", "out", "override", "package",
-                    "private", "protected", "public", "reified", "return", "sealed", "set", "super",
-                    "suspend", "this", "throw", "true", "try", "typealias", "typeof", "val", "var",
-                    "when", "where", "while");
+                // Kotlin Reserved Words
+
+                // Kotlin Reserved Keywords but available for field name/class name/func name cause naming is more general
+                // "native", "actual", "annotation", "companion", "const", "expect", "operator", "out", "reified", "protected", "final", "tailrec",
+
+                // Kotlin Reserved Words available but restricted cause naming is too close to Kotlin general usage words
+                "enum", "suspend", "abstract", "lateinit", "override", "private", "public", "sealed",
+
+                "as", "break", "by", "catch", "class",
+                "constructor", "continue", "data", "do", "dynamic",
+                "else", "enum", "external", "false", "finally", "for",
+                "fun", "if", "import", "in", "inline", "interface", "internal", "is",
+                "null", "object", "package",
+                "public", "return", "set", "super",
+                "this", "throw", "true", "try", "typealias", "typeof",
+                "val", "var", "when", "where", "while");
         }
 
         setReservedWordsLowerCase(
-                Stream.concat(
-                        Stream.of(
-                                // special words
-                                "object",
-                                // used as internal variables, can collide with parameter names
-                                "error",
-                                "localVarPath", "localVarQueryParams", "localVarCollectionQueryParams",
-                                "localVarHeaderParams", "localVarCookieParams", "localVarFormParams", "localVarPostBody",
-                                "localVarAccepts", "localVarAccept", "localVarContentTypes",
-                                "localVarContentType", "localVarAuthNames", "localReturnType"
-                                //  "ApiClient", "ApiException", "ApiResponse", "Configuration", "StringUtil",
-                        ),
-                        languageReservedWords
-                ).distinct().toList()
+            Stream.concat(
+                Stream.of(
+                    // special words
+                    "object",
+                    // used as internal variables, can collide with parameter names
+                    "error",
+                    "localVarPath", "localVarQueryParams", "localVarCollectionQueryParams",
+                    "localVarHeaderParams", "localVarCookieParams", "localVarFormParams", "localVarPostBody",
+                    "localVarAccepts", "localVarAccept", "localVarContentTypes",
+                    "localVarContentType", "localVarAuthNames", "localReturnType"
+                    //  "ApiClient", "ApiException", "ApiResponse", "Configuration", "StringUtil",
+                ),
+                languageReservedWords
+            ).distinct().toList()
         );
 
         if (!additionalProperties.containsKey(CodegenConstants.MODEL_PACKAGE)) {
@@ -1369,7 +1376,7 @@ public class KoraCodegen extends DefaultCodegen {
             var apiPackage = apiFileFolder() + File.separator + "package-info.java";
             this.supportingFiles.add(new SupportingFile("apiPackage.mustache", apiPackage));
         }
-        if (!Objects.requireNonNullElse(securitySchemas, Map.of()).isEmpty() && (params.codegenMode.isServer()||params.codegenMode.isClient() && !params.authAsMethodArgument)) {
+        if (!Objects.requireNonNullElse(securitySchemas, Map.of()).isEmpty() && (params.codegenMode.isServer() || params.codegenMode.isClient() && !params.authAsMethodArgument)) {
             switch (params.codegenMode) {
                 case JAVA_CLIENT -> {
                     var securitySchemaClass = apiFileFolder() + File.separator + "ApiSecurity.java";


### PR DESCRIPTION
* OpenAPI generator Kotlin reserved words reliefs (#652)
* Relief on Kotlin reserved words usage for vars/class names/funcs on more general and non-wide used