### PR TITLE
feat(database): Kotlin lambda extensions for JdbcConnectionFactory

### DIFF
--- a/database/database-jdbc/src/main/kotlin/ru/tinkoff/kora/database/jdbc/JdbcDatabaseExtension.kt
+++ b/database/database-jdbc/src/main/kotlin/ru/tinkoff/kora/database/jdbc/JdbcDatabaseExtension.kt
@@ -81,3 +81,31 @@ suspend fun <T> JdbcConnectionFactory.inTxSuspend(context: CoroutineDispatcher? 
         result
     }
 }
+
+/**
+ * <b>Русский</b>: Выполняет операцию на JDBC-соединении в ручном режиме. Kotlin-обёртка над
+ * перегруженными методами [JdbcConnectionFactory.withConnection], которая снимает неоднозначность
+ * вывода перегрузок (overload resolution ambiguity) при передаче лямбды из Kotlin.
+ * <hr>
+ * <b>English</b>: Runs an operation on a JDBC connection in manual mode. A Kotlin wrapper over the
+ * overloaded [JdbcConnectionFactory.withConnection] methods that removes the overload-resolution
+ * ambiguity when a lambda is passed from Kotlin.
+ *
+ * @see withConnectionSuspend coroutine variant
+ */
+inline fun <T> JdbcConnectionFactory.withConnectionKt(crossinline callback: (Connection) -> T): T =
+    withConnection(JdbcHelper.SqlFunction1<Connection, T> { callback(it) })
+
+/**
+ * <b>Русский</b>: Выполняет операцию на JDBC-соединении в рамках транзакции. Kotlin-обёртка над
+ * перегруженными методами [JdbcConnectionFactory.inTx], которая снимает неоднозначность вывода
+ * перегрузок (overload resolution ambiguity) при передаче лямбды из Kotlin.
+ * <hr>
+ * <b>English</b>: Runs an operation on a JDBC connection within a transaction. A Kotlin wrapper over
+ * the overloaded [JdbcConnectionFactory.inTx] methods that removes the overload-resolution ambiguity
+ * when a lambda is passed from Kotlin.
+ *
+ * @see inTxSuspend coroutine variant
+ */
+inline fun <T> JdbcConnectionFactory.inTxKt(crossinline callback: (Connection) -> T): T =
+    inTx(JdbcHelper.SqlFunction1<Connection, T> { callback(it) })


### PR DESCRIPTION
## What
Add `withConnectionKt` / `inTxKt` extension functions to `database-jdbc` so Kotlin code can call `JdbcConnectionFactory#withConnection` / `#inTx` with a lambda.

## Why
`JdbcConnectionFactory` declares four SAM overloads of each method (`SqlFunction1`, `SqlFunction0`, `SqlConsumer`, `SqlRunnable`). From Kotlin a lambda matches several of them → "overload resolution ambiguity". A same-named extension does not help — Java members shadow extensions in overload resolution (verified with the compiler) — so a distinct `*Kt` name is used.

## How
One generic `(Connection) -> T` extension per method delegates to the `SqlFunction1` overload and covers every case: value-returning, `void` (`T = Unit`), and connection-less lambdas. `inline` + `crossinline` avoids the extra `Function1` allocation.

Verified with a temporary compiler probe exercising all former overload shapes (value / void / no-arg / empty lambda): no problems reported.

https://claude.ai/code/session_01P8DwrthoLMkaYnNe2ctJ14
