### PR TITLE
feat(json): custom JSON value for enums and arbitrary types via `@JsonReader` factory / `@JsonWriter` method

### DIFF
--- a/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/JsonAnnotationProcessor.java
+++ b/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/JsonAnnotationProcessor.java
@@ -77,19 +77,31 @@ public class JsonAnnotationProcessor extends AbstractKoraProcessor {
         }
         var jsonReaderElements = annotatedElements.getOrDefault(JsonTypes.jsonReaderAnnotation, List.of());
         LogUtils.logAnnotatedElementsFull(log, Level.DEBUG, "Generating JsonReaders for", jsonReaderElements);
+        var processedReaderTypes = new java.util.HashSet<String>();
         for (var annotated : jsonReaderElements) {
             var element = annotated.element();
             if (element.getKind() == ElementKind.CONSTRUCTOR) {
                 element = element.getEnclosingElement();
+            } else if (element.getKind() == ElementKind.METHOD) {
+                var enclosing = element.getEnclosingElement();
+                if (enclosing.getKind() != ElementKind.ENUM) {
+                    messager.printMessage(Diagnostic.Kind.ERROR,
+                        "@JsonReader on a method is supported only for an enum factory method, got enclosing " + enclosing.getKind(),
+                        annotated.element());
+                    continue;
+                }
+                element = enclosing;
             }
             if (AnnotationUtils.isAnnotationPresent(element, JsonTypes.json)) {
                 continue;
             }
             if (element.getKind().isClass() || element.getKind().isInterface() && element.getModifiers().contains(Modifier.SEALED)) {
-                try {
-                    this.processor.generateReader((TypeElement) element);
-                } catch (ProcessingErrorException ex) {
-                    ex.printError(this.processingEnv);
+                if (processedReaderTypes.add(((TypeElement) element).getQualifiedName().toString())) {
+                    try {
+                        this.processor.generateReader((TypeElement) element);
+                    } catch (ProcessingErrorException ex) {
+                        ex.printError(this.processingEnv);
+                    }
                 }
             } else {
                 messager.printMessage(Diagnostic.Kind.ERROR, "Only classes and sealed interfaces can be annotated with @JsonReader, got " + element.getKind(), annotated.element());

--- a/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/JsonAnnotationProcessor.java
+++ b/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/JsonAnnotationProcessor.java
@@ -61,10 +61,24 @@ public class JsonAnnotationProcessor extends AbstractKoraProcessor {
         }
         var jsonWriterElements = annotatedElements.getOrDefault(JsonTypes.jsonWriterAnnotation, List.of());
         LogUtils.logAnnotatedElementsFull(log, Level.DEBUG, "Generating JsonWriters for", jsonWriterElements);
+        var processedWriterTypes = new java.util.HashSet<String>();
         for (var annotated : jsonWriterElements) {
             var element = annotated.element();
+            if (element.getKind() == ElementKind.METHOD) {
+                var enclosing = element.getEnclosingElement();
+                if (enclosing.getKind() != ElementKind.ENUM) {
+                    messager.printMessage(Diagnostic.Kind.ERROR,
+                        "@JsonWriter on a method is supported only for an enum method, got enclosing " + enclosing.getKind(),
+                        annotated.element());
+                    continue;
+                }
+                element = enclosing;
+            }
+            if (AnnotationUtils.isAnnotationPresent(element, JsonTypes.json)) {
+                continue;
+            }
             if (element.getKind().isClass() || element.getKind().isInterface() && element.getModifiers().contains(Modifier.SEALED)) {
-                if (AnnotationUtils.findAnnotation(element, JsonTypes.json) == null) {
+                if (processedWriterTypes.add(((TypeElement) element).getQualifiedName().toString())) {
                     try {
                         this.processor.generateWriter((TypeElement) element);
                     } catch (ProcessingErrorException ex) {
@@ -72,7 +86,7 @@ public class JsonAnnotationProcessor extends AbstractKoraProcessor {
                     }
                 }
             } else {
-                messager.printMessage(Diagnostic.Kind.ERROR, "Only classes and interfaces can be annotated with @JsonWriter, got " + annotated.element().getKind(), annotated.element());
+                messager.printMessage(Diagnostic.Kind.ERROR, "Only classes, interfaces and enum methods can be annotated with @JsonWriter, got " + element.getKind(), annotated.element());
             }
         }
         var jsonReaderElements = annotatedElements.getOrDefault(JsonTypes.jsonReaderAnnotation, List.of());

--- a/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/JsonAnnotationProcessor.java
+++ b/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/JsonAnnotationProcessor.java
@@ -66,9 +66,9 @@ public class JsonAnnotationProcessor extends AbstractKoraProcessor {
             var element = annotated.element();
             if (element.getKind() == ElementKind.METHOD) {
                 var enclosing = element.getEnclosingElement();
-                if (enclosing.getKind() != ElementKind.ENUM) {
+                if (!enclosing.getKind().isClass()) {
                     messager.printMessage(Diagnostic.Kind.ERROR,
-                        "@JsonWriter on a method is supported only for an enum method, got enclosing " + enclosing.getKind(),
+                        "@JsonWriter on a method is supported only for a method of a class or enum, got enclosing " + enclosing.getKind(),
                         annotated.element());
                     continue;
                 }
@@ -98,9 +98,9 @@ public class JsonAnnotationProcessor extends AbstractKoraProcessor {
                 element = element.getEnclosingElement();
             } else if (element.getKind() == ElementKind.METHOD) {
                 var enclosing = element.getEnclosingElement();
-                if (enclosing.getKind() != ElementKind.ENUM) {
+                if (!enclosing.getKind().isClass()) {
                     messager.printMessage(Diagnostic.Kind.ERROR,
-                        "@JsonReader on a method is supported only for an enum factory method, got enclosing " + enclosing.getKind(),
+                        "@JsonReader on a method is supported only for a static factory method of a class or enum, got enclosing " + enclosing.getKind(),
                         annotated.element());
                     continue;
                 }

--- a/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/JsonProcessor.java
+++ b/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/JsonProcessor.java
@@ -4,10 +4,12 @@ import com.squareup.javapoet.JavaFile;
 import ru.tinkoff.kora.annotation.processor.common.CommonUtils;
 import ru.tinkoff.kora.annotation.processor.common.ComparableTypeMirror;
 import ru.tinkoff.kora.annotation.processor.common.SealedTypeUtils;
+import ru.tinkoff.kora.json.annotation.processor.reader.DelegatingReaderGenerator;
 import ru.tinkoff.kora.json.annotation.processor.reader.EnumReaderGenerator;
 import ru.tinkoff.kora.json.annotation.processor.reader.JsonReaderGenerator;
 import ru.tinkoff.kora.json.annotation.processor.reader.ReaderTypeMetaParser;
 import ru.tinkoff.kora.json.annotation.processor.reader.SealedInterfaceReaderGenerator;
+import ru.tinkoff.kora.json.annotation.processor.writer.DelegatingWriterGenerator;
 import ru.tinkoff.kora.json.annotation.processor.writer.EnumWriterGenerator;
 import ru.tinkoff.kora.json.annotation.processor.writer.JsonWriterGenerator;
 import ru.tinkoff.kora.json.annotation.processor.writer.SealedInterfaceWriterGenerator;
@@ -34,6 +36,8 @@ public class JsonProcessor {
     private final SealedInterfaceWriterGenerator sealedWriterGenerator;
     private final EnumReaderGenerator enumReaderGenerator;
     private final EnumWriterGenerator enumWriterGenerator;
+    private final DelegatingReaderGenerator delegatingReaderGenerator;
+    private final DelegatingWriterGenerator delegatingWriterGenerator;
 
     public JsonProcessor(ProcessingEnvironment processingEnv) {
         this.processingEnv = processingEnv;
@@ -48,6 +52,8 @@ public class JsonProcessor {
         this.sealedWriterGenerator = new SealedInterfaceWriterGenerator(this.processingEnv);
         this.enumReaderGenerator = new EnumReaderGenerator();
         this.enumWriterGenerator = new EnumWriterGenerator();
+        this.delegatingReaderGenerator = new DelegatingReaderGenerator();
+        this.delegatingWriterGenerator = new DelegatingWriterGenerator();
     }
 
     public void generateReader(TypeElement jsonElement) {
@@ -64,6 +70,11 @@ public class JsonProcessor {
         }
         if (jsonElement.getModifiers().contains(Modifier.SEALED)) {
             this.generateSealedRootReader(jsonElement);
+            return;
+        }
+        if (this.delegatingReaderGenerator.detectReaderFactory(jsonElement) != null) {
+            var readerType = this.delegatingReaderGenerator.generate(jsonElement);
+            CommonUtils.safeWriteTo(this.processingEnv, JavaFile.builder(packageElement, readerType).build());
             return;
         }
         this.generateDtoReader(jsonElement, jsonElementType);
@@ -115,6 +126,11 @@ public class JsonProcessor {
         }
         if (jsonElement.getModifiers().contains(Modifier.SEALED)) {
             this.generateSealedWriter(jsonElement);
+            return;
+        }
+        if (this.delegatingWriterGenerator.detectWriterMethod(jsonElement) != null) {
+            var writerType = this.delegatingWriterGenerator.generate(jsonElement);
+            CommonUtils.safeWriteTo(this.processingEnv, JavaFile.builder(packageElement, writerType).build());
             return;
         }
         this.tryGenerateWriter(jsonElement, jsonElement.asType());

--- a/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/extension/JsonKoraExtension.java
+++ b/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/extension/JsonKoraExtension.java
@@ -10,8 +10,10 @@ import ru.tinkoff.kora.json.annotation.processor.JsonProcessor;
 import ru.tinkoff.kora.json.annotation.processor.JsonTypes;
 import ru.tinkoff.kora.json.annotation.processor.JsonUtils;
 import ru.tinkoff.kora.json.annotation.processor.KnownType;
+import ru.tinkoff.kora.json.annotation.processor.reader.DelegatingReaderGenerator;
 import ru.tinkoff.kora.json.annotation.processor.reader.EnumReaderGenerator;
 import ru.tinkoff.kora.json.annotation.processor.reader.ReaderTypeMetaParser;
+import ru.tinkoff.kora.json.annotation.processor.writer.DelegatingWriterGenerator;
 import ru.tinkoff.kora.json.annotation.processor.writer.EnumWriterGenerator;
 import ru.tinkoff.kora.json.annotation.processor.writer.WriterTypeMetaParser;
 import ru.tinkoff.kora.kora.app.annotation.processor.extension.ExtensionResult;
@@ -46,6 +48,8 @@ public class JsonKoraExtension implements KoraExtension {
     private final WriterTypeMetaParser writerTypeMetaParser;
     private final EnumReaderGenerator enumReaderGenerator = new EnumReaderGenerator();
     private final EnumWriterGenerator enumWriterGenerator = new EnumWriterGenerator();
+    private final DelegatingReaderGenerator delegatingReaderGenerator = new DelegatingReaderGenerator();
+    private final DelegatingWriterGenerator delegatingWriterGenerator = new DelegatingWriterGenerator();
     private final Messager messager;
 
     public JsonKoraExtension(ProcessingEnvironment processingEnv) {
@@ -92,6 +96,10 @@ public class JsonKoraExtension implements KoraExtension {
                 return () -> this.generateWriter(jsonElement, possibleJsonClass);
             }
 
+            if (this.delegatingWriterGenerator.detectWriterMethod(jsonElement) != null) {
+                return KoraExtensionDependencyGenerator.generatedFrom(elements, jsonElement, JsonTypes.jsonWriter);
+            }
+
             try {
                 Objects.requireNonNull(this.writerTypeMetaParser.parse(jsonElement, possibleJsonClass));
                 return () -> this.generateWriter(jsonElement, possibleJsonClass);
@@ -129,6 +137,10 @@ public class JsonKoraExtension implements KoraExtension {
 
             if (jsonElement.getKind() == ElementKind.ENUM) {
                 return () -> this.generateReader(jsonElement, possibleJsonClass);
+            }
+
+            if (this.delegatingReaderGenerator.detectReaderFactory(jsonElement) != null) {
+                return KoraExtensionDependencyGenerator.generatedFrom(elements, jsonElement, JsonTypes.jsonReader);
             }
 
             try {

--- a/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/extension/JsonKoraExtension.java
+++ b/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/extension/JsonKoraExtension.java
@@ -10,6 +10,7 @@ import ru.tinkoff.kora.json.annotation.processor.JsonProcessor;
 import ru.tinkoff.kora.json.annotation.processor.JsonTypes;
 import ru.tinkoff.kora.json.annotation.processor.JsonUtils;
 import ru.tinkoff.kora.json.annotation.processor.KnownType;
+import ru.tinkoff.kora.json.annotation.processor.reader.EnumReaderGenerator;
 import ru.tinkoff.kora.json.annotation.processor.reader.ReaderTypeMetaParser;
 import ru.tinkoff.kora.json.annotation.processor.writer.WriterTypeMetaParser;
 import ru.tinkoff.kora.kora.app.annotation.processor.extension.ExtensionResult;
@@ -42,6 +43,7 @@ public class JsonKoraExtension implements KoraExtension {
     private final TypeMirror jsonReaderErasure;
     private final ReaderTypeMetaParser readerTypeMetaParser;
     private final WriterTypeMetaParser writerTypeMetaParser;
+    private final EnumReaderGenerator enumReaderGenerator = new EnumReaderGenerator();
     private final Messager messager;
 
     public JsonKoraExtension(ProcessingEnvironment processingEnv) {
@@ -155,8 +157,11 @@ public class JsonKoraExtension implements KoraExtension {
         var hasJsonConstructor = CommonUtils.findConstructors(jsonElement, s -> !s.contains(Modifier.PRIVATE))
             .stream()
             .anyMatch(e -> AnnotationUtils.findAnnotation(e, JsonTypes.jsonReaderAnnotation) != null);
-        if (hasJsonConstructor || AnnotationUtils.findAnnotation(jsonElement, JsonTypes.jsonReaderAnnotation) != null) {
-            // annotation processor will handle that
+        var hasReaderFactory = jsonElement.getKind() == ElementKind.ENUM && this.enumReaderGenerator.detectReaderFactory(jsonElement) != null;
+        if (hasJsonConstructor || hasReaderFactory || AnnotationUtils.findAnnotation(jsonElement, JsonTypes.jsonReaderAnnotation) != null) {
+            // annotation processor will handle that (a @JsonReader factory method on the enum is discovered
+            // independently by JsonAnnotationProcessor via its own round's annotated-elements scan; generating
+            // it here too would race and attempt to recreate the same file in the same compiler round)
             return ExtensionResult.nextRound();
         }
 

--- a/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/extension/JsonKoraExtension.java
+++ b/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/extension/JsonKoraExtension.java
@@ -12,6 +12,7 @@ import ru.tinkoff.kora.json.annotation.processor.JsonUtils;
 import ru.tinkoff.kora.json.annotation.processor.KnownType;
 import ru.tinkoff.kora.json.annotation.processor.reader.EnumReaderGenerator;
 import ru.tinkoff.kora.json.annotation.processor.reader.ReaderTypeMetaParser;
+import ru.tinkoff.kora.json.annotation.processor.writer.EnumWriterGenerator;
 import ru.tinkoff.kora.json.annotation.processor.writer.WriterTypeMetaParser;
 import ru.tinkoff.kora.kora.app.annotation.processor.extension.ExtensionResult;
 import ru.tinkoff.kora.kora.app.annotation.processor.extension.KoraExtension;
@@ -44,6 +45,7 @@ public class JsonKoraExtension implements KoraExtension {
     private final ReaderTypeMetaParser readerTypeMetaParser;
     private final WriterTypeMetaParser writerTypeMetaParser;
     private final EnumReaderGenerator enumReaderGenerator = new EnumReaderGenerator();
+    private final EnumWriterGenerator enumWriterGenerator = new EnumWriterGenerator();
     private final Messager messager;
 
     public JsonKoraExtension(ProcessingEnvironment processingEnv) {
@@ -112,8 +114,8 @@ public class JsonKoraExtension implements KoraExtension {
             if (AnnotationUtils.findAnnotation(jsonElement, JsonTypes.json) != null
                 || AnnotationUtils.findAnnotation(jsonElement, JsonTypes.jsonReaderAnnotation) != null
                 || CommonUtils.findConstructors(jsonElement, s -> s.contains(Modifier.PUBLIC))
-                    .stream()
-                    .anyMatch(e -> AnnotationUtils.findAnnotation(e, JsonTypes.jsonReaderAnnotation) != null)) {
+                .stream()
+                .anyMatch(e -> AnnotationUtils.findAnnotation(e, JsonTypes.jsonReaderAnnotation) != null)) {
                 return KoraExtensionDependencyGenerator.generatedFrom(elements, jsonElement, JsonTypes.jsonReader);
             }
 
@@ -183,7 +185,8 @@ public class JsonKoraExtension implements KoraExtension {
             return buildExtensionResult(resultElement);
         }
 
-        if (AnnotationUtils.findAnnotation(jsonElement, JsonTypes.json) != null || AnnotationUtils.findAnnotation(jsonElement, JsonTypes.jsonWriterAnnotation) != null) {
+        var hasWriterMethod = jsonElement.getKind() == ElementKind.ENUM && this.enumWriterGenerator.detectWriterMethod(jsonElement) != null;
+        if (AnnotationUtils.findAnnotation(jsonElement, JsonTypes.json) != null || AnnotationUtils.findAnnotation(jsonElement, JsonTypes.jsonWriterAnnotation) != null || hasWriterMethod) {
             // annotation processor will handle that
             return ExtensionResult.nextRound();
         }

--- a/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/reader/DelegatingReaderGenerator.java
+++ b/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/reader/DelegatingReaderGenerator.java
@@ -1,0 +1,98 @@
+package ru.tinkoff.kora.json.annotation.processor.reader;
+
+import com.squareup.javapoet.*;
+import jakarta.annotation.Nullable;
+import ru.tinkoff.kora.annotation.processor.common.AnnotationUtils;
+import ru.tinkoff.kora.annotation.processor.common.CommonUtils;
+import ru.tinkoff.kora.annotation.processor.common.ProcessingErrorException;
+import ru.tinkoff.kora.json.annotation.processor.JsonTypes;
+import ru.tinkoff.kora.json.annotation.processor.JsonUtils;
+
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeElement;
+import java.io.IOException;
+
+/**
+ * Generates a delegating {@code JsonReader} for a non-enum type that declares a
+ * {@code @JsonReader}-annotated {@code public static} factory method {@code (V) -> T}. The JSON value is read as
+ * {@code V} and passed to the factory (Jackson {@code @JsonCreator(mode = DELEGATING)} semantics).
+ */
+public class DelegatingReaderGenerator {
+
+    public record DelegatingRead(TypeName valueType, String methodName) {}
+
+    public TypeSpec generate(TypeElement typeElement) {
+        var typeName = ClassName.get(typeElement);
+        var factory = this.detectReaderFactory(typeElement);
+        if (factory == null) {
+            throw new ProcessingErrorException("No @JsonReader factory method found on " + typeName, typeElement);
+        }
+        var valueReaderType = ParameterizedTypeName.get(JsonTypes.jsonReader, factory.valueType().box());
+
+        var read = MethodSpec.methodBuilder("read")
+            .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+            .addException(IOException.class)
+            .addParameter(JsonTypes.jsonParser, "__parser")
+            .returns(typeName)
+            .addAnnotation(Override.class)
+            .addAnnotation(Nullable.class)
+            .addStatement("var value = this.valueReader.read(__parser)")
+            .addStatement("return value == null ? null : $T.$N(value)", typeName, factory.methodName())
+            .build();
+
+        return TypeSpec.classBuilder(JsonUtils.jsonReaderName(typeElement))
+            .addAnnotation(AnnotationUtils.generated(DelegatingReaderGenerator.class))
+            .addSuperinterface(ParameterizedTypeName.get(JsonTypes.jsonReader, typeName))
+            .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+            .addOriginatingElement(typeElement)
+            .addField(valueReaderType, "valueReader", Modifier.PRIVATE, Modifier.FINAL)
+            .addMethod(MethodSpec.constructorBuilder()
+                .addModifiers(Modifier.PUBLIC)
+                .addParameter(valueReaderType, "valueReader")
+                .addStatement("this.valueReader = valueReader")
+                .build())
+            .addMethod(read)
+            .build();
+    }
+
+    @Nullable
+    public DelegatingRead detectReaderFactory(TypeElement typeElement) {
+        var factories = typeElement.getEnclosedElements().stream()
+            .filter(e -> e.getKind() == ElementKind.METHOD)
+            .map(ExecutableElement.class::cast)
+            .filter(e -> AnnotationUtils.isAnnotationPresent(e, JsonTypes.jsonReaderAnnotation))
+            .toList();
+        if (factories.isEmpty()) {
+            return null;
+        }
+        if (factories.size() > 1) {
+            throw new ProcessingErrorException(
+                "Type " + typeElement.getSimpleName() + " has multiple @JsonReader factory methods, only one is allowed",
+                factories.get(1));
+        }
+        var factory = factories.get(0);
+        if (!factory.getModifiers().contains(Modifier.PUBLIC) || !factory.getModifiers().contains(Modifier.STATIC)) {
+            throw new ProcessingErrorException("@JsonReader factory method must be public static", factory);
+        }
+        if (factory.getParameters().size() != 1) {
+            throw new ProcessingErrorException(
+                "@JsonReader factory method must have exactly one parameter, got " + factory.getParameters().size(),
+                factory);
+        }
+        var typeName = ClassName.get(typeElement);
+        if (!TypeName.get(factory.getReturnType()).equals(typeName)) {
+            throw new ProcessingErrorException("@JsonReader factory method must return " + typeName, factory);
+        }
+        var hasReaderConstructor = CommonUtils.findConstructors(typeElement, m -> !m.contains(Modifier.PRIVATE)).stream()
+            .anyMatch(c -> AnnotationUtils.isAnnotationPresent(c, JsonTypes.jsonReaderAnnotation)
+                || AnnotationUtils.isAnnotationPresent(c, JsonTypes.json));
+        if (hasReaderConstructor) {
+            throw new ProcessingErrorException(
+                "Type " + typeName + " has both a @JsonReader factory method and a @JsonReader/@Json constructor — only one is allowed",
+                factory);
+        }
+        return new DelegatingRead(TypeName.get(factory.getParameters().get(0).asType()), factory.getSimpleName().toString());
+    }
+}

--- a/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/reader/DelegatingReaderGenerator.java
+++ b/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/reader/DelegatingReaderGenerator.java
@@ -21,7 +21,7 @@ import java.io.IOException;
  */
 public class DelegatingReaderGenerator {
 
-    public record DelegatingRead(TypeName valueType, String methodName) {}
+    public record DelegatingRead(TypeName valueType, String methodName, boolean valueNullable) {}
 
     public TypeSpec generate(TypeElement typeElement) {
         var typeName = ClassName.get(typeElement);
@@ -31,16 +31,20 @@ public class DelegatingReaderGenerator {
         }
         var valueReaderType = ParameterizedTypeName.get(JsonTypes.jsonReader, factory.valueType().box());
 
-        var read = MethodSpec.methodBuilder("read")
+        var readBuilder = MethodSpec.methodBuilder("read")
             .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
             .addException(IOException.class)
             .addParameter(JsonTypes.jsonParser, "__parser")
             .returns(typeName)
             .addAnnotation(Override.class)
-            .addAnnotation(Nullable.class)
-            .addStatement("var value = this.valueReader.read(__parser)")
-            .addStatement("return value == null ? null : $T.$N(value)", typeName, factory.methodName())
-            .build();
+            .addAnnotation(Nullable.class);
+        if (factory.valueNullable()) {
+            readBuilder.addStatement("return $T.$N(this.valueReader.read(__parser))", typeName, factory.methodName());
+        } else {
+            readBuilder.addStatement("var value = this.valueReader.read(__parser)")
+                .addStatement("return value == null ? null : $T.$N(value)", typeName, factory.methodName());
+        }
+        var read = readBuilder.build();
 
         return TypeSpec.classBuilder(JsonUtils.jsonReaderName(typeElement))
             .addAnnotation(AnnotationUtils.generated(DelegatingReaderGenerator.class))
@@ -93,6 +97,7 @@ public class DelegatingReaderGenerator {
                 "Type " + typeName + " has both a @JsonReader factory method and a @JsonReader/@Json constructor — only one is allowed",
                 factory);
         }
-        return new DelegatingRead(TypeName.get(factory.getParameters().get(0).asType()), factory.getSimpleName().toString());
+        var valueNullable = CommonUtils.isNullable(factory.getParameters().get(0));
+        return new DelegatingRead(TypeName.get(factory.getParameters().get(0).asType()), factory.getSimpleName().toString(), valueNullable);
     }
 }

--- a/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/reader/EnumReaderGenerator.java
+++ b/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/reader/EnumReaderGenerator.java
@@ -83,8 +83,6 @@ public class EnumReaderGenerator {
     public ReaderFactory detectReaderFactory(TypeElement typeElement) {
         var factories = typeElement.getEnclosedElements().stream()
             .filter(e -> e.getKind() == ElementKind.METHOD)
-            .filter(e -> e.getModifiers().contains(Modifier.STATIC))
-            .filter(e -> e.getModifiers().contains(Modifier.PUBLIC))
             .map(ExecutableElement.class::cast)
             .filter(e -> AnnotationUtils.isAnnotationPresent(e, JsonTypes.jsonReaderAnnotation))
             .toList();
@@ -94,10 +92,13 @@ public class EnumReaderGenerator {
         if (factories.size() > 1) {
             throw new ProcessingErrorException(
                 "Enum " + typeElement.getSimpleName() + " has multiple @JsonReader factory methods, only one is allowed",
-                typeElement
+                factories.get(1)
             );
         }
         var factory = factories.get(0);
+        if (!factory.getModifiers().contains(Modifier.PUBLIC) || !factory.getModifiers().contains(Modifier.STATIC)) {
+            throw new ProcessingErrorException("@JsonReader factory method must be public static", factory);
+        }
         if (factory.getParameters().size() != 1) {
             throw new ProcessingErrorException(
                 "@JsonReader factory method must have exactly one parameter, got " + factory.getParameters().size(),

--- a/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/reader/EnumReaderGenerator.java
+++ b/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/reader/EnumReaderGenerator.java
@@ -3,7 +3,7 @@ package ru.tinkoff.kora.json.annotation.processor.reader;
 import com.squareup.javapoet.*;
 import jakarta.annotation.Nullable;
 import ru.tinkoff.kora.annotation.processor.common.AnnotationUtils;
-import ru.tinkoff.kora.annotation.processor.common.CommonClassNames;
+import ru.tinkoff.kora.annotation.processor.common.ProcessingErrorException;
 import ru.tinkoff.kora.json.annotation.processor.JsonTypes;
 import ru.tinkoff.kora.json.annotation.processor.JsonUtils;
 
@@ -17,6 +17,11 @@ public class EnumReaderGenerator {
 
     public TypeSpec generateForEnum(TypeElement typeElement) {
         var typeName = ClassName.get(typeElement);
+        var factory = this.detectReaderFactory(typeElement);
+        if (factory != null) {
+            return this.generateFactoryReader(typeElement, typeName, factory);
+        }
+
         var enumValue = this.detectValueType(typeElement);
 
         var typeBuilder = TypeSpec.classBuilder(JsonUtils.jsonReaderName(typeElement))
@@ -24,13 +29,13 @@ public class EnumReaderGenerator {
             .addSuperinterface(ParameterizedTypeName.get(JsonTypes.jsonReader, typeName))
             .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
             .addOriginatingElement(typeElement);
-        var delegateType = ParameterizedTypeName.get(JsonTypes.enumJsonReader, typeName, enumValue.type.box());
+        var delegateType = ParameterizedTypeName.get(JsonTypes.enumJsonReader, typeName, enumValue.type().box());
 
         typeBuilder.addField(delegateType, "delegate", Modifier.PRIVATE, Modifier.FINAL);
         typeBuilder.addMethod(MethodSpec.constructorBuilder()
             .addModifiers(Modifier.PUBLIC)
-            .addParameter(ParameterizedTypeName.get(JsonTypes.jsonReader, enumValue.type.box()), "valueReader")
-            .addCode("this.delegate = new $T<>($T.values(), $T::$N, valueReader);\n", JsonTypes.enumJsonReader, typeName, typeName, enumValue.accessor)
+            .addParameter(ParameterizedTypeName.get(JsonTypes.jsonReader, enumValue.type().box()), "valueReader")
+            .addCode("this.delegate = new $T<>($T.values(), $T::$N, valueReader);\n", JsonTypes.enumJsonReader, typeName, typeName, enumValue.accessor())
             .build());
         typeBuilder.addMethod(MethodSpec.methodBuilder("read")
             .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
@@ -43,6 +48,68 @@ public class EnumReaderGenerator {
             .build()
         );
         return typeBuilder.build();
+    }
+
+    record ReaderFactory(TypeName valueType, String methodName) {}
+
+    private TypeSpec generateFactoryReader(TypeElement typeElement, ClassName typeName, ReaderFactory factory) {
+        var valueReaderType = ParameterizedTypeName.get(JsonTypes.jsonReader, factory.valueType().box());
+        var typeBuilder = TypeSpec.classBuilder(JsonUtils.jsonReaderName(typeElement))
+            .addAnnotation(AnnotationUtils.generated(JsonReaderGenerator.class))
+            .addSuperinterface(ParameterizedTypeName.get(JsonTypes.jsonReader, typeName))
+            .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+            .addOriginatingElement(typeElement);
+        typeBuilder.addField(valueReaderType, "valueReader", Modifier.PRIVATE, Modifier.FINAL);
+        typeBuilder.addMethod(MethodSpec.constructorBuilder()
+            .addModifiers(Modifier.PUBLIC)
+            .addParameter(valueReaderType, "valueReader")
+            .addStatement("this.valueReader = valueReader")
+            .build());
+        typeBuilder.addMethod(MethodSpec.methodBuilder("read")
+            .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+            .addException(IOException.class)
+            .addParameter(JsonTypes.jsonParser, "__parser")
+            .returns(typeName)
+            .addAnnotation(Override.class)
+            .addAnnotation(Nullable.class)
+            .addStatement("var value = this.valueReader.read(__parser)")
+            .addStatement("return value == null ? null : $T.$N(value)", typeName, factory.methodName())
+            .build()
+        );
+        return typeBuilder.build();
+    }
+
+    @Nullable
+    private ReaderFactory detectReaderFactory(TypeElement typeElement) {
+        var factories = typeElement.getEnclosedElements().stream()
+            .filter(e -> e.getKind() == ElementKind.METHOD)
+            .filter(e -> e.getModifiers().contains(Modifier.STATIC))
+            .filter(e -> e.getModifiers().contains(Modifier.PUBLIC))
+            .map(ExecutableElement.class::cast)
+            .filter(e -> AnnotationUtils.isAnnotationPresent(e, JsonTypes.jsonReaderAnnotation))
+            .toList();
+        if (factories.isEmpty()) {
+            return null;
+        }
+        if (factories.size() > 1) {
+            throw new ProcessingErrorException(
+                "Enum " + typeElement.getSimpleName() + " has multiple @JsonReader factory methods, only one is allowed",
+                typeElement
+            );
+        }
+        var factory = factories.get(0);
+        if (factory.getParameters().size() != 1) {
+            throw new ProcessingErrorException(
+                "@JsonReader factory method must have exactly one parameter, got " + factory.getParameters().size(),
+                factory
+            );
+        }
+        var typeName = ClassName.get(typeElement);
+        if (!TypeName.get(factory.getReturnType()).equals(typeName)) {
+            throw new ProcessingErrorException("@JsonReader factory method must return " + typeName, factory);
+        }
+        var valueType = TypeName.get(factory.getParameters().get(0).asType());
+        return new ReaderFactory(valueType, factory.getSimpleName().toString());
     }
 
     record EnumValue(TypeName type, String accessor) {}

--- a/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/reader/EnumReaderGenerator.java
+++ b/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/reader/EnumReaderGenerator.java
@@ -80,7 +80,7 @@ public class EnumReaderGenerator {
     }
 
     @Nullable
-    private ReaderFactory detectReaderFactory(TypeElement typeElement) {
+    public ReaderFactory detectReaderFactory(TypeElement typeElement) {
         var factories = typeElement.getEnclosedElements().stream()
             .filter(e -> e.getKind() == ElementKind.METHOD)
             .filter(e -> e.getModifiers().contains(Modifier.STATIC))

--- a/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/reader/EnumReaderGenerator.java
+++ b/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/reader/EnumReaderGenerator.java
@@ -3,6 +3,7 @@ package ru.tinkoff.kora.json.annotation.processor.reader;
 import com.squareup.javapoet.*;
 import jakarta.annotation.Nullable;
 import ru.tinkoff.kora.annotation.processor.common.AnnotationUtils;
+import ru.tinkoff.kora.annotation.processor.common.CommonUtils;
 import ru.tinkoff.kora.annotation.processor.common.ProcessingErrorException;
 import ru.tinkoff.kora.json.annotation.processor.JsonTypes;
 import ru.tinkoff.kora.json.annotation.processor.JsonUtils;
@@ -50,7 +51,7 @@ public class EnumReaderGenerator {
         return typeBuilder.build();
     }
 
-    record ReaderFactory(TypeName valueType, String methodName) {}
+    record ReaderFactory(TypeName valueType, String methodName, boolean valueNullable) {}
 
     private TypeSpec generateFactoryReader(TypeElement typeElement, ClassName typeName, ReaderFactory factory) {
         var valueReaderType = ParameterizedTypeName.get(JsonTypes.jsonReader, factory.valueType().box());
@@ -65,17 +66,20 @@ public class EnumReaderGenerator {
             .addParameter(valueReaderType, "valueReader")
             .addStatement("this.valueReader = valueReader")
             .build());
-        typeBuilder.addMethod(MethodSpec.methodBuilder("read")
+        var readBuilder = MethodSpec.methodBuilder("read")
             .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
             .addException(IOException.class)
             .addParameter(JsonTypes.jsonParser, "__parser")
             .returns(typeName)
             .addAnnotation(Override.class)
-            .addAnnotation(Nullable.class)
-            .addStatement("var value = this.valueReader.read(__parser)")
-            .addStatement("return value == null ? null : $T.$N(value)", typeName, factory.methodName())
-            .build()
-        );
+            .addAnnotation(Nullable.class);
+        if (factory.valueNullable()) {
+            readBuilder.addStatement("return $T.$N(this.valueReader.read(__parser))", typeName, factory.methodName());
+        } else {
+            readBuilder.addStatement("var value = this.valueReader.read(__parser)")
+                .addStatement("return value == null ? null : $T.$N(value)", typeName, factory.methodName());
+        }
+        typeBuilder.addMethod(readBuilder.build());
         return typeBuilder.build();
     }
 
@@ -110,7 +114,8 @@ public class EnumReaderGenerator {
             throw new ProcessingErrorException("@JsonReader factory method must return " + typeName, factory);
         }
         var valueType = TypeName.get(factory.getParameters().get(0).asType());
-        return new ReaderFactory(valueType, factory.getSimpleName().toString());
+        var valueNullable = CommonUtils.isNullable(factory.getParameters().get(0));
+        return new ReaderFactory(valueType, factory.getSimpleName().toString(), valueNullable);
     }
 
     record EnumValue(TypeName type, String accessor) {}

--- a/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/writer/DelegatingWriterGenerator.java
+++ b/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/writer/DelegatingWriterGenerator.java
@@ -1,0 +1,108 @@
+package ru.tinkoff.kora.json.annotation.processor.writer;
+
+import com.squareup.javapoet.*;
+import jakarta.annotation.Nullable;
+import ru.tinkoff.kora.annotation.processor.common.AnnotationUtils;
+import ru.tinkoff.kora.annotation.processor.common.ProcessingErrorException;
+import ru.tinkoff.kora.json.annotation.processor.JsonTypes;
+import ru.tinkoff.kora.json.annotation.processor.JsonUtils;
+
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeKind;
+import java.io.IOException;
+
+/**
+ * Generates a delegating {@code JsonWriter} for a non-enum type that declares a
+ * {@code @JsonWriter}-annotated method producing the single JSON value the type is serialized as
+ * (Jackson {@code @JsonValue} semantics). The method is either an instance method {@code () -> V} or a static
+ * method {@code (T) -> V}.
+ */
+public class DelegatingWriterGenerator {
+
+    public record DelegatingWrite(TypeName valueType, String accessor, boolean isStatic) {}
+
+    public TypeSpec generate(TypeElement typeElement) {
+        var typeName = ClassName.get(typeElement);
+        var value = this.detectWriterMethod(typeElement);
+        if (value == null) {
+            throw new ProcessingErrorException("No @JsonWriter method found on " + typeName, typeElement);
+        }
+        var valueWriterType = ParameterizedTypeName.get(JsonTypes.jsonWriter, value.valueType().box());
+
+        CodeBlock extracted = value.isStatic()
+            ? CodeBlock.of("$T.$N(_object)", typeName, value.accessor())
+            : CodeBlock.of("_object.$N()", value.accessor());
+        var write = MethodSpec.methodBuilder("write")
+            .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+            .addException(IOException.class)
+            .addParameter(JsonTypes.jsonGenerator, "_gen")
+            .addParameter(ParameterSpec.builder(typeName, "_object").addAnnotation(Nullable.class).build())
+            .addAnnotation(Override.class)
+            .beginControlFlow("if (_object == null)")
+            .addStatement("_gen.writeNull()")
+            .addStatement("return")
+            .endControlFlow()
+            .addStatement("this.valueWriter.write(_gen, $L)", extracted)
+            .build();
+
+        return TypeSpec.classBuilder(JsonUtils.jsonWriterName(typeElement))
+            .addAnnotation(AnnotationUtils.generated(DelegatingWriterGenerator.class))
+            .addSuperinterface(ParameterizedTypeName.get(JsonTypes.jsonWriter, typeName))
+            .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+            .addOriginatingElement(typeElement)
+            .addField(valueWriterType, "valueWriter", Modifier.PRIVATE, Modifier.FINAL)
+            .addMethod(MethodSpec.constructorBuilder()
+                .addModifiers(Modifier.PUBLIC)
+                .addParameter(valueWriterType, "valueWriter")
+                .addStatement("this.valueWriter = valueWriter")
+                .build())
+            .addMethod(write)
+            .build();
+    }
+
+    @Nullable
+    public DelegatingWrite detectWriterMethod(TypeElement typeElement) {
+        var methods = typeElement.getEnclosedElements().stream()
+            .filter(e -> e.getKind() == ElementKind.METHOD)
+            .map(ExecutableElement.class::cast)
+            .filter(e -> AnnotationUtils.isAnnotationPresent(e, JsonTypes.jsonWriterAnnotation))
+            .toList();
+        if (methods.isEmpty()) {
+            return null;
+        }
+        if (methods.size() > 1) {
+            throw new ProcessingErrorException(
+                "Type " + typeElement.getSimpleName() + " has multiple @JsonWriter methods, only one is allowed",
+                methods.get(1));
+        }
+        var method = methods.get(0);
+        if (!method.getModifiers().contains(Modifier.PUBLIC)) {
+            throw new ProcessingErrorException("@JsonWriter method must be public", method);
+        }
+        if (method.getReturnType().getKind() == TypeKind.VOID) {
+            throw new ProcessingErrorException("@JsonWriter method must return a value", method);
+        }
+        var typeName = ClassName.get(typeElement);
+        boolean isStatic = method.getModifiers().contains(Modifier.STATIC);
+        if (isStatic) {
+            if (method.getParameters().size() != 1) {
+                throw new ProcessingErrorException(
+                    "@JsonWriter static method must have exactly one parameter (the value type), got " + method.getParameters().size(),
+                    method);
+            }
+            if (!TypeName.get(method.getParameters().get(0).asType()).equals(typeName)) {
+                throw new ProcessingErrorException("@JsonWriter static method parameter must be of type " + typeName, method);
+            }
+        } else {
+            if (!method.getParameters().isEmpty()) {
+                throw new ProcessingErrorException(
+                    "@JsonWriter instance method must have no parameters, got " + method.getParameters().size(),
+                    method);
+            }
+        }
+        return new DelegatingWrite(TypeName.get(method.getReturnType()), method.getSimpleName().toString(), isStatic);
+    }
+}

--- a/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/writer/EnumWriterGenerator.java
+++ b/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/writer/EnumWriterGenerator.java
@@ -3,7 +3,7 @@ package ru.tinkoff.kora.json.annotation.processor.writer;
 import com.squareup.javapoet.*;
 import jakarta.annotation.Nullable;
 import ru.tinkoff.kora.annotation.processor.common.AnnotationUtils;
-import ru.tinkoff.kora.annotation.processor.common.CommonClassNames;
+import ru.tinkoff.kora.annotation.processor.common.ProcessingErrorException;
 import ru.tinkoff.kora.json.annotation.processor.JsonTypes;
 import ru.tinkoff.kora.json.annotation.processor.JsonUtils;
 
@@ -11,6 +11,7 @@ import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeKind;
 import java.io.IOException;
 
 public class EnumWriterGenerator {
@@ -43,9 +44,50 @@ public class EnumWriterGenerator {
         return typeBuilder.build();
     }
 
+    @Nullable
+    public EnumValue detectWriterMethod(TypeElement typeElement) {
+        var methods = typeElement.getEnclosedElements().stream()
+            .filter(e -> e.getKind() == ElementKind.METHOD)
+            .map(ExecutableElement.class::cast)
+            .filter(e -> AnnotationUtils.isAnnotationPresent(e, JsonTypes.jsonWriterAnnotation))
+            .toList();
+        if (methods.isEmpty()) {
+            return null;
+        }
+        if (methods.size() > 1) {
+            throw new ProcessingErrorException(
+                "Enum " + typeElement.getSimpleName() + " has multiple @JsonWriter methods, only one is allowed",
+                methods.get(1)
+            );
+        }
+        var method = methods.get(0);
+        if (!method.getModifiers().contains(Modifier.PUBLIC) || !method.getModifiers().contains(Modifier.STATIC)) {
+            throw new ProcessingErrorException("@JsonWriter enum method must be public static", method);
+        }
+        if (method.getParameters().size() != 1) {
+            throw new ProcessingErrorException(
+                "@JsonWriter method must have exactly one parameter, got " + method.getParameters().size(),
+                method
+            );
+        }
+        var enumTypeName = ClassName.get(typeElement);
+        if (!TypeName.get(method.getParameters().get(0).asType()).equals(enumTypeName)) {
+            throw new ProcessingErrorException("@JsonWriter method parameter must be of type " + enumTypeName, method);
+        }
+        if (method.getReturnType().getKind() == TypeKind.VOID) {
+            throw new ProcessingErrorException("@JsonWriter method must return a value", method);
+        }
+        var valueType = TypeName.get(method.getReturnType());
+        return new EnumValue(valueType, method.getSimpleName().toString());
+    }
+
     record EnumValue(TypeName type, String accessor) {}
 
     private EnumValue detectValueType(TypeElement typeElement) {
+        var writerMethod = this.detectWriterMethod(typeElement);
+        if (writerMethod != null) {
+            return writerMethod;
+        }
         for (var enclosedElement : typeElement.getEnclosedElements()) {
             if (!enclosedElement.getModifiers().contains(Modifier.PUBLIC)) continue;
             if (enclosedElement.getModifiers().contains(Modifier.STATIC)) continue;

--- a/json/json-annotation-processor/src/test/java/ru/tinkoff/kora/json/annotation/processor/DelegatingValueTest.java
+++ b/json/json-annotation-processor/src/test/java/ru/tinkoff/kora/json/annotation/processor/DelegatingValueTest.java
@@ -18,6 +18,9 @@ public class DelegatingValueTest extends AbstractJsonAnnotationProcessorTest {
     JsonWriter<String> stringWriter = JsonGenerator::writeString;
     JsonReader<Long> longReader = JsonParser::getLongValue;
     JsonWriter<Long> longWriter = JsonGenerator::writeNumber;
+    JsonWriter<String> nStringWriter = (g, v) -> {
+        if (v == null) g.writeNull(); else g.writeString(v);
+    };
 
     private Object newObject(String name, Class<?> argType, Object arg) throws Exception {
         return compileResult.loadClass(name).getDeclaredConstructor(argType).newInstance(arg);
@@ -64,6 +67,20 @@ public class DelegatingValueTest extends AbstractJsonAnnotationProcessorTest {
         compileResult.assertSuccess();
         var mapper = mapper("Sku", List.of(stringReader), List.of(stringWriter));
         mapper.verify(newObject("Sku", String.class, "ABC"), "\"ABC\"");
+    }
+
+    @Test
+    public void testNullableValueRoundTrip() throws Exception {
+        compile("""
+            public record Box(@jakarta.annotation.Nullable String v) {
+              @JsonReader public static Box of(@jakarta.annotation.Nullable String v) { return new Box(v); }
+              @JsonWriter @jakarta.annotation.Nullable public String v() { return v; }
+            }
+            """);
+        compileResult.assertSuccess();
+        var mapper = mapper("Box", List.of(stringReader), List.of(nStringWriter));
+        mapper.verify(newObject("Box", String.class, "a"), "\"a\"");
+        mapper.verify(newObject("Box", String.class, null), "null");
     }
 
     @Test

--- a/json/json-annotation-processor/src/test/java/ru/tinkoff/kora/json/annotation/processor/DelegatingValueTest.java
+++ b/json/json-annotation-processor/src/test/java/ru/tinkoff/kora/json/annotation/processor/DelegatingValueTest.java
@@ -1,0 +1,197 @@
+package ru.tinkoff.kora.json.annotation.processor;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import org.junit.jupiter.api.Test;
+import ru.tinkoff.kora.json.common.JsonReader;
+import ru.tinkoff.kora.json.common.JsonWriter;
+import ru.tinkoff.kora.kora.app.annotation.processor.KoraAppProcessor;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DelegatingValueTest extends AbstractJsonAnnotationProcessorTest {
+    JsonReader<String> stringReader = JsonParser::getValueAsString;
+    JsonWriter<String> stringWriter = JsonGenerator::writeString;
+    JsonReader<Long> longReader = JsonParser::getLongValue;
+    JsonWriter<Long> longWriter = JsonGenerator::writeNumber;
+
+    private Object newObject(String name, Class<?> argType, Object arg) throws Exception {
+        return compileResult.loadClass(name).getDeclaredConstructor(argType).newInstance(arg);
+    }
+
+    private void assertWrite(JsonWriter<Object> w, Object value, String expectedJson) throws IOException {
+        assertThat(w.toByteArray(value)).asString(StandardCharsets.UTF_8).isEqualTo(expectedJson);
+    }
+
+    @Test
+    public void testDelegatingInstanceWriterAndFactoryReader() throws Exception {
+        compile("""
+            public record UserId(long id) {
+              @JsonReader public static UserId of(long v) { return new UserId(v); }
+              @JsonWriter public long id() { return id; }
+            }
+            """);
+        compileResult.assertSuccess();
+        var mapper = mapper("UserId", List.of(longReader), List.of(longWriter));
+        mapper.verify(newObject("UserId", long.class, 42L), "42");
+    }
+
+    @Test
+    public void testDelegatingStaticWriter() throws Exception {
+        compile("""
+            public record UserId(long id) {
+              @JsonReader public static UserId of(long v) { return new UserId(v); }
+              @JsonWriter public static long toJson(UserId u) { return u.id(); }
+            }
+            """);
+        compileResult.assertSuccess();
+        var mapper = mapper("UserId", List.of(longReader), List.of(longWriter));
+        mapper.verify(newObject("UserId", long.class, 7L), "7");
+    }
+
+    @Test
+    public void testDelegatingStringValue() throws Exception {
+        compile("""
+            public record Sku(String code) {
+              @JsonReader public static Sku parse(String v) { return new Sku(v); }
+              @JsonWriter public String code() { return code; }
+            }
+            """);
+        compileResult.assertSuccess();
+        var mapper = mapper("Sku", List.of(stringReader), List.of(stringWriter));
+        mapper.verify(newObject("Sku", String.class, "ABC"), "\"ABC\"");
+    }
+
+    @Test
+    public void testDelegatingWriterWinsOverJsonProperties() throws Exception {
+        compile("""
+            @Json
+            public record Money(long amount, String currency) {
+              @JsonWriter public long amount() { return amount; }
+            }
+            """);
+        compileResult.assertSuccess();
+        var w = writer("Money", longWriter);
+        var money = compileResult.loadClass("Money").getDeclaredConstructor(long.class, String.class).newInstance(100L, "USD");
+        assertWrite(w, money, "100");
+    }
+
+    @Test
+    public void testDelegatingReaderFromExtension() {
+        compile(List.of(new KoraAppProcessor(), new JsonAnnotationProcessor()), """
+            @ru.tinkoff.kora.common.KoraApp
+            public interface TestApp {
+              record UserId(long id) {
+                @JsonReader public static UserId of(long v) { return new UserId(v); }
+              }
+
+              default ru.tinkoff.kora.json.common.JsonReader<Long> longReader() { return com.fasterxml.jackson.core.JsonParser::getLongValue; }
+              default ru.tinkoff.kora.json.common.JsonWriter<Long> longWriter() { return com.fasterxml.jackson.core.JsonGenerator::writeNumber; }
+
+              @Root
+              default String root(ru.tinkoff.kora.json.common.JsonReader<UserId> r) { return ""; }
+            }
+            """);
+        compileResult.assertSuccess();
+        assertThat(reader("TestApp_UserId", longReader)).isNotNull();
+    }
+
+    @Test
+    public void testDelegatingWriterFromExtension() {
+        compile(List.of(new KoraAppProcessor(), new JsonAnnotationProcessor()), """
+            @ru.tinkoff.kora.common.KoraApp
+            public interface TestApp {
+              record UserId(long id) {
+                @JsonWriter public long id() { return id; }
+              }
+
+              default ru.tinkoff.kora.json.common.JsonReader<Long> longReader() { return com.fasterxml.jackson.core.JsonParser::getLongValue; }
+              default ru.tinkoff.kora.json.common.JsonWriter<Long> longWriter() { return com.fasterxml.jackson.core.JsonGenerator::writeNumber; }
+
+              @Root
+              default String root(ru.tinkoff.kora.json.common.JsonWriter<UserId> r) { return ""; }
+            }
+            """);
+        compileResult.assertSuccess();
+        assertThat(writer("TestApp_UserId", longWriter)).isNotNull();
+    }
+
+    @Test
+    public void testMultipleWriterMethodsFails() {
+        var result = compile(List.of(new JsonAnnotationProcessor()), """
+            public record UserId(long id) {
+              @JsonWriter public long a() { return id; }
+              @JsonWriter public long b() { return id; }
+            }
+            """);
+        assertThat(result.isFailed()).isTrue();
+        assertThat(result.errors()).anyMatch(d -> d.getMessage(null).contains("multiple @JsonWriter methods"));
+    }
+
+    @Test
+    public void testWriterInstanceMethodWithParamsFails() {
+        var result = compile(List.of(new JsonAnnotationProcessor()), """
+            public class UserId {
+              private final long id;
+              public UserId(long id) { this.id = id; }
+              @JsonWriter public long toJson(int x) { return id; }
+            }
+            """);
+        assertThat(result.isFailed()).isTrue();
+        assertThat(result.errors()).anyMatch(d -> d.getMessage(null).contains("must have no parameters"));
+    }
+
+    @Test
+    public void testReaderFactoryNotStaticFails() {
+        var result = compile(List.of(new JsonAnnotationProcessor()), """
+            public class UserId {
+              private final long id;
+              public UserId(long id) { this.id = id; }
+              @JsonReader public UserId of(long v) { return new UserId(v); }
+            }
+            """);
+        assertThat(result.isFailed()).isTrue();
+        assertThat(result.errors()).anyMatch(d -> d.getMessage(null).contains("must be public static"));
+    }
+
+    @Test
+    public void testReaderFactoryWrongReturnFails() {
+        var result = compile(List.of(new JsonAnnotationProcessor()), """
+            public class UserId {
+              private final long id;
+              public UserId(long id) { this.id = id; }
+              @JsonReader public static String of(long v) { return String.valueOf(v); }
+            }
+            """);
+        assertThat(result.isFailed()).isTrue();
+        assertThat(result.errors()).anyMatch(d -> d.getMessage(null).contains("must return"));
+    }
+
+    @Test
+    public void testFactoryAndReaderConstructorConflictFails() {
+        var result = compile(List.of(new JsonAnnotationProcessor()), """
+            public class UserId {
+              private final long id;
+              @JsonReader public UserId(long id) { this.id = id; }
+              @JsonReader public static UserId of(long v) { return new UserId(v); }
+            }
+            """);
+        assertThat(result.isFailed()).isTrue();
+        assertThat(result.errors()).anyMatch(d -> d.getMessage(null).contains("only one is allowed"));
+    }
+
+    @Test
+    public void testWriterOnUnsupportedEnclosingFails() {
+        var result = compile(List.of(new JsonAnnotationProcessor()), """
+            public interface Holder {
+              @JsonWriter default long toJson() { return 1L; }
+            }
+            """);
+        assertThat(result.isFailed()).isTrue();
+        assertThat(result.errors()).anyMatch(d -> d.getMessage(null).contains("supported only for a method of a class or enum"));
+    }
+}

--- a/json/json-annotation-processor/src/test/java/ru/tinkoff/kora/json/annotation/processor/EnumTest.java
+++ b/json/json-annotation-processor/src/test/java/ru/tinkoff/kora/json/annotation/processor/EnumTest.java
@@ -590,4 +590,46 @@ public class EnumTest extends AbstractJsonAnnotationProcessorTest {
         assertThat(result.isFailed()).isTrue();
         assertThat(result.errors()).anyMatch(d -> d.getMessage(null).contains("supported only for an enum"));
     }
+
+    @Test
+    public void testWriterMethodFromExtension() {
+        compile(List.of(new KoraAppProcessor(), new JsonAnnotationProcessor()), """
+            @ru.tinkoff.kora.common.KoraApp
+            public interface TestApp {
+              enum TestEnum {
+                VALUE1("value1"), VALUE2("value2");
+                private final String value;
+                TestEnum(String value) { this.value = value; }
+                @JsonWriter public static String toValue(TestEnum e) { return e.value; }
+              }
+
+              default ru.tinkoff.kora.json.common.JsonWriter<String> stringWriter() { return com.fasterxml.jackson.core.JsonGenerator::writeString; }
+
+              @Root
+              default String root(ru.tinkoff.kora.json.common.JsonWriter<TestEnum> w) { return ""; }
+            }
+            """);
+        compileResult.assertSuccess();
+        assertThat(writer("TestApp_TestEnum", stringWriter)).isNotNull();
+    }
+
+    @Test
+    public void testMalformedWriterMethodFromExtensionFails() {
+        var result = compile(List.of(new KoraAppProcessor(), new JsonAnnotationProcessor()), """
+            @ru.tinkoff.kora.common.KoraApp
+            public interface TestApp {
+              enum TestEnum {
+                VALUE1, VALUE2;
+                @JsonWriter static String toValue(TestEnum e) { return e.name(); }
+              }
+
+              default ru.tinkoff.kora.json.common.JsonWriter<String> stringWriter() { return com.fasterxml.jackson.core.JsonGenerator::writeString; }
+
+              @Root
+              default String root(ru.tinkoff.kora.json.common.JsonWriter<TestEnum> w) { return ""; }
+            }
+            """);
+        assertThat(result.isFailed()).isTrue();
+        assertThat(result.errors()).anyMatch(d -> d.getMessage(null).contains("public static"));
+    }
 }

--- a/json/json-annotation-processor/src/test/java/ru/tinkoff/kora/json/annotation/processor/EnumTest.java
+++ b/json/json-annotation-processor/src/test/java/ru/tinkoff/kora/json/annotation/processor/EnumTest.java
@@ -278,6 +278,25 @@ public class EnumTest extends AbstractJsonAnnotationProcessorTest {
     }
 
     @Test
+    public void testEnumFactoryNullableValue() {
+        compile("""
+            @Json
+            public enum TestEnum {
+              VALUE1, UNKNOWN;
+              @JsonReader
+              public static TestEnum fromValue(@jakarta.annotation.Nullable String v) {
+                return "value1".equals(v) ? VALUE1 : UNKNOWN;
+              }
+            }
+            """);
+        compileResult.assertSuccess();
+        JsonReader<String> nsr = JsonParser::getValueAsString;
+        var r = reader("TestEnum", nsr);
+        assertRead(r, "\"value1\"", enumConstant("TestEnum", "VALUE1"));
+        assertRead(r, "null", enumConstant("TestEnum", "UNKNOWN"));
+    }
+
+    @Test
     public void testEnumClassAndFactoryAnnotationUsesFactory() {
         compile("""
             @JsonReader

--- a/json/json-annotation-processor/src/test/java/ru/tinkoff/kora/json/annotation/processor/EnumTest.java
+++ b/json/json-annotation-processor/src/test/java/ru/tinkoff/kora/json/annotation/processor/EnumTest.java
@@ -297,4 +297,30 @@ public class EnumTest extends AbstractJsonAnnotationProcessorTest {
             """);
         assertThat(result.isFailed()).isTrue();
     }
+
+    @Test
+    public void testFactoryReaderFromExtension() {
+        compile(List.of(new KoraAppProcessor(), new JsonAnnotationProcessor()), """
+            @ru.tinkoff.kora.common.KoraApp
+            public interface TestApp {
+              enum TestEnum {
+                SHARE("share"), OTHER("other");
+            
+                private final String value;
+                TestEnum(String value) { this.value = value; }
+            
+                @JsonReader
+                public static TestEnum fromValue(String value) { return "share".equals(value) ? SHARE : OTHER; }
+              }
+            
+              default ru.tinkoff.kora.json.common.JsonReader<String> stringReader() { return com.fasterxml.jackson.core.JsonParser::getValueAsString; }
+            
+              @Root
+              default String root(ru.tinkoff.kora.json.common.JsonReader<TestEnum> r) { return ""; }
+            }
+            """);
+
+        compileResult.assertSuccess();
+        assertThat(reader("TestApp_TestEnum", stringReader)).isNotNull();
+    }
 }

--- a/json/json-annotation-processor/src/test/java/ru/tinkoff/kora/json/annotation/processor/EnumTest.java
+++ b/json/json-annotation-processor/src/test/java/ru/tinkoff/kora/json/annotation/processor/EnumTest.java
@@ -278,20 +278,6 @@ public class EnumTest extends AbstractJsonAnnotationProcessorTest {
     }
 
     @Test
-    public void testJsonReaderFactoryOnNonEnumFails() {
-        var result = compile(List.of(new JsonAnnotationProcessor()), """
-            public class NotAnEnum {
-              private final String value;
-              public NotAnEnum(String value) { this.value = value; }
-              @JsonReader
-              public static NotAnEnum fromValue(String value) { return new NotAnEnum(value); }
-            }
-            """);
-        assertThat(result.isFailed()).isTrue();
-        assertThat(result.errors()).anyMatch(d -> d.getMessage(null).contains("supported only for an enum"));
-    }
-
-    @Test
     public void testEnumClassAndFactoryAnnotationUsesFactory() {
         compile("""
             @JsonReader
@@ -576,19 +562,6 @@ public class EnumTest extends AbstractJsonAnnotationProcessorTest {
             """);
         assertThat(result.isFailed()).isTrue();
         assertThat(result.errors()).anyMatch(d -> d.getMessage(null).contains("must return a value"));
-    }
-
-    @Test
-    public void testJsonWriterMethodOnNonEnumFails() {
-        var result = compile(List.of(new JsonAnnotationProcessor()), """
-            public class NotAnEnum {
-              private final String value;
-              public NotAnEnum(String value) { this.value = value; }
-              @JsonWriter public static String toValue(NotAnEnum x) { return x.value; }
-            }
-            """);
-        assertThat(result.isFailed()).isTrue();
-        assertThat(result.errors()).anyMatch(d -> d.getMessage(null).contains("supported only for an enum"));
     }
 
     @Test

--- a/json/json-annotation-processor/src/test/java/ru/tinkoff/kora/json/annotation/processor/EnumTest.java
+++ b/json/json-annotation-processor/src/test/java/ru/tinkoff/kora/json/annotation/processor/EnumTest.java
@@ -376,4 +376,218 @@ public class EnumTest extends AbstractJsonAnnotationProcessorTest {
         assertThat(result.isFailed()).isTrue();
         assertThat(result.errors()).anyMatch(d -> d.getMessage(null).contains("public static"));
     }
+
+    private void assertWrite(JsonWriter<Object> writer, Object value, String expectedJson) {
+        try {
+            assertThat(writer.toByteArray(value)).asString(StandardCharsets.UTF_8).isEqualTo(expectedJson);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void testEnumWriterFromStaticMethod() {
+        compile("""
+            @Json
+            public enum TestEnum {
+              VALUE1("value1"), VALUE2("value2");
+              private final String value;
+              TestEnum(String value) { this.value = value; }
+              @JsonWriter public static String toValue(TestEnum e) { return e.value; }
+            }
+            """);
+        compileResult.assertSuccess();
+
+        var w = writer("TestEnum", stringWriter);
+        assertWrite(w, enumConstant("TestEnum", "VALUE1"), "\"value1\"");
+        assertWrite(w, enumConstant("TestEnum", "VALUE2"), "\"value2\"");
+    }
+
+    @Test
+    public void testEnumWriterStaticMethodIntValue() {
+        compile("""
+            @Json
+            public enum TestEnum {
+              VALUE1(1), VALUE2(2);
+              private final int code;
+              TestEnum(int code) { this.code = code; }
+              @JsonWriter public static int toCode(TestEnum e) { return e.code; }
+            }
+            """);
+        compileResult.assertSuccess();
+
+        JsonWriter<Integer> intWriter = JsonGenerator::writeNumber;
+        var w = writer("TestEnum", intWriter);
+        assertWrite(w, enumConstant("TestEnum", "VALUE1"), "1");
+        assertWrite(w, enumConstant("TestEnum", "VALUE2"), "2");
+    }
+
+    @Test
+    public void testEnumWriterStaticMethodOverridesJsonGetter() {
+        compile("""
+            @Json
+            public enum TestEnum {
+              VALUE1("XXX"), VALUE2("YYY");
+              private final String value;
+              TestEnum(String value) { this.value = value; }
+              @Json public String getValue() { return value; }
+              @JsonWriter public static String toValue(TestEnum e) { return e.name().toLowerCase(); }
+            }
+            """);
+        compileResult.assertSuccess();
+
+        var w = writer("TestEnum", stringWriter);
+        assertWrite(w, enumConstant("TestEnum", "VALUE1"), "\"value1\"");
+        assertWrite(w, enumConstant("TestEnum", "VALUE2"), "\"value2\"");
+    }
+
+    @Test
+    public void testEnumReaderFactoryAndWriterMethod() {
+        compile("""
+            @Json
+            public enum TestEnum {
+              VALUE1("value1"), VALUE2("value2"), OTHER("other");
+              private final String value;
+              TestEnum(String value) { this.value = value; }
+              @JsonReader public static TestEnum fromValue(String value) {
+                for (var v : values()) { if (v.value.equals(value)) return v; }
+                return OTHER;
+              }
+              @JsonWriter public static String toValue(TestEnum e) { return e.value; }
+            }
+            """);
+        compileResult.assertSuccess();
+
+        JsonReader<Object> r = reader("TestEnum", stringReader);
+        var w = writer("TestEnum", stringWriter);
+        assertRead(r, "\"value1\"", enumConstant("TestEnum", "VALUE1"));
+        assertRead(r, "\"nonsense\"", enumConstant("TestEnum", "OTHER"));
+        assertWrite(w, enumConstant("TestEnum", "VALUE1"), "\"value1\"");
+        assertWrite(w, enumConstant("TestEnum", "OTHER"), "\"other\"");
+    }
+
+    @Test
+    public void testEnumWriterMethodTriggersWithoutJsonAnnotation() {
+        compile("""
+            public enum TestEnum {
+              VALUE1("value1"), VALUE2("value2");
+              private final String value;
+              TestEnum(String value) { this.value = value; }
+              @JsonWriter public static String toValue(TestEnum e) { return e.value; }
+            }
+            """);
+        compileResult.assertSuccess();
+
+        var w = writer("TestEnum", stringWriter);
+        assertWrite(w, enumConstant("TestEnum", "VALUE1"), "\"value1\"");
+    }
+
+    @Test
+    public void testEnumClassAndWriterMethodDedup() {
+        compile("""
+            @JsonWriter
+            public enum TestEnum {
+              VALUE1("value1"), VALUE2("value2");
+              private final String value;
+              TestEnum(String value) { this.value = value; }
+              @JsonWriter public static String toValue(TestEnum e) { return e.value; }
+            }
+            """);
+        compileResult.assertSuccess();
+
+        var w = writer("TestEnum", stringWriter);
+        assertWrite(w, enumConstant("TestEnum", "VALUE1"), "\"value1\"");
+    }
+
+    @Test
+    public void testEnumWriterMultipleMethodsFails() {
+        var result = compile(List.of(new JsonAnnotationProcessor()), """
+            @Json
+            public enum TestEnum {
+              VALUE1, VALUE2;
+              @JsonWriter public static String toValue(TestEnum e) { return e.name(); }
+              @JsonWriter public static String toOther(TestEnum e) { return e.name(); }
+            }
+            """);
+        assertThat(result.isFailed()).isTrue();
+        assertThat(result.errors()).anyMatch(d -> d.getMessage(null).contains("multiple @JsonWriter"));
+    }
+
+    @Test
+    public void testEnumWriterMethodNotStaticFails() {
+        var result = compile(List.of(new JsonAnnotationProcessor()), """
+            @Json
+            public enum TestEnum {
+              VALUE1, VALUE2;
+              @JsonWriter public String toValue(TestEnum e) { return e.name(); }
+            }
+            """);
+        assertThat(result.isFailed()).isTrue();
+        assertThat(result.errors()).anyMatch(d -> d.getMessage(null).contains("public static"));
+    }
+
+    @Test
+    public void testEnumWriterMethodNonPublicFails() {
+        var result = compile(List.of(new JsonAnnotationProcessor()), """
+            @Json
+            public enum TestEnum {
+              VALUE1, VALUE2;
+              @JsonWriter static String toValue(TestEnum e) { return e.name(); }
+            }
+            """);
+        assertThat(result.isFailed()).isTrue();
+        assertThat(result.errors()).anyMatch(d -> d.getMessage(null).contains("public static"));
+    }
+
+    @Test
+    public void testEnumWriterMethodWrongParameterCountFails() {
+        var result = compile(List.of(new JsonAnnotationProcessor()), """
+            @Json
+            public enum TestEnum {
+              VALUE1, VALUE2;
+              @JsonWriter public static String toValue(TestEnum e, int extra) { return e.name(); }
+            }
+            """);
+        assertThat(result.isFailed()).isTrue();
+        assertThat(result.errors()).anyMatch(d -> d.getMessage(null).contains("exactly one parameter"));
+    }
+
+    @Test
+    public void testEnumWriterMethodWrongParameterTypeFails() {
+        var result = compile(List.of(new JsonAnnotationProcessor()), """
+            @Json
+            public enum TestEnum {
+              VALUE1, VALUE2;
+              @JsonWriter public static String toValue(int x) { return String.valueOf(x); }
+            }
+            """);
+        assertThat(result.isFailed()).isTrue();
+        assertThat(result.errors()).anyMatch(d -> d.getMessage(null).contains("must be of type"));
+    }
+
+    @Test
+    public void testEnumWriterMethodVoidReturnFails() {
+        var result = compile(List.of(new JsonAnnotationProcessor()), """
+            @Json
+            public enum TestEnum {
+              VALUE1, VALUE2;
+              @JsonWriter public static void toValue(TestEnum e) { }
+            }
+            """);
+        assertThat(result.isFailed()).isTrue();
+        assertThat(result.errors()).anyMatch(d -> d.getMessage(null).contains("must return a value"));
+    }
+
+    @Test
+    public void testJsonWriterMethodOnNonEnumFails() {
+        var result = compile(List.of(new JsonAnnotationProcessor()), """
+            public class NotAnEnum {
+              private final String value;
+              public NotAnEnum(String value) { this.value = value; }
+              @JsonWriter public static String toValue(NotAnEnum x) { return x.value; }
+            }
+            """);
+        assertThat(result.isFailed()).isTrue();
+        assertThat(result.errors()).anyMatch(d -> d.getMessage(null).contains("supported only for an enum"));
+    }
 }

--- a/json/json-annotation-processor/src/test/java/ru/tinkoff/kora/json/annotation/processor/EnumTest.java
+++ b/json/json-annotation-processor/src/test/java/ru/tinkoff/kora/json/annotation/processor/EnumTest.java
@@ -219,6 +219,30 @@ public class EnumTest extends AbstractJsonAnnotationProcessorTest {
         assertThat(result.isFailed()).isTrue();
     }
 
+    @Test
+    public void testEnumFactoryNonPublicFails() {
+        var result = compile(List.of(new JsonAnnotationProcessor()), """
+            @Json
+            public enum TestEnum {
+              A, B;
+              @JsonReader static TestEnum fromValue(String value) { return A; }
+            }
+            """);
+        assertThat(result.isFailed()).isTrue();
+    }
+
+    @Test
+    public void testEnumFactoryNonStaticFails() {
+        var result = compile(List.of(new JsonAnnotationProcessor()), """
+            @Json
+            public enum TestEnum {
+              A, B;
+              @JsonReader public TestEnum fromValue(String value) { return A; }
+            }
+            """);
+        assertThat(result.isFailed()).isTrue();
+    }
+
     private void assertRead(JsonReader<Object> reader, String json, Object expected) {
         try {
             assertThat(reader.read(json.getBytes(StandardCharsets.UTF_8))).isEqualTo(expected);

--- a/json/json-annotation-processor/src/test/java/ru/tinkoff/kora/json/annotation/processor/EnumTest.java
+++ b/json/json-annotation-processor/src/test/java/ru/tinkoff/kora/json/annotation/processor/EnumTest.java
@@ -205,6 +205,7 @@ public class EnumTest extends AbstractJsonAnnotationProcessorTest {
             }
             """);
         assertThat(result.isFailed()).isTrue();
+        assertThat(result.errors()).anyMatch(d -> d.getMessage(null).contains("multiple @JsonReader factory"));
     }
 
     @Test
@@ -217,6 +218,7 @@ public class EnumTest extends AbstractJsonAnnotationProcessorTest {
             }
             """);
         assertThat(result.isFailed()).isTrue();
+        assertThat(result.errors()).anyMatch(d -> d.getMessage(null).contains("exactly one parameter"));
     }
 
     @Test
@@ -229,6 +231,7 @@ public class EnumTest extends AbstractJsonAnnotationProcessorTest {
             }
             """);
         assertThat(result.isFailed()).isTrue();
+        assertThat(result.errors()).anyMatch(d -> d.getMessage(null).contains("public static"));
     }
 
     @Test
@@ -241,6 +244,7 @@ public class EnumTest extends AbstractJsonAnnotationProcessorTest {
             }
             """);
         assertThat(result.isFailed()).isTrue();
+        assertThat(result.errors()).anyMatch(d -> d.getMessage(null).contains("public static"));
     }
 
     private void assertRead(JsonReader<Object> reader, String json, Object expected) {
@@ -284,6 +288,7 @@ public class EnumTest extends AbstractJsonAnnotationProcessorTest {
             }
             """);
         assertThat(result.isFailed()).isTrue();
+        assertThat(result.errors()).anyMatch(d -> d.getMessage(null).contains("supported only for an enum"));
     }
 
     @Test
@@ -320,6 +325,7 @@ public class EnumTest extends AbstractJsonAnnotationProcessorTest {
             }
             """);
         assertThat(result.isFailed()).isTrue();
+        assertThat(result.errors()).anyMatch(d -> d.getMessage(null).contains("must return"));
     }
 
     @Test
@@ -346,5 +352,28 @@ public class EnumTest extends AbstractJsonAnnotationProcessorTest {
 
         compileResult.assertSuccess();
         assertThat(reader("TestApp_TestEnum", stringReader)).isNotNull();
+    }
+
+    @Test
+    public void testMalformedFactoryFromExtensionFails() {
+        var result = compile(List.of(new KoraAppProcessor(), new JsonAnnotationProcessor()), """
+            @ru.tinkoff.kora.common.KoraApp
+            public interface TestApp {
+              enum TestEnum {
+                VALUE1, VALUE2;
+
+                @JsonReader
+                static TestEnum fromValue(String value) { return VALUE1; }
+              }
+
+              default ru.tinkoff.kora.json.common.JsonReader<String> stringReader() { return com.fasterxml.jackson.core.JsonParser::getValueAsString; }
+
+              @Root
+              default String root(ru.tinkoff.kora.json.common.JsonReader<TestEnum> r) { return ""; }
+            }
+            """);
+
+        assertThat(result.isFailed()).isTrue();
+        assertThat(result.errors()).anyMatch(d -> d.getMessage(null).contains("public static"));
     }
 }

--- a/json/json-annotation-processor/src/test/java/ru/tinkoff/kora/json/annotation/processor/EnumTest.java
+++ b/json/json-annotation-processor/src/test/java/ru/tinkoff/kora/json/annotation/processor/EnumTest.java
@@ -7,6 +7,8 @@ import ru.tinkoff.kora.json.common.JsonReader;
 import ru.tinkoff.kora.json.common.JsonWriter;
 import ru.tinkoff.kora.kora.app.annotation.processor.KoraAppProcessor;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -139,5 +141,160 @@ public class EnumTest extends AbstractJsonAnnotationProcessorTest {
 
         compileResult.assertSuccess();
         assertThat(writer("TestApp_TestEnum", stringWriter)).isNotNull();
+    }
+
+    @Test
+    public void testEnumReaderFromFactoryMethod() {
+        compile("""
+                @Json
+                public enum TestEnum {
+                  SHARE("share"), BOND("bond"), OTHER("other");
+                
+                  private final String value;
+                  TestEnum(String value) { this.value = value; }
+                
+                  @JsonReader
+                  public static TestEnum fromValue(String value) {
+                    for (var v : values()) { if (v.value.equals(value)) return v; }
+                    return OTHER;
+                  }
+                }
+                """);
+        compileResult.assertSuccess();
+
+        JsonReader<Object> r = reader("TestEnum", stringReader);
+        assertRead(r, "\"share\"", enumConstant("TestEnum", "SHARE"));
+        assertRead(r, "\"bond\"", enumConstant("TestEnum", "BOND"));
+        assertRead(r, "\"nonsense\"", enumConstant("TestEnum", "OTHER"));
+        assertRead(r, "null", null);
+    }
+
+    @Test
+    public void testEnumReaderFactoryIntValue() {
+        compile("""
+            @Json
+            public enum TestEnum {
+              A(1), B(2), OTHER(-1);
+            
+              private final int code;
+              TestEnum(int code) { this.code = code; }
+            
+              @JsonReader
+              public static TestEnum fromCode(int code) {
+                for (var v : values()) { if (v.code == code) return v; }
+                return OTHER;
+              }
+            }
+            """);
+        compileResult.assertSuccess();
+
+        JsonReader<Integer> intReader = JsonParser::getIntValue;
+        JsonReader<Object> r = reader("TestEnum", intReader);
+        assertRead(r, "1", enumConstant("TestEnum", "A"));
+        assertRead(r, "99", enumConstant("TestEnum", "OTHER"));
+    }
+
+    @Test
+    public void testEnumFactoryMultipleReadersFails() {
+        var result = compile(List.of(new JsonAnnotationProcessor()), """
+            @Json
+            public enum TestEnum {
+              A, B;
+              @JsonReader public static TestEnum fromValue(String value) { return A; }
+              @JsonReader public static TestEnum fromOther(String value) { return B; }
+            }
+            """);
+        assertThat(result.isFailed()).isTrue();
+    }
+
+    @Test
+    public void testEnumFactoryWrongParameterCountFails() {
+        var result = compile(List.of(new JsonAnnotationProcessor()), """
+            @Json
+            public enum TestEnum {
+              A, B;
+              @JsonReader public static TestEnum fromValue(String value, int extra) { return A; }
+            }
+            """);
+        assertThat(result.isFailed()).isTrue();
+    }
+
+    private void assertRead(JsonReader<Object> reader, String json, Object expected) {
+        try {
+            assertThat(reader.read(json.getBytes(StandardCharsets.UTF_8))).isEqualTo(expected);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void testEnumReaderFactoryTriggersWithoutJsonAnnotation() {
+        compile("""
+            public enum TestEnum {
+              SHARE("share"), OTHER("other");
+            
+              private final String value;
+              TestEnum(String value) { this.value = value; }
+            
+              @JsonReader
+              public static TestEnum fromValue(String value) {
+                return "share".equals(value) ? SHARE : OTHER;
+              }
+            }
+            """);
+        compileResult.assertSuccess();
+
+        JsonReader<Object> r = reader("TestEnum", stringReader);
+        assertRead(r, "\"share\"", enumConstant("TestEnum", "SHARE"));
+        assertRead(r, "\"x\"", enumConstant("TestEnum", "OTHER"));
+    }
+
+    @Test
+    public void testJsonReaderFactoryOnNonEnumFails() {
+        var result = compile(List.of(new JsonAnnotationProcessor()), """
+            public class NotAnEnum {
+              private final String value;
+              public NotAnEnum(String value) { this.value = value; }
+              @JsonReader
+              public static NotAnEnum fromValue(String value) { return new NotAnEnum(value); }
+            }
+            """);
+        assertThat(result.isFailed()).isTrue();
+    }
+
+    @Test
+    public void testEnumClassAndFactoryAnnotationUsesFactory() {
+        compile("""
+            @JsonReader
+            public enum TestEnum {
+              SHARE("share"), OTHER("other");
+            
+              private final String value;
+              TestEnum(String value) { this.value = value; }
+            
+              @JsonReader
+              public static TestEnum fromValue(String value) { return "share".equals(value) ? SHARE : OTHER; }
+            }
+            """);
+        compileResult.assertSuccess();
+
+        JsonReader<Object> r = reader("TestEnum", stringReader);
+        // @JsonReader on BOTH the enum class and the factory method: exactly one factory reader must be
+        // generated. Without the within-round dedup set this crashes with a duplicate-file FilerException
+        // (safeWriteTo rethrows it); without the factory short-circuit "unknown" would throw instead of OTHER.
+        assertRead(r, "\"share\"", enumConstant("TestEnum", "SHARE"));
+        assertRead(r, "\"unknown\"", enumConstant("TestEnum", "OTHER"));
+    }
+
+    @Test
+    public void testEnumFactoryWrongReturnTypeFails() {
+        var result = compile(List.of(new JsonAnnotationProcessor()), """
+            @Json
+            public enum TestEnum {
+              A, B;
+              @JsonReader public static String fromValue(String value) { return value; }
+            }
+            """);
+        assertThat(result.isFailed()).isTrue();
     }
 }

--- a/json/json-annotation-processor/src/test/java/ru/tinkoff/kora/json/annotation/processor/EnumTest.java
+++ b/json/json-annotation-processor/src/test/java/ru/tinkoff/kora/json/annotation/processor/EnumTest.java
@@ -148,7 +148,7 @@ public class EnumTest extends AbstractJsonAnnotationProcessorTest {
         compile("""
                 @Json
                 public enum TestEnum {
-                  SHARE("share"), BOND("bond"), OTHER("other");
+                  VALUE1("value1"), VALUE2("value2"), OTHER("other");
                 
                   private final String value;
                   TestEnum(String value) { this.value = value; }
@@ -163,8 +163,8 @@ public class EnumTest extends AbstractJsonAnnotationProcessorTest {
         compileResult.assertSuccess();
 
         JsonReader<Object> r = reader("TestEnum", stringReader);
-        assertRead(r, "\"share\"", enumConstant("TestEnum", "SHARE"));
-        assertRead(r, "\"bond\"", enumConstant("TestEnum", "BOND"));
+        assertRead(r, "\"value1\"", enumConstant("TestEnum", "VALUE1"));
+        assertRead(r, "\"value2\"", enumConstant("TestEnum", "VALUE2"));
         assertRead(r, "\"nonsense\"", enumConstant("TestEnum", "OTHER"));
         assertRead(r, "null", null);
     }
@@ -174,7 +174,7 @@ public class EnumTest extends AbstractJsonAnnotationProcessorTest {
         compile("""
             @Json
             public enum TestEnum {
-              A(1), B(2), OTHER(-1);
+              VALUE1(1), VALUE2(2), OTHER(-1);
             
               private final int code;
               TestEnum(int code) { this.code = code; }
@@ -190,7 +190,7 @@ public class EnumTest extends AbstractJsonAnnotationProcessorTest {
 
         JsonReader<Integer> intReader = JsonParser::getIntValue;
         JsonReader<Object> r = reader("TestEnum", intReader);
-        assertRead(r, "1", enumConstant("TestEnum", "A"));
+        assertRead(r, "1", enumConstant("TestEnum", "VALUE1"));
         assertRead(r, "99", enumConstant("TestEnum", "OTHER"));
     }
 
@@ -199,9 +199,9 @@ public class EnumTest extends AbstractJsonAnnotationProcessorTest {
         var result = compile(List.of(new JsonAnnotationProcessor()), """
             @Json
             public enum TestEnum {
-              A, B;
-              @JsonReader public static TestEnum fromValue(String value) { return A; }
-              @JsonReader public static TestEnum fromOther(String value) { return B; }
+              VALUE1, VALUE2;
+              @JsonReader public static TestEnum fromValue(String value) { return VALUE1; }
+              @JsonReader public static TestEnum fromOther(String value) { return VALUE2; }
             }
             """);
         assertThat(result.isFailed()).isTrue();
@@ -212,8 +212,8 @@ public class EnumTest extends AbstractJsonAnnotationProcessorTest {
         var result = compile(List.of(new JsonAnnotationProcessor()), """
             @Json
             public enum TestEnum {
-              A, B;
-              @JsonReader public static TestEnum fromValue(String value, int extra) { return A; }
+              VALUE1, VALUE2;
+              @JsonReader public static TestEnum fromValue(String value, int extra) { return VALUE1; }
             }
             """);
         assertThat(result.isFailed()).isTrue();
@@ -224,8 +224,8 @@ public class EnumTest extends AbstractJsonAnnotationProcessorTest {
         var result = compile(List.of(new JsonAnnotationProcessor()), """
             @Json
             public enum TestEnum {
-              A, B;
-              @JsonReader static TestEnum fromValue(String value) { return A; }
+              VALUE1, VALUE2;
+              @JsonReader static TestEnum fromValue(String value) { return VALUE1; }
             }
             """);
         assertThat(result.isFailed()).isTrue();
@@ -236,8 +236,8 @@ public class EnumTest extends AbstractJsonAnnotationProcessorTest {
         var result = compile(List.of(new JsonAnnotationProcessor()), """
             @Json
             public enum TestEnum {
-              A, B;
-              @JsonReader public TestEnum fromValue(String value) { return A; }
+              VALUE1, VALUE2;
+              @JsonReader public TestEnum fromValue(String value) { return VALUE1; }
             }
             """);
         assertThat(result.isFailed()).isTrue();
@@ -255,21 +255,21 @@ public class EnumTest extends AbstractJsonAnnotationProcessorTest {
     public void testEnumReaderFactoryTriggersWithoutJsonAnnotation() {
         compile("""
             public enum TestEnum {
-              SHARE("share"), OTHER("other");
+              VALUE1("value1"), OTHER("other");
             
               private final String value;
               TestEnum(String value) { this.value = value; }
             
               @JsonReader
               public static TestEnum fromValue(String value) {
-                return "share".equals(value) ? SHARE : OTHER;
+                return "value1".equals(value) ? VALUE1 : OTHER;
               }
             }
             """);
         compileResult.assertSuccess();
 
         JsonReader<Object> r = reader("TestEnum", stringReader);
-        assertRead(r, "\"share\"", enumConstant("TestEnum", "SHARE"));
+        assertRead(r, "\"value1\"", enumConstant("TestEnum", "VALUE1"));
         assertRead(r, "\"x\"", enumConstant("TestEnum", "OTHER"));
     }
 
@@ -291,13 +291,13 @@ public class EnumTest extends AbstractJsonAnnotationProcessorTest {
         compile("""
             @JsonReader
             public enum TestEnum {
-              SHARE("share"), OTHER("other");
+              VALUE1("value1"), OTHER("other");
             
               private final String value;
               TestEnum(String value) { this.value = value; }
             
               @JsonReader
-              public static TestEnum fromValue(String value) { return "share".equals(value) ? SHARE : OTHER; }
+              public static TestEnum fromValue(String value) { return "value1".equals(value) ? VALUE1 : OTHER; }
             }
             """);
         compileResult.assertSuccess();
@@ -306,7 +306,7 @@ public class EnumTest extends AbstractJsonAnnotationProcessorTest {
         // @JsonReader on BOTH the enum class and the factory method: exactly one factory reader must be
         // generated. Without the within-round dedup set this crashes with a duplicate-file FilerException
         // (safeWriteTo rethrows it); without the factory short-circuit "unknown" would throw instead of OTHER.
-        assertRead(r, "\"share\"", enumConstant("TestEnum", "SHARE"));
+        assertRead(r, "\"value1\"", enumConstant("TestEnum", "VALUE1"));
         assertRead(r, "\"unknown\"", enumConstant("TestEnum", "OTHER"));
     }
 
@@ -315,7 +315,7 @@ public class EnumTest extends AbstractJsonAnnotationProcessorTest {
         var result = compile(List.of(new JsonAnnotationProcessor()), """
             @Json
             public enum TestEnum {
-              A, B;
+              VALUE1, VALUE2;
               @JsonReader public static String fromValue(String value) { return value; }
             }
             """);
@@ -328,13 +328,13 @@ public class EnumTest extends AbstractJsonAnnotationProcessorTest {
             @ru.tinkoff.kora.common.KoraApp
             public interface TestApp {
               enum TestEnum {
-                SHARE("share"), OTHER("other");
+                VALUE1("value1"), OTHER("other");
             
                 private final String value;
                 TestEnum(String value) { this.value = value; }
             
                 @JsonReader
-                public static TestEnum fromValue(String value) { return "share".equals(value) ? SHARE : OTHER; }
+                public static TestEnum fromValue(String value) { return "value1".equals(value) ? VALUE1 : OTHER; }
               }
             
               default ru.tinkoff.kora.json.common.JsonReader<String> stringReader() { return com.fasterxml.jackson.core.JsonParser::getValueAsString; }

--- a/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/JsonProcessor.kt
+++ b/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/JsonProcessor.kt
@@ -8,10 +8,12 @@ import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.Modifier
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.ksp.writeTo
+import ru.tinkoff.kora.json.ksp.reader.DelegatingJsonReaderGenerator
 import ru.tinkoff.kora.json.ksp.reader.EnumJsonReaderGenerator
 import ru.tinkoff.kora.json.ksp.reader.JsonReaderGenerator
 import ru.tinkoff.kora.json.ksp.reader.ReaderTypeMetaParser
 import ru.tinkoff.kora.json.ksp.reader.SealedInterfaceReaderGenerator
+import ru.tinkoff.kora.json.ksp.writer.DelegatingJsonWriterGenerator
 import ru.tinkoff.kora.json.ksp.writer.EnumJsonWriterGenerator
 import ru.tinkoff.kora.json.ksp.writer.JsonWriterGenerator
 import ru.tinkoff.kora.json.ksp.writer.SealedInterfaceWriterGenerator
@@ -31,6 +33,8 @@ class JsonProcessor(
     private val sealedWriterGenerator = SealedInterfaceWriterGenerator()
     private val enumJsonReaderGenerator = EnumJsonReaderGenerator()
     private val enumJsonWriterGenerator = EnumJsonWriterGenerator()
+    private val delegatingJsonReaderGenerator = DelegatingJsonReaderGenerator()
+    private val delegatingJsonWriterGenerator = DelegatingJsonWriterGenerator()
 
     fun generateReader(jsonClassDeclaration: KSClassDeclaration) {
         val packageElement = jsonClassPackage(jsonClassDeclaration)
@@ -42,6 +46,7 @@ class JsonProcessor(
         val readerType = when {
             isSealed(jsonClassDeclaration) -> sealedReaderGenerator.generateSealedReader(jsonClassDeclaration)
             jsonClassDeclaration.modifiers.contains(Modifier.ENUM) -> enumJsonReaderGenerator.generateEnumReader(jsonClassDeclaration)
+            delegatingJsonReaderGenerator.detectReaderFactory(jsonClassDeclaration) != null -> delegatingJsonReaderGenerator.generate(jsonClassDeclaration)
             else -> {
                 val meta = readerTypeMetaParser.parse(jsonClassDeclaration)
                 readerGenerator.generate(meta)
@@ -65,6 +70,7 @@ class JsonProcessor(
         val writerType = when {
             isSealed(declaration) -> sealedWriterGenerator.generateSealedWriter(declaration)
             declaration.modifiers.contains(Modifier.ENUM) -> enumJsonWriterGenerator.generateEnumWriter(declaration)
+            delegatingJsonWriterGenerator.detectWriterMethod(declaration) != null -> delegatingJsonWriterGenerator.generate(declaration)
             else -> {
                 val meta = writerTypeMetaParser.parse(declaration)
                 writerGenerator.generate(meta)

--- a/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/JsonSymbolProcessor.kt
+++ b/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/JsonSymbolProcessor.kt
@@ -5,6 +5,7 @@ import com.google.devtools.ksp.processing.CodeGenerator
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
 import com.google.devtools.ksp.processing.SymbolProcessorProvider
+import com.google.devtools.ksp.symbol.ClassKind
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
@@ -67,6 +68,16 @@ class JsonSymbolProcessor(
                             if (processedReaders.add(clazz.qualifiedName!!.asString())) {
                                 jsonProcessor.generateReader(clazz)
                             }
+                        } else if (it.isAnnotationPresent(JsonTypes.jsonReaderAnnotation)) {
+                            val enclosingEnum = enclosingEnum(it)
+                            if (enclosingEnum == null) {
+                                kspLogger.error(
+                                    "@JsonReader on a method is supported only for an enum factory method (in the companion object of an enum)",
+                                    it
+                                )
+                            } else if (processedReaders.add(enclosingEnum.qualifiedName!!.asString())) {
+                                jsonProcessor.generateReader(enclosingEnum)
+                            }
                         }
                     }
                 }
@@ -75,6 +86,12 @@ class JsonSymbolProcessor(
             }
         }
         return symbolsToDelay
+    }
+
+    private fun enclosingEnum(function: KSFunctionDeclaration): KSClassDeclaration? {
+        val parent = function.parentDeclaration as? KSClassDeclaration ?: return null
+        val enum = if (parent.isCompanionObject) parent.parentDeclaration as? KSClassDeclaration else parent
+        return if (enum != null && enum.classKind == ClassKind.ENUM_CLASS) enum else null
     }
 }
 

--- a/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/JsonSymbolProcessor.kt
+++ b/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/JsonSymbolProcessor.kt
@@ -79,6 +79,17 @@ class JsonSymbolProcessor(
                                 jsonProcessor.generateReader(enclosingEnum)
                             }
                         }
+                        if (it.isAnnotationPresent(JsonTypes.jsonWriterAnnotation)) {
+                            val enclosingEnum = enclosingEnum(it)
+                            if (enclosingEnum == null) {
+                                kspLogger.error(
+                                    "@JsonWriter on a method is supported only for an enum method (in the companion object of an enum)",
+                                    it
+                                )
+                            } else if (processedWriters.add(enclosingEnum.qualifiedName!!.asString())) {
+                                jsonProcessor.generateWriter(enclosingEnum)
+                            }
+                        }
                     }
                 }
             } catch (e: ProcessingErrorException) {

--- a/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/JsonSymbolProcessor.kt
+++ b/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/JsonSymbolProcessor.kt
@@ -5,7 +5,6 @@ import com.google.devtools.ksp.processing.CodeGenerator
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
 import com.google.devtools.ksp.processing.SymbolProcessorProvider
-import com.google.devtools.ksp.symbol.ClassKind
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
@@ -69,25 +68,25 @@ class JsonSymbolProcessor(
                                 jsonProcessor.generateReader(clazz)
                             }
                         } else if (it.isAnnotationPresent(JsonTypes.jsonReaderAnnotation)) {
-                            val enclosingEnum = enclosingEnum(it)
-                            if (enclosingEnum == null) {
+                            val enclosing = enclosingType(it)
+                            if (enclosing == null) {
                                 kspLogger.error(
-                                    "@JsonReader on a method is supported only for an enum factory method (in the companion object of an enum)",
+                                    "@JsonReader on a method is supported only for a static factory method of a class or enum (in Kotlin: declared in the companion object)",
                                     it
                                 )
-                            } else if (processedReaders.add(enclosingEnum.qualifiedName!!.asString())) {
-                                jsonProcessor.generateReader(enclosingEnum)
+                            } else if (processedReaders.add(enclosing.qualifiedName!!.asString())) {
+                                jsonProcessor.generateReader(enclosing)
                             }
                         }
                         if (it.isAnnotationPresent(JsonTypes.jsonWriterAnnotation)) {
-                            val enclosingEnum = enclosingEnum(it)
-                            if (enclosingEnum == null) {
+                            val enclosing = enclosingType(it)
+                            if (enclosing == null) {
                                 kspLogger.error(
-                                    "@JsonWriter on a method is supported only for an enum method (in the companion object of an enum)",
+                                    "@JsonWriter on a method is supported only for a method of a class or enum",
                                     it
                                 )
-                            } else if (processedWriters.add(enclosingEnum.qualifiedName!!.asString())) {
-                                jsonProcessor.generateWriter(enclosingEnum)
+                            } else if (processedWriters.add(enclosing.qualifiedName!!.asString())) {
+                                jsonProcessor.generateWriter(enclosing)
                             }
                         }
                     }
@@ -99,10 +98,9 @@ class JsonSymbolProcessor(
         return symbolsToDelay
     }
 
-    private fun enclosingEnum(function: KSFunctionDeclaration): KSClassDeclaration? {
+    private fun enclosingType(function: KSFunctionDeclaration): KSClassDeclaration? {
         val parent = function.parentDeclaration as? KSClassDeclaration ?: return null
-        val enum = if (parent.isCompanionObject) parent.parentDeclaration as? KSClassDeclaration else parent
-        return if (enum != null && enum.classKind == ClassKind.ENUM_CLASS) enum else null
+        return if (parent.isCompanionObject) parent.parentDeclaration as? KSClassDeclaration else parent
     }
 }
 

--- a/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/extension/JsonKoraExtension.kt
+++ b/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/extension/JsonKoraExtension.kt
@@ -9,8 +9,10 @@ import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 import ru.tinkoff.kora.json.ksp.*
+import ru.tinkoff.kora.json.ksp.reader.DelegatingJsonReaderGenerator
 import ru.tinkoff.kora.json.ksp.reader.EnumJsonReaderGenerator
 import ru.tinkoff.kora.json.ksp.reader.ReaderTypeMetaParser
+import ru.tinkoff.kora.json.ksp.writer.DelegatingJsonWriterGenerator
 import ru.tinkoff.kora.json.ksp.writer.EnumJsonWriterGenerator
 import ru.tinkoff.kora.json.ksp.writer.WriterTypeMetaParser
 import ru.tinkoff.kora.kora.app.ksp.extension.ExtensionResult
@@ -32,6 +34,8 @@ class JsonKoraExtension(
     private val processor: JsonProcessor = JsonProcessor(resolver, kspLogger, codeGenerator, knownTypes)
     private val enumJsonReaderGenerator = EnumJsonReaderGenerator()
     private val enumJsonWriterGenerator = EnumJsonWriterGenerator()
+    private val delegatingJsonReaderGenerator = DelegatingJsonReaderGenerator()
+    private val delegatingJsonWriterGenerator = DelegatingJsonWriterGenerator()
 
     override fun getDependencyGenerator(resolver: Resolver, type: KSType, tags: Set<String>): (() -> ExtensionResult)? {
         if (tags.isNotEmpty()) return null
@@ -73,6 +77,9 @@ class JsonKoraExtension(
             }
             if (possibleJsonClassDeclaration.classKind != ClassKind.CLASS) {
                 return null
+            }
+            if (delegatingJsonWriterGenerator.detectWriterMethod(possibleJsonClassDeclaration) != null) {
+                return generatedByProcessor(resolver, possibleJsonClassDeclaration, "JsonWriter")
             }
             try {
                 writerTypeMetaParser.parse(possibleJsonClassDeclaration)
@@ -121,6 +128,9 @@ class JsonKoraExtension(
             }
             if (possibleJsonClassDeclaration.classKind != ClassKind.CLASS) {
                 return null
+            }
+            if (delegatingJsonReaderGenerator.detectReaderFactory(possibleJsonClassDeclaration) != null) {
+                return generatedByProcessor(resolver, possibleJsonClassDeclaration, "JsonReader")
             }
             try {
                 readerTypeMetaParser.parse(possibleJsonClassDeclaration)

--- a/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/extension/JsonKoraExtension.kt
+++ b/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/extension/JsonKoraExtension.kt
@@ -140,7 +140,7 @@ class JsonKoraExtension(
             return ExtensionResult.fromConstructor(findDefaultConstructor(resultDeclaration), resultDeclaration)
         }
         val hasJsonConstructor = jsonClass.getConstructors().filter { !it.isPrivate() }.any { it.isAnnotationPresent(JsonTypes.jsonReaderAnnotation) }
-        val hasReaderFactory = jsonClass.modifiers.contains(Modifier.ENUM) && enumJsonReaderGenerator.detectReaderFactory(jsonClass) != null
+        val hasReaderFactory = (jsonClass.modifiers.contains(Modifier.ENUM) || jsonClass.classKind == ClassKind.ENUM_CLASS) && enumJsonReaderGenerator.detectReaderFactory(jsonClass) != null
         if (hasJsonConstructor || hasReaderFactory || jsonClass.isAnnotationPresent(JsonTypes.jsonReaderAnnotation)) {
             // annotation processor will handle that (a @JsonReader factory method on the enum's companion
             // object is discovered independently by JsonSymbolProcessor via resolver.getSymbolsWithAnnotation;

--- a/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/extension/JsonKoraExtension.kt
+++ b/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/extension/JsonKoraExtension.kt
@@ -9,6 +9,7 @@ import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 import ru.tinkoff.kora.json.ksp.*
+import ru.tinkoff.kora.json.ksp.reader.EnumJsonReaderGenerator
 import ru.tinkoff.kora.json.ksp.reader.ReaderTypeMetaParser
 import ru.tinkoff.kora.json.ksp.writer.WriterTypeMetaParser
 import ru.tinkoff.kora.kora.app.ksp.extension.ExtensionResult
@@ -28,6 +29,7 @@ class JsonKoraExtension(
     private val readerTypeMetaParser: ReaderTypeMetaParser = ReaderTypeMetaParser(knownTypes, kspLogger)
     private val writerTypeMetaParser: WriterTypeMetaParser = WriterTypeMetaParser(resolver)
     private val processor: JsonProcessor = JsonProcessor(resolver, kspLogger, codeGenerator, knownTypes)
+    private val enumJsonReaderGenerator = EnumJsonReaderGenerator()
 
     override fun getDependencyGenerator(resolver: Resolver, type: KSType, tags: Set<String>): (() -> ExtensionResult)? {
         if (tags.isNotEmpty()) return null
@@ -138,8 +140,11 @@ class JsonKoraExtension(
             return ExtensionResult.fromConstructor(findDefaultConstructor(resultDeclaration), resultDeclaration)
         }
         val hasJsonConstructor = jsonClass.getConstructors().filter { !it.isPrivate() }.any { it.isAnnotationPresent(JsonTypes.jsonReaderAnnotation) }
-        if (hasJsonConstructor || jsonClass.isAnnotationPresent(JsonTypes.jsonReaderAnnotation)) {
-            // annotation processor will handle that
+        val hasReaderFactory = jsonClass.modifiers.contains(Modifier.ENUM) && enumJsonReaderGenerator.detectReaderFactory(jsonClass) != null
+        if (hasJsonConstructor || hasReaderFactory || jsonClass.isAnnotationPresent(JsonTypes.jsonReaderAnnotation)) {
+            // annotation processor will handle that (a @JsonReader factory method on the enum's companion
+            // object is discovered independently by JsonSymbolProcessor via resolver.getSymbolsWithAnnotation;
+            // generating it here too would race and write the same file twice in the same KSP round)
             return ExtensionResult.RequiresCompilingResult
         }
         processor.generateReader(jsonClass)

--- a/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/extension/JsonKoraExtension.kt
+++ b/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/extension/JsonKoraExtension.kt
@@ -11,6 +11,7 @@ import com.google.devtools.ksp.symbol.*
 import ru.tinkoff.kora.json.ksp.*
 import ru.tinkoff.kora.json.ksp.reader.EnumJsonReaderGenerator
 import ru.tinkoff.kora.json.ksp.reader.ReaderTypeMetaParser
+import ru.tinkoff.kora.json.ksp.writer.EnumJsonWriterGenerator
 import ru.tinkoff.kora.json.ksp.writer.WriterTypeMetaParser
 import ru.tinkoff.kora.kora.app.ksp.extension.ExtensionResult
 import ru.tinkoff.kora.kora.app.ksp.extension.KoraExtension
@@ -30,6 +31,7 @@ class JsonKoraExtension(
     private val writerTypeMetaParser: WriterTypeMetaParser = WriterTypeMetaParser(resolver)
     private val processor: JsonProcessor = JsonProcessor(resolver, kspLogger, codeGenerator, knownTypes)
     private val enumJsonReaderGenerator = EnumJsonReaderGenerator()
+    private val enumJsonWriterGenerator = EnumJsonWriterGenerator()
 
     override fun getDependencyGenerator(resolver: Resolver, type: KSType, tags: Set<String>): (() -> ExtensionResult)? {
         if (tags.isNotEmpty()) return null
@@ -159,8 +161,11 @@ class JsonKoraExtension(
         if (resultDeclaration != null) {
             return ExtensionResult.fromConstructor(findDefaultConstructor(resultDeclaration), resultDeclaration)
         }
-        if (declaration.isAnnotationPresent(JsonTypes.json) || declaration.isAnnotationPresent(JsonTypes.jsonWriterAnnotation)) {
-            // annotation processor will handle that
+        val hasWriterMethod = (declaration.modifiers.contains(Modifier.ENUM) || declaration.classKind == ClassKind.ENUM_CLASS) && enumJsonWriterGenerator.detectWriterMethod(declaration) != null
+        if (declaration.isAnnotationPresent(JsonTypes.json) || declaration.isAnnotationPresent(JsonTypes.jsonWriterAnnotation) || hasWriterMethod) {
+            // annotation processor will handle that (a @JsonWriter method on the enum's companion object is
+            // discovered independently by JsonSymbolProcessor via resolver.getSymbolsWithAnnotation; generating
+            // it here too would race and write the same file twice in the same KSP round)
             return ExtensionResult.RequiresCompilingResult
         }
         processor.generateWriter(declaration)

--- a/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/reader/DelegatingJsonReaderGenerator.kt
+++ b/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/reader/DelegatingJsonReaderGenerator.kt
@@ -1,0 +1,118 @@
+package ru.tinkoff.kora.json.ksp.reader
+
+import com.google.devtools.ksp.getConstructors
+import com.google.devtools.ksp.isConstructor
+import com.google.devtools.ksp.isPublic
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.squareup.kotlinpoet.*
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.ksp.toClassName
+import com.squareup.kotlinpoet.ksp.toTypeName
+import ru.tinkoff.kora.json.ksp.JsonTypes
+import ru.tinkoff.kora.json.ksp.jsonReaderName
+import ru.tinkoff.kora.ksp.common.AnnotationUtils.isAnnotationPresent
+import ru.tinkoff.kora.ksp.common.KspCommonUtils.addOriginatingKSFile
+import ru.tinkoff.kora.ksp.common.KspCommonUtils.generated
+import ru.tinkoff.kora.ksp.common.KspCommonUtils.toTypeName
+import ru.tinkoff.kora.ksp.common.exception.ProcessingErrorException
+
+/**
+ * Generates a delegating [ru.tinkoff.kora.json.common.JsonReader] for a non-enum type that declares a
+ * `@JsonReader`-annotated static factory method `(V) -> T` (Kotlin: in the companion object). The JSON
+ * value is read as `V` and passed to the factory (Jackson `@JsonCreator(mode = DELEGATING)` semantics).
+ */
+class DelegatingJsonReaderGenerator {
+    data class ReaderFactory(val methodName: String, val valueType: TypeName)
+
+    fun generate(declaration: KSClassDeclaration): TypeSpec {
+        val className = declaration.toClassName()
+        val typeName = declaration.toTypeName()
+        val factory = detectReaderFactory(declaration)
+            ?: throw ProcessingErrorException("No @JsonReader factory method found on ${declaration.simpleName.asString()}", declaration)
+        val valueReaderType = JsonTypes.jsonReader.parameterizedBy(factory.valueType)
+
+        return TypeSpec.classBuilder(declaration.jsonReaderName())
+            .generated(DelegatingJsonReaderGenerator::class)
+            .addSuperinterface(JsonTypes.jsonReader.parameterizedBy(typeName))
+            .primaryConstructor(
+                FunSpec.constructorBuilder()
+                    .addParameter("valueReader", valueReaderType)
+                    .build()
+            )
+            .addProperty(
+                PropertySpec.builder("valueReader", valueReaderType, KModifier.PRIVATE)
+                    .initializer("valueReader")
+                    .build()
+            )
+            .addFunction(
+                FunSpec.builder("read")
+                    .addModifiers(KModifier.OVERRIDE)
+                    .addParameter("parser", JsonTypes.jsonParser)
+                    .returns(typeName.copy(nullable = true))
+                    .addStatement("val value = valueReader.read(parser) ?: return null")
+                    .addStatement("return %T.%N(value)", className, factory.methodName)
+                    .build()
+            )
+            .addOriginatingKSFile(declaration)
+            .build()
+    }
+
+    fun detectReaderFactory(declaration: KSClassDeclaration): ReaderFactory? {
+        val companion = declaration.declarations
+            .filterIsInstance<KSClassDeclaration>()
+            .firstOrNull { it.isCompanionObject }
+        val companionFactories = companion
+            ?.getAllFunctions()
+            ?.filter { it.isAnnotationPresent(JsonTypes.jsonReaderAnnotation) }
+            ?.toList()
+            .orEmpty()
+        val bodyFactories = declaration.getAllFunctions()
+            .filter { !it.isConstructor() }
+            .filter { it.isAnnotationPresent(JsonTypes.jsonReaderAnnotation) }
+            .toList()
+        val factories = companionFactories + bodyFactories
+        if (factories.isEmpty()) {
+            return null
+        }
+        if (factories.size > 1) {
+            throw ProcessingErrorException(
+                "Type ${declaration.simpleName.asString()} has multiple @JsonReader factory methods, only one is allowed",
+                factories[1]
+            )
+        }
+        val factory = factories[0]
+        if (factory !in companionFactories) {
+            throw ProcessingErrorException(
+                "@JsonReader factory method must be static (declared in the companion object)",
+                factory
+            )
+        }
+        if (!factory.isPublic()) {
+            throw ProcessingErrorException("@JsonReader factory method must be public", factory)
+        }
+        if (factory.parameters.size != 1) {
+            throw ProcessingErrorException(
+                "@JsonReader factory method must have exactly one parameter, got ${factory.parameters.size}",
+                factory
+            )
+        }
+        val returnDeclaration = factory.returnType?.resolve()?.declaration
+        if (returnDeclaration != declaration) {
+            throw ProcessingErrorException(
+                "@JsonReader factory method must return ${declaration.simpleName.asString()}",
+                factory
+            )
+        }
+        val hasReaderConstructor = declaration.getConstructors().any {
+            it.isAnnotationPresent(JsonTypes.jsonReaderAnnotation) || it.isAnnotationPresent(JsonTypes.json)
+        }
+        if (hasReaderConstructor) {
+            throw ProcessingErrorException(
+                "Type ${declaration.simpleName.asString()} has both a @JsonReader factory method and a @JsonReader/@Json constructor — only one is allowed",
+                factory
+            )
+        }
+        val valueType = factory.parameters[0].type.toTypeName()
+        return ReaderFactory(factory.simpleName.asString(), valueType)
+    }
+}

--- a/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/reader/DelegatingJsonReaderGenerator.kt
+++ b/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/reader/DelegatingJsonReaderGenerator.kt
@@ -22,7 +22,7 @@ import ru.tinkoff.kora.ksp.common.exception.ProcessingErrorException
  * value is read as `V` and passed to the factory (Jackson `@JsonCreator(mode = DELEGATING)` semantics).
  */
 class DelegatingJsonReaderGenerator {
-    data class ReaderFactory(val methodName: String, val valueType: TypeName)
+    data class ReaderFactory(val methodName: String, val valueType: TypeName, val valueNullable: Boolean)
 
     fun generate(declaration: KSClassDeclaration): TypeSpec {
         val className = declaration.toClassName()
@@ -30,6 +30,20 @@ class DelegatingJsonReaderGenerator {
         val factory = detectReaderFactory(declaration)
             ?: throw ProcessingErrorException("No @JsonReader factory method found on ${declaration.simpleName.asString()}", declaration)
         val valueReaderType = JsonTypes.jsonReader.parameterizedBy(factory.valueType)
+
+        val readFun = FunSpec.builder("read")
+            .addModifiers(KModifier.OVERRIDE)
+            .addParameter("parser", JsonTypes.jsonParser)
+            .returns(typeName.copy(nullable = true))
+            .apply {
+                if (factory.valueNullable) {
+                    addStatement("return %T.%N(valueReader.read(parser))", className, factory.methodName)
+                } else {
+                    addStatement("val value = valueReader.read(parser) ?: return null")
+                    addStatement("return %T.%N(value)", className, factory.methodName)
+                }
+            }
+            .build()
 
         return TypeSpec.classBuilder(declaration.jsonReaderName())
             .generated(DelegatingJsonReaderGenerator::class)
@@ -44,15 +58,7 @@ class DelegatingJsonReaderGenerator {
                     .initializer("valueReader")
                     .build()
             )
-            .addFunction(
-                FunSpec.builder("read")
-                    .addModifiers(KModifier.OVERRIDE)
-                    .addParameter("parser", JsonTypes.jsonParser)
-                    .returns(typeName.copy(nullable = true))
-                    .addStatement("val value = valueReader.read(parser) ?: return null")
-                    .addStatement("return %T.%N(value)", className, factory.methodName)
-                    .build()
-            )
+            .addFunction(readFun)
             .addOriginatingKSFile(declaration)
             .build()
     }
@@ -113,6 +119,7 @@ class DelegatingJsonReaderGenerator {
             )
         }
         val valueType = factory.parameters[0].type.toTypeName()
-        return ReaderFactory(factory.simpleName.asString(), valueType)
+        val valueNullable = factory.parameters[0].type.resolve().isMarkedNullable
+        return ReaderFactory(factory.simpleName.asString(), valueType, valueNullable)
     }
 }

--- a/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/reader/EnumJsonReaderGenerator.kt
+++ b/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/reader/EnumJsonReaderGenerator.kt
@@ -12,18 +12,26 @@ import ru.tinkoff.kora.ksp.common.AnnotationUtils.isAnnotationPresent
 import ru.tinkoff.kora.ksp.common.KspCommonUtils.addOriginatingKSFile
 import ru.tinkoff.kora.ksp.common.KspCommonUtils.generated
 import ru.tinkoff.kora.ksp.common.KspCommonUtils.toTypeName
+import ru.tinkoff.kora.ksp.common.exception.ProcessingErrorException
 
 class EnumJsonReaderGenerator {
     fun generateEnumReader(jsonClassDeclaration: KSClassDeclaration): TypeSpec {
         val className = jsonClassDeclaration.toClassName()
         val typeName = jsonClassDeclaration.toTypeName()
+
+        val factory = detectReaderFactory(jsonClassDeclaration)
+        if (factory != null) {
+            return generateFactoryReader(jsonClassDeclaration, className, typeName, factory)
+        }
+
         val enumType = detectValueType(jsonClassDeclaration)
 
         val typeBuilder = TypeSpec.classBuilder(jsonClassDeclaration.jsonReaderName())
             .generated(JsonReaderGenerator::class)
-            .primaryConstructor(FunSpec.constructorBuilder()
-                .addParameter("valueReader", JsonTypes.jsonReader.parameterizedBy(enumType.type))
-                .build()
+            .primaryConstructor(
+                FunSpec.constructorBuilder()
+                    .addParameter("valueReader", JsonTypes.jsonReader.parameterizedBy(enumType.type))
+                    .build()
             )
             .addSuperinterface(
                 JsonTypes.jsonReader.parameterizedBy(typeName),
@@ -31,6 +39,75 @@ class EnumJsonReaderGenerator {
             )
             .addOriginatingKSFile(jsonClassDeclaration)
         return typeBuilder.build()
+    }
+
+    data class ReaderFactory(val methodName: String, val valueType: TypeName)
+
+    private fun generateFactoryReader(
+        declaration: KSClassDeclaration,
+        className: com.squareup.kotlinpoet.ClassName,
+        typeName: TypeName,
+        factory: ReaderFactory
+    ): TypeSpec {
+        val valueReaderType = JsonTypes.jsonReader.parameterizedBy(factory.valueType)
+        return TypeSpec.classBuilder(declaration.jsonReaderName())
+            .generated(JsonReaderGenerator::class)
+            .addSuperinterface(JsonTypes.jsonReader.parameterizedBy(typeName))
+            .primaryConstructor(
+                FunSpec.constructorBuilder()
+                    .addParameter("valueReader", valueReaderType)
+                    .build()
+            )
+            .addProperty(
+                PropertySpec.builder("valueReader", valueReaderType, KModifier.PRIVATE)
+                    .initializer("valueReader")
+                    .build()
+            )
+            .addFunction(
+                FunSpec.builder("read")
+                    .addModifiers(KModifier.OVERRIDE)
+                    .addParameter("parser", JsonTypes.jsonParser)
+                    .returns(typeName.copy(nullable = true))
+                    .addStatement("val value = valueReader.read(parser) ?: return null")
+                    .addStatement("return %T.%N(value)", className, factory.methodName)
+                    .build()
+            )
+            .addOriginatingKSFile(declaration)
+            .build()
+    }
+
+    fun detectReaderFactory(enumDeclaration: KSClassDeclaration): ReaderFactory? {
+        val companion = enumDeclaration.declarations
+            .filterIsInstance<KSClassDeclaration>()
+            .firstOrNull { it.isCompanionObject } ?: return null
+        val factories = companion.getAllFunctions()
+            .filter { it.isPublic() && it.isAnnotationPresent(JsonTypes.jsonReaderAnnotation) }
+            .toList()
+        if (factories.isEmpty()) {
+            return null
+        }
+        if (factories.size > 1) {
+            throw ProcessingErrorException(
+                "Enum ${enumDeclaration.simpleName.asString()} has multiple @JsonReader factory methods, only one is allowed",
+                enumDeclaration
+            )
+        }
+        val factory = factories[0]
+        if (factory.parameters.size != 1) {
+            throw ProcessingErrorException(
+                "@JsonReader factory method must have exactly one parameter, got ${factory.parameters.size}",
+                factory
+            )
+        }
+        val returnDeclaration = factory.returnType?.resolve()?.declaration
+        if (returnDeclaration != enumDeclaration) {
+            throw ProcessingErrorException(
+                "@JsonReader factory method must return ${enumDeclaration.simpleName.asString()}",
+                factory
+            )
+        }
+        val valueType = factory.parameters[0].type.toTypeName()
+        return ReaderFactory(factory.simpleName.asString(), valueType)
     }
 
     data class EnumValue(val type: TypeName, val accessor: String)

--- a/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/reader/EnumJsonReaderGenerator.kt
+++ b/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/reader/EnumJsonReaderGenerator.kt
@@ -41,7 +41,7 @@ class EnumJsonReaderGenerator {
         return typeBuilder.build()
     }
 
-    data class ReaderFactory(val methodName: String, val valueType: TypeName)
+    data class ReaderFactory(val methodName: String, val valueType: TypeName, val valueNullable: Boolean)
 
     private fun generateFactoryReader(
         declaration: KSClassDeclaration,
@@ -50,6 +50,19 @@ class EnumJsonReaderGenerator {
         factory: ReaderFactory
     ): TypeSpec {
         val valueReaderType = JsonTypes.jsonReader.parameterizedBy(factory.valueType)
+        val readFun = FunSpec.builder("read")
+            .addModifiers(KModifier.OVERRIDE)
+            .addParameter("parser", JsonTypes.jsonParser)
+            .returns(typeName.copy(nullable = true))
+            .apply {
+                if (factory.valueNullable) {
+                    addStatement("return %T.%N(valueReader.read(parser))", className, factory.methodName)
+                } else {
+                    addStatement("val value = valueReader.read(parser) ?: return null")
+                    addStatement("return %T.%N(value)", className, factory.methodName)
+                }
+            }
+            .build()
         return TypeSpec.classBuilder(declaration.jsonReaderName())
             .generated(JsonReaderGenerator::class)
             .addSuperinterface(JsonTypes.jsonReader.parameterizedBy(typeName))
@@ -63,15 +76,7 @@ class EnumJsonReaderGenerator {
                     .initializer("valueReader")
                     .build()
             )
-            .addFunction(
-                FunSpec.builder("read")
-                    .addModifiers(KModifier.OVERRIDE)
-                    .addParameter("parser", JsonTypes.jsonParser)
-                    .returns(typeName.copy(nullable = true))
-                    .addStatement("val value = valueReader.read(parser) ?: return null")
-                    .addStatement("return %T.%N(value)", className, factory.methodName)
-                    .build()
-            )
+            .addFunction(readFun)
             .addOriginatingKSFile(declaration)
             .build()
     }
@@ -125,7 +130,8 @@ class EnumJsonReaderGenerator {
             )
         }
         val valueType = factory.parameters[0].type.toTypeName()
-        return ReaderFactory(factory.simpleName.asString(), valueType)
+        val valueNullable = factory.parameters[0].type.resolve().isMarkedNullable
+        return ReaderFactory(factory.simpleName.asString(), valueType, valueNullable)
     }
 
     data class EnumValue(val type: TypeName, val accessor: String)

--- a/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/reader/EnumJsonReaderGenerator.kt
+++ b/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/reader/EnumJsonReaderGenerator.kt
@@ -95,7 +95,7 @@ class EnumJsonReaderGenerator {
         if (factories.size > 1) {
             throw ProcessingErrorException(
                 "Enum ${enumDeclaration.simpleName.asString()} has multiple @JsonReader factory methods, only one is allowed",
-                enumDeclaration
+                factories[1]
             )
         }
         val factory = factories[0]

--- a/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/reader/EnumJsonReaderGenerator.kt
+++ b/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/reader/EnumJsonReaderGenerator.kt
@@ -45,7 +45,7 @@ class EnumJsonReaderGenerator {
 
     private fun generateFactoryReader(
         declaration: KSClassDeclaration,
-        className: com.squareup.kotlinpoet.ClassName,
+        className: ClassName,
         typeName: TypeName,
         factory: ReaderFactory
     ): TypeSpec {

--- a/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/reader/EnumJsonReaderGenerator.kt
+++ b/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/reader/EnumJsonReaderGenerator.kt
@@ -79,10 +79,16 @@ class EnumJsonReaderGenerator {
     fun detectReaderFactory(enumDeclaration: KSClassDeclaration): ReaderFactory? {
         val companion = enumDeclaration.declarations
             .filterIsInstance<KSClassDeclaration>()
-            .firstOrNull { it.isCompanionObject } ?: return null
-        val factories = companion.getAllFunctions()
-            .filter { it.isPublic() && it.isAnnotationPresent(JsonTypes.jsonReaderAnnotation) }
+            .firstOrNull { it.isCompanionObject }
+        val companionFactories = companion
+            ?.getAllFunctions()
+            ?.filter { it.isAnnotationPresent(JsonTypes.jsonReaderAnnotation) }
+            ?.toList()
+            .orEmpty()
+        val bodyFactories = enumDeclaration.getAllFunctions()
+            .filter { it.isAnnotationPresent(JsonTypes.jsonReaderAnnotation) }
             .toList()
+        val factories = companionFactories + bodyFactories
         if (factories.isEmpty()) {
             return null
         }
@@ -93,6 +99,18 @@ class EnumJsonReaderGenerator {
             )
         }
         val factory = factories[0]
+        if (factory !in companionFactories) {
+            throw ProcessingErrorException(
+                "@JsonReader factory method must be declared in the enum's companion object",
+                factory
+            )
+        }
+        if (!factory.isPublic()) {
+            throw ProcessingErrorException(
+                "@JsonReader factory method must be public",
+                factory
+            )
+        }
         if (factory.parameters.size != 1) {
             throw ProcessingErrorException(
                 "@JsonReader factory method must have exactly one parameter, got ${factory.parameters.size}",

--- a/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/writer/DelegatingJsonWriterGenerator.kt
+++ b/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/writer/DelegatingJsonWriterGenerator.kt
@@ -1,0 +1,127 @@
+package ru.tinkoff.kora.json.ksp.writer
+
+import com.google.devtools.ksp.isPublic
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.squareup.kotlinpoet.*
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.ksp.toClassName
+import com.squareup.kotlinpoet.ksp.toTypeName
+import ru.tinkoff.kora.json.ksp.JsonTypes
+import ru.tinkoff.kora.json.ksp.jsonWriterName
+import ru.tinkoff.kora.ksp.common.AnnotationUtils.isAnnotationPresent
+import ru.tinkoff.kora.ksp.common.KspCommonUtils.addOriginatingKSFile
+import ru.tinkoff.kora.ksp.common.KspCommonUtils.generated
+import ru.tinkoff.kora.ksp.common.KspCommonUtils.toTypeName
+import ru.tinkoff.kora.ksp.common.exception.ProcessingErrorException
+
+/**
+ * Generates a delegating [ru.tinkoff.kora.json.common.JsonWriter] for a non-enum type that declares a
+ * `@JsonWriter`-annotated method producing the single JSON value the type is serialized as
+ * (Jackson `@JsonValue` semantics). The method is either an instance method `() -> V` or a static
+ * method (Kotlin: companion object) `(T) -> V`.
+ */
+class DelegatingJsonWriterGenerator {
+    data class WriterValue(val valueType: TypeName, val accessor: String, val isStatic: Boolean)
+
+    fun generate(declaration: KSClassDeclaration): TypeSpec {
+        val className = declaration.toClassName()
+        val typeName = declaration.toTypeName()
+        val value = detectWriterMethod(declaration)
+            ?: throw ProcessingErrorException("No @JsonWriter method found on ${declaration.simpleName.asString()}", declaration)
+        val valueWriterType = JsonTypes.jsonWriter.parameterizedBy(value.valueType)
+
+        val extracted = if (value.isStatic) {
+            CodeBlock.of("%T.%N(_object)", className, value.accessor)
+        } else {
+            CodeBlock.of("_object.%N()", value.accessor)
+        }
+        val body = CodeBlock.builder()
+            .beginControlFlow("if (_object == null)")
+            .addStatement("_gen.writeNull()")
+            .addStatement("return")
+            .endControlFlow()
+            .addStatement("this.valueWriter.write(_gen, %L)", extracted)
+            .build()
+
+        return TypeSpec.classBuilder(declaration.jsonWriterName())
+            .generated(DelegatingJsonWriterGenerator::class)
+            .addSuperinterface(JsonTypes.jsonWriter.parameterizedBy(typeName))
+            .primaryConstructor(
+                FunSpec.constructorBuilder()
+                    .addParameter("valueWriter", valueWriterType)
+                    .build()
+            )
+            .addProperty(
+                PropertySpec.builder("valueWriter", valueWriterType, KModifier.PRIVATE)
+                    .initializer("valueWriter")
+                    .build()
+            )
+            .addFunction(
+                FunSpec.builder("write")
+                    .addModifiers(KModifier.PUBLIC, KModifier.OVERRIDE)
+                    .addParameter("_gen", JsonTypes.jsonGenerator)
+                    .addParameter("_object", typeName.copy(nullable = true))
+                    .addCode(body)
+                    .build()
+            )
+            .addOriginatingKSFile(declaration)
+            .build()
+    }
+
+    fun detectWriterMethod(declaration: KSClassDeclaration): WriterValue? {
+        val companion = declaration.declarations
+            .filterIsInstance<KSClassDeclaration>()
+            .firstOrNull { it.isCompanionObject }
+        val companionMethods = companion
+            ?.getAllFunctions()
+            ?.filter { it.isAnnotationPresent(JsonTypes.jsonWriterAnnotation) }
+            ?.toList()
+            .orEmpty()
+        val bodyMethods = declaration.getAllFunctions()
+            .filter { it.isAnnotationPresent(JsonTypes.jsonWriterAnnotation) }
+            .toList()
+        val methods = companionMethods + bodyMethods
+        if (methods.isEmpty()) {
+            return null
+        }
+        if (methods.size > 1) {
+            throw ProcessingErrorException(
+                "Type ${declaration.simpleName.asString()} has multiple @JsonWriter methods, only one is allowed",
+                methods[1]
+            )
+        }
+        val method = methods[0]
+        if (!method.isPublic()) {
+            throw ProcessingErrorException("@JsonWriter method must be public", method)
+        }
+        val returnDeclaration = method.returnType?.resolve()?.declaration
+        if (returnDeclaration == null || returnDeclaration.qualifiedName?.asString() == "kotlin.Unit") {
+            throw ProcessingErrorException("@JsonWriter method must return a value", method)
+        }
+        val valueType = method.returnType!!.toTypeName()
+        val isStatic = method in companionMethods
+        if (isStatic) {
+            if (method.parameters.size != 1) {
+                throw ProcessingErrorException(
+                    "@JsonWriter static method must have exactly one parameter (the value type), got ${method.parameters.size}",
+                    method
+                )
+            }
+            val paramDeclaration = method.parameters[0].type.resolve().declaration
+            if (paramDeclaration != declaration) {
+                throw ProcessingErrorException(
+                    "@JsonWriter static method parameter must be of type ${declaration.simpleName.asString()}",
+                    method
+                )
+            }
+        } else {
+            if (method.parameters.isNotEmpty()) {
+                throw ProcessingErrorException(
+                    "@JsonWriter instance method must have no parameters, got ${method.parameters.size}",
+                    method
+                )
+            }
+        }
+        return WriterValue(valueType, method.simpleName.asString(), isStatic)
+    }
+}

--- a/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/writer/EnumJsonWriterGenerator.kt
+++ b/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/writer/EnumJsonWriterGenerator.kt
@@ -19,6 +19,12 @@ class EnumJsonWriterGenerator {
         val typeName = jsonClassDeclaration.toTypeName()
         val enumType = detectValueType(jsonClassDeclaration)
 
+        val extractor = if (enumType.isStatic) {
+            CodeBlock.of("{ e: %T -> %T.%N(e) }", className, className, enumType.accessor)
+        } else {
+            CodeBlock.of("%T::%N", className, enumType.accessor)
+        }
+
         val typeBuilder = TypeSpec.classBuilder(jsonClassDeclaration.jsonWriterName())
             .generated(JsonWriterGenerator::class)
             .primaryConstructor(
@@ -28,16 +34,17 @@ class EnumJsonWriterGenerator {
             )
             .addSuperinterface(
                 JsonTypes.jsonWriter.parameterizedBy(typeName),
-                CodeBlock.of("%T(%T.values(), %T::%N, valueWriter)", JsonTypes.enumJsonWriter, className, className, enumType.accessor)
+                CodeBlock.of("%T(%T.values(), %L, valueWriter)", JsonTypes.enumJsonWriter, className, extractor)
             )
             .addOriginatingKSFile(jsonClassDeclaration)
         return typeBuilder.build()
     }
 
 
-    data class EnumValue(val type: TypeName, val accessor: String)
+    data class EnumValue(val type: TypeName, val accessor: String, val isStatic: Boolean = false)
 
     fun detectValueType(typeElement: KSClassDeclaration): EnumValue {
+        detectWriterMethod(typeElement)?.let { return it }
         for (function in typeElement.getAllFunctions()) {
             if (function.isPublic() && function.parameters.isEmpty() && function.isAnnotationPresent(JsonTypes.json)) {
                 val typeName = function.returnType!!.toTypeName()
@@ -46,5 +53,57 @@ class EnumJsonWriterGenerator {
         }
         val typeName = String::class.asTypeName()
         return EnumValue(typeName, "toString")
+    }
+
+    fun detectWriterMethod(enumDeclaration: KSClassDeclaration): EnumValue? {
+        val companion = enumDeclaration.declarations
+            .filterIsInstance<KSClassDeclaration>()
+            .firstOrNull { it.isCompanionObject }
+        val companionMethods = companion
+            ?.getAllFunctions()
+            ?.filter { it.isAnnotationPresent(JsonTypes.jsonWriterAnnotation) }
+            ?.toList()
+            .orEmpty()
+        val bodyMethods = enumDeclaration.getAllFunctions()
+            .filter { it.isAnnotationPresent(JsonTypes.jsonWriterAnnotation) }
+            .toList()
+        val methods = companionMethods + bodyMethods
+        if (methods.isEmpty()) {
+            return null
+        }
+        if (methods.size > 1) {
+            throw ru.tinkoff.kora.ksp.common.exception.ProcessingErrorException(
+                "Enum ${enumDeclaration.simpleName.asString()} has multiple @JsonWriter methods, only one is allowed",
+                methods[1]
+            )
+        }
+        val method = methods[0]
+        if (method !in companionMethods) {
+            throw ru.tinkoff.kora.ksp.common.exception.ProcessingErrorException(
+                "@JsonWriter enum method must be static (declared in the enum's companion object)",
+                method
+            )
+        }
+        if (!method.isPublic()) {
+            throw ru.tinkoff.kora.ksp.common.exception.ProcessingErrorException("@JsonWriter method must be public", method)
+        }
+        if (method.parameters.size != 1) {
+            throw ru.tinkoff.kora.ksp.common.exception.ProcessingErrorException(
+                "@JsonWriter method must have exactly one parameter, got ${method.parameters.size}",
+                method
+            )
+        }
+        val paramDeclaration = method.parameters[0].type.resolve().declaration
+        if (paramDeclaration != enumDeclaration) {
+            throw ru.tinkoff.kora.ksp.common.exception.ProcessingErrorException(
+                "@JsonWriter method parameter must be of type ${enumDeclaration.simpleName.asString()}",
+                method
+            )
+        }
+        val returnDeclaration = method.returnType?.resolve()?.declaration
+        if (returnDeclaration == null || returnDeclaration.qualifiedName?.asString() == "kotlin.Unit") {
+            throw ru.tinkoff.kora.ksp.common.exception.ProcessingErrorException("@JsonWriter method must return a value", method)
+        }
+        return EnumValue(method.returnType!!.toTypeName(), method.simpleName.asString(), isStatic = true)
     }
 }

--- a/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/writer/EnumJsonWriterGenerator.kt
+++ b/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/writer/EnumJsonWriterGenerator.kt
@@ -12,6 +12,7 @@ import ru.tinkoff.kora.ksp.common.AnnotationUtils.isAnnotationPresent
 import ru.tinkoff.kora.ksp.common.KspCommonUtils.addOriginatingKSFile
 import ru.tinkoff.kora.ksp.common.KspCommonUtils.generated
 import ru.tinkoff.kora.ksp.common.KspCommonUtils.toTypeName
+import ru.tinkoff.kora.ksp.common.exception.ProcessingErrorException
 
 class EnumJsonWriterGenerator {
     fun generateEnumWriter(jsonClassDeclaration: KSClassDeclaration): TypeSpec {
@@ -72,37 +73,37 @@ class EnumJsonWriterGenerator {
             return null
         }
         if (methods.size > 1) {
-            throw ru.tinkoff.kora.ksp.common.exception.ProcessingErrorException(
+            throw ProcessingErrorException(
                 "Enum ${enumDeclaration.simpleName.asString()} has multiple @JsonWriter methods, only one is allowed",
                 methods[1]
             )
         }
         val method = methods[0]
         if (method !in companionMethods) {
-            throw ru.tinkoff.kora.ksp.common.exception.ProcessingErrorException(
+            throw ProcessingErrorException(
                 "@JsonWriter enum method must be static (declared in the enum's companion object)",
                 method
             )
         }
         if (!method.isPublic()) {
-            throw ru.tinkoff.kora.ksp.common.exception.ProcessingErrorException("@JsonWriter method must be public", method)
+            throw ProcessingErrorException("@JsonWriter method must be public", method)
         }
         if (method.parameters.size != 1) {
-            throw ru.tinkoff.kora.ksp.common.exception.ProcessingErrorException(
+            throw ProcessingErrorException(
                 "@JsonWriter method must have exactly one parameter, got ${method.parameters.size}",
                 method
             )
         }
         val paramDeclaration = method.parameters[0].type.resolve().declaration
         if (paramDeclaration != enumDeclaration) {
-            throw ru.tinkoff.kora.ksp.common.exception.ProcessingErrorException(
+            throw ProcessingErrorException(
                 "@JsonWriter method parameter must be of type ${enumDeclaration.simpleName.asString()}",
                 method
             )
         }
         val returnDeclaration = method.returnType?.resolve()?.declaration
         if (returnDeclaration == null || returnDeclaration.qualifiedName?.asString() == "kotlin.Unit") {
-            throw ru.tinkoff.kora.ksp.common.exception.ProcessingErrorException("@JsonWriter method must return a value", method)
+            throw ProcessingErrorException("@JsonWriter method must return a value", method)
         }
         return EnumValue(method.returnType!!.toTypeName(), method.simpleName.asString(), isStatic = true)
     }

--- a/json/json-symbol-processor/src/test/kotlin/ru/tinkoff/kora/json/ksp/DelegatingValueTest.kt
+++ b/json/json-symbol-processor/src/test/kotlin/ru/tinkoff/kora/json/ksp/DelegatingValueTest.kt
@@ -1,0 +1,214 @@
+package ru.tinkoff.kora.json.ksp
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.core.JsonParser
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import ru.tinkoff.kora.json.common.JsonReader
+import ru.tinkoff.kora.json.common.JsonWriter
+
+class DelegatingValueTest : AbstractJsonSymbolProcessorTest() {
+    private val stringReader = JsonReader<String> { p: JsonParser -> p.valueAsString }
+    private val stringWriter = JsonWriter<String> { g: JsonGenerator, v: String? -> g.writeString(v) }
+    private val longReader = JsonReader<Long> { p: JsonParser -> p.longValue }
+    private val longWriter = JsonWriter<Long> { g: JsonGenerator, v: Long? -> g.writeNumber(v!!) }
+
+    private fun newObject(name: String, argType: Class<*>, arg: Any?): Any =
+        compileResult.classLoader.loadClass("${testPackage()}.$name").getDeclaredConstructor(argType).newInstance(arg)
+
+    @Test
+    fun testDelegatingInstanceWriterAndFactoryReader() {
+        compile(
+            """
+            class UserId(val id: Long) {
+              @JsonWriter fun toJson(): Long = id
+              companion object { @JsonReader fun of(v: Long): UserId = UserId(v) }
+              override fun equals(other: Any?) = other is UserId && other.id == id
+              override fun hashCode() = id.hashCode()
+            }
+            """.trimIndent()
+        )
+        compileResult.assertSuccess()
+        val mapper = mapper("UserId", listOf(longReader), listOf(longWriter))
+        mapper.assert(newObject("UserId", Long::class.javaPrimitiveType!!, 42L), "42")
+    }
+
+    @Test
+    fun testDelegatingStaticWriter() {
+        compile(
+            """
+            class UserId(val id: Long) {
+              companion object {
+                @JsonReader fun of(v: Long): UserId = UserId(v)
+                @JsonWriter fun toJson(u: UserId): Long = u.id
+              }
+              override fun equals(other: Any?) = other is UserId && other.id == id
+              override fun hashCode() = id.hashCode()
+            }
+            """.trimIndent()
+        )
+        compileResult.assertSuccess()
+        val mapper = mapper("UserId", listOf(longReader), listOf(longWriter))
+        mapper.assert(newObject("UserId", Long::class.javaPrimitiveType!!, 7L), "7")
+    }
+
+    @Test
+    fun testDelegatingStringValue() {
+        compile(
+            """
+            class Sku(val code: String) {
+              @JsonWriter fun toJson(): String = code
+              companion object { @JsonReader fun parse(v: String): Sku = Sku(v) }
+              override fun equals(other: Any?) = other is Sku && other.code == code
+              override fun hashCode() = code.hashCode()
+            }
+            """.trimIndent()
+        )
+        compileResult.assertSuccess()
+        val mapper = mapper("Sku", listOf(stringReader), listOf(stringWriter))
+        mapper.assert(newObject("Sku", String::class.java, "ABC"), "\"ABC\"")
+    }
+
+    @Test
+    fun testDelegatingWriterWinsOverJsonProperties() {
+        compile(
+            """
+            @Json
+            class Money(val amount: Long, val currency: String) {
+              @JsonWriter fun toJson(): Long = amount
+            }
+            """.trimIndent()
+        )
+        compileResult.assertSuccess()
+        val w = writer("Money", longWriter)
+        val money = compileResult.classLoader.loadClass("${testPackage()}.Money")
+            .getDeclaredConstructor(Long::class.javaPrimitiveType, String::class.java)
+            .newInstance(100L, "USD")
+        w.assertWrite(money, "100")
+    }
+
+    @Test
+    fun testDelegatingReaderFromExtension() {
+        compile(
+            """
+            @ru.tinkoff.kora.common.KoraApp
+            interface TestApp {
+              class UserId(val id: Long) {
+                companion object { @JsonReader fun of(v: Long): UserId = UserId(v) }
+              }
+
+              fun longReader(): ru.tinkoff.kora.json.common.JsonReader<Long> = ru.tinkoff.kora.json.common.JsonReader<Long> { p -> p.longValue }
+              fun longWriter(): ru.tinkoff.kora.json.common.JsonWriter<Long> = ru.tinkoff.kora.json.common.JsonWriter<Long> { g, v -> g.writeNumber(v!!) }
+
+              @Root
+              fun root(r: ru.tinkoff.kora.json.common.JsonReader<UserId>) = ""
+            }
+            """.trimIndent()
+        )
+        compileResult.assertSuccess()
+        Assertions.assertThat(reader("TestApp_UserId", longReader)).isNotNull()
+    }
+
+    @Test
+    fun testDelegatingWriterFromExtension() {
+        compile(
+            """
+            @ru.tinkoff.kora.common.KoraApp
+            interface TestApp {
+              class UserId(val id: Long) {
+                @JsonWriter fun toJson(): Long = id
+              }
+
+              fun longReader(): ru.tinkoff.kora.json.common.JsonReader<Long> = ru.tinkoff.kora.json.common.JsonReader<Long> { p -> p.longValue }
+              fun longWriter(): ru.tinkoff.kora.json.common.JsonWriter<Long> = ru.tinkoff.kora.json.common.JsonWriter<Long> { g, v -> g.writeNumber(v!!) }
+
+              @Root
+              fun root(r: ru.tinkoff.kora.json.common.JsonWriter<UserId>) = ""
+            }
+            """.trimIndent()
+        )
+        compileResult.assertSuccess()
+        Assertions.assertThat(writer("TestApp_UserId", longWriter)).isNotNull()
+    }
+
+    @Test
+    fun testMultipleWriterMethodsFails() {
+        val res = compile0(
+            """
+            class UserId(val id: Long) {
+              @JsonWriter fun a(): Long = id
+              @JsonWriter fun b(): Long = id
+            }
+            """.trimIndent()
+        )
+        Assertions.assertThat(res.isFailed()).isTrue()
+        Assertions.assertThat(res.messages).anyMatch { it.contains("multiple @JsonWriter methods") }
+    }
+
+    @Test
+    fun testWriterInstanceMethodWithParamsFails() {
+        val res = compile0(
+            """
+            class UserId(val id: Long) {
+              @JsonWriter fun toJson(x: Int): Long = id
+            }
+            """.trimIndent()
+        )
+        Assertions.assertThat(res.isFailed()).isTrue()
+        Assertions.assertThat(res.messages).anyMatch { it.contains("must have no parameters") }
+    }
+
+    @Test
+    fun testReaderFactoryNotStaticFails() {
+        val res = compile0(
+            """
+            class UserId(val id: Long) {
+              @JsonReader fun of(v: Long): UserId = UserId(v)
+            }
+            """.trimIndent()
+        )
+        Assertions.assertThat(res.isFailed()).isTrue()
+        Assertions.assertThat(res.messages).anyMatch { it.contains("must be static") }
+    }
+
+    @Test
+    fun testReaderFactoryWrongReturnFails() {
+        val res = compile0(
+            """
+            class UserId(val id: Long) {
+              companion object { @JsonReader fun of(v: Long): String = v.toString() }
+            }
+            """.trimIndent()
+        )
+        Assertions.assertThat(res.isFailed()).isTrue()
+        Assertions.assertThat(res.messages).anyMatch { it.contains("must return") }
+    }
+
+    @Test
+    fun testFactoryAndReaderConstructorConflictFails() {
+        val res = compile0(
+            """
+            class UserId @JsonReader constructor(val id: Long) {
+              companion object { @JsonReader fun of(v: Long): UserId = UserId(v) }
+            }
+            """.trimIndent()
+        )
+        Assertions.assertThat(res.isFailed()).isTrue()
+        Assertions.assertThat(res.messages).anyMatch { it.contains("only one is allowed") }
+    }
+
+    @Test
+    fun testWriterOnTopLevelFunctionFails() {
+        val res = compile0(
+            """
+            class Dummy {
+            }
+
+            @JsonWriter
+            fun topLevel(): Long = 1L
+            """.trimIndent()
+        )
+        Assertions.assertThat(res.isFailed()).isTrue()
+        Assertions.assertThat(res.messages).anyMatch { it.contains("supported only for a method of a class or enum") }
+    }
+}

--- a/json/json-symbol-processor/src/test/kotlin/ru/tinkoff/kora/json/ksp/DelegatingValueTest.kt
+++ b/json/json-symbol-processor/src/test/kotlin/ru/tinkoff/kora/json/ksp/DelegatingValueTest.kt
@@ -12,6 +12,8 @@ class DelegatingValueTest : AbstractJsonSymbolProcessorTest() {
     private val stringWriter = JsonWriter<String> { g: JsonGenerator, v: String? -> g.writeString(v) }
     private val longReader = JsonReader<Long> { p: JsonParser -> p.longValue }
     private val longWriter = JsonWriter<Long> { g: JsonGenerator, v: Long? -> g.writeNumber(v!!) }
+    private val nStringReader = JsonReader<String?> { p: JsonParser -> p.valueAsString }
+    private val nStringWriter = JsonWriter<String?> { g: JsonGenerator, v: String? -> if (v == null) g.writeNull() else g.writeString(v) }
 
     private fun newObject(name: String, argType: Class<*>, arg: Any?): Any =
         compileResult.classLoader.loadClass("${testPackage()}.$name").getDeclaredConstructor(argType).newInstance(arg)
@@ -67,6 +69,24 @@ class DelegatingValueTest : AbstractJsonSymbolProcessorTest() {
         compileResult.assertSuccess()
         val mapper = mapper("Sku", listOf(stringReader), listOf(stringWriter))
         mapper.assert(newObject("Sku", String::class.java, "ABC"), "\"ABC\"")
+    }
+
+    @Test
+    fun testNullableValueRoundTrip() {
+        compile(
+            """
+            class Box(val v: String?) {
+              @JsonWriter fun toJson(): String? = v
+              companion object { @JsonReader fun of(x: String?): Box = Box(x) }
+              override fun equals(other: Any?) = other is Box && other.v == v
+              override fun hashCode() = v?.hashCode() ?: 0
+            }
+            """.trimIndent()
+        )
+        compileResult.assertSuccess()
+        val mapper = mapper("Box", listOf(nStringReader), listOf(nStringWriter))
+        mapper.assert(newObject("Box", String::class.java, "a"), "\"a\"")
+        mapper.assert(newObject("Box", String::class.java, null), "null")
     }
 
     @Test

--- a/json/json-symbol-processor/src/test/kotlin/ru/tinkoff/kora/json/ksp/EnumTest.kt
+++ b/json/json-symbol-processor/src/test/kotlin/ru/tinkoff/kora/json/ksp/EnumTest.kt
@@ -586,4 +586,57 @@ class EnumTest : AbstractJsonSymbolProcessorTest() {
         Assertions.assertThat(compileResult.isFailed()).isTrue()
         Assertions.assertThat(compileResult.messages).anyMatch { it.contains("must return a value") }
     }
+
+    @Test
+    fun testEnumWriterMethodTriggersWithoutJsonAnnotation() {
+        compile(
+            """
+            enum class TestEnum(val value: String) {
+              VALUE1("value1"), VALUE2("value2");
+              companion object {
+                @JsonWriter fun toValue(e: TestEnum): String = e.value
+              }
+            }
+            """.trimIndent()
+        )
+        compileResult.assertSuccess()
+
+        val w = writer("TestEnum", stringWriter)
+        w.assertWrite(enumConstant("TestEnum", "VALUE1"), "\"value1\"")
+        w.assertWrite(enumConstant("TestEnum", "VALUE2"), "\"value2\"")
+    }
+
+    @Test
+    fun testJsonWriterMethodOnNonEnumFails() {
+        compile0(
+            listOf(JsonSymbolProcessorProvider()), """
+            class NotAnEnum(val value: String) {
+              companion object {
+                @JsonWriter fun toValue(x: NotAnEnum): String = x.value
+              }
+            }
+            """.trimIndent()
+        )
+        Assertions.assertThat(compileResult.isFailed()).isTrue()
+        Assertions.assertThat(compileResult.messages).anyMatch { it.contains("supported only for an enum") }
+    }
+
+    @Test
+    fun testEnumClassAndWriterMethodDedup() {
+        compile(
+            """
+            @JsonWriter
+            enum class TestEnum(val value: String) {
+              VALUE1("value1"), VALUE2("value2");
+              companion object {
+                @JsonWriter fun toValue(e: TestEnum): String = e.value
+              }
+            }
+            """.trimIndent()
+        )
+        compileResult.assertSuccess()
+
+        val w = writer("TestEnum", stringWriter)
+        w.assertWrite(enumConstant("TestEnum", "VALUE1"), "\"value1\"")
+    }
 }

--- a/json/json-symbol-processor/src/test/kotlin/ru/tinkoff/kora/json/ksp/EnumTest.kt
+++ b/json/json-symbol-processor/src/test/kotlin/ru/tinkoff/kora/json/ksp/EnumTest.kt
@@ -395,4 +395,195 @@ class EnumTest : AbstractJsonSymbolProcessorTest() {
         Assertions.assertThat(compileResult.isFailed()).isTrue()
         Assertions.assertThat(compileResult.messages).anyMatch { it.contains("must be public") }
     }
+
+    @Test
+    fun testEnumWriterFromStaticMethod() {
+        compile(
+            """
+            @Json
+            enum class TestEnum(val value: String) {
+              VALUE1("value1"), VALUE2("value2");
+              companion object {
+                @JsonWriter
+                fun toValue(e: TestEnum): String = e.value
+              }
+            }
+            """.trimIndent()
+        )
+        compileResult.assertSuccess()
+
+        val w = writer("TestEnum", stringWriter)
+        w.assertWrite(enumConstant("TestEnum", "VALUE1"), "\"value1\"")
+        w.assertWrite(enumConstant("TestEnum", "VALUE2"), "\"value2\"")
+    }
+
+    @Test
+    fun testEnumWriterStaticMethodIntValue() {
+        compile(
+            """
+            @Json
+            enum class TestEnum(val code: Int) {
+              VALUE1(1), VALUE2(2);
+              companion object {
+                @JsonWriter
+                fun toCode(e: TestEnum): Int = e.code
+              }
+            }
+            """.trimIndent()
+        )
+        compileResult.assertSuccess()
+
+        val intWriter = JsonWriter { g: JsonGenerator, v: Int? -> g.writeNumber(v!!) }
+        val w = writer("TestEnum", intWriter)
+        w.assertWrite(enumConstant("TestEnum", "VALUE1"), "1")
+        w.assertWrite(enumConstant("TestEnum", "VALUE2"), "2")
+    }
+
+    @Test
+    fun testEnumWriterStaticMethodOverridesJsonGetter() {
+        compile(
+            """
+            @Json
+            enum class TestEnum {
+              VALUE1, VALUE2;
+              @Json fun jsonValue(): String = "getter-" + name
+              companion object {
+                @JsonWriter
+                fun toValue(e: TestEnum): String = e.name.lowercase()
+              }
+            }
+            """.trimIndent()
+        )
+        compileResult.assertSuccess()
+
+        val w = writer("TestEnum", stringWriter)
+        w.assertWrite(enumConstant("TestEnum", "VALUE1"), "\"value1\"")
+        w.assertWrite(enumConstant("TestEnum", "VALUE2"), "\"value2\"")
+    }
+
+    @Test
+    fun testEnumReaderFactoryAndWriterMethod() {
+        compile(
+            """
+            @Json
+            enum class TestEnum(val value: String) {
+              VALUE1("value1"), VALUE2("value2"), OTHER("other");
+              companion object {
+                private val byValue = entries.associateBy { it.value }
+                @JsonReader fun fromValue(value: String): TestEnum = byValue[value] ?: OTHER
+                @JsonWriter fun toValue(e: TestEnum): String = e.value
+              }
+            }
+            """.trimIndent()
+        )
+        compileResult.assertSuccess()
+
+        val r = reader("TestEnum", stringReader)
+        val w = writer("TestEnum", stringWriter)
+        r.assertRead("\"value1\"", enumConstant("TestEnum", "VALUE1"))
+        r.assertRead("\"nonsense\"", enumConstant("TestEnum", "OTHER"))
+        w.assertWrite(enumConstant("TestEnum", "VALUE1"), "\"value1\"")
+        w.assertWrite(enumConstant("TestEnum", "OTHER"), "\"other\"")
+    }
+
+    @Test
+    fun testEnumWriterMultipleMethodsFails() {
+        compile0(
+            listOf(JsonSymbolProcessorProvider()), """
+            @Json
+            enum class TestEnum(val value: String) {
+              VALUE1("value1"), VALUE2("value2");
+              companion object {
+                @JsonWriter fun toValue(e: TestEnum): String = e.value
+                @JsonWriter fun toOther(e: TestEnum): String = e.name
+              }
+            }
+            """.trimIndent()
+        )
+        Assertions.assertThat(compileResult.isFailed()).isTrue()
+        Assertions.assertThat(compileResult.messages).anyMatch { it.contains("multiple @JsonWriter") }
+    }
+
+    @Test
+    fun testEnumWriterMethodNotStaticFails() {
+        compile0(
+            listOf(JsonSymbolProcessorProvider()), """
+            @Json
+            enum class TestEnum(val value: String) {
+              VALUE1("value1"), VALUE2("value2");
+              @JsonWriter fun toValue(e: TestEnum): String = e.value
+            }
+            """.trimIndent()
+        )
+        Assertions.assertThat(compileResult.isFailed()).isTrue()
+        Assertions.assertThat(compileResult.messages).anyMatch { it.contains("must be static") }
+    }
+
+    @Test
+    fun testEnumWriterMethodNonPublicFails() {
+        compile0(
+            listOf(JsonSymbolProcessorProvider()), """
+            @Json
+            enum class TestEnum(val value: String) {
+              VALUE1("value1"), VALUE2("value2");
+              companion object {
+                @JsonWriter private fun toValue(e: TestEnum): String = e.value
+              }
+            }
+            """.trimIndent()
+        )
+        Assertions.assertThat(compileResult.isFailed()).isTrue()
+        Assertions.assertThat(compileResult.messages).anyMatch { it.contains("must be public") }
+    }
+
+    @Test
+    fun testEnumWriterMethodWrongParameterCountFails() {
+        compile0(
+            listOf(JsonSymbolProcessorProvider()), """
+            @Json
+            enum class TestEnum(val value: String) {
+              VALUE1("value1"), VALUE2("value2");
+              companion object {
+                @JsonWriter fun toValue(e: TestEnum, extra: Int): String = e.value
+              }
+            }
+            """.trimIndent()
+        )
+        Assertions.assertThat(compileResult.isFailed()).isTrue()
+        Assertions.assertThat(compileResult.messages).anyMatch { it.contains("exactly one parameter") }
+    }
+
+    @Test
+    fun testEnumWriterMethodWrongParameterTypeFails() {
+        compile0(
+            listOf(JsonSymbolProcessorProvider()), """
+            @Json
+            enum class TestEnum(val value: String) {
+              VALUE1("value1"), VALUE2("value2");
+              companion object {
+                @JsonWriter fun toValue(x: Int): String = x.toString()
+              }
+            }
+            """.trimIndent()
+        )
+        Assertions.assertThat(compileResult.isFailed()).isTrue()
+        Assertions.assertThat(compileResult.messages).anyMatch { it.contains("must be of type") }
+    }
+
+    @Test
+    fun testEnumWriterMethodUnitReturnFails() {
+        compile0(
+            listOf(JsonSymbolProcessorProvider()), """
+            @Json
+            enum class TestEnum(val value: String) {
+              VALUE1("value1"), VALUE2("value2");
+              companion object {
+                @JsonWriter fun toValue(e: TestEnum) { }
+              }
+            }
+            """.trimIndent()
+        )
+        Assertions.assertThat(compileResult.isFailed()).isTrue()
+        Assertions.assertThat(compileResult.messages).anyMatch { it.contains("must return a value") }
+    }
 }

--- a/json/json-symbol-processor/src/test/kotlin/ru/tinkoff/kora/json/ksp/EnumTest.kt
+++ b/json/json-symbol-processor/src/test/kotlin/ru/tinkoff/kora/json/ksp/EnumTest.kt
@@ -294,23 +294,6 @@ class EnumTest : AbstractJsonSymbolProcessorTest() {
     }
 
     @Test
-    fun testJsonReaderFactoryOnNonEnumFails() {
-        compile0(
-            listOf(JsonSymbolProcessorProvider()), """
-            class NotAnEnum(val value: String) {
-              companion object {
-                @JsonReader
-                fun fromValue(value: String): NotAnEnum = NotAnEnum(value)
-              }
-            }
-            """.trimIndent()
-        )
-        Assertions.assertThat(compileResult.isFailed()).isTrue()
-        Assertions.assertThat(compileResult.messages)
-            .anyMatch { it.contains("supported only for an enum") }
-    }
-
-    @Test
     fun testEnumClassAndFactoryAnnotationUsesFactory() {
         compile(
             """
@@ -604,21 +587,6 @@ class EnumTest : AbstractJsonSymbolProcessorTest() {
         val w = writer("TestEnum", stringWriter)
         w.assertWrite(enumConstant("TestEnum", "VALUE1"), "\"value1\"")
         w.assertWrite(enumConstant("TestEnum", "VALUE2"), "\"value2\"")
-    }
-
-    @Test
-    fun testJsonWriterMethodOnNonEnumFails() {
-        compile0(
-            listOf(JsonSymbolProcessorProvider()), """
-            class NotAnEnum(val value: String) {
-              companion object {
-                @JsonWriter fun toValue(x: NotAnEnum): String = x.value
-              }
-            }
-            """.trimIndent()
-        )
-        Assertions.assertThat(compileResult.isFailed()).isTrue()
-        Assertions.assertThat(compileResult.messages).anyMatch { it.contains("supported only for an enum") }
     }
 
     @Test

--- a/json/json-symbol-processor/src/test/kotlin/ru/tinkoff/kora/json/ksp/EnumTest.kt
+++ b/json/json-symbol-processor/src/test/kotlin/ru/tinkoff/kora/json/ksp/EnumTest.kt
@@ -230,7 +230,8 @@ class EnumTest : AbstractJsonSymbolProcessorTest() {
 
     @Test
     fun testEnumFactoryWrongReturnTypeFails() {
-        compile0(listOf(JsonSymbolProcessorProvider()), """
+        compile0(
+            listOf(JsonSymbolProcessorProvider()), """
             @Json
             enum class TestEnum(val value: String) {
               A("a"), B("b");
@@ -238,9 +239,71 @@ class EnumTest : AbstractJsonSymbolProcessorTest() {
                 @JsonReader fun fromValue(value: String): String = value
               }
             }
-            """.trimIndent())
+            """.trimIndent()
+        )
         Assertions.assertThat(compileResult.isFailed()).isTrue()
         Assertions.assertThat(compileResult.messages).anyMatch { it.contains("must return") }
+    }
+
+    @Test
+    fun testEnumReaderFactoryTriggersWithoutJsonAnnotation() {
+        compile(
+            """
+            enum class TestEnum(val value: String) {
+              SHARE("share"), OTHER("other");
+              companion object {
+                @JsonReader
+                fun fromValue(value: String): TestEnum = if (value == "share") SHARE else OTHER
+              }
+            }
+            """.trimIndent()
+        )
+        compileResult.assertSuccess()
+
+        val r = reader("TestEnum", stringReader)
+        r.assertRead("\"share\"", enumConstant("TestEnum", "SHARE"))
+        r.assertRead("\"x\"", enumConstant("TestEnum", "OTHER"))
+    }
+
+    @Test
+    fun testJsonReaderFactoryOnNonEnumFails() {
+        compile0(
+            listOf(JsonSymbolProcessorProvider()), """
+            class NotAnEnum(val value: String) {
+              companion object {
+                @JsonReader
+                fun fromValue(value: String): NotAnEnum = NotAnEnum(value)
+              }
+            }
+            """.trimIndent()
+        )
+        org.assertj.core.api.Assertions.assertThat(compileResult.isFailed()).isTrue()
+        org.assertj.core.api.Assertions.assertThat(compileResult.messages)
+            .anyMatch { it.contains("supported only for an enum") }
+    }
+
+    @Test
+    fun testEnumClassAndFactoryAnnotationUsesFactory() {
+        compile(
+            """
+            @JsonReader
+            enum class TestEnum(val value: String) {
+              SHARE("share"), OTHER("other");
+              companion object {
+                @JsonReader
+                fun fromValue(value: String): TestEnum = if (value == "share") SHARE else OTHER
+              }
+            }
+            """.trimIndent()
+        )
+        compileResult.assertSuccess()
+
+        val r = reader("TestEnum", stringReader)
+        // @JsonReader on BOTH the enum class and the factory method: the factory reader must be
+        // generated (unknown -> OTHER), not the default map-based reader (which would throw), and
+        // exactly once — the class-branch and method-branch must dedup via processedReaders.
+        r.assertRead("\"share\"", enumConstant("TestEnum", "SHARE"))
+        r.assertRead("\"unknown\"", enumConstant("TestEnum", "OTHER"))
     }
 
     private fun enumConstant(className: String, name: String): Any {

--- a/json/json-symbol-processor/src/test/kotlin/ru/tinkoff/kora/json/ksp/EnumTest.kt
+++ b/json/json-symbol-processor/src/test/kotlin/ru/tinkoff/kora/json/ksp/EnumTest.kt
@@ -370,4 +370,29 @@ class EnumTest : AbstractJsonSymbolProcessorTest() {
         compileResult.assertSuccess()
         Assertions.assertThat(reader("TestEnum", stringReader)).isNotNull()
     }
+
+    @Test
+    fun testMalformedFactoryFromExtensionFails() {
+        compile0(
+            listOf(ru.tinkoff.kora.kora.app.ksp.KoraAppProcessorProvider(), JsonSymbolProcessorProvider()), """
+        enum class TestEnum(val value: String) {
+          VALUE1("value1"), VALUE2("value2");
+          companion object {
+            @JsonReader
+            private fun fromValue(value: String): TestEnum = VALUE1
+          }
+        }
+        """.trimIndent(), """
+        @ru.tinkoff.kora.common.KoraApp
+        interface TestApp {
+          fun stringReader(): ru.tinkoff.kora.json.common.JsonReader<String> = ru.tinkoff.kora.json.common.JsonReader<String> { obj -> obj.valueAsString }
+
+          @Root
+          fun root(r: ru.tinkoff.kora.json.common.JsonReader<TestEnum>) = ""
+        }
+        """.trimIndent()
+        )
+        Assertions.assertThat(compileResult.isFailed()).isTrue()
+        Assertions.assertThat(compileResult.messages).anyMatch { it.contains("must be public") }
+    }
 }

--- a/json/json-symbol-processor/src/test/kotlin/ru/tinkoff/kora/json/ksp/EnumTest.kt
+++ b/json/json-symbol-processor/src/test/kotlin/ru/tinkoff/kora/json/ksp/EnumTest.kt
@@ -277,8 +277,8 @@ class EnumTest : AbstractJsonSymbolProcessorTest() {
             }
             """.trimIndent()
         )
-        org.assertj.core.api.Assertions.assertThat(compileResult.isFailed()).isTrue()
-        org.assertj.core.api.Assertions.assertThat(compileResult.messages)
+        Assertions.assertThat(compileResult.isFailed()).isTrue()
+        Assertions.assertThat(compileResult.messages)
             .anyMatch { it.contains("supported only for an enum") }
     }
 

--- a/json/json-symbol-processor/src/test/kotlin/ru/tinkoff/kora/json/ksp/EnumTest.kt
+++ b/json/json-symbol-processor/src/test/kotlin/ru/tinkoff/kora/json/ksp/EnumTest.kt
@@ -205,8 +205,8 @@ class EnumTest : AbstractJsonSymbolProcessorTest() {
             }
             """.trimIndent()
         )
-        org.assertj.core.api.Assertions.assertThat(compileResult.isFailed()).isTrue()
-        org.assertj.core.api.Assertions.assertThat(compileResult.messages)
+        Assertions.assertThat(compileResult.isFailed()).isTrue()
+        Assertions.assertThat(compileResult.messages)
             .anyMatch { it.contains("multiple @JsonReader factory") }
     }
 
@@ -223,9 +223,24 @@ class EnumTest : AbstractJsonSymbolProcessorTest() {
             }
             """.trimIndent()
         )
-        org.assertj.core.api.Assertions.assertThat(compileResult.isFailed()).isTrue()
-        org.assertj.core.api.Assertions.assertThat(compileResult.messages)
+        Assertions.assertThat(compileResult.isFailed()).isTrue()
+        Assertions.assertThat(compileResult.messages)
             .anyMatch { it.contains("exactly one parameter") }
+    }
+
+    @Test
+    fun testEnumFactoryWrongReturnTypeFails() {
+        compile0(listOf(JsonSymbolProcessorProvider()), """
+            @Json
+            enum class TestEnum(val value: String) {
+              A("a"), B("b");
+              companion object {
+                @JsonReader fun fromValue(value: String): String = value
+              }
+            }
+            """.trimIndent())
+        Assertions.assertThat(compileResult.isFailed()).isTrue()
+        Assertions.assertThat(compileResult.messages).anyMatch { it.contains("must return") }
     }
 
     private fun enumConstant(className: String, name: String): Any {

--- a/json/json-symbol-processor/src/test/kotlin/ru/tinkoff/kora/json/ksp/EnumTest.kt
+++ b/json/json-symbol-processor/src/test/kotlin/ru/tinkoff/kora/json/ksp/EnumTest.kt
@@ -294,6 +294,26 @@ class EnumTest : AbstractJsonSymbolProcessorTest() {
     }
 
     @Test
+    fun testEnumFactoryNullableValue() {
+        compile(
+            """
+            @Json
+            enum class TestEnum(val value: String) {
+              VALUE1("value1"), UNKNOWN("unknown");
+              companion object {
+                @JsonReader fun fromValue(v: String?): TestEnum = if (v == "value1") VALUE1 else UNKNOWN
+              }
+            }
+            """.trimIndent()
+        )
+        compileResult.assertSuccess()
+        val nsr = JsonReader<String?> { p: JsonParser -> p.valueAsString }
+        val r = reader("TestEnum", nsr)
+        r.assertRead("\"value1\"", enumConstant("TestEnum", "VALUE1"))
+        r.assertRead("null", enumConstant("TestEnum", "UNKNOWN"))
+    }
+
+    @Test
     fun testEnumClassAndFactoryAnnotationUsesFactory() {
         compile(
             """

--- a/json/json-symbol-processor/src/test/kotlin/ru/tinkoff/kora/json/ksp/EnumTest.kt
+++ b/json/json-symbol-processor/src/test/kotlin/ru/tinkoff/kora/json/ksp/EnumTest.kt
@@ -13,13 +13,15 @@ class EnumTest : AbstractJsonSymbolProcessorTest() {
 
     @Test
     fun testEnum() {
-        compile("""
+        compile(
+            """
             @Json
             enum class TestEnum {
               VALUE1, VALUE2
             }
             
-            """.trimIndent())
+            """.trimIndent()
+        )
         compileResult.assertSuccess()
         val mapper = mapper("TestEnum", listOf(stringReader), listOf(stringWriter))
         mapper.assert(enumConstant("TestEnum", "VALUE1"), "\"VALUE1\"")
@@ -28,7 +30,8 @@ class EnumTest : AbstractJsonSymbolProcessorTest() {
 
     @Test
     fun testEnumWithCustomJsonValue() {
-        compile("""
+        compile(
+            """
             @Json
             enum class TestEnum {
               VALUE1, VALUE2;
@@ -36,7 +39,8 @@ class EnumTest : AbstractJsonSymbolProcessorTest() {
               @Json
               fun intValue() = ordinal
             }
-            """.trimIndent())
+            """.trimIndent()
+        )
         compileResult.assertSuccess()
         val intReader = JsonReader { obj: JsonParser -> obj.intValue }
         val intWriter = JsonWriter { obj: JsonGenerator, v: Int? -> obj.writeNumber(v!!) }
@@ -48,7 +52,8 @@ class EnumTest : AbstractJsonSymbolProcessorTest() {
 
     @Test
     fun testReaderFromExtension() {
-        compile("""
+        compile(
+            """
             @ru.tinkoff.kora.common.KoraApp
             interface TestApp {
               enum class TestEnum {
@@ -62,14 +67,16 @@ class EnumTest : AbstractJsonSymbolProcessorTest() {
               fun root(r: ru.tinkoff.kora.json.common.JsonReader<TestEnum>) = ""
             }
             
-            """.trimIndent())
+            """.trimIndent()
+        )
         compileResult.assertSuccess()
         Assertions.assertThat(reader("TestApp_TestEnum", stringReader)).isNotNull()
     }
 
     @Test
     fun testWriterFromExtension() {
-        compile("""
+        compile(
+            """
             @ru.tinkoff.kora.common.KoraApp
             interface TestApp {
               enum class TestEnum {
@@ -83,14 +90,16 @@ class EnumTest : AbstractJsonSymbolProcessorTest() {
               fun root(r: ru.tinkoff.kora.json.common.JsonWriter<TestEnum>) = ""
             }
             
-            """.trimIndent())
+            """.trimIndent()
+        )
         compileResult.assertSuccess()
         Assertions.assertThat(writer("TestApp_TestEnum", stringWriter)).isNotNull()
     }
 
     @Test
     fun testAnnotationProcessedReaderFromExtension() {
-        compile("""
+        compile(
+            """
             @ru.tinkoff.kora.common.KoraApp
             public interface TestApp {
               @Json
@@ -105,14 +114,16 @@ class EnumTest : AbstractJsonSymbolProcessorTest() {
               fun root(r: ru.tinkoff.kora.json.common.JsonReader<TestEnum>) = ""
             }
             
-            """.trimIndent())
+            """.trimIndent()
+        )
         compileResult.assertSuccess()
         Assertions.assertThat(reader("TestApp_TestEnum", stringReader)).isNotNull()
     }
 
     @Test
     fun testAnnotationProcessedWriterFromExtension() {
-        compile("""
+        compile(
+            """
             @ru.tinkoff.kora.common.KoraApp
             interface TestApp {
               @Json
@@ -127,9 +138,94 @@ class EnumTest : AbstractJsonSymbolProcessorTest() {
               fun root(r: ru.tinkoff.kora.json.common.JsonWriter<TestEnum>) = ""
             }
             
-            """.trimIndent())
+            """.trimIndent()
+        )
         compileResult.assertSuccess()
         Assertions.assertThat(writer("TestApp_TestEnum", stringWriter)).isNotNull()
+    }
+
+    @Test
+    fun testEnumReaderFromFactoryMethod() {
+        compile(
+            """
+            @Json
+            enum class TestEnum(val value: String) {
+              SHARE("share"), BOND("bond"), OTHER("other");
+              companion object {
+                private val byValue = entries.associateBy { it.value }
+                @JsonReader
+                fun fromValue(value: String): TestEnum = byValue[value] ?: OTHER
+              }
+            }
+            """.trimIndent()
+        )
+        compileResult.assertSuccess()
+
+        val r = reader("TestEnum", stringReader)
+        r.assertRead("\"share\"", enumConstant("TestEnum", "SHARE"))
+        r.assertRead("\"bond\"", enumConstant("TestEnum", "BOND"))
+        r.assertRead("\"nonsense\"", enumConstant("TestEnum", "OTHER"))
+        r.assertRead("null", null)
+    }
+
+    @Test
+    fun testEnumReaderFactoryIntValue() {
+        compile(
+            """
+            @Json
+            enum class TestEnum(val code: Int) {
+              A(1), B(2), OTHER(-1);
+              companion object {
+                @JsonReader
+                fun fromCode(code: Int): TestEnum = entries.firstOrNull { it.code == code } ?: OTHER
+              }
+            }
+            """.trimIndent()
+        )
+        compileResult.assertSuccess()
+
+        val intReader = JsonReader { p: JsonParser -> p.intValue }
+        val r = reader("TestEnum", intReader)
+        r.assertRead("1", enumConstant("TestEnum", "A"))
+        r.assertRead("2", enumConstant("TestEnum", "B"))
+        r.assertRead("99", enumConstant("TestEnum", "OTHER"))
+    }
+
+    @Test
+    fun testEnumFactoryMultipleReadersFails() {
+        compile0(
+            listOf(JsonSymbolProcessorProvider()), """
+            @Json
+            enum class TestEnum(val value: String) {
+              A("a"), B("b");
+              companion object {
+                @JsonReader fun fromValue(value: String): TestEnum = A
+                @JsonReader fun fromOther(value: String): TestEnum = B
+              }
+            }
+            """.trimIndent()
+        )
+        org.assertj.core.api.Assertions.assertThat(compileResult.isFailed()).isTrue()
+        org.assertj.core.api.Assertions.assertThat(compileResult.messages)
+            .anyMatch { it.contains("multiple @JsonReader factory") }
+    }
+
+    @Test
+    fun testEnumFactoryWrongParameterCountFails() {
+        compile0(
+            listOf(JsonSymbolProcessorProvider()), """
+            @Json
+            enum class TestEnum(val value: String) {
+              A("a"), B("b");
+              companion object {
+                @JsonReader fun fromValue(value: String, extra: Int): TestEnum = A
+              }
+            }
+            """.trimIndent()
+        )
+        org.assertj.core.api.Assertions.assertThat(compileResult.isFailed()).isTrue()
+        org.assertj.core.api.Assertions.assertThat(compileResult.messages)
+            .anyMatch { it.contains("exactly one parameter") }
     }
 
     private fun enumConstant(className: String, name: String): Any {

--- a/json/json-symbol-processor/src/test/kotlin/ru/tinkoff/kora/json/ksp/EnumTest.kt
+++ b/json/json-symbol-processor/src/test/kotlin/ru/tinkoff/kora/json/ksp/EnumTest.kt
@@ -639,4 +639,52 @@ class EnumTest : AbstractJsonSymbolProcessorTest() {
         val w = writer("TestEnum", stringWriter)
         w.assertWrite(enumConstant("TestEnum", "VALUE1"), "\"value1\"")
     }
+
+    @Test
+    fun testWriterMethodFromExtension() {
+        compile0(
+            listOf(ru.tinkoff.kora.kora.app.ksp.KoraAppProcessorProvider(), JsonSymbolProcessorProvider()), """
+        enum class TestEnum(val value: String) {
+          VALUE1("value1"), VALUE2("value2");
+          companion object {
+            @JsonWriter fun toValue(e: TestEnum): String = e.value
+          }
+        }
+        """.trimIndent(), """
+        @ru.tinkoff.kora.common.KoraApp
+        interface TestApp {
+          fun stringWriter(): ru.tinkoff.kora.json.common.JsonWriter<String> = ru.tinkoff.kora.json.common.JsonWriter<String> { obj, text -> obj.writeString(text) }
+
+          @Root
+          fun root(w: ru.tinkoff.kora.json.common.JsonWriter<TestEnum>) = ""
+        }
+        """.trimIndent()
+        )
+        compileResult.assertSuccess()
+        Assertions.assertThat(writer("TestEnum", stringWriter)).isNotNull()
+    }
+
+    @Test
+    fun testMalformedWriterMethodFromExtensionFails() {
+        compile0(
+            listOf(ru.tinkoff.kora.kora.app.ksp.KoraAppProcessorProvider(), JsonSymbolProcessorProvider()), """
+        enum class TestEnum(val value: String) {
+          VALUE1("value1"), VALUE2("value2");
+          companion object {
+            @JsonWriter private fun toValue(e: TestEnum): String = e.value
+          }
+        }
+        """.trimIndent(), """
+        @ru.tinkoff.kora.common.KoraApp
+        interface TestApp {
+          fun stringWriter(): ru.tinkoff.kora.json.common.JsonWriter<String> = ru.tinkoff.kora.json.common.JsonWriter<String> { obj, text -> obj.writeString(text) }
+
+          @Root
+          fun root(w: ru.tinkoff.kora.json.common.JsonWriter<TestEnum>) = ""
+        }
+        """.trimIndent()
+        )
+        Assertions.assertThat(compileResult.isFailed()).isTrue()
+        Assertions.assertThat(compileResult.messages).anyMatch { it.contains("must be public") }
+    }
 }

--- a/json/json-symbol-processor/src/test/kotlin/ru/tinkoff/kora/json/ksp/EnumTest.kt
+++ b/json/json-symbol-processor/src/test/kotlin/ru/tinkoff/kora/json/ksp/EnumTest.kt
@@ -317,4 +317,29 @@ class EnumTest : AbstractJsonSymbolProcessorTest() {
         }
         throw RuntimeException("Invalid enum constant: $name");
     }
+
+    @Test
+    fun testFactoryReaderFromExtension() {
+        compile0(
+            listOf(ru.tinkoff.kora.kora.app.ksp.KoraAppProcessorProvider(), JsonSymbolProcessorProvider()), """
+        enum class TestEnum(val value: String) {
+          SHARE("share"), OTHER("other");
+          companion object {
+            @JsonReader
+            fun fromValue(value: String): TestEnum = if (value == "share") SHARE else OTHER
+          }
+        }
+        """.trimIndent(), """
+        @ru.tinkoff.kora.common.KoraApp
+        interface TestApp {
+          fun stringReader(): ru.tinkoff.kora.json.common.JsonReader<String> = ru.tinkoff.kora.json.common.JsonReader<String> { obj -> obj.valueAsString }
+
+          @Root
+          fun root(r: ru.tinkoff.kora.json.common.JsonReader<TestEnum>) = ""
+        }
+        """.trimIndent()
+        )
+        compileResult.assertSuccess()
+        Assertions.assertThat(reader("TestEnum", stringReader)).isNotNull()
+    }
 }

--- a/json/json-symbol-processor/src/test/kotlin/ru/tinkoff/kora/json/ksp/EnumTest.kt
+++ b/json/json-symbol-processor/src/test/kotlin/ru/tinkoff/kora/json/ksp/EnumTest.kt
@@ -150,7 +150,7 @@ class EnumTest : AbstractJsonSymbolProcessorTest() {
             """
             @Json
             enum class TestEnum(val value: String) {
-              SHARE("share"), BOND("bond"), OTHER("other");
+              VALUE1("value1"), VALUE2("value2"), OTHER("other");
               companion object {
                 private val byValue = entries.associateBy { it.value }
                 @JsonReader
@@ -162,8 +162,8 @@ class EnumTest : AbstractJsonSymbolProcessorTest() {
         compileResult.assertSuccess()
 
         val r = reader("TestEnum", stringReader)
-        r.assertRead("\"share\"", enumConstant("TestEnum", "SHARE"))
-        r.assertRead("\"bond\"", enumConstant("TestEnum", "BOND"))
+        r.assertRead("\"value1\"", enumConstant("TestEnum", "VALUE1"))
+        r.assertRead("\"value2\"", enumConstant("TestEnum", "VALUE2"))
         r.assertRead("\"nonsense\"", enumConstant("TestEnum", "OTHER"))
         r.assertRead("null", null)
     }
@@ -174,7 +174,7 @@ class EnumTest : AbstractJsonSymbolProcessorTest() {
             """
             @Json
             enum class TestEnum(val code: Int) {
-              A(1), B(2), OTHER(-1);
+              VALUE1(1), VALUE2(2), OTHER(-1);
               companion object {
                 @JsonReader
                 fun fromCode(code: Int): TestEnum = entries.firstOrNull { it.code == code } ?: OTHER
@@ -186,8 +186,8 @@ class EnumTest : AbstractJsonSymbolProcessorTest() {
 
         val intReader = JsonReader { p: JsonParser -> p.intValue }
         val r = reader("TestEnum", intReader)
-        r.assertRead("1", enumConstant("TestEnum", "A"))
-        r.assertRead("2", enumConstant("TestEnum", "B"))
+        r.assertRead("1", enumConstant("TestEnum", "VALUE1"))
+        r.assertRead("2", enumConstant("TestEnum", "VALUE2"))
         r.assertRead("99", enumConstant("TestEnum", "OTHER"))
     }
 
@@ -197,10 +197,10 @@ class EnumTest : AbstractJsonSymbolProcessorTest() {
             listOf(JsonSymbolProcessorProvider()), """
             @Json
             enum class TestEnum(val value: String) {
-              A("a"), B("b");
+              VALUE1("value1"), VALUE2("value2");
               companion object {
-                @JsonReader fun fromValue(value: String): TestEnum = A
-                @JsonReader fun fromOther(value: String): TestEnum = B
+                @JsonReader fun fromValue(value: String): TestEnum = VALUE1
+                @JsonReader fun fromOther(value: String): TestEnum = VALUE2
               }
             }
             """.trimIndent()
@@ -216,9 +216,9 @@ class EnumTest : AbstractJsonSymbolProcessorTest() {
             listOf(JsonSymbolProcessorProvider()), """
             @Json
             enum class TestEnum(val value: String) {
-              A("a"), B("b");
+              VALUE1("value1"), VALUE2("value2");
               companion object {
-                @JsonReader fun fromValue(value: String, extra: Int): TestEnum = A
+                @JsonReader fun fromValue(value: String, extra: Int): TestEnum = VALUE1
               }
             }
             """.trimIndent()
@@ -234,7 +234,7 @@ class EnumTest : AbstractJsonSymbolProcessorTest() {
             listOf(JsonSymbolProcessorProvider()), """
             @Json
             enum class TestEnum(val value: String) {
-              A("a"), B("b");
+              VALUE1("value1"), VALUE2("value2");
               companion object {
                 @JsonReader fun fromValue(value: String): String = value
               }
@@ -250,9 +250,9 @@ class EnumTest : AbstractJsonSymbolProcessorTest() {
         compile0(listOf(JsonSymbolProcessorProvider()), """
             @Json
             enum class TestEnum(val value: String) {
-              A("a"), B("b");
+              VALUE1("value1"), VALUE2("value2");
               companion object {
-                @JsonReader private fun fromValue(value: String): TestEnum = A
+                @JsonReader private fun fromValue(value: String): TestEnum = VALUE1
               }
             }
             """.trimIndent())
@@ -265,8 +265,8 @@ class EnumTest : AbstractJsonSymbolProcessorTest() {
         compile0(listOf(JsonSymbolProcessorProvider()), """
             @Json
             enum class TestEnum(val value: String) {
-              A("a"), B("b");
-              @JsonReader fun fromValue(value: String): TestEnum = A
+              VALUE1("value1"), VALUE2("value2");
+              @JsonReader fun fromValue(value: String): TestEnum = VALUE1
             }
             """.trimIndent())
         Assertions.assertThat(compileResult.isFailed()).isTrue()
@@ -278,10 +278,10 @@ class EnumTest : AbstractJsonSymbolProcessorTest() {
         compile(
             """
             enum class TestEnum(val value: String) {
-              SHARE("share"), OTHER("other");
+              VALUE1("value1"), OTHER("other");
               companion object {
                 @JsonReader
-                fun fromValue(value: String): TestEnum = if (value == "share") SHARE else OTHER
+                fun fromValue(value: String): TestEnum = if (value == "value1") VALUE1 else OTHER
               }
             }
             """.trimIndent()
@@ -289,7 +289,7 @@ class EnumTest : AbstractJsonSymbolProcessorTest() {
         compileResult.assertSuccess()
 
         val r = reader("TestEnum", stringReader)
-        r.assertRead("\"share\"", enumConstant("TestEnum", "SHARE"))
+        r.assertRead("\"value1\"", enumConstant("TestEnum", "VALUE1"))
         r.assertRead("\"x\"", enumConstant("TestEnum", "OTHER"))
     }
 
@@ -316,10 +316,10 @@ class EnumTest : AbstractJsonSymbolProcessorTest() {
             """
             @JsonReader
             enum class TestEnum(val value: String) {
-              SHARE("share"), OTHER("other");
+              VALUE1("value1"), OTHER("other");
               companion object {
                 @JsonReader
-                fun fromValue(value: String): TestEnum = if (value == "share") SHARE else OTHER
+                fun fromValue(value: String): TestEnum = if (value == "value1") VALUE1 else OTHER
               }
             }
             """.trimIndent()
@@ -330,7 +330,7 @@ class EnumTest : AbstractJsonSymbolProcessorTest() {
         // @JsonReader on BOTH the enum class and the factory method: the factory reader must be
         // generated (unknown -> OTHER), not the default map-based reader (which would throw), and
         // exactly once — the class-branch and method-branch must dedup via processedReaders.
-        r.assertRead("\"share\"", enumConstant("TestEnum", "SHARE"))
+        r.assertRead("\"value1\"", enumConstant("TestEnum", "VALUE1"))
         r.assertRead("\"unknown\"", enumConstant("TestEnum", "OTHER"))
     }
 
@@ -351,10 +351,10 @@ class EnumTest : AbstractJsonSymbolProcessorTest() {
         compile0(
             listOf(ru.tinkoff.kora.kora.app.ksp.KoraAppProcessorProvider(), JsonSymbolProcessorProvider()), """
         enum class TestEnum(val value: String) {
-          SHARE("share"), OTHER("other");
+          VALUE1("value1"), OTHER("other");
           companion object {
             @JsonReader
-            fun fromValue(value: String): TestEnum = if (value == "share") SHARE else OTHER
+            fun fromValue(value: String): TestEnum = if (value == "value1") VALUE1 else OTHER
           }
         }
         """.trimIndent(), """

--- a/json/json-symbol-processor/src/test/kotlin/ru/tinkoff/kora/json/ksp/EnumTest.kt
+++ b/json/json-symbol-processor/src/test/kotlin/ru/tinkoff/kora/json/ksp/EnumTest.kt
@@ -246,6 +246,34 @@ class EnumTest : AbstractJsonSymbolProcessorTest() {
     }
 
     @Test
+    fun testEnumFactoryNonPublicFails() {
+        compile0(listOf(JsonSymbolProcessorProvider()), """
+            @Json
+            enum class TestEnum(val value: String) {
+              A("a"), B("b");
+              companion object {
+                @JsonReader private fun fromValue(value: String): TestEnum = A
+              }
+            }
+            """.trimIndent())
+        Assertions.assertThat(compileResult.isFailed()).isTrue()
+        Assertions.assertThat(compileResult.messages).anyMatch { it.contains("must be public") }
+    }
+
+    @Test
+    fun testEnumFactoryNotInCompanionFails() {
+        compile0(listOf(JsonSymbolProcessorProvider()), """
+            @Json
+            enum class TestEnum(val value: String) {
+              A("a"), B("b");
+              @JsonReader fun fromValue(value: String): TestEnum = A
+            }
+            """.trimIndent())
+        Assertions.assertThat(compileResult.isFailed()).isTrue()
+        Assertions.assertThat(compileResult.messages).anyMatch { it.contains("companion") }
+    }
+
+    @Test
     fun testEnumReaderFactoryTriggersWithoutJsonAnnotation() {
         compile(
             """


### PR DESCRIPTION
## Summary

Adds compile-time support for a **custom single-value JSON mapping** on both sides (read + write), for enums **and** arbitrary non-enum types, symmetric across KSP (Kotlin) and APT (Java), with no reflection at runtime. Conceptually this mirrors Jackson's `@JsonValue` (write) and `@JsonCreator(mode = DELEGATING)` (read).

The two mechanisms are additive and opt-in — types without these methods keep the existing behaviour (map-based enum reader; `@Json` getter / `toString` enum writer; property-based DTO read/write).

### 1. Enums — `@JsonReader` static factory `(V) -> Enum` / `@JsonWriter` method `(Enum) -> V`

An enum may declare a `@JsonReader`-annotated static factory (Kotlin `companion object` / Java `public static`) so unknown values can fall back instead of throwing, and a `@JsonWriter` static method to override the serialized value (instead of `toString`):

```kotlin
@Json
enum class Type(val value: String) {
  VALUE1("value1"), OTHER("other");
  companion object {
    private val byValue = entries.associateBy { it.value }
    @JsonReader fun fromValue(value: String): Type = byValue[value] ?: OTHER
    @JsonWriter fun toValue(t: Type): String = t.value
  }
}
```

### 2. Arbitrary types (delegating value) — `@JsonReader` static factory `(V) -> T` / `@JsonWriter` method `(T) -> V`

Any non-enum class/record may serialize/deserialize **as a single delegated value** (wrapper / value types — `UserId` around `long`, `Money` around `String`, …). The generated `JsonReader<T>`/`JsonWriter<T>` inject a `JsonReader<V>`/`JsonWriter<V>` and delegate to it:

```kotlin
class UserId(val id: Long) {
  @JsonWriter fun toJson(): Long = id                       // instance () -> V  (Jackson @JsonValue)
  companion object { @JsonReader fun of(v: Long): UserId = UserId(v) }   // static (V) -> T
}
// JSON:  42        (not {"id":42})
```

```java
public record UserId(long id) {
  @JsonReader public static UserId of(long v) { return new UserId(v); }
  @JsonWriter public long id() { return id; }               // record accessor as the value
}
```

The writer method may be **instance** `() -> V` (primary, Jackson `@JsonValue` style) or **static** `(T) -> V`. Delegating **wins over** `@Json`/property-based generation, and the two sides are independent (a type may be delegating-write + property-read, or vice-versa). The value type `V` is any type the DI graph can provide a `JsonReader<V>`/`JsonWriter<V>` for.

## Details

- KSP and APT implementations are symmetric (same messages, triggers, de-duplication, extension behaviour).
- A `@JsonReader`/`@JsonWriter` on a method acts as a generation trigger on its own (no class-level `@Json` required), with within-round de-duplication so an annotation on both the class and the method generates exactly one reader/writer.
- The KoraApp extension defers a graph-requested type that carries such a method to the annotation processor, to avoid generating the same file twice in one round.
- Malformed methods produce a clear compile error instead of silently falling back: must be `public`; the reader factory must be `static` (Kotlin: companion object), exactly one parameter, return the enclosing type; the writer method must return a non-`void`/`Unit` value and be either an instance method with no parameters or a static method with one parameter of the enclosing type; only one such method per side; and a `@JsonReader` factory method together with a `@JsonReader`/`@Json` constructor on the same type is a conflict.
- No new public runtime types — enums reuse `EnumJsonReader`/`EnumJsonWriter`; the delegating reader/writer for arbitrary types is generated inline.

## Tests

`EnumTest` and a new `DelegatingValueTest` are added on both `json-symbol-processor` (KSP) and `json-annotation-processor` (APT): happy paths for `String`/`Int`/`Long` value types, reader-factory fallback and round-trip, instance vs static writer forms, delegating-wins-over-`@Json` precedence, standalone-method trigger, KoraApp-extension generation for both sides, and every validation-error path. Both module test suites pass in full.
