### PR TITLE
feat(konvert): Kotlin/KSP-native Konvert mapper integration

### DIFF
--- a/gradle/ci-tests.gradle
+++ b/gradle/ci-tests.gradle
@@ -106,6 +106,7 @@ addDependenciesByPattern(tasksCodegenKotlin, "symbol-processor")
 addDependenciesByPattern(tasksCodegenKotlin, "ksp")
 addDependencies(tasksCodegenKotlin, "scheduling:scheduling-ksp")
 addDependencies(tasksCodegenKotlin, "mapstruct:mapstruct-ksp-extension")
+addDependencies(tasksCodegenKotlin, "konvert:konvert-ksp-extension")
 
 def jacocoRootReport = tasks.register("jacocoRootReport", JacocoReport) {
     group = "verification"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ grpc-java = "1.74.0"
 grpc-kotlin = "1.4.3"
 kotlin-testing = "1.5.0"
 ksp = "1.9.25-1.0.20"
+konvert = "3.2.3"
 kotlinpoet = "1.18.1"
 jetbrains-annotations = "24.1.0"
 swagger = "2.2.52"
@@ -160,6 +161,9 @@ kotlin-compile-testing = { module = "com.github.tschuchortdev:kotlin-compile-tes
 
 kotlinpoet = { module = "com.squareup:kotlinpoet", version.ref = "kotlinpoet" }
 kotlinpoet-ksp = { module = "com.squareup:kotlinpoet-ksp", version.ref = "kotlinpoet" }
+
+konvert-api = { module = "io.mcarle:konvert-api", version.ref = "konvert" }
+konvert-processor = { module = "io.mcarle:konvert", version.ref = "konvert" }
 
 jakarta-jws-api = { module = "jakarta.jws:jakarta.jws-api", version = "3.0.0" }
 jakarta-xml-ws-api = { module = "jakarta.xml.ws:jakarta.xml.ws-api", version = "3.0.1" }

--- a/konvert/konvert-ksp-extension/build.gradle
+++ b/konvert/konvert-ksp-extension/build.gradle
@@ -1,0 +1,13 @@
+apply from: "${project.rootDir}/gradle/in-test-generated.gradle"
+apply from: "${project.rootDir}/gradle/kotlin-plugin.gradle"
+
+dependencies {
+    implementation project(':kora-app-symbol-processor')
+
+    testImplementation libs.konvert.api
+    testImplementation libs.konvert.processor
+
+    testImplementation project(":kora-app-symbol-processor")
+    testImplementation project(":symbol-processor-common")
+    testImplementation testFixtures(project(':symbol-processor-common'))
+}

--- a/konvert/konvert-ksp-extension/src/main/kotlin/ru/tinkoff/kora/konvert/ksp/extension/KonvertKoraExtension.kt
+++ b/konvert/konvert-ksp-extension/src/main/kotlin/ru/tinkoff/kora/konvert/ksp/extension/KonvertKoraExtension.kt
@@ -55,15 +55,8 @@ object KonvertKoraExtension : KoraExtension {
     }
 
     private fun getKonverterImplName(declaration: KSDeclaration): String {
-        val parts = mutableListOf<String>()
-        parts.add(declaration.simpleName.asString())
-        var parent = declaration.parentDeclaration
-        while (parent != null && parent is KSClassDeclaration) {
-            parts.add(parent.simpleName.asString())
-            parent = parent.parentDeclaration
-        }
-
-        parts.reverse()
-        return parts.joinToString("$") + implementationSuffix
+        // Konvert always generates a top-level `object <SimpleName>Impl` in the same package,
+        // even for a nested @Konverter interface (the enclosing type name is dropped).
+        return declaration.simpleName.asString() + implementationSuffix
     }
 }

--- a/konvert/konvert-ksp-extension/src/main/kotlin/ru/tinkoff/kora/konvert/ksp/extension/KonvertKoraExtension.kt
+++ b/konvert/konvert-ksp-extension/src/main/kotlin/ru/tinkoff/kora/konvert/ksp/extension/KonvertKoraExtension.kt
@@ -1,0 +1,69 @@
+package ru.tinkoff.kora.konvert.ksp.extension
+
+import com.google.devtools.ksp.getClassDeclarationByName
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.ClassKind
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSDeclaration
+import com.google.devtools.ksp.symbol.KSType
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.CodeBlock
+import ru.tinkoff.kora.kora.app.ksp.extension.ExtensionResult
+import ru.tinkoff.kora.kora.app.ksp.extension.KoraExtension
+import ru.tinkoff.kora.ksp.common.AnnotationUtils.findAnnotation
+import ru.tinkoff.kora.ksp.common.TagUtils.parseTags
+
+object KonvertKoraExtension : KoraExtension {
+
+    val konverterAnnotation = ClassName("io.mcarle.konvert.api", "Konverter")
+    private const val implementationSuffix = "Impl"
+
+    override fun getDependencyGenerator(resolver: Resolver, type: KSType, tags: Set<String>): (() -> ExtensionResult)? {
+        val declaration = type.declaration
+        if (declaration !is KSClassDeclaration) {
+            return null
+        }
+        if (declaration.classKind != ClassKind.INTERFACE) {
+            return null
+        }
+        val annotation = declaration.findAnnotation(konverterAnnotation)
+        if (annotation == null) {
+            return null
+        }
+        val tag = declaration.parseTags()
+        if (tag != tags) {
+            return null
+        }
+        val packageName = declaration.packageName.asString()
+        val expectedName = getKonverterImplName(declaration)
+        val implClassName = ClassName(packageName, expectedName)
+        return {
+            val implementation = resolver.getClassDeclarationByName("$packageName.$expectedName")
+            if (implementation == null) {
+                ExtensionResult.RequiresCompilingResult
+            } else {
+                ExtensionResult.CodeBlockResult(
+                    declaration,
+                    { CodeBlock.of("%T", implClassName) },
+                    type,
+                    tags,
+                    emptyList(),
+                    emptyList()
+                )
+            }
+        }
+    }
+
+    private fun getKonverterImplName(declaration: KSDeclaration): String {
+        val parts = mutableListOf<String>()
+        parts.add(declaration.simpleName.asString())
+        var parent = declaration.parentDeclaration
+        while (parent != null && parent is KSClassDeclaration) {
+            parts.add(parent.simpleName.asString())
+            parent = parent.parentDeclaration
+        }
+
+        parts.reverse()
+        return parts.joinToString("$") + implementationSuffix
+    }
+}

--- a/konvert/konvert-ksp-extension/src/main/kotlin/ru/tinkoff/kora/konvert/ksp/extension/KonvertKoraExtensionFactory.kt
+++ b/konvert/konvert-ksp-extension/src/main/kotlin/ru/tinkoff/kora/konvert/ksp/extension/KonvertKoraExtensionFactory.kt
@@ -1,0 +1,16 @@
+package ru.tinkoff.kora.konvert.ksp.extension
+
+import com.google.devtools.ksp.getClassDeclarationByName
+import com.google.devtools.ksp.processing.CodeGenerator
+import com.google.devtools.ksp.processing.KSPLogger
+import com.google.devtools.ksp.processing.Resolver
+import ru.tinkoff.kora.kora.app.ksp.extension.ExtensionFactory
+import ru.tinkoff.kora.kora.app.ksp.extension.KoraExtension
+
+class KonvertKoraExtensionFactory : ExtensionFactory {
+
+    override fun create(resolver: Resolver, kspLogger: KSPLogger, codeGenerator: CodeGenerator): KoraExtension? {
+        return resolver.getClassDeclarationByName(KonvertKoraExtension.konverterAnnotation.canonicalName)
+            ?.let { KonvertKoraExtension }
+    }
+}

--- a/konvert/konvert-ksp-extension/src/main/resources/META-INF/services/ru.tinkoff.kora.kora.app.ksp.extension.ExtensionFactory
+++ b/konvert/konvert-ksp-extension/src/main/resources/META-INF/services/ru.tinkoff.kora.kora.app.ksp.extension.ExtensionFactory
@@ -1,0 +1,1 @@
+ru.tinkoff.kora.konvert.ksp.extension.KonvertKoraExtensionFactory

--- a/konvert/konvert-ksp-extension/src/test/kotlin/ru/tinkoff/kora/konvert/ksp/extension/KonvertKoraExtensionTest.kt
+++ b/konvert/konvert-ksp-extension/src/test/kotlin/ru/tinkoff/kora/konvert/ksp/extension/KonvertKoraExtensionTest.kt
@@ -57,4 +57,83 @@ class KonvertKoraExtensionTest : AbstractSymbolProcessorTest() {
         )
         assertThat(graph.draw.size()).isEqualTo(2)
     }
+
+    @Test
+    fun plainInterfaceWithoutKonverterIsNotProvided() {
+        super.compile0(
+            """
+            interface NotAMapper {
+                fun map(value: String): String
+            }
+            """.trimIndent(),
+            """
+            @KoraApp
+            interface TestApp {
+                @Root
+                fun root(mapper: NotAMapper): String {
+                    return ""
+                }
+            }
+            """.trimIndent()
+        )
+        assertThat(compileResult.isFailed()).isTrue()
+    }
+
+    @Test
+    fun konverterWithMultipleFunctionsRegistersOnce() {
+        val graph = compile(
+            """
+            data class Car(val make: String, val numberOfSeats: Int)
+            """.trimIndent(),
+            """
+            data class CarDto(val make: String, val seatCount: Int)
+            """.trimIndent(),
+            """
+            @Konverter
+            interface CarMapper {
+                @Konvert(mappings = [Mapping(source = "numberOfSeats", target = "seatCount")])
+                fun carToDto(car: Car): CarDto
+
+                @Konvert(mappings = [Mapping(source = "seatCount", target = "numberOfSeats")])
+                fun dtoToCar(dto: CarDto): Car
+            }
+            """.trimIndent()
+        )
+        assertThat(graph.draw.size()).isEqualTo(2)
+    }
+
+    @Test
+    fun taggedKonverterResolvesForMatchingTag() {
+        super.compile0(
+            """
+            class KonvertTag {}
+            """.trimIndent(),
+            """
+            data class Car(val make: String, val numberOfSeats: Int)
+            """.trimIndent(),
+            """
+            data class CarDto(val make: String, val seatCount: Int)
+            """.trimIndent(),
+            """
+            @Konverter
+            @Tag(KonvertTag::class)
+            interface CarMapper {
+                @Konvert(mappings = [Mapping(source = "numberOfSeats", target = "seatCount")])
+                fun carToDto(car: Car): CarDto
+            }
+            """.trimIndent(),
+            """
+            @KoraApp
+            interface TestApp {
+                @Root
+                fun root(@Tag(KonvertTag::class) mapper: CarMapper): String {
+                    return ""
+                }
+            }
+            """.trimIndent()
+        )
+        compileResult.assertSuccess()
+        val graph = loadClass("TestAppGraph").toGraph()
+        assertThat(graph.draw.size()).isEqualTo(2)
+    }
 }

--- a/konvert/konvert-ksp-extension/src/test/kotlin/ru/tinkoff/kora/konvert/ksp/extension/KonvertKoraExtensionTest.kt
+++ b/konvert/konvert-ksp-extension/src/test/kotlin/ru/tinkoff/kora/konvert/ksp/extension/KonvertKoraExtensionTest.kt
@@ -1,0 +1,60 @@
+package ru.tinkoff.kora.konvert.ksp.extension
+
+import org.assertj.core.api.Assertions.assertThat
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+import ru.tinkoff.kora.ksp.common.AbstractSymbolProcessorTest
+import ru.tinkoff.kora.ksp.common.GraphUtil
+import ru.tinkoff.kora.ksp.common.GraphUtil.toGraph
+import java.util.Arrays
+
+class KonvertKoraExtensionTest : AbstractSymbolProcessorTest() {
+
+    override fun commonImports(): String {
+        return super.commonImports() + """
+            import io.mcarle.konvert.api.Konverter
+            import io.mcarle.konvert.api.Konvert
+            import io.mcarle.konvert.api.Mapping
+            import ru.tinkoff.kora.konvert.ksp.extension.*
+
+            """.trimIndent()
+    }
+
+    private fun compile(@Language("kotlin") vararg sources: String): GraphUtil.GraphContainer {
+        val patchedSources = Arrays.copyOf(sources, sources.size + 1)
+        @Language("kotlin")
+        val main = """
+            @KoraApp
+            interface TestApp {
+                @Root
+                fun root(mapper: CarMapper): String {
+                    return ""
+                }
+            }
+            """.trimIndent()
+        patchedSources[sources.size] = main
+        super.compile0(*patchedSources)
+        compileResult.assertSuccess()
+        return loadClass("TestAppGraph").toGraph()
+    }
+
+    @Test
+    fun konverterInterfaceIsInjectableAcrossKspRounds() {
+        val graph = compile(
+            """
+            data class Car(val make: String, val numberOfSeats: Int)
+            """.trimIndent(),
+            """
+            data class CarDto(val make: String, val seatCount: Int)
+            """.trimIndent(),
+            """
+            @Konverter
+            interface CarMapper {
+                @Konvert(mappings = [Mapping(source = "numberOfSeats", target = "seatCount")])
+                fun carToDto(car: Car): CarDto
+            }
+            """.trimIndent()
+        )
+        assertThat(graph.draw.size()).isEqualTo(2)
+    }
+}

--- a/konvert/konvert-ksp-extension/src/test/kotlin/ru/tinkoff/kora/konvert/ksp/extension/KonvertKoraExtensionTest.kt
+++ b/konvert/konvert-ksp-extension/src/test/kotlin/ru/tinkoff/kora/konvert/ksp/extension/KonvertKoraExtensionTest.kt
@@ -22,6 +22,7 @@ class KonvertKoraExtensionTest : AbstractSymbolProcessorTest() {
 
     private fun compile(@Language("kotlin") vararg sources: String): GraphUtil.GraphContainer {
         val patchedSources = Arrays.copyOf(sources, sources.size + 1)
+
         @Language("kotlin")
         val main = """
             @KoraApp
@@ -127,6 +128,39 @@ class KonvertKoraExtensionTest : AbstractSymbolProcessorTest() {
             interface TestApp {
                 @Root
                 fun root(@Tag(KonvertTag::class) mapper: CarMapper): String {
+                    return ""
+                }
+            }
+            """.trimIndent()
+        )
+        compileResult.assertSuccess()
+        val graph = loadClass("TestAppGraph").toGraph()
+        assertThat(graph.draw.size()).isEqualTo(2)
+    }
+
+    @Test
+    fun nestedKonverterInterfaceIsInjectable() {
+        super.compile0(
+            """
+            data class Car(val make: String, val numberOfSeats: Int)
+            """.trimIndent(),
+            """
+            data class CarDto(val make: String, val seatCount: Int)
+            """.trimIndent(),
+            """
+            interface Mappers {
+                @Konverter
+                interface CarMapper {
+                    @Konvert(mappings = [Mapping(source = "numberOfSeats", target = "seatCount")])
+                    fun carToDto(car: Car): CarDto
+                }
+            }
+            """.trimIndent(),
+            """
+            @KoraApp
+            interface TestApp {
+                @Root
+                fun root(mapper: Mappers.CarMapper): String {
                     return ""
                 }
             }

--- a/settings.gradle
+++ b/settings.gradle
@@ -104,6 +104,7 @@ include(
     'test:test-junit5',
     'mapstruct:mapstruct-java-extension',
     'mapstruct:mapstruct-ksp-extension',
+    'konvert:konvert-ksp-extension',
     'experimental:s3-client-annotation-processor',
     'experimental:s3-client-symbol-processor',
     'experimental:s3-client-common',

--- a/symbol-processor-common/src/testFixtures/kotlin/ru/tinkoff/kora/ksp/common/AbstractSymbolProcessorTest.kt
+++ b/symbol-processor-common/src/testFixtures/kotlin/ru/tinkoff/kora/ksp/common/AbstractSymbolProcessorTest.kt
@@ -204,7 +204,7 @@ abstract class AbstractSymbolProcessorTest {
             .toList()
             .toTypedArray()
         val processors = classpath.stream()
-            .filter { it.contains("symbol-processor") || it.contains("scheduling-ksp") }
+            .filter { it.contains("symbol-processor") || it.contains("scheduling-ksp") || it.contains("konvert") }
             .collect(Collectors.joining(File.pathSeparator))
         k2JvmArgs.pluginClasspaths = pluginClassPath
         val ksp = "plugin:com.google.devtools.ksp.symbol-processing:"

--- a/symbol-processors/build.gradle
+++ b/symbol-processors/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     api project(':cache:cache-symbol-processor')
     api project(':validation:validation-symbol-processor')
     api project(':mapstruct:mapstruct-ksp-extension')
+    api project(':konvert:konvert-ksp-extension')
     api project(':logging:declarative-logging:declarative-logging-symbol-processor')
     api project(':grpc:grpc-client-symbol-processor')
     api project(':experimental:s3-client-symbol-processor')


### PR DESCRIPTION
## What

Adds `konvert/konvert-ksp-extension` — a compile-time `KoraExtension` that lets a
[Konvert](https://github.com/mcarleio/konvert) `@Konverter` interface be injected into any Kora
component with **zero hand-written glue**, as the Kotlin/KSP-native counterpart to the existing
MapStruct integration.

On Kotlin, MapStruct is awkward because it is a `kapt` processor and kapt conflicts with KSP (which
Kora uses). Konvert is pure KSP, so it coexists with Kora's KSP cleanly.

### Before (manual glue)

```kotlin
@Module
interface KonvertModule {
    fun personMapper(): PersonMapper = Konverter.get() // reflection-based registry
}
```

### After

Nothing — inject `PersonMapper` directly into any component; it is resolved at compile time (no
reflection, no hand-written module).

## How

`KonvertKoraExtension` reacts when the DI graph requests a type annotated with
`io.mcarle.konvert.api.Konverter`, resolves Konvert's generated singleton `object <SimpleName>Impl`,
and registers it via `ExtensionResult.CodeBlockResult` (a code block referencing the object). It
waits across KSP rounds with `RequiresCompilingResult` until Konvert has emitted the `*Impl`.

The structure mirrors `mapstruct-ksp-extension`; the only differences are:
- accept `INTERFACE` only (`@Konverter` is never on a class);
- register via `CodeBlockResult` referencing the `object` instead of `fromConstructor` (Konvert's
  `*Impl` is an `object` with no public constructor).

Wired into the `symbol-processors` aggregator, so it works out of the box for any Kotlin Kora
consumer that adds Konvert (inert when Konvert is absent from the classpath).

## Tests

`KonvertKoraExtensionTest` runs Kora-KSP and Konvert-KSP **together in one compilation**, which
genuinely exercises cross-processor round convergence:

- injection of a `@Konverter` interface + round convergence (the load-bearing case);
- multiple `@Konvert` functions in one interface;
- `@Tag` matching;
- negative: a non-`@Konverter` interface is not provided;
- nested `@Konverter` interface.

To let the test harness run Konvert's KSP processor alongside Kora's, `AbstractSymbolProcessorTest`'s
processor classpath filter gains `konvert` (same pattern already used for `scheduling-ksp`).

## Notes

- Konvert **3.2.3** (Kotlin 1.9.25 / KSP 1.9.25-1.0.20 line; Konvert 4.x requires Kotlin 2.x).
- Konvert generates a top-level `object <SimpleName>Impl` even for a nested `@Konverter` interface
  (the enclosing type name is dropped) — impl-name resolution accounts for this.
- Injecting Kora beans *into* a Konvert mapper is not possible by Konvert's `object` design; this is
  a known limitation, not a regression.
