### PR TITLE
Added advanced `CircuitBreaker` implementations

### DIFF
--- a/resilient/resilient-annotation-processor/src/test/java/io/koraframework/resilient/annotation/processor/aop/testdata/AppWithConfig.java
+++ b/resilient/resilient-annotation-processor/src/test/java/io/koraframework/resilient/annotation/processor/aop/testdata/AppWithConfig.java
@@ -21,7 +21,7 @@ public interface AppWithConfig extends ConfigValueMapperModule, CircuitBreakerMo
                 resilient {
                   circuitbreaker {
                     default {
-                      slidingWindowSize = 1
+                      windowSize = 1
                       minimumRequiredCalls = 1
                       failureRateThreshold = 100
                       permittedCallsInHalfOpenState = 1

--- a/resilient/resilient-annotation-processor/src/test/java/io/koraframework/resilient/annotation/processor/aop/testdata/AppWithConfig.java
+++ b/resilient/resilient-annotation-processor/src/test/java/io/koraframework/resilient/annotation/processor/aop/testdata/AppWithConfig.java
@@ -21,7 +21,13 @@ public interface AppWithConfig extends ConfigValueMapperModule, CircuitBreakerMo
                 resilient {
                   circuitbreaker {
                     default {
-                      windowSize = 1
+                      type = STRIPED_APPROX
+                      countBased {
+                        windowSize = 1
+                        stripedApprox {
+                          stripes = 1
+                        }
+                      }
                       minimumRequiredCalls = 1
                       failureRateThreshold = 100
                       permittedCallsInHalfOpenState = 1

--- a/resilient/resilient-kora/src/main/java/io/koraframework/resilient/circuitbreaker/CircuitBreaker.java
+++ b/resilient/resilient-kora/src/main/java/io/koraframework/resilient/circuitbreaker/CircuitBreaker.java
@@ -7,7 +7,7 @@ import java.util.function.Supplier;
 
 /**
  * A {@link CircuitBreaker} manages the state of a backend system. The CircuitBreaker is implemented
- * via a finite state machine with five states: CLOSED, OPEN, HALF_OPEN.
+ * via a finite state machine with three states: CLOSED, OPEN, HALF_OPEN.
  * The CircuitBreaker does not know anything about the backend's state by itself, but uses the
  * information provided by the decorators via {@link CircuitBreaker#releaseOnSuccess()} and {@link
  * CircuitBreaker#releaseOnError(Throwable)} events. Before communicating with the backend, the permission to do so

--- a/resilient/resilient-kora/src/main/java/io/koraframework/resilient/circuitbreaker/CircuitBreakerConfig.java
+++ b/resilient/resilient-kora/src/main/java/io/koraframework/resilient/circuitbreaker/CircuitBreakerConfig.java
@@ -11,6 +11,12 @@ import java.util.Map;
 public interface CircuitBreakerConfig {
 
     String DEFAULT = "default";
+    int STRIPED_APPROX_DEFAULT_STRIPES = 16;
+    int STRIPED_APPROX_MAX_STRIPES = 64;
+    int TIME_BASED_DEFAULT_SAMPLE_COUNT = 16;
+    int TIME_BASED_MAX_SAMPLE_COUNT = 1024;
+    int TIME_BASED_DEFAULT_COUNTER_STRIPES = 16;
+    int TIME_BASED_MAX_COUNTER_STRIPES = 64;
 
     default Map<String, NamedConfig> circuitbreaker() {
         return Map.of();
@@ -18,13 +24,52 @@ public interface CircuitBreakerConfig {
 
     CircuitBreakerTelemetryConfig telemetry();
 
+    enum CircuitBreakerType {
+        /**
+         * Lowest overhead implementation with a single packed counter state.
+         * It is cheap and simple, but its CLOSED window is fixed-counter based and does not keep exact last-N call history.
+         */
+        FIXED_WINDOW,
+        /**
+         * Fastest high-concurrency implementation for hot paths.
+         * It spreads writes across independent stripes, so CLOSED statistics are approximate and can drift under uneven load.
+         */
+        STRIPED_APPROX,
+        /**
+         * Strong count-based implementation with exact global completion ordering.
+         * It uses a global sequencer and slot-level CAS ring buffer, so it is more precise than STRIPED_APPROX but has higher coordination overhead.
+         */
+        RING_BUFFER,
+        /**
+         * High-throughput time-based implementation with a fixed LeapArray of time buckets.
+         * It does not keep last-N calls; CLOSED statistics cover the latest configured time window and are eventually consistent around bucket rollover.
+         */
+        TIME_BASED
+    }
+
+    enum TimeBasedCounterType {
+        /**
+         * Striped atomic counters. Default mode: predictable reset semantics and fixed memory.
+         */
+        ATOMIC,
+        /**
+         * LongAdder counters. Faster under heavy contention, but bucket reset is more approximate around time boundaries.
+         */
+        LONG_ADDER
+    }
+
     /**
      * You can use <a href="https://resilience4j.readme.io/docs/circuitbreaker">Resilient4j documentation</a> as a description of how CircuitBreaker works and how similar properties are configution its parts
      * <p>
      * {@link #failureRateThreshold} Configures the failure rate threshold in percentage. If the failure rate is equal to or greater than the threshold, the CircuitBreaker transitions to open and starts short-circuiting calls. The threshold must be greater than 0 and not greater than 100.<br>
      * {@link #waitDurationInOpenState} Configures an interval function with a fixed wait duration which controls how long the CircuitBreaker should stay open, before it switches to half open.<br>
      * {@link #permittedCallsInHalfOpenState} Configures the number of permitted calls that must succeed when the CircuitBreaker is half open.<br>
-     * {@link #windowSize} Configures the fixed window which is used to record the outcome of calls when the CircuitBreaker is closed.<br>
+     * {@link #countBased} Configures count-based implementations.<br>
+     * {@link #timeBased} Configures time-based implementation.<br>
+     * {@link #type} Selects implementation trade-off: {@link CircuitBreakerType#FIXED_WINDOW} for the cheapest fixed counter,
+     * {@link CircuitBreakerType#STRIPED_APPROX} for the fastest approximate high-concurrency mode, or
+     * {@link CircuitBreakerType#RING_BUFFER} for exact global count-based order with higher coordination overhead, or
+     * {@link CircuitBreakerType#TIME_BASED} for a fixed-memory time window backed by a LeapArray.<br>
      * {@link #minimumRequiredCalls} Configures the minimum number of calls which are required (per fixed window period) before the CircuitBreaker can calculate the error rate.<br>
      * {@link #failurePredicateName} {@link CircuitBreakerPredicate#name()} default is {@link KoraCircuitBreakerPredicate}<br>
      */
@@ -33,6 +78,15 @@ public interface CircuitBreakerConfig {
 
         @Nullable
         Boolean enabled();
+
+        @Nullable
+        CircuitBreakerType type();
+
+        @Nullable
+        CountBasedConfig countBased();
+
+        @Nullable
+        TimeBasedConfig timeBased();
 
         @Nullable
         Integer failureRateThreshold();
@@ -44,14 +98,44 @@ public interface CircuitBreakerConfig {
         Integer permittedCallsInHalfOpenState();
 
         @Nullable
-        Long windowSize();
-
-        @Nullable
         Long minimumRequiredCalls();
 
         default String failurePredicateName() {
             return KoraCircuitBreakerPredicate.class.getCanonicalName();
         }
+    }
+
+    @ConfigMapper
+    interface CountBasedConfig {
+
+        @Nullable
+        Long windowSize();
+
+        @Nullable
+        StripedApproxConfig stripedApprox();
+    }
+
+    @ConfigMapper
+    interface StripedApproxConfig {
+
+        @Nullable
+        Integer stripes();
+    }
+
+    @ConfigMapper
+    interface TimeBasedConfig {
+
+        @Nullable
+        Duration windowDuration();
+
+        @Nullable
+        Integer sampleCount();
+
+        @Nullable
+        Integer counterStripes();
+
+        @Nullable
+        TimeBasedCounterType counterType();
     }
 
     default NamedConfig getNamedConfig(String name) {
@@ -70,31 +154,77 @@ public interface CircuitBreakerConfig {
         if (mergedConfig.permittedCallsInHalfOpenState() == null)
             throw new IllegalStateException("CircuitBreaker property '%s' is not configured in either '%s' or '%s' config"
                 .formatted("permittedCallsInHalfOpenState", name, DEFAULT));
-        if (mergedConfig.windowSize() == null)
+        if (mergedConfig.type() == CircuitBreakerType.TIME_BASED) {
+            if (mergedConfig.timeBased() == null || mergedConfig.timeBased().windowDuration() == null) {
+                throw new IllegalStateException("CircuitBreaker property '%s' is not configured in either '%s' or '%s' config"
+                    .formatted("timeBased.windowDuration", name, DEFAULT));
+            }
+        } else if (mergedConfig.countBased() == null || mergedConfig.countBased().windowSize() == null) {
             throw new IllegalStateException("CircuitBreaker property '%s' is not configured in either '%s' or '%s' config"
-                .formatted("windowSize", name, DEFAULT));
+                .formatted("countBased.windowSize", name, DEFAULT));
+        }
         if (mergedConfig.minimumRequiredCalls() == null)
             throw new IllegalStateException("CircuitBreaker property '%s' is not configured in either '%s' or '%s' config"
                 .formatted("minimumRequiredCalls", name, DEFAULT));
 
+        if (mergedConfig.type() == null)
+            throw new IllegalArgumentException("CircuitBreaker '%s' property '%s' is not configured"
+                .formatted(name, "type"));
+        if (mergedConfig.countBased() == null)
+            throw new IllegalArgumentException("CircuitBreaker '%s' property '%s' is not configured"
+                .formatted(name, "countBased"));
+        if (mergedConfig.countBased().stripedApprox() == null)
+            throw new IllegalArgumentException("CircuitBreaker '%s' property '%s' is not configured"
+                .formatted(name, "countBased.stripedApprox"));
+        if (mergedConfig.timeBased() == null)
+            throw new IllegalArgumentException("CircuitBreaker '%s' property '%s' is not configured"
+                .formatted(name, "timeBased"));
         if (mergedConfig.minimumRequiredCalls() < 1)
             throw new IllegalArgumentException("CircuitBreaker '%s' property '%s' can't be negative or zero value, but was: %s"
                 .formatted(name, "minimumRequiredCalls", mergedConfig.minimumRequiredCalls()));
-        if (mergedConfig.windowSize() < 1)
+        if (mergedConfig.type() != CircuitBreakerType.TIME_BASED && mergedConfig.countBased().windowSize() < 1)
             throw new IllegalArgumentException("CircuitBreaker '%s' property '%s' can't be negative or zero value, but was: %s"
-                .formatted(name, "windowSize", mergedConfig.windowSize()));
+                .formatted(name, "countBased.windowSize", mergedConfig.countBased().windowSize()));
         if (mergedConfig.permittedCallsInHalfOpenState() < 1)
             throw new IllegalArgumentException("CircuitBreaker '%s' property '%s' can't be negative or zero value, but was: %s"
                 .formatted(name, "permittedCallsInHalfOpenState", mergedConfig.permittedCallsInHalfOpenState()));
-        if (mergedConfig.windowSize() > 0x7FFF_FFFFL)
+        if (mergedConfig.type() != CircuitBreakerType.TIME_BASED && mergedConfig.countBased().windowSize() > 0x7FFF_FFFFL)
             throw new IllegalArgumentException("CircuitBreaker '%s' property '%s' can't be greater than %s, but was: %s"
-                .formatted(name, "windowSize", 0x7FFF_FFFFL, mergedConfig.windowSize()));
+                .formatted(name, "countBased.windowSize", 0x7FFF_FFFFL, mergedConfig.countBased().windowSize()));
+        if (mergedConfig.countBased().stripedApprox().stripes() == null || mergedConfig.countBased().stripedApprox().stripes() < 1)
+            throw new IllegalArgumentException("CircuitBreaker '%s' property '%s' can't be negative or zero value, but was: %s"
+                .formatted(name, "countBased.stripedApprox.stripes", mergedConfig.countBased().stripedApprox().stripes()));
+        if (mergedConfig.countBased().stripedApprox().stripes() > STRIPED_APPROX_MAX_STRIPES)
+            throw new IllegalArgumentException("CircuitBreaker '%s' property '%s' can't be greater than %s, but was: %s"
+                .formatted(name, "countBased.stripedApprox.stripes", STRIPED_APPROX_MAX_STRIPES, mergedConfig.countBased().stripedApprox().stripes()));
+        if (mergedConfig.type() == CircuitBreakerType.STRIPED_APPROX && mergedConfig.countBased().windowSize() > (long) mergedConfig.countBased().stripedApprox().stripes() * 0xFFFFL)
+            throw new IllegalArgumentException("CircuitBreaker '%s' property '%s' can't be greater than %s for '%s' type, but was: %s"
+                .formatted(name, "countBased.windowSize", (long) mergedConfig.countBased().stripedApprox().stripes() * 0xFFFFL, CircuitBreakerType.STRIPED_APPROX, mergedConfig.countBased().windowSize()));
+        if (mergedConfig.type() == CircuitBreakerType.TIME_BASED && mergedConfig.timeBased().windowDuration().isZero()
+            || mergedConfig.type() == CircuitBreakerType.TIME_BASED && mergedConfig.timeBased().windowDuration().isNegative())
+            throw new IllegalArgumentException("CircuitBreaker '%s' property '%s' can't be negative or zero value, but was: %s"
+                .formatted(name, "timeBased.windowDuration", mergedConfig.timeBased().windowDuration()));
+        if (mergedConfig.timeBased().sampleCount() == null || mergedConfig.timeBased().sampleCount() < 1)
+            throw new IllegalArgumentException("CircuitBreaker '%s' property '%s' can't be negative or zero value, but was: %s"
+                .formatted(name, "timeBased.sampleCount", mergedConfig.timeBased().sampleCount()));
+        if (mergedConfig.timeBased().sampleCount() > TIME_BASED_MAX_SAMPLE_COUNT)
+            throw new IllegalArgumentException("CircuitBreaker '%s' property '%s' can't be greater than %s, but was: %s"
+                .formatted(name, "timeBased.sampleCount", TIME_BASED_MAX_SAMPLE_COUNT, mergedConfig.timeBased().sampleCount()));
+        if (mergedConfig.timeBased().counterStripes() == null || mergedConfig.timeBased().counterStripes() < 1)
+            throw new IllegalArgumentException("CircuitBreaker '%s' property '%s' can't be negative or zero value, but was: %s"
+                .formatted(name, "timeBased.counterStripes", mergedConfig.timeBased().counterStripes()));
+        if (mergedConfig.timeBased().counterStripes() > TIME_BASED_MAX_COUNTER_STRIPES)
+            throw new IllegalArgumentException("CircuitBreaker '%s' property '%s' can't be greater than %s, but was: %s"
+                .formatted(name, "timeBased.counterStripes", TIME_BASED_MAX_COUNTER_STRIPES, mergedConfig.timeBased().counterStripes()));
+        if (mergedConfig.type() == CircuitBreakerType.TIME_BASED && toNanosSaturated(mergedConfig.timeBased().windowDuration()) / mergedConfig.timeBased().sampleCount() < 1)
+            throw new IllegalArgumentException("CircuitBreaker '%s' property '%s' is too small for '%s' value: %s"
+                .formatted(name, "timeBased.windowDuration", "timeBased.sampleCount", mergedConfig.timeBased().sampleCount()));
         if (mergedConfig.permittedCallsInHalfOpenState() > 0xFFFF)
             throw new IllegalArgumentException("CircuitBreaker '%s' property '%s' can't be greater than %s, but was: %s"
                 .formatted(name, "permittedCallsInHalfOpenState", 0xFFFF, mergedConfig.permittedCallsInHalfOpenState()));
-        if (mergedConfig.minimumRequiredCalls() > mergedConfig.windowSize())
+        if (mergedConfig.type() != CircuitBreakerType.TIME_BASED && mergedConfig.minimumRequiredCalls() > mergedConfig.countBased().windowSize())
             throw new IllegalArgumentException("CircuitBreaker '%s' property '%s' has value %s, it can't be greater than property '%s' which value was: %s"
-                .formatted(name, "minimumRequiredCalls", mergedConfig.minimumRequiredCalls(), "windowSize", mergedConfig.windowSize()));
+                .formatted(name, "minimumRequiredCalls", mergedConfig.minimumRequiredCalls(), "countBased.windowSize", mergedConfig.countBased().windowSize()));
         if (mergedConfig.failureRateThreshold() > 100 || mergedConfig.failureRateThreshold() < 1)
             throw new IllegalArgumentException("CircuitBreaker '%s' failureRateThreshold is percentage and must be in range from 1 to 100, but was: %s"
                 .formatted(name, mergedConfig.failureRateThreshold()));
@@ -102,19 +232,55 @@ public interface CircuitBreakerConfig {
         return mergedConfig;
     }
 
-    private static NamedConfig merge(NamedConfig namedConfig, NamedConfig defaultConfig) {
-        if (defaultConfig == null) {
-            return namedConfig;
-        }
-
+    private static NamedConfig merge(NamedConfig namedConfig, @Nullable NamedConfig defaultConfig) {
         return new $CircuitBreakerConfig_NamedConfig_ConfigValueMapper.NamedConfig_Impl(
-            namedConfig.enabled() != null ? Boolean.TRUE.equals(namedConfig.enabled()) : (defaultConfig.enabled() == null || Boolean.TRUE.equals(defaultConfig.enabled())),
-            namedConfig.failureRateThreshold() == null ? defaultConfig.failureRateThreshold() : namedConfig.failureRateThreshold(),
-            namedConfig.waitDurationInOpenState() == null ? defaultConfig.waitDurationInOpenState() : namedConfig.waitDurationInOpenState(),
-            namedConfig.permittedCallsInHalfOpenState() == null ? defaultConfig.permittedCallsInHalfOpenState() : namedConfig.permittedCallsInHalfOpenState(),
-            namedConfig.windowSize() == null ? defaultConfig.windowSize() : namedConfig.windowSize(),
-            namedConfig.minimumRequiredCalls() == null ? defaultConfig.minimumRequiredCalls() : namedConfig.minimumRequiredCalls(),
-            namedConfig.failurePredicateName() == null ? defaultConfig.failurePredicateName() : namedConfig.failurePredicateName()
+            namedConfig.enabled() != null ? Boolean.TRUE.equals(namedConfig.enabled()) : (defaultConfig == null || defaultConfig.enabled() == null || Boolean.TRUE.equals(defaultConfig.enabled())),
+            namedConfig.type() == null ? (defaultConfig == null || defaultConfig.type() == null ? CircuitBreakerType.FIXED_WINDOW : defaultConfig.type()) : namedConfig.type(),
+            mergeCountBased(namedConfig.countBased(), defaultConfig == null ? null : defaultConfig.countBased()),
+            mergeTimeBased(namedConfig.timeBased(), defaultConfig == null ? null : defaultConfig.timeBased()),
+            namedConfig.failureRateThreshold() == null ? (defaultConfig == null ? null : defaultConfig.failureRateThreshold()) : namedConfig.failureRateThreshold(),
+            namedConfig.waitDurationInOpenState() == null ? (defaultConfig == null ? null : defaultConfig.waitDurationInOpenState()) : namedConfig.waitDurationInOpenState(),
+            namedConfig.permittedCallsInHalfOpenState() == null ? (defaultConfig == null ? null : defaultConfig.permittedCallsInHalfOpenState()) : namedConfig.permittedCallsInHalfOpenState(),
+            namedConfig.minimumRequiredCalls() == null ? (defaultConfig == null ? null : defaultConfig.minimumRequiredCalls()) : namedConfig.minimumRequiredCalls(),
+            namedConfig.failurePredicateName() == null ? (defaultConfig == null ? KoraCircuitBreakerPredicate.class.getCanonicalName() : defaultConfig.failurePredicateName()) : namedConfig.failurePredicateName()
         );
+    }
+
+    private static CountBasedConfig mergeCountBased(@Nullable CountBasedConfig config, @Nullable CountBasedConfig defaultConfig) {
+        return new $CircuitBreakerConfig_CountBasedConfig_ConfigValueMapper.CountBasedConfig_Impl(
+            config == null || config.windowSize() == null ? (defaultConfig == null ? null : defaultConfig.windowSize()) : config.windowSize(),
+            mergeStripedApprox(config == null ? null : config.stripedApprox(), defaultConfig == null ? null : defaultConfig.stripedApprox())
+        );
+    }
+
+    private static TimeBasedConfig mergeTimeBased(@Nullable TimeBasedConfig config, @Nullable TimeBasedConfig defaultConfig) {
+        return new $CircuitBreakerConfig_TimeBasedConfig_ConfigValueMapper.TimeBasedConfig_Impl(
+            config == null || config.windowDuration() == null ? (defaultConfig == null ? null : defaultConfig.windowDuration()) : config.windowDuration(),
+            config == null || config.sampleCount() == null
+                ? (defaultConfig == null || defaultConfig.sampleCount() == null ? TIME_BASED_DEFAULT_SAMPLE_COUNT : defaultConfig.sampleCount())
+                : config.sampleCount(),
+            config == null || config.counterStripes() == null
+                ? (defaultConfig == null || defaultConfig.counterStripes() == null ? TIME_BASED_DEFAULT_COUNTER_STRIPES : defaultConfig.counterStripes())
+                : config.counterStripes(),
+            config == null || config.counterType() == null
+                ? (defaultConfig == null || defaultConfig.counterType() == null ? TimeBasedCounterType.ATOMIC : defaultConfig.counterType())
+                : config.counterType()
+        );
+    }
+
+    private static StripedApproxConfig mergeStripedApprox(@Nullable StripedApproxConfig config, @Nullable StripedApproxConfig defaultConfig) {
+        return new $CircuitBreakerConfig_StripedApproxConfig_ConfigValueMapper.StripedApproxConfig_Impl(
+            config == null || config.stripes() == null
+                ? (defaultConfig == null || defaultConfig.stripes() == null ? STRIPED_APPROX_DEFAULT_STRIPES : defaultConfig.stripes())
+                : config.stripes()
+        );
+    }
+
+    private static long toNanosSaturated(Duration duration) {
+        try {
+            return duration.toNanos();
+        } catch (ArithmeticException e) {
+            return Long.MAX_VALUE;
+        }
     }
 }

--- a/resilient/resilient-kora/src/main/java/io/koraframework/resilient/circuitbreaker/CircuitBreakerConfig.java
+++ b/resilient/resilient-kora/src/main/java/io/koraframework/resilient/circuitbreaker/CircuitBreakerConfig.java
@@ -24,8 +24,8 @@ public interface CircuitBreakerConfig {
      * {@link #failureRateThreshold} Configures the failure rate threshold in percentage. If the failure rate is equal to or greater than the threshold, the CircuitBreaker transitions to open and starts short-circuiting calls. The threshold must be greater than 0 and not greater than 100.<br>
      * {@link #waitDurationInOpenState} Configures an interval function with a fixed wait duration which controls how long the CircuitBreaker should stay open, before it switches to half open.<br>
      * {@link #permittedCallsInHalfOpenState} Configures the number of permitted calls that must succeed when the CircuitBreaker is half open.<br>
-     * {@link #slidingWindowSize} Configures the sliding window which is used to record the outcome of calls when the CircuitBreaker is closed.<br>
-     * {@link #minimumRequiredCalls} Configures the minimum number of calls which are required (per sliding window period) before the CircuitBreaker can calculate the error rate.<br>
+     * {@link #windowSize} Configures the fixed window which is used to record the outcome of calls when the CircuitBreaker is closed.<br>
+     * {@link #minimumRequiredCalls} Configures the minimum number of calls which are required (per fixed window period) before the CircuitBreaker can calculate the error rate.<br>
      * {@link #failurePredicateName} {@link CircuitBreakerPredicate#name()} default is {@link KoraCircuitBreakerPredicate}<br>
      */
     @ConfigMapper
@@ -44,7 +44,7 @@ public interface CircuitBreakerConfig {
         Integer permittedCallsInHalfOpenState();
 
         @Nullable
-        Long slidingWindowSize();
+        Long windowSize();
 
         @Nullable
         Long minimumRequiredCalls();
@@ -70,9 +70,9 @@ public interface CircuitBreakerConfig {
         if (mergedConfig.permittedCallsInHalfOpenState() == null)
             throw new IllegalStateException("CircuitBreaker property '%s' is not configured in either '%s' or '%s' config"
                 .formatted("permittedCallsInHalfOpenState", name, DEFAULT));
-        if (mergedConfig.slidingWindowSize() == null)
+        if (mergedConfig.windowSize() == null)
             throw new IllegalStateException("CircuitBreaker property '%s' is not configured in either '%s' or '%s' config"
-                .formatted("slidingWindowSize", name, DEFAULT));
+                .formatted("windowSize", name, DEFAULT));
         if (mergedConfig.minimumRequiredCalls() == null)
             throw new IllegalStateException("CircuitBreaker property '%s' is not configured in either '%s' or '%s' config"
                 .formatted("minimumRequiredCalls", name, DEFAULT));
@@ -80,15 +80,21 @@ public interface CircuitBreakerConfig {
         if (mergedConfig.minimumRequiredCalls() < 1)
             throw new IllegalArgumentException("CircuitBreaker '%s' property '%s' can't be negative or zero value, but was: %s"
                 .formatted(name, "minimumRequiredCalls", mergedConfig.minimumRequiredCalls()));
-        if (mergedConfig.slidingWindowSize() < 1)
+        if (mergedConfig.windowSize() < 1)
             throw new IllegalArgumentException("CircuitBreaker '%s' property '%s' can't be negative or zero value, but was: %s"
-                .formatted(name, "slidingWindowSize", mergedConfig.slidingWindowSize()));
+                .formatted(name, "windowSize", mergedConfig.windowSize()));
         if (mergedConfig.permittedCallsInHalfOpenState() < 1)
             throw new IllegalArgumentException("CircuitBreaker '%s' property '%s' can't be negative or zero value, but was: %s"
-                .formatted(name, "permittedCallsInHalfOpenState", mergedConfig.slidingWindowSize()));
-        if (mergedConfig.minimumRequiredCalls() > mergedConfig.slidingWindowSize())
+                .formatted(name, "permittedCallsInHalfOpenState", mergedConfig.permittedCallsInHalfOpenState()));
+        if (mergedConfig.windowSize() > 0x7FFF_FFFFL)
+            throw new IllegalArgumentException("CircuitBreaker '%s' property '%s' can't be greater than %s, but was: %s"
+                .formatted(name, "windowSize", 0x7FFF_FFFFL, mergedConfig.windowSize()));
+        if (mergedConfig.permittedCallsInHalfOpenState() > 0xFFFF)
+            throw new IllegalArgumentException("CircuitBreaker '%s' property '%s' can't be greater than %s, but was: %s"
+                .formatted(name, "permittedCallsInHalfOpenState", 0xFFFF, mergedConfig.permittedCallsInHalfOpenState()));
+        if (mergedConfig.minimumRequiredCalls() > mergedConfig.windowSize())
             throw new IllegalArgumentException("CircuitBreaker '%s' property '%s' has value %s, it can't be greater than property '%s' which value was: %s"
-                .formatted(name, "minimumRequiredCalls", mergedConfig.minimumRequiredCalls(), "slidingWindowSize", mergedConfig.slidingWindowSize()));
+                .formatted(name, "minimumRequiredCalls", mergedConfig.minimumRequiredCalls(), "windowSize", mergedConfig.windowSize()));
         if (mergedConfig.failureRateThreshold() > 100 || mergedConfig.failureRateThreshold() < 1)
             throw new IllegalArgumentException("CircuitBreaker '%s' failureRateThreshold is percentage and must be in range from 1 to 100, but was: %s"
                 .formatted(name, mergedConfig.failureRateThreshold()));
@@ -106,7 +112,7 @@ public interface CircuitBreakerConfig {
             namedConfig.failureRateThreshold() == null ? defaultConfig.failureRateThreshold() : namedConfig.failureRateThreshold(),
             namedConfig.waitDurationInOpenState() == null ? defaultConfig.waitDurationInOpenState() : namedConfig.waitDurationInOpenState(),
             namedConfig.permittedCallsInHalfOpenState() == null ? defaultConfig.permittedCallsInHalfOpenState() : namedConfig.permittedCallsInHalfOpenState(),
-            namedConfig.slidingWindowSize() == null ? defaultConfig.slidingWindowSize() : namedConfig.slidingWindowSize(),
+            namedConfig.windowSize() == null ? defaultConfig.windowSize() : namedConfig.windowSize(),
             namedConfig.minimumRequiredCalls() == null ? defaultConfig.minimumRequiredCalls() : namedConfig.minimumRequiredCalls(),
             namedConfig.failurePredicateName() == null ? defaultConfig.failurePredicateName() : namedConfig.failurePredicateName()
         );

--- a/resilient/resilient-kora/src/main/java/io/koraframework/resilient/circuitbreaker/FixedWindowKoraCircuitBreaker.java
+++ b/resilient/resilient-kora/src/main/java/io/koraframework/resilient/circuitbreaker/FixedWindowKoraCircuitBreaker.java
@@ -4,10 +4,12 @@ import io.koraframework.resilient.circuitbreaker.exception.CallNotPermittedExcep
 import io.koraframework.resilient.circuitbreaker.telemetry.CircuitBreakerTelemetry;
 import io.koraframework.resilient.circuitbreaker.telemetry.CircuitBreakerObservation;
 import io.koraframework.resilient.circuitbreaker.telemetry.CircuitBreakerObservation.CallAcquireStatus;
+import io.koraframework.resilient.circuitbreaker.telemetry.CircuitBreakerObservation.CallResult;
 import org.jspecify.annotations.Nullable;
 
-import java.time.Clock;
+import java.time.Duration;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 
 /**
@@ -30,7 +32,7 @@ import java.util.function.Supplier;
  * --------------------------------------------------------------------------------------------------
  */
 @SuppressWarnings("ConstantConditions")
-final class KoraCircuitBreaker implements CircuitBreaker {
+final class FixedWindowKoraCircuitBreaker implements CircuitBreaker {
 
     private static final long CLOSED_COUNTER_MASK = 0x7FFF_FFFFL;
     private static final long CLOSED_STATE = 1L << 63;
@@ -49,17 +51,23 @@ final class KoraCircuitBreaker implements CircuitBreaker {
     private final CircuitBreakerConfig.NamedConfig config;
     private final CircuitBreakerPredicate failurePredicate;
     private final CircuitBreakerTelemetry telemetry;
-    private final long waitDurationInOpenStateInMillis;
-    private final Clock clock;
+    private final long waitDurationInOpenStateInNanos;
+    private final LongSupplier currentTimeNanos;
+    private final long startedNanos;
 
-    KoraCircuitBreaker(String name, CircuitBreakerConfig.NamedConfig config, CircuitBreakerPredicate failurePredicate, CircuitBreakerTelemetry telemetry) {
+    FixedWindowKoraCircuitBreaker(String name, CircuitBreakerConfig.NamedConfig config, CircuitBreakerPredicate failurePredicate, CircuitBreakerTelemetry telemetry) {
+        this(name, config, failurePredicate, telemetry, System::nanoTime);
+    }
+
+    FixedWindowKoraCircuitBreaker(String name, CircuitBreakerConfig.NamedConfig config, CircuitBreakerPredicate failurePredicate, CircuitBreakerTelemetry telemetry, LongSupplier currentTimeNanos) {
         this.state = new AtomicLong(CLOSED_STATE);
         this.name = name;
         this.config = config;
         this.failurePredicate = failurePredicate;
         this.telemetry = telemetry;
-        this.waitDurationInOpenStateInMillis = config.waitDurationInOpenState().toMillis();
-        this.clock = Clock.systemDefaultZone();
+        this.waitDurationInOpenStateInNanos = toNanosSaturated(config.waitDurationInOpenState());
+        this.currentTimeNanos = currentTimeNanos;
+        this.startedNanos = currentTimeNanos.getAsLong();
     }
 
     State getState() {
@@ -85,9 +93,12 @@ final class KoraCircuitBreaker implements CircuitBreaker {
             var observation = this.telemetry.observe();
             try {
                 observation.recordCallAcquire(State.CLOSED, CallAcquireStatus.DISABLED);
-                return supplier.get();
+                var result = supplier.get();
+                observation.recordCallResult(State.CLOSED, CallResult.SUCCESS);
+                return result;
             } catch (Throwable e) {
                 observation.observeError(e);
+                observation.recordCallResult(State.CLOSED, CallResult.FAILURE);
                 throw e;
             } finally {
                 observation.end();
@@ -103,6 +114,7 @@ final class KoraCircuitBreaker implements CircuitBreaker {
             if (fallback == null) {
                 throw e;
             }
+            recordFallback(e);
         } catch (Throwable e) {
             releaseOnError(e);
             throw e;
@@ -127,20 +139,24 @@ final class KoraCircuitBreaker implements CircuitBreaker {
         return (int) (value & CLOSED_COUNTER_MASK);
     }
 
-    private short countHalfOpenSuccess(long value) {
-        return (short) ((value >> 16) & HALF_OPEN_COUNTER_MASK);
+    private int countHalfOpenSuccess(long value) {
+        return (int) ((value >> 16) & HALF_OPEN_COUNTER_MASK);
     }
 
-    private short countHalfOpenError(long value) {
-        return (short) ((value >> 32) & HALF_OPEN_COUNTER_MASK);
+    private int countHalfOpenError(long value) {
+        return (int) ((value >> 32) & HALF_OPEN_COUNTER_MASK);
     }
 
-    private short countHalfOpenAcquired(long value) {
-        return (short) (value & HALF_OPEN_COUNTER_MASK);
+    private int countHalfOpenAcquired(long value) {
+        return (int) (value & HALF_OPEN_COUNTER_MASK);
     }
 
     private long getOpenState() {
-        return clock.millis();
+        return currentElapsedNanos();
+    }
+
+    private long currentElapsedNanos() {
+        return Math.max(0, currentTimeNanos.getAsLong() - startedNanos);
     }
 
     private void onStateChange(State prevState,
@@ -187,7 +203,7 @@ final class KoraCircuitBreaker implements CircuitBreaker {
         }
 
         if (state == State.HALF_OPEN) {
-            final short acquired = countHalfOpenAcquired(stateLong);
+            final int acquired = countHalfOpenAcquired(stateLong);
             if (acquired < config.permittedCallsInHalfOpenState()) {
                 final boolean isAcquired = this.state.compareAndSet(stateLong, stateLong + 1);
                 if (isAcquired) {
@@ -202,10 +218,10 @@ final class KoraCircuitBreaker implements CircuitBreaker {
             }
         }
 
-        final long currentTimeInMillis = clock.millis();
-        final long beenInOpenState = currentTimeInMillis - stateLong;
+        final long currentTimeInNanos = currentElapsedNanos();
+        final long beenInOpenState = currentTimeInNanos - stateLong;
         // go to half open
-        if (beenInOpenState >= waitDurationInOpenStateInMillis) {
+        if (beenInOpenState >= waitDurationInOpenStateInNanos) {
             if (this.state.compareAndSet(stateLong, HALF_OPEN_STATE + 1)) {
                 onStateChange(State.OPEN, State.HALF_OPEN, null, observation);
                 observation.recordCallAcquire(State.HALF_OPEN, CallAcquireStatus.PERMITTED);
@@ -243,6 +259,7 @@ final class KoraCircuitBreaker implements CircuitBreaker {
             if (prevState != newState) {
                 onStateChange(prevState, newState, null, observation);
             }
+            observation.recordCallResult(prevState, CallResult.SUCCESS);
         } finally {
             observation.end();
         }
@@ -252,7 +269,7 @@ final class KoraCircuitBreaker implements CircuitBreaker {
         final State state = getState(currentState);
         if (state == State.CLOSED) {
             final int total = countClosedTotal(currentState) + 1;
-            if (total == config.slidingWindowSize()) {
+            if (total == config.windowSize()) {
                 return CLOSED_STATE;
             } else {
                 // just increase counter
@@ -281,13 +298,8 @@ final class KoraCircuitBreaker implements CircuitBreaker {
             }
 
             if (!failurePredicate.test(throwable)) {
-                final long currentStateLong = state.get();
-                final State currentState = getState(currentStateLong);
-                if (currentState == State.HALF_OPEN) {
-                    this.state.decrementAndGet();
-                    return;
-                }
-
+                releaseIgnoredError();
+                observation.recordCallResult(getState(state.get()), CallResult.IGNORED_FAILURE);
                 return;
             }
 
@@ -308,6 +320,7 @@ final class KoraCircuitBreaker implements CircuitBreaker {
             } else {
                 observation.observeError(throwable);
             }
+            observation.recordCallResult(prevState, CallResult.FAILURE);
         } finally {
             observation.end();
         }
@@ -326,7 +339,7 @@ final class KoraCircuitBreaker implements CircuitBreaker {
             final int failureRatePercentage = (int) (errors / total * 100);
             if (failureRatePercentage >= config.failureRateThreshold()) {
                 return getOpenState();
-            } else if (total == config.slidingWindowSize()) {
+            } else if (total == config.windowSize()) {
                 return CLOSED_STATE;
             } else {
                 // just increase both counters
@@ -338,6 +351,37 @@ final class KoraCircuitBreaker implements CircuitBreaker {
         } else {
             // do nothing with open state
             return currentState;
+        }
+    }
+
+    private void releaseIgnoredError() {
+        while (true) {
+            final long currentStateLong = state.get();
+            final State currentState = getState(currentStateLong);
+            if (currentState != State.HALF_OPEN) {
+                return;
+            }
+
+            if (state.compareAndSet(currentStateLong, currentStateLong - 1)) {
+                return;
+            }
+        }
+    }
+
+    private void recordFallback(CallNotPermittedException exception) {
+        var observation = this.telemetry.observe();
+        try {
+            observation.recordCallResult(exception.state(), CallResult.FALLBACK);
+        } finally {
+            observation.end();
+        }
+    }
+
+    private static long toNanosSaturated(Duration duration) {
+        try {
+            return duration.toNanos();
+        } catch (ArithmeticException e) {
+            return Long.MAX_VALUE;
         }
     }
 }

--- a/resilient/resilient-kora/src/main/java/io/koraframework/resilient/circuitbreaker/KoraCircuitBreakerManager.java
+++ b/resilient/resilient-kora/src/main/java/io/koraframework/resilient/circuitbreaker/KoraCircuitBreakerManager.java
@@ -34,7 +34,7 @@ final class KoraCircuitBreakerManager implements CircuitBreakerManager {
                 .addKeyValue("config", config)
                 .log("Creating CircuitBreaker");
 
-            return new KoraCircuitBreaker(name, config, failurePredicate, this.telemetryFactory.get(name, this.config.telemetry()));
+            return new FixedWindowKoraCircuitBreaker(name, config, failurePredicate, this.telemetryFactory.get(name, this.config.telemetry()));
         });
     }
 

--- a/resilient/resilient-kora/src/main/java/io/koraframework/resilient/circuitbreaker/KoraCircuitBreakerManager.java
+++ b/resilient/resilient-kora/src/main/java/io/koraframework/resilient/circuitbreaker/KoraCircuitBreakerManager.java
@@ -34,7 +34,13 @@ final class KoraCircuitBreakerManager implements CircuitBreakerManager {
                 .addKeyValue("config", config)
                 .log("Creating CircuitBreaker");
 
-            return new FixedWindowKoraCircuitBreaker(name, config, failurePredicate, this.telemetryFactory.get(name, this.config.telemetry()));
+            var telemetry = this.telemetryFactory.get(name, this.config.telemetry());
+            return switch (config.type()) {
+                case FIXED_WINDOW -> new FixedWindowKoraCircuitBreaker(name, config, failurePredicate, telemetry);
+                case STRIPED_APPROX -> new StripedApproxKoraCircuitBreaker(name, config, failurePredicate, telemetry);
+                case RING_BUFFER -> new RingBufferKoraCircuitBreaker(name, config, failurePredicate, telemetry);
+                case TIME_BASED -> new TimeBasedKoraCircuitBreaker(name, config, failurePredicate, telemetry);
+            };
         });
     }
 

--- a/resilient/resilient-kora/src/main/java/io/koraframework/resilient/circuitbreaker/RingBufferKoraCircuitBreaker.java
+++ b/resilient/resilient-kora/src/main/java/io/koraframework/resilient/circuitbreaker/RingBufferKoraCircuitBreaker.java
@@ -1,56 +1,50 @@
 package io.koraframework.resilient.circuitbreaker;
 
 import io.koraframework.resilient.circuitbreaker.exception.CallNotPermittedException;
-import io.koraframework.resilient.circuitbreaker.telemetry.CircuitBreakerTelemetry;
 import io.koraframework.resilient.circuitbreaker.telemetry.CircuitBreakerObservation;
 import io.koraframework.resilient.circuitbreaker.telemetry.CircuitBreakerObservation.CallAcquireStatus;
 import io.koraframework.resilient.circuitbreaker.telemetry.CircuitBreakerObservation.CallResult;
+import io.koraframework.resilient.circuitbreaker.telemetry.CircuitBreakerTelemetry;
 import org.jspecify.annotations.Nullable;
 
 import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicLongArray;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 
 /**
- * CircuitBreaker - Fixed Window implementation
+ * CircuitBreaker - exact count-based sequenced ring buffer implementation.
  * <p>
- * Cheapest implementation: one packed {@link AtomicLong} stores CLOSED and HALF_OPEN counters.
- * It has very low memory overhead and a small hot path, but CLOSED statistics are a fixed counter window,
- * not an exact ring of the globally latest N calls.
- * --------------------------------------------------------------------------------------------------
- * Closed {@link #state}
- * 10 | 0000000000000000000000000000000 | 0000000000000000000000000000000
- * ^                     ^                              ^
- * state sign     errors count (31 bits)      request count (31 bits)
+ * CLOSED-state statistics use one global completion sequence and per-slot CAS. This preserves a global
+ * order for completed calls without locks, synchronized blocks, or a global CAS loop around the whole ring.
+ * Counters are maintained incrementally and can be briefly eventually consistent while a completion owns a
+ * sequence but has not yet published its slot. The state machine itself remains strict and atomic.
  * <p>
- * Open {@link #state}
- * 00 | 00000000000000000000000000000000000000000000000000000000000000
- * ^                                    ^
- * state sign             start time of open state (millis)
- * <p>
- * Half open {@link #state}
- * 01 | 00000000000000 | 0000000000000000 | 0000000000000000 | 0000000000000000
- * ^                           ^                   ^                  ^
- * state sign     error count (16 bit)   success count (16 bits)   acquired count (16 bits)
- * --------------------------------------------------------------------------------------------------
+ * This is the strongest count-based implementation: the CLOSED window tracks the globally latest N completion
+ * events by sequence. It is more precise than {@link StripedApproxKoraCircuitBreaker}, but the global sequencer
+ * and slot CAS make the hot path more expensive under very high contention.
  */
 @SuppressWarnings("ConstantConditions")
-final class FixedWindowKoraCircuitBreaker implements CircuitBreaker {
+final class RingBufferKoraCircuitBreaker implements CircuitBreaker {
 
-    private static final long CLOSED_COUNTER_MASK = 0x7FFF_FFFFL;
-    private static final long CLOSED_STATE = 1L << 63;
     private static final long HALF_OPEN_COUNTER_MASK = 0xFFFFL;
+    private static final long CLOSED_STATE = 1L << 63;
     private static final long HALF_OPEN_STATE = 1L << 62;
     private static final long HALF_OPEN_INCREMENT_SUCCESS = 1L << 16;
-    private static final long HALF_OPEN_INCREMENT_ERROR = 1L << 32;
-    private static final long OPEN_STATE = 0;
 
-    private static final long COUNTER_INC = 1L;
-    private static final long ERR_COUNTER_INC = 1L << 31;
-    private static final long BOTH_COUNTERS_INC = ERR_COUNTER_INC + COUNTER_INC;
+    private static final int OUTCOME_EMPTY = 0;
+    private static final int OUTCOME_SUCCESS = 1;
+    private static final int OUTCOME_FAILURE = 2;
+    private static final int OUTCOME_IGNORED = 8;
 
-    private final AtomicLong state;
+    private static final long OUTCOME_MASK = 0xFFL;
+    private static final long SEQUENCE_MASK = 0xFFFF_FFFFFFL;
+    private static final int SEQUENCE_SHIFT = 8;
+    private static final int EPOCH_SHIFT = 48;
+
+    private final AtomicLong state = new AtomicLong(CLOSED_STATE);
     private final String name;
     private final CircuitBreakerConfig.NamedConfig config;
     private final CircuitBreakerPredicate failurePredicate;
@@ -58,13 +52,20 @@ final class FixedWindowKoraCircuitBreaker implements CircuitBreaker {
     private final long waitDurationInOpenStateInNanos;
     private final LongSupplier currentTimeNanos;
     private final long startedNanos;
+    private final AtomicLong sequence = new AtomicLong();
+    private final AtomicLong windowEpoch = new AtomicLong(2);
+    private final AtomicLongArray ringSlots;
+    private final int windowSize;
+    private final AtomicInteger bufferedCalls = new AtomicInteger();
+    private final AtomicInteger failedCalls = new AtomicInteger();
+    private final AtomicInteger slowCalls = new AtomicInteger();
+    private final AtomicInteger ignoredCalls = new AtomicInteger();
 
-    FixedWindowKoraCircuitBreaker(String name, CircuitBreakerConfig.NamedConfig config, CircuitBreakerPredicate failurePredicate, CircuitBreakerTelemetry telemetry) {
+    RingBufferKoraCircuitBreaker(String name, CircuitBreakerConfig.NamedConfig config, CircuitBreakerPredicate failurePredicate, CircuitBreakerTelemetry telemetry) {
         this(name, config, failurePredicate, telemetry, System::nanoTime);
     }
 
-    FixedWindowKoraCircuitBreaker(String name, CircuitBreakerConfig.NamedConfig config, CircuitBreakerPredicate failurePredicate, CircuitBreakerTelemetry telemetry, LongSupplier currentTimeNanos) {
-        this.state = new AtomicLong(CLOSED_STATE);
+    RingBufferKoraCircuitBreaker(String name, CircuitBreakerConfig.NamedConfig config, CircuitBreakerPredicate failurePredicate, CircuitBreakerTelemetry telemetry, LongSupplier currentTimeNanos) {
         this.name = name;
         this.config = config;
         this.failurePredicate = failurePredicate;
@@ -72,6 +73,8 @@ final class FixedWindowKoraCircuitBreaker implements CircuitBreaker {
         this.waitDurationInOpenStateInNanos = toNanosSaturated(config.waitDurationInOpenState());
         this.currentTimeNanos = currentTimeNanos;
         this.startedNanos = currentTimeNanos.getAsLong();
+        this.windowSize = Math.toIntExact(config.countBased().windowSize());
+        this.ringSlots = new AtomicLongArray(this.windowSize);
     }
 
     State getState() {
@@ -80,6 +83,15 @@ final class FixedWindowKoraCircuitBreaker implements CircuitBreaker {
         } else {
             return getState(state.get());
         }
+    }
+
+    Snapshot snapshot() {
+        return new Snapshot(
+            bufferedCalls.get(),
+            failedCalls.get(),
+            slowCalls.get(),
+            ignoredCalls.get()
+        );
     }
 
     @Override
@@ -111,9 +123,9 @@ final class FixedWindowKoraCircuitBreaker implements CircuitBreaker {
 
         try {
             acquire();
-            var t = supplier.get();
+            var result = supplier.get();
             releaseOnSuccess();
-            return t;
+            return result;
         } catch (CallNotPermittedException e) {
             if (fallback == null) {
                 throw e;
@@ -135,20 +147,8 @@ final class FixedWindowKoraCircuitBreaker implements CircuitBreaker {
         };
     }
 
-    private int countClosedErrors(long value) {
-        return (int) ((value >> 31) & CLOSED_COUNTER_MASK);
-    }
-
-    private int countClosedTotal(long value) {
-        return (int) (value & CLOSED_COUNTER_MASK);
-    }
-
     private int countHalfOpenSuccess(long value) {
         return (int) ((value >> 16) & HALF_OPEN_COUNTER_MASK);
-    }
-
-    private int countHalfOpenError(long value) {
-        return (int) ((value >> 32) & HALF_OPEN_COUNTER_MASK);
     }
 
     private int countHalfOpenAcquired(long value) {
@@ -224,14 +224,13 @@ final class FixedWindowKoraCircuitBreaker implements CircuitBreaker {
 
         final long currentTimeInNanos = currentElapsedNanos();
         final long beenInOpenState = currentTimeInNanos - stateLong;
-        // go to half open
         if (beenInOpenState >= waitDurationInOpenStateInNanos) {
             if (this.state.compareAndSet(stateLong, HALF_OPEN_STATE + 1)) {
+                clearWindow();
                 onStateChange(State.OPEN, State.HALF_OPEN, null, observation);
                 observation.recordCallAcquire(State.HALF_OPEN, CallAcquireStatus.PERMITTED);
                 return true;
             } else {
-                // prob concurrently switched to half open and have to reacquire
                 return tryAcquire(observation);
             }
         } else {
@@ -248,19 +247,27 @@ final class FixedWindowKoraCircuitBreaker implements CircuitBreaker {
                 return;
             }
 
+            final long currentStateLong = state.get();
+            final State currentState = getState(currentStateLong);
+            if (currentState == State.CLOSED) {
+                record(OUTCOME_SUCCESS);
+                observation.recordCallResult(State.CLOSED, CallResult.SUCCESS);
+                return;
+            }
+
             State prevState;
             State newState;
             while (true) {
-                final long currentStateLong = state.get();
-                final long newStateLong = calculateStateOnSuccess(currentStateLong);
-                if (state.compareAndSet(currentStateLong, newStateLong)) {
+                final long observedStateLong = state.get();
+                final long newStateLong = calculateStateOnSuccess(observedStateLong);
+                if (state.compareAndSet(observedStateLong, newStateLong)) {
+                    prevState = getState(observedStateLong);
                     newState = getState(newStateLong);
-                    prevState = getState(currentStateLong);
                     break;
                 }
             }
-
             if (prevState != newState) {
+                clearWindow();
                 onStateChange(prevState, newState, null, observation);
             }
             observation.recordCallResult(prevState, CallResult.SUCCESS);
@@ -271,15 +278,7 @@ final class FixedWindowKoraCircuitBreaker implements CircuitBreaker {
 
     private long calculateStateOnSuccess(long currentState) {
         final State state = getState(currentState);
-        if (state == State.CLOSED) {
-            final int total = countClosedTotal(currentState) + 1;
-            if (total == config.countBased().windowSize()) {
-                return CLOSED_STATE;
-            } else {
-                // just increase counter
-                return currentState + COUNTER_INC;
-            }
-        } else if (state == State.HALF_OPEN) {
+        if (state == State.HALF_OPEN) {
             final int success = countHalfOpenSuccess(currentState) + 1;
             final int permitted = config.permittedCallsInHalfOpenState();
             if (success >= permitted) {
@@ -288,7 +287,6 @@ final class FixedWindowKoraCircuitBreaker implements CircuitBreaker {
 
             return currentState + HALF_OPEN_INCREMENT_SUCCESS;
         } else {
-            //do nothing with open state
             return currentState;
         }
     }
@@ -303,23 +301,40 @@ final class FixedWindowKoraCircuitBreaker implements CircuitBreaker {
 
             if (!failurePredicate.test(throwable)) {
                 releaseIgnoredError();
+                if (getState(state.get()) == State.CLOSED) {
+                    record(OUTCOME_IGNORED);
+                }
                 observation.recordCallResult(getState(state.get()), CallResult.IGNORED_FAILURE);
+                return;
+            }
+
+            final long currentStateLong = state.get();
+            final State currentState = getState(currentStateLong);
+            if (currentState == State.CLOSED) {
+                record(OUTCOME_FAILURE);
+                if (shouldOpen()) {
+                    openFromClosed(observation, throwable);
+                } else {
+                    observation.observeError(throwable);
+                }
+                observation.recordCallResult(State.CLOSED, CallResult.FAILURE);
                 return;
             }
 
             State prevState;
             State newState;
             while (true) {
-                final long currentStateLong = state.get();
-                final long newStateLong = calculateStateOnFailure(currentStateLong);
-                if (state.compareAndSet(currentStateLong, newStateLong)) {
+                final long observedStateLong = state.get();
+                final long newStateLong = calculateStateOnFailure(observedStateLong);
+                if (state.compareAndSet(observedStateLong, newStateLong)) {
+                    prevState = getState(observedStateLong);
                     newState = getState(newStateLong);
-                    prevState = getState(currentStateLong);
                     break;
                 }
             }
 
             if (prevState != newState) {
+                clearWindow();
                 onStateChange(prevState, newState, throwable, observation);
             } else {
                 observation.observeError(throwable);
@@ -332,29 +347,90 @@ final class FixedWindowKoraCircuitBreaker implements CircuitBreaker {
 
     private long calculateStateOnFailure(long currentState) {
         final State state = getState(currentState);
-        if (state == State.CLOSED) {
-            final int total = countClosedTotal(currentState) + 1;
-            if (total < config.minimumRequiredCalls()) {
-                // just increase both counters
-                return currentState + BOTH_COUNTERS_INC;
-            }
-
-            final float errors = countClosedErrors(currentState) + 1;
-            final int failureRatePercentage = (int) (errors / total * 100);
-            if (failureRatePercentage >= config.failureRateThreshold()) {
-                return getOpenState();
-            } else if (total == config.countBased().windowSize()) {
-                return CLOSED_STATE;
-            } else {
-                // just increase both counters
-                return currentState + BOTH_COUNTERS_INC;
-            }
-        } else if (state == State.HALF_OPEN) {
-            // if any error in half-open then go to open state
+        if (state == State.HALF_OPEN) {
             return getOpenState();
         } else {
-            // do nothing with open state
             return currentState;
+        }
+    }
+
+    private boolean record(int outcome) {
+        final long fullEpoch = stableEpoch();
+        final long slotEpoch = slotEpoch(fullEpoch);
+        final long seq = sequence.getAndIncrement() & SEQUENCE_MASK;
+        final int slot = (int) (seq % windowSize);
+        final long newPacked = pack(slotEpoch, seq, outcome);
+
+        while (windowEpoch.get() == fullEpoch) {
+            final long oldPacked = ringSlots.get(slot);
+            final long oldEpoch = epoch(oldPacked);
+            if (oldEpoch == slotEpoch && sequence(oldPacked) >= seq) {
+                return false;
+            }
+
+            if (ringSlots.compareAndSet(slot, oldPacked, newPacked)) {
+                if (windowEpoch.get() != fullEpoch) {
+                    ringSlots.compareAndSet(slot, newPacked, 0);
+                    return false;
+                }
+
+                final int oldOutcome = oldEpoch == slotEpoch ? outcome(oldPacked) : OUTCOME_EMPTY;
+                applyDelta(oldOutcome, outcome);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private long stableEpoch() {
+        while (true) {
+            final long epoch = windowEpoch.get();
+            if ((epoch & 1L) == 0) {
+                return epoch;
+            }
+            Thread.onSpinWait();
+        }
+    }
+
+    private void applyDelta(int oldOutcome, int newOutcome) {
+        final int totalDelta = totalDelta(newOutcome) - totalDelta(oldOutcome);
+        if (totalDelta != 0) {
+            bufferedCalls.addAndGet(totalDelta);
+        }
+
+        final int failureDelta = failureDelta(newOutcome) - failureDelta(oldOutcome);
+        if (failureDelta != 0) {
+            failedCalls.addAndGet(failureDelta);
+        }
+
+        final int slowDelta = slowDelta(newOutcome) - slowDelta(oldOutcome);
+        if (slowDelta != 0) {
+            slowCalls.addAndGet(slowDelta);
+        }
+
+        final int ignoredDelta = ignoredDelta(newOutcome) - ignoredDelta(oldOutcome);
+        if (ignoredDelta != 0) {
+            ignoredCalls.addAndGet(ignoredDelta);
+        }
+    }
+
+    private boolean shouldOpen() {
+        final int total = bufferedCalls.get();
+        if (total < config.minimumRequiredCalls()) {
+            return false;
+        }
+
+        return failedCalls.get() * 100 / total >= config.failureRateThreshold();
+    }
+
+    private void openFromClosed(CircuitBreakerObservation observation, Throwable throwable) {
+        final long currentStateLong = state.get();
+        if (getState(currentStateLong) == State.CLOSED && state.compareAndSet(currentStateLong, getOpenState())) {
+            clearWindow();
+            onStateChange(State.CLOSED, State.OPEN, throwable, observation);
+        } else {
+            observation.observeError(throwable);
         }
     }
 
@@ -372,6 +448,19 @@ final class FixedWindowKoraCircuitBreaker implements CircuitBreaker {
         }
     }
 
+    private void clearWindow() {
+        windowEpoch.incrementAndGet();
+        for (int i = 0; i < ringSlots.length(); i++) {
+            ringSlots.set(i, 0);
+        }
+        sequence.set(0);
+        bufferedCalls.set(0);
+        failedCalls.set(0);
+        slowCalls.set(0);
+        ignoredCalls.set(0);
+        windowEpoch.incrementAndGet();
+    }
+
     private void recordFallback(CallNotPermittedException exception) {
         var observation = this.telemetry.observe();
         try {
@@ -381,6 +470,45 @@ final class FixedWindowKoraCircuitBreaker implements CircuitBreaker {
         }
     }
 
+    private static long pack(long epoch, long sequence, int outcome) {
+        return (epoch << EPOCH_SHIFT) | ((sequence & SEQUENCE_MASK) << SEQUENCE_SHIFT) | (outcome & OUTCOME_MASK);
+    }
+
+    private static long slotEpoch(long epoch) {
+        return epoch & 0xFFFFL;
+    }
+
+    private static long epoch(long packed) {
+        return packed >>> EPOCH_SHIFT;
+    }
+
+    private static long sequence(long packed) {
+        return (packed >>> SEQUENCE_SHIFT) & SEQUENCE_MASK;
+    }
+
+    private static int outcome(long packed) {
+        return (int) (packed & OUTCOME_MASK);
+    }
+
+    private static int totalDelta(int outcome) {
+        return switch (outcome) {
+            case OUTCOME_SUCCESS, OUTCOME_FAILURE -> 1;
+            default -> 0;
+        };
+    }
+
+    private static int failureDelta(int outcome) {
+        return outcome == OUTCOME_FAILURE ? 1 : 0;
+    }
+
+    private static int slowDelta(int outcome) {
+        return 0;
+    }
+
+    private static int ignoredDelta(int outcome) {
+        return outcome == OUTCOME_IGNORED ? 1 : 0;
+    }
+
     private static long toNanosSaturated(Duration duration) {
         try {
             return duration.toNanos();
@@ -388,4 +516,6 @@ final class FixedWindowKoraCircuitBreaker implements CircuitBreaker {
             return Long.MAX_VALUE;
         }
     }
+
+    record Snapshot(int total, int failures, int slowCalls, int ignored) {}
 }

--- a/resilient/resilient-kora/src/main/java/io/koraframework/resilient/circuitbreaker/StripedApproxKoraCircuitBreaker.java
+++ b/resilient/resilient-kora/src/main/java/io/koraframework/resilient/circuitbreaker/StripedApproxKoraCircuitBreaker.java
@@ -1,56 +1,52 @@
 package io.koraframework.resilient.circuitbreaker;
 
 import io.koraframework.resilient.circuitbreaker.exception.CallNotPermittedException;
-import io.koraframework.resilient.circuitbreaker.telemetry.CircuitBreakerTelemetry;
 import io.koraframework.resilient.circuitbreaker.telemetry.CircuitBreakerObservation;
 import io.koraframework.resilient.circuitbreaker.telemetry.CircuitBreakerObservation.CallAcquireStatus;
 import io.koraframework.resilient.circuitbreaker.telemetry.CircuitBreakerObservation.CallResult;
+import io.koraframework.resilient.circuitbreaker.telemetry.CircuitBreakerTelemetry;
 import org.jspecify.annotations.Nullable;
 
 import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicIntegerArray;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 
 /**
- * CircuitBreaker - Fixed Window implementation
+ * CircuitBreaker - striped approximate count window implementation.
  * <p>
- * Cheapest implementation: one packed {@link AtomicLong} stores CLOSED and HALF_OPEN counters.
- * It has very low memory overhead and a small hot path, but CLOSED statistics are a fixed counter window,
- * not an exact ring of the globally latest N calls.
- * --------------------------------------------------------------------------------------------------
- * Closed {@link #state}
- * 10 | 0000000000000000000000000000000 | 0000000000000000000000000000000
- * ^                     ^                              ^
- * state sign     errors count (31 bits)      request count (31 bits)
+ * CLOSED-state statistics are intentionally approximate: every stripe owns a local ring and local counters,
+ * and global snapshot is the sum of stripe snapshots. Under uneven thread distribution the effective global
+ * window can be shifted and does not represent a strict FIFO of last N calls. The state machine remains strict
+ * and atomic.
  * <p>
- * Open {@link #state}
- * 00 | 00000000000000000000000000000000000000000000000000000000000000
- * ^                                    ^
- * state sign             start time of open state (millis)
- * <p>
- * Half open {@link #state}
- * 01 | 00000000000000 | 0000000000000000 | 0000000000000000 | 0000000000000000
- * ^                           ^                   ^                  ^
- * state sign     error count (16 bit)   success count (16 bits)   acquired count (16 bits)
- * --------------------------------------------------------------------------------------------------
+ * This is the fastest hot-path implementation for high concurrency: writes avoid a global sequencer and
+ * update only one stripe. The trade-off is approximate statistics instead of exact global count-based order.
  */
 @SuppressWarnings("ConstantConditions")
-final class FixedWindowKoraCircuitBreaker implements CircuitBreaker {
+final class StripedApproxKoraCircuitBreaker implements CircuitBreaker {
 
-    private static final long CLOSED_COUNTER_MASK = 0x7FFF_FFFFL;
-    private static final long CLOSED_STATE = 1L << 63;
     private static final long HALF_OPEN_COUNTER_MASK = 0xFFFFL;
+    private static final long CLOSED_STATE = 1L << 63;
     private static final long HALF_OPEN_STATE = 1L << 62;
     private static final long HALF_OPEN_INCREMENT_SUCCESS = 1L << 16;
     private static final long HALF_OPEN_INCREMENT_ERROR = 1L << 32;
-    private static final long OPEN_STATE = 0;
 
-    private static final long COUNTER_INC = 1L;
-    private static final long ERR_COUNTER_INC = 1L << 31;
-    private static final long BOTH_COUNTERS_INC = ERR_COUNTER_INC + COUNTER_INC;
+    private static final int OUTCOME_EMPTY = 0;
+    private static final int OUTCOME_SUCCESS = 1;
+    private static final int OUTCOME_FAILURE = 2;
+    private static final int OUTCOME_IGNORED = 3;
+    private static final int OUTCOME_SLOW = 4;
 
-    private final AtomicLong state;
+    private static final int COUNTER_BITS = 16;
+    private static final long COUNTER_MASK = 0xFFFFL;
+    private static final int FAILURE_SHIFT = 16;
+    private static final int SLOW_SHIFT = 32;
+    private static final int IGNORED_SHIFT = 48;
+
+    private final AtomicLong state = new AtomicLong(CLOSED_STATE);
     private final String name;
     private final CircuitBreakerConfig.NamedConfig config;
     private final CircuitBreakerPredicate failurePredicate;
@@ -58,13 +54,14 @@ final class FixedWindowKoraCircuitBreaker implements CircuitBreaker {
     private final long waitDurationInOpenStateInNanos;
     private final LongSupplier currentTimeNanos;
     private final long startedNanos;
+    private final Stripe[] stripes;
+    private final int stripeMask;
 
-    FixedWindowKoraCircuitBreaker(String name, CircuitBreakerConfig.NamedConfig config, CircuitBreakerPredicate failurePredicate, CircuitBreakerTelemetry telemetry) {
+    StripedApproxKoraCircuitBreaker(String name, CircuitBreakerConfig.NamedConfig config, CircuitBreakerPredicate failurePredicate, CircuitBreakerTelemetry telemetry) {
         this(name, config, failurePredicate, telemetry, System::nanoTime);
     }
 
-    FixedWindowKoraCircuitBreaker(String name, CircuitBreakerConfig.NamedConfig config, CircuitBreakerPredicate failurePredicate, CircuitBreakerTelemetry telemetry, LongSupplier currentTimeNanos) {
-        this.state = new AtomicLong(CLOSED_STATE);
+    StripedApproxKoraCircuitBreaker(String name, CircuitBreakerConfig.NamedConfig config, CircuitBreakerPredicate failurePredicate, CircuitBreakerTelemetry telemetry, LongSupplier currentTimeNanos) {
         this.name = name;
         this.config = config;
         this.failurePredicate = failurePredicate;
@@ -72,6 +69,15 @@ final class FixedWindowKoraCircuitBreaker implements CircuitBreaker {
         this.waitDurationInOpenStateInNanos = toNanosSaturated(config.waitDurationInOpenState());
         this.currentTimeNanos = currentTimeNanos;
         this.startedNanos = currentTimeNanos.getAsLong();
+
+        var stripeCount = Math.min(config.countBased().stripedApprox().stripes(), Math.toIntExact(config.countBased().windowSize()));
+        stripeCount = nextPowerOfTwo(stripeCount);
+        this.stripes = new Stripe[stripeCount];
+        this.stripeMask = stripeCount - 1;
+        var stripeWindowSize = Math.toIntExact((config.countBased().windowSize() + stripeCount - 1) / stripeCount);
+        for (int i = 0; i < stripeCount; i++) {
+            this.stripes[i] = new Stripe(stripeWindowSize);
+        }
     }
 
     State getState() {
@@ -80,6 +86,21 @@ final class FixedWindowKoraCircuitBreaker implements CircuitBreaker {
         } else {
             return getState(state.get());
         }
+    }
+
+    Snapshot snapshot() {
+        long total = 0;
+        long failures = 0;
+        long slowCalls = 0;
+        long ignored = 0;
+        for (Stripe localStripe : this.stripes) {
+            var counters = localStripe.counters.get();
+            total += total(counters);
+            failures += failures(counters);
+            slowCalls += slowCalls(counters);
+            ignored += ignored(counters);
+        }
+        return new Snapshot(total, failures, slowCalls, ignored);
     }
 
     @Override
@@ -111,9 +132,9 @@ final class FixedWindowKoraCircuitBreaker implements CircuitBreaker {
 
         try {
             acquire();
-            var t = supplier.get();
+            var result = supplier.get();
             releaseOnSuccess();
-            return t;
+            return result;
         } catch (CallNotPermittedException e) {
             if (fallback == null) {
                 throw e;
@@ -135,20 +156,8 @@ final class FixedWindowKoraCircuitBreaker implements CircuitBreaker {
         };
     }
 
-    private int countClosedErrors(long value) {
-        return (int) ((value >> 31) & CLOSED_COUNTER_MASK);
-    }
-
-    private int countClosedTotal(long value) {
-        return (int) (value & CLOSED_COUNTER_MASK);
-    }
-
     private int countHalfOpenSuccess(long value) {
         return (int) ((value >> 16) & HALF_OPEN_COUNTER_MASK);
-    }
-
-    private int countHalfOpenError(long value) {
-        return (int) ((value >> 32) & HALF_OPEN_COUNTER_MASK);
     }
 
     private int countHalfOpenAcquired(long value) {
@@ -224,14 +233,12 @@ final class FixedWindowKoraCircuitBreaker implements CircuitBreaker {
 
         final long currentTimeInNanos = currentElapsedNanos();
         final long beenInOpenState = currentTimeInNanos - stateLong;
-        // go to half open
         if (beenInOpenState >= waitDurationInOpenStateInNanos) {
             if (this.state.compareAndSet(stateLong, HALF_OPEN_STATE + 1)) {
                 onStateChange(State.OPEN, State.HALF_OPEN, null, observation);
                 observation.recordCallAcquire(State.HALF_OPEN, CallAcquireStatus.PERMITTED);
                 return true;
             } else {
-                // prob concurrently switched to half open and have to reacquire
                 return tryAcquire(observation);
             }
         } else {
@@ -248,19 +255,27 @@ final class FixedWindowKoraCircuitBreaker implements CircuitBreaker {
                 return;
             }
 
+            final long currentStateLong = state.get();
+            final State currentState = getState(currentStateLong);
+            if (currentState == State.CLOSED) {
+                stripe().record(OUTCOME_SUCCESS);
+                observation.recordCallResult(State.CLOSED, CallResult.SUCCESS);
+                return;
+            }
+
             State prevState;
             State newState;
             while (true) {
-                final long currentStateLong = state.get();
-                final long newStateLong = calculateStateOnSuccess(currentStateLong);
-                if (state.compareAndSet(currentStateLong, newStateLong)) {
+                final long observedStateLong = state.get();
+                final long newStateLong = calculateStateOnSuccess(observedStateLong);
+                if (state.compareAndSet(observedStateLong, newStateLong)) {
+                    prevState = getState(observedStateLong);
                     newState = getState(newStateLong);
-                    prevState = getState(currentStateLong);
                     break;
                 }
             }
-
             if (prevState != newState) {
+                clearWindow();
                 onStateChange(prevState, newState, null, observation);
             }
             observation.recordCallResult(prevState, CallResult.SUCCESS);
@@ -271,15 +286,7 @@ final class FixedWindowKoraCircuitBreaker implements CircuitBreaker {
 
     private long calculateStateOnSuccess(long currentState) {
         final State state = getState(currentState);
-        if (state == State.CLOSED) {
-            final int total = countClosedTotal(currentState) + 1;
-            if (total == config.countBased().windowSize()) {
-                return CLOSED_STATE;
-            } else {
-                // just increase counter
-                return currentState + COUNTER_INC;
-            }
-        } else if (state == State.HALF_OPEN) {
+        if (state == State.HALF_OPEN) {
             final int success = countHalfOpenSuccess(currentState) + 1;
             final int permitted = config.permittedCallsInHalfOpenState();
             if (success >= permitted) {
@@ -288,7 +295,6 @@ final class FixedWindowKoraCircuitBreaker implements CircuitBreaker {
 
             return currentState + HALF_OPEN_INCREMENT_SUCCESS;
         } else {
-            //do nothing with open state
             return currentState;
         }
     }
@@ -303,23 +309,40 @@ final class FixedWindowKoraCircuitBreaker implements CircuitBreaker {
 
             if (!failurePredicate.test(throwable)) {
                 releaseIgnoredError();
+                if (getState(state.get()) == State.CLOSED) {
+                    stripe().record(OUTCOME_IGNORED);
+                }
                 observation.recordCallResult(getState(state.get()), CallResult.IGNORED_FAILURE);
+                return;
+            }
+
+            final long currentStateLong = state.get();
+            final State currentState = getState(currentStateLong);
+            if (currentState == State.CLOSED) {
+                stripe().record(OUTCOME_FAILURE);
+                if (shouldOpen()) {
+                    openFromClosed(observation, throwable);
+                } else {
+                    observation.observeError(throwable);
+                }
+                observation.recordCallResult(State.CLOSED, CallResult.FAILURE);
                 return;
             }
 
             State prevState;
             State newState;
             while (true) {
-                final long currentStateLong = state.get();
-                final long newStateLong = calculateStateOnFailure(currentStateLong);
-                if (state.compareAndSet(currentStateLong, newStateLong)) {
+                final long observedStateLong = state.get();
+                final long newStateLong = calculateStateOnFailure(observedStateLong);
+                if (state.compareAndSet(observedStateLong, newStateLong)) {
+                    prevState = getState(observedStateLong);
                     newState = getState(newStateLong);
-                    prevState = getState(currentStateLong);
                     break;
                 }
             }
 
             if (prevState != newState) {
+                clearWindow();
                 onStateChange(prevState, newState, throwable, observation);
             } else {
                 observation.observeError(throwable);
@@ -332,29 +355,35 @@ final class FixedWindowKoraCircuitBreaker implements CircuitBreaker {
 
     private long calculateStateOnFailure(long currentState) {
         final State state = getState(currentState);
-        if (state == State.CLOSED) {
-            final int total = countClosedTotal(currentState) + 1;
-            if (total < config.minimumRequiredCalls()) {
-                // just increase both counters
-                return currentState + BOTH_COUNTERS_INC;
-            }
-
-            final float errors = countClosedErrors(currentState) + 1;
-            final int failureRatePercentage = (int) (errors / total * 100);
-            if (failureRatePercentage >= config.failureRateThreshold()) {
-                return getOpenState();
-            } else if (total == config.countBased().windowSize()) {
-                return CLOSED_STATE;
-            } else {
-                // just increase both counters
-                return currentState + BOTH_COUNTERS_INC;
-            }
-        } else if (state == State.HALF_OPEN) {
-            // if any error in half-open then go to open state
+        if (state == State.HALF_OPEN) {
             return getOpenState();
         } else {
-            // do nothing with open state
             return currentState;
+        }
+    }
+
+    private boolean shouldOpen() {
+        long total = 0;
+        long failures = 0;
+        for (Stripe localStripe : this.stripes) {
+            var counters = localStripe.counters.get();
+            total += total(counters);
+            failures += failures(counters);
+        }
+        if (total < config.minimumRequiredCalls()) {
+            return false;
+        }
+
+        return (int) (failures * 100 / total) >= config.failureRateThreshold();
+    }
+
+    private void openFromClosed(CircuitBreakerObservation observation, Throwable throwable) {
+        final long currentStateLong = state.get();
+        if (getState(currentStateLong) == State.CLOSED && state.compareAndSet(currentStateLong, getOpenState())) {
+            clearWindow();
+            onStateChange(State.CLOSED, State.OPEN, throwable, observation);
+        } else {
+            observation.observeError(throwable);
         }
     }
 
@@ -372,6 +401,24 @@ final class FixedWindowKoraCircuitBreaker implements CircuitBreaker {
         }
     }
 
+    private void clearWindow() {
+        for (Stripe localStripe : this.stripes) {
+            localStripe.clear();
+        }
+    }
+
+    private Stripe stripe() {
+        return this.stripes[stripeIndex()];
+    }
+
+    private int stripeIndex() {
+        var x = (int) Thread.currentThread().threadId();
+        x ^= x >>> 16;
+        x *= 0x7feb352d;
+        x ^= x >>> 15;
+        return x & stripeMask;
+    }
+
     private void recordFallback(CallNotPermittedException exception) {
         var observation = this.telemetry.observe();
         try {
@@ -381,11 +428,70 @@ final class FixedWindowKoraCircuitBreaker implements CircuitBreaker {
         }
     }
 
+    private static long packedDelta(int outcome) {
+        return switch (outcome) {
+            case OUTCOME_SUCCESS -> 1L;
+            case OUTCOME_FAILURE -> 1L | (1L << FAILURE_SHIFT);
+            case OUTCOME_IGNORED -> 1L << IGNORED_SHIFT;
+            case OUTCOME_SLOW -> 1L | (1L << SLOW_SHIFT);
+            default -> 0L;
+        };
+    }
+
+    private static long total(long counters) {
+        return counters & COUNTER_MASK;
+    }
+
+    private static long failures(long counters) {
+        return (counters >>> FAILURE_SHIFT) & COUNTER_MASK;
+    }
+
+    private static long slowCalls(long counters) {
+        return (counters >>> SLOW_SHIFT) & COUNTER_MASK;
+    }
+
+    private static long ignored(long counters) {
+        return (counters >>> IGNORED_SHIFT) & COUNTER_MASK;
+    }
+
+    private static int nextPowerOfTwo(int value) {
+        var highest = Integer.highestOneBit(value);
+        return highest == value ? value : highest << 1;
+    }
+
     private static long toNanosSaturated(Duration duration) {
         try {
             return duration.toNanos();
         } catch (ArithmeticException e) {
             return Long.MAX_VALUE;
+        }
+    }
+
+    record Snapshot(long total, long failures, long slowCalls, long ignored) {}
+
+    private static final class Stripe {
+
+        private final AtomicInteger cursor = new AtomicInteger();
+        private final AtomicIntegerArray outcomes;
+        private final AtomicLong counters = new AtomicLong();
+
+        private Stripe(int windowSize) {
+            this.outcomes = new AtomicIntegerArray(windowSize);
+        }
+
+        private void record(int outcome) {
+            var position = cursor.getAndIncrement();
+            var slot = (position & Integer.MAX_VALUE) % outcomes.length();
+            var previous = outcomes.getAndSet(slot, outcome);
+            counters.addAndGet(packedDelta(outcome) - packedDelta(previous));
+        }
+
+        private void clear() {
+            for (int i = 0; i < outcomes.length(); i++) {
+                outcomes.set(i, OUTCOME_EMPTY);
+            }
+            counters.set(0);
+            cursor.set(0);
         }
     }
 }

--- a/resilient/resilient-kora/src/main/java/io/koraframework/resilient/circuitbreaker/TimeBasedKoraCircuitBreaker.java
+++ b/resilient/resilient-kora/src/main/java/io/koraframework/resilient/circuitbreaker/TimeBasedKoraCircuitBreaker.java
@@ -1,0 +1,604 @@
+package io.koraframework.resilient.circuitbreaker;
+
+import io.koraframework.resilient.circuitbreaker.exception.CallNotPermittedException;
+import io.koraframework.resilient.circuitbreaker.telemetry.CircuitBreakerObservation;
+import io.koraframework.resilient.circuitbreaker.telemetry.CircuitBreakerObservation.CallAcquireStatus;
+import io.koraframework.resilient.circuitbreaker.telemetry.CircuitBreakerObservation.CallResult;
+import io.koraframework.resilient.circuitbreaker.telemetry.CircuitBreakerTelemetry;
+import org.jspecify.annotations.Nullable;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicIntegerArray;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicLongArray;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.function.LongSupplier;
+import java.util.function.Supplier;
+
+/**
+ * CircuitBreaker - time-based LeapArray implementation.
+ * <p>
+ * CLOSED-state statistics are stored in a fixed ring of time buckets. The window is time-based, not
+ * count-based: it covers the latest configured duration and does not preserve the exact latest N calls.
+ * Snapshot is built by summing currently valid buckets and can be briefly eventually consistent around
+ * bucket rollover/reset. The state machine and HALF_OPEN counters remain strict and atomic.
+ * <p>
+ * This implementation is designed for high-RPS hot paths: fixed memory, no per-call allocation, one clock
+ * read per CLOSED outcome, and CAS only when a bucket rolls over. {@link CircuitBreakerConfig.TimeBasedCounterType#LONG_ADDER}
+ * can reduce contention further, but makes rollover boundaries more approximate than the default striped
+ * atomic counters.
+ */
+@SuppressWarnings("ConstantConditions")
+final class TimeBasedKoraCircuitBreaker implements CircuitBreaker {
+
+    private static final long HALF_OPEN_COUNTER_MASK = 0xFFFFL;
+    private static final long CLOSED_STATE = 1L << 63;
+    private static final long HALF_OPEN_STATE = 1L << 62;
+    private static final long HALF_OPEN_INCREMENT_SUCCESS = 1L << 16;
+
+    private static final int OUTCOME_SUCCESS = 1;
+    private static final int OUTCOME_FAILURE = 2;
+    private static final int OUTCOME_IGNORED = 3;
+
+    private static final long BUCKET_UNINITIALIZED = Long.MIN_VALUE;
+    private static final long BUCKET_RESETTING = Long.MIN_VALUE + 1;
+
+    private final AtomicLong state = new AtomicLong(CLOSED_STATE);
+    private final String name;
+    private final CircuitBreakerConfig.NamedConfig config;
+    private final CircuitBreakerPredicate failurePredicate;
+    private final CircuitBreakerTelemetry telemetry;
+    private final long waitDurationInOpenStateInNanos;
+    private final LongSupplier currentTimeNanos;
+    private final long startedNanos;
+    private final long windowDurationNanos;
+    private final long bucketLengthNanos;
+    private final Bucket[] buckets;
+    private final int bucketMask;
+    private final boolean bucketCountPowerOfTwo;
+    private final int counterStripeMask;
+
+    TimeBasedKoraCircuitBreaker(String name, CircuitBreakerConfig.NamedConfig config, CircuitBreakerPredicate failurePredicate, CircuitBreakerTelemetry telemetry) {
+        this(name, config, failurePredicate, telemetry, System::nanoTime);
+    }
+
+    TimeBasedKoraCircuitBreaker(String name, CircuitBreakerConfig.NamedConfig config, CircuitBreakerPredicate failurePredicate, CircuitBreakerTelemetry telemetry, LongSupplier currentTimeNanos) {
+        this.name = name;
+        this.config = config;
+        this.failurePredicate = failurePredicate;
+        this.telemetry = telemetry;
+        this.waitDurationInOpenStateInNanos = toNanosSaturated(config.waitDurationInOpenState());
+        this.currentTimeNanos = currentTimeNanos;
+        this.startedNanos = currentTimeNanos.getAsLong();
+        this.windowDurationNanos = toNanosSaturated(config.timeBased().windowDuration());
+        this.bucketLengthNanos = ceilDiv(this.windowDurationNanos, config.timeBased().sampleCount());
+        var bucketCount = config.timeBased().sampleCount();
+        this.buckets = new Bucket[bucketCount];
+        this.bucketMask = bucketCount - 1;
+        this.bucketCountPowerOfTwo = Integer.bitCount(bucketCount) == 1;
+        var counterStripes = nextPowerOfTwo(config.timeBased().counterStripes());
+        this.counterStripeMask = counterStripes - 1;
+        var counterType = config.timeBased().counterType() == null
+            ? CircuitBreakerConfig.TimeBasedCounterType.ATOMIC
+            : config.timeBased().counterType();
+        for (int i = 0; i < bucketCount; i++) {
+            this.buckets[i] = new Bucket(counterType, counterStripes);
+        }
+    }
+
+    State getState() {
+        if (Boolean.FALSE.equals(config.enabled())) {
+            return State.CLOSED;
+        } else {
+            return getState(state.get());
+        }
+    }
+
+    Snapshot snapshot() {
+        return snapshot(currentElapsedNanos());
+    }
+
+    @Override
+    public <T> T accept(Supplier<T> callable) {
+        return internalAccept(callable, null);
+    }
+
+    @Override
+    public <T> T accept(Supplier<T> callable, Supplier<T> fallback) {
+        return internalAccept(callable, fallback);
+    }
+
+    private <T> T internalAccept(Supplier<T> supplier, @Nullable Supplier<T> fallback) {
+        if (Boolean.FALSE.equals(config.enabled())) {
+            var observation = this.telemetry.observe();
+            try {
+                observation.recordCallAcquire(State.CLOSED, CallAcquireStatus.DISABLED);
+                var result = supplier.get();
+                observation.recordCallResult(State.CLOSED, CallResult.SUCCESS);
+                return result;
+            } catch (Throwable e) {
+                observation.observeError(e);
+                observation.recordCallResult(State.CLOSED, CallResult.FAILURE);
+                throw e;
+            } finally {
+                observation.end();
+            }
+        }
+
+        try {
+            acquire();
+            var result = supplier.get();
+            releaseOnSuccess();
+            return result;
+        } catch (CallNotPermittedException e) {
+            if (fallback == null) {
+                throw e;
+            }
+            recordFallback(e);
+        } catch (Throwable e) {
+            releaseOnError(e);
+            throw e;
+        }
+
+        return fallback.get();
+    }
+
+    private State getState(long value) {
+        return switch ((int) (value >> 62 & 0x03)) {
+            case 0 -> State.OPEN;
+            case 1 -> State.HALF_OPEN;
+            default -> State.CLOSED;
+        };
+    }
+
+    private int countHalfOpenSuccess(long value) {
+        return (int) ((value >> 16) & HALF_OPEN_COUNTER_MASK);
+    }
+
+    private int countHalfOpenAcquired(long value) {
+        return (int) (value & HALF_OPEN_COUNTER_MASK);
+    }
+
+    private long currentElapsedNanos() {
+        return Math.max(0, currentTimeNanos.getAsLong() - startedNanos);
+    }
+
+    private void onStateChange(State prevState,
+                               State newState,
+                               @Nullable Throwable throwable,
+                               CircuitBreakerObservation observation) {
+        if (throwable != null) {
+            observation.observeError(throwable);
+        }
+        observation.recordStateChange(prevState, newState);
+    }
+
+    @Override
+    public void acquire() throws CallNotPermittedException {
+        if (!tryAcquire()) {
+            throw new CallNotPermittedException(getState(state.get()), name);
+        }
+    }
+
+    @Override
+    public boolean tryAcquire() {
+        var observation = this.telemetry.observe();
+        try {
+            return tryAcquire(observation);
+        } catch (Throwable e) {
+            observation.observeError(e);
+            throw e;
+        } finally {
+            observation.end();
+        }
+    }
+
+    private boolean tryAcquire(CircuitBreakerObservation observation) {
+        if (Boolean.FALSE.equals(config.enabled())) {
+            observation.recordCallAcquire(State.CLOSED, CallAcquireStatus.DISABLED);
+            return true;
+        }
+
+        final long stateLong = state.get();
+        final State state = getState(stateLong);
+        if (state == State.CLOSED) {
+            observation.recordCallAcquire(state, CallAcquireStatus.PERMITTED);
+            return true;
+        }
+
+        if (state == State.HALF_OPEN) {
+            final int acquired = countHalfOpenAcquired(stateLong);
+            if (acquired < config.permittedCallsInHalfOpenState()) {
+                final boolean isAcquired = this.state.compareAndSet(stateLong, stateLong + 1);
+                if (isAcquired) {
+                    observation.recordCallAcquire(state, CallAcquireStatus.PERMITTED);
+                    return true;
+                } else {
+                    return tryAcquire(observation);
+                }
+            } else {
+                observation.recordCallAcquire(state, CallAcquireStatus.REJECTED);
+                return false;
+            }
+        }
+
+        final long currentTimeInNanos = currentElapsedNanos();
+        final long beenInOpenState = currentTimeInNanos - stateLong;
+        if (beenInOpenState >= waitDurationInOpenStateInNanos) {
+            if (this.state.compareAndSet(stateLong, HALF_OPEN_STATE + 1)) {
+                clearWindow();
+                onStateChange(State.OPEN, State.HALF_OPEN, null, observation);
+                observation.recordCallAcquire(State.HALF_OPEN, CallAcquireStatus.PERMITTED);
+                return true;
+            } else {
+                return tryAcquire(observation);
+            }
+        } else {
+            observation.recordCallAcquire(state, CallAcquireStatus.REJECTED);
+            return false;
+        }
+    }
+
+    @Override
+    public void releaseOnSuccess() {
+        var observation = this.telemetry.observe();
+        try {
+            if (Boolean.FALSE.equals(config.enabled())) {
+                return;
+            }
+
+            final long currentStateLong = state.get();
+            final State currentState = getState(currentStateLong);
+            if (currentState == State.CLOSED) {
+                final long now = currentElapsedNanos();
+                record(OUTCOME_SUCCESS, now);
+                observation.recordCallResult(State.CLOSED, CallResult.SUCCESS);
+                return;
+            }
+
+            State prevState;
+            State newState;
+            while (true) {
+                final long observedStateLong = state.get();
+                final long newStateLong = calculateStateOnSuccess(observedStateLong);
+                if (state.compareAndSet(observedStateLong, newStateLong)) {
+                    prevState = getState(observedStateLong);
+                    newState = getState(newStateLong);
+                    break;
+                }
+            }
+            if (prevState != newState) {
+                clearWindow();
+                onStateChange(prevState, newState, null, observation);
+            }
+            observation.recordCallResult(prevState, CallResult.SUCCESS);
+        } finally {
+            observation.end();
+        }
+    }
+
+    private long calculateStateOnSuccess(long currentState) {
+        final State state = getState(currentState);
+        if (state == State.HALF_OPEN) {
+            final int success = countHalfOpenSuccess(currentState) + 1;
+            final int permitted = config.permittedCallsInHalfOpenState();
+            if (success >= permitted) {
+                return CLOSED_STATE;
+            }
+
+            return currentState + HALF_OPEN_INCREMENT_SUCCESS;
+        } else {
+            return currentState;
+        }
+    }
+
+    @Override
+    public void releaseOnError(Throwable throwable) {
+        var observation = this.telemetry.observe();
+        try {
+            if (Boolean.FALSE.equals(config.enabled())) {
+                return;
+            }
+
+            if (!failurePredicate.test(throwable)) {
+                releaseIgnoredError();
+                if (getState(state.get()) == State.CLOSED) {
+                    record(OUTCOME_IGNORED, currentElapsedNanos());
+                }
+                observation.recordCallResult(getState(state.get()), CallResult.IGNORED_FAILURE);
+                return;
+            }
+
+            final long currentStateLong = state.get();
+            final State currentState = getState(currentStateLong);
+            if (currentState == State.CLOSED) {
+                final long now = currentElapsedNanos();
+                record(OUTCOME_FAILURE, now);
+                if (shouldOpen(now)) {
+                    openFromClosed(observation, throwable, now);
+                } else {
+                    observation.observeError(throwable);
+                }
+                observation.recordCallResult(State.CLOSED, CallResult.FAILURE);
+                return;
+            }
+
+            State prevState;
+            State newState;
+            while (true) {
+                final long observedStateLong = state.get();
+                final long newStateLong = calculateStateOnFailure(observedStateLong);
+                if (state.compareAndSet(observedStateLong, newStateLong)) {
+                    prevState = getState(observedStateLong);
+                    newState = getState(newStateLong);
+                    break;
+                }
+            }
+
+            if (prevState != newState) {
+                clearWindow();
+                onStateChange(prevState, newState, throwable, observation);
+            } else {
+                observation.observeError(throwable);
+            }
+            observation.recordCallResult(prevState, CallResult.FAILURE);
+        } finally {
+            observation.end();
+        }
+    }
+
+    private long calculateStateOnFailure(long currentState) {
+        final State state = getState(currentState);
+        if (state == State.HALF_OPEN) {
+            return currentElapsedNanos();
+        } else {
+            return currentState;
+        }
+    }
+
+    private void record(int outcome, long now) {
+        final Bucket bucket = currentBucket(now);
+        bucket.counters.increment(outcome, stripeIndex());
+    }
+
+    private Bucket currentBucket(long now) {
+        final long bucketStart = bucketStart(now);
+        final Bucket bucket = this.buckets[bucketIndex(bucketStart)];
+        while (true) {
+            final long currentStart = bucket.startNanos.get();
+            if (currentStart == bucketStart) {
+                return bucket;
+            }
+            if (currentStart == BUCKET_RESETTING) {
+                Thread.onSpinWait();
+                continue;
+            }
+            if (currentStart > bucketStart) {
+                return bucket;
+            }
+            if (bucket.startNanos.compareAndSet(currentStart, BUCKET_RESETTING)) {
+                bucket.counters.reset();
+                bucket.startNanos.set(bucketStart);
+                return bucket;
+            }
+        }
+    }
+
+    private boolean shouldOpen(long now) {
+        final Snapshot snapshot = snapshot(now);
+        if (snapshot.total() < config.minimumRequiredCalls()) {
+            return false;
+        }
+
+        return snapshot.failures() * 100 / snapshot.total() >= config.failureRateThreshold();
+    }
+
+    private Snapshot snapshot(long now) {
+        long total = 0;
+        long failures = 0;
+        long slowCalls = 0;
+        long ignored = 0;
+        final long minBucketStart = bucketStart(Math.max(0, now - windowDurationNanos));
+        for (Bucket bucket : this.buckets) {
+            final long bucketStart = bucket.startNanos.get();
+            if (bucketStart >= minBucketStart && bucketStart <= now) {
+                final Snapshot snapshot = bucket.counters.snapshot();
+                total += snapshot.total();
+                failures += snapshot.failures();
+                slowCalls += snapshot.slowCalls();
+                ignored += snapshot.ignored();
+            }
+        }
+        return new Snapshot(total, failures, slowCalls, ignored);
+    }
+
+    private void openFromClosed(CircuitBreakerObservation observation, Throwable throwable, long now) {
+        final long currentStateLong = state.get();
+        if (getState(currentStateLong) == State.CLOSED && state.compareAndSet(currentStateLong, now)) {
+            clearWindow();
+            onStateChange(State.CLOSED, State.OPEN, throwable, observation);
+        } else {
+            observation.observeError(throwable);
+        }
+    }
+
+    private void releaseIgnoredError() {
+        while (true) {
+            final long currentStateLong = state.get();
+            final State currentState = getState(currentStateLong);
+            if (currentState != State.HALF_OPEN) {
+                return;
+            }
+
+            if (state.compareAndSet(currentStateLong, currentStateLong - 1)) {
+                return;
+            }
+        }
+    }
+
+    private void clearWindow() {
+        for (Bucket bucket : this.buckets) {
+            bucket.startNanos.set(BUCKET_RESETTING);
+            bucket.counters.reset();
+            bucket.startNanos.set(BUCKET_UNINITIALIZED);
+        }
+    }
+
+    private long bucketStart(long now) {
+        return now - (now % bucketLengthNanos);
+    }
+
+    private int bucketIndex(long bucketStart) {
+        var bucketPosition = bucketStart / bucketLengthNanos;
+        return this.bucketCountPowerOfTwo
+            ? (int) (bucketPosition & bucketMask)
+            : (int) (bucketPosition % buckets.length);
+    }
+
+    private int stripeIndex() {
+        var x = (int) Thread.currentThread().threadId();
+        x ^= x >>> 16;
+        x *= 0x7feb352d;
+        x ^= x >>> 15;
+        return x & counterStripeMask;
+    }
+
+    private void recordFallback(CallNotPermittedException exception) {
+        var observation = this.telemetry.observe();
+        try {
+            observation.recordCallResult(exception.state(), CallResult.FALLBACK);
+        } finally {
+            observation.end();
+        }
+    }
+
+    private static int nextPowerOfTwo(int value) {
+        var highest = Integer.highestOneBit(value);
+        return highest == value ? value : highest << 1;
+    }
+
+    private static long ceilDiv(long value, long divisor) {
+        return value / divisor + (value % divisor == 0 ? 0 : 1);
+    }
+
+    private static long toNanosSaturated(Duration duration) {
+        try {
+            return duration.toNanos();
+        } catch (ArithmeticException e) {
+            return Long.MAX_VALUE;
+        }
+    }
+
+    record Snapshot(long total, long failures, long slowCalls, long ignored) {}
+
+    private interface BucketCounters {
+
+        void increment(int outcome, int stripe);
+
+        Snapshot snapshot();
+
+        void reset();
+    }
+
+    private static final class Bucket {
+
+        private final AtomicLong startNanos = new AtomicLong(BUCKET_UNINITIALIZED);
+        private final BucketCounters counters;
+
+        private Bucket(CircuitBreakerConfig.TimeBasedCounterType counterType, int counterStripes) {
+            this.counters = switch (counterType) {
+                case ATOMIC -> new AtomicCounters(counterStripes);
+                case LONG_ADDER -> new LongAdderCounters();
+            };
+        }
+    }
+
+    private static final class AtomicCounters implements BucketCounters {
+
+        private final AtomicLongArray total;
+        private final AtomicLongArray failures;
+        private final AtomicLongArray slowCalls;
+        private final AtomicLongArray ignored;
+
+        private AtomicCounters(int stripes) {
+            this.total = new AtomicLongArray(stripes);
+            this.failures = new AtomicLongArray(stripes);
+            this.slowCalls = new AtomicLongArray(stripes);
+            this.ignored = new AtomicLongArray(stripes);
+        }
+
+        @Override
+        public void increment(int outcome, int stripe) {
+            switch (outcome) {
+                case OUTCOME_SUCCESS -> total.incrementAndGet(stripe);
+                case OUTCOME_FAILURE -> {
+                    total.incrementAndGet(stripe);
+                    failures.incrementAndGet(stripe);
+                }
+                case OUTCOME_IGNORED -> ignored.incrementAndGet(stripe);
+                default -> {
+                }
+            }
+        }
+
+        @Override
+        public Snapshot snapshot() {
+            long total = 0;
+            long failures = 0;
+            long slowCalls = 0;
+            long ignored = 0;
+            for (int i = 0; i < this.total.length(); i++) {
+                total += this.total.get(i);
+                failures += this.failures.get(i);
+                slowCalls += this.slowCalls.get(i);
+                ignored += this.ignored.get(i);
+            }
+            return new Snapshot(total, failures, slowCalls, ignored);
+        }
+
+        @Override
+        public void reset() {
+            for (int i = 0; i < this.total.length(); i++) {
+                total.set(i, 0);
+                failures.set(i, 0);
+                slowCalls.set(i, 0);
+                ignored.set(i, 0);
+            }
+        }
+    }
+
+    private static final class LongAdderCounters implements BucketCounters {
+
+        private final LongAdder total = new LongAdder();
+        private final LongAdder failures = new LongAdder();
+        private final LongAdder slowCalls = new LongAdder();
+        private final LongAdder ignored = new LongAdder();
+
+        @Override
+        public void increment(int outcome, int stripe) {
+            switch (outcome) {
+                case OUTCOME_SUCCESS -> total.increment();
+                case OUTCOME_FAILURE -> {
+                    total.increment();
+                    failures.increment();
+                }
+                case OUTCOME_IGNORED -> ignored.increment();
+                default -> {
+                }
+            }
+        }
+
+        @Override
+        public Snapshot snapshot() {
+            return new Snapshot(total.sum(), failures.sum(), slowCalls.sum(), ignored.sum());
+        }
+
+        @Override
+        public void reset() {
+            total.reset();
+            failures.reset();
+            slowCalls.reset();
+            ignored.reset();
+        }
+    }
+}

--- a/resilient/resilient-kora/src/main/java/io/koraframework/resilient/circuitbreaker/telemetry/CircuitBreakerObservation.java
+++ b/resilient/resilient-kora/src/main/java/io/koraframework/resilient/circuitbreaker/telemetry/CircuitBreakerObservation.java
@@ -11,7 +11,16 @@ public interface CircuitBreakerObservation extends Observation {
         DISABLED,
     }
 
+    enum CallResult {
+        SUCCESS,
+        FAILURE,
+        IGNORED_FAILURE,
+        FALLBACK
+    }
+
     void recordCallAcquire(CircuitBreaker.State state, CallAcquireStatus callStatus);
+
+    void recordCallResult(CircuitBreaker.State state, CallResult callResult);
 
     void recordStateChange(CircuitBreaker.State previousState, CircuitBreaker.State newState);
 }

--- a/resilient/resilient-kora/src/main/java/io/koraframework/resilient/circuitbreaker/telemetry/impl/DefaultCircuitBreakerLoggerFactory.java
+++ b/resilient/resilient-kora/src/main/java/io/koraframework/resilient/circuitbreaker/telemetry/impl/DefaultCircuitBreakerLoggerFactory.java
@@ -85,6 +85,38 @@ public class DefaultCircuitBreakerLoggerFactory {
                 .addKeyValue("newState", newState.name())
                 .log("CircuitBreaker state changed");
         }
+
+        public void logResult(CircuitBreaker.State state,
+                              CircuitBreakerObservation.CallResult callResult,
+                              long processingTimeNanos,
+                              @Nullable Throwable exception) {
+            if (exception != null && callResult == CircuitBreakerObservation.CallResult.FAILURE) {
+                if (!logger.isWarnEnabled()) {
+                    return;
+                }
+                logger.atWarn()
+                    .addKeyValue("resilientType", "circuitbreaker")
+                    .addKeyValue("resilientName", this.context.name())
+                    .addKeyValue("state", state.name())
+                    .addKeyValue("callResult", callResult.name())
+                    .addKeyValue("processingTime", processingTimeNanos / 1_000_000)
+                    .addKeyValue("exceptionType", exception.getClass().getCanonicalName())
+                    .addKeyValue("exceptionMessage", exception.getMessage())
+                    .log("CircuitBreaker call failed");
+            } else if (logger.isDebugEnabled()) {
+                var event = logger.atDebug()
+                    .addKeyValue("resilientType", "circuitbreaker")
+                    .addKeyValue("resilientName", this.context.name())
+                    .addKeyValue("state", state.name())
+                    .addKeyValue("callResult", callResult.name())
+                    .addKeyValue("processingTime", processingTimeNanos / 1_000_000);
+                if (exception != null) {
+                    event.addKeyValue("exceptionType", exception.getClass().getCanonicalName())
+                        .addKeyValue("exceptionMessage", exception.getMessage());
+                }
+                event.log("CircuitBreaker call result recorded");
+            }
+        }
     }
 
 }

--- a/resilient/resilient-kora/src/main/java/io/koraframework/resilient/circuitbreaker/telemetry/impl/DefaultCircuitBreakerMetricsFactory.java
+++ b/resilient/resilient-kora/src/main/java/io/koraframework/resilient/circuitbreaker/telemetry/impl/DefaultCircuitBreakerMetricsFactory.java
@@ -50,10 +50,21 @@ public class DefaultCircuitBreakerMetricsFactory {
             }
         }
 
+        public record ResultKey(String name,
+                                CircuitBreaker.State state,
+                                CircuitBreakerObservation.CallResult result,
+                                @Nullable Tags extraTags) {
+
+            public ResultKey withExtraTags(Tags tags) {
+                return new ResultKey(name, state, result, tags);
+            }
+        }
+
         protected final ConcurrentHashMap<StateKey, AtomicInteger> stateValueCache = new ConcurrentHashMap<>();
         protected final ConcurrentHashMap<StateKey, Gauge> stateCache = new ConcurrentHashMap<>();
         protected final ConcurrentHashMap<TransitionKey, Counter> transitionCache = new ConcurrentHashMap<>();
         protected final ConcurrentHashMap<AcquireKey, Counter> acquireCache = new ConcurrentHashMap<>();
+        protected final ConcurrentHashMap<ResultKey, Counter> resultCache = new ConcurrentHashMap<>();
         protected final DefaultCircuitBreakerTelemetry.TelemetryContext context;
 
         public DefaultCircuitBreakerMetrics(DefaultCircuitBreakerTelemetry.TelemetryContext context) {
@@ -71,6 +82,12 @@ public class DefaultCircuitBreakerMetricsFactory {
                 var meter = this.acquireCache.computeIfAbsent(key, k -> createMetricAcquire(k).register(this.context.meterRegistry()));
                 meter.increment();
             }
+        }
+
+        public void recordCallResult(CircuitBreaker.State state, CircuitBreakerObservation.CallResult callResult) {
+            var key = createMetricResultKey(state, callResult);
+            var meter = this.resultCache.computeIfAbsent(key, k -> createMetricResult(k).register(this.context.meterRegistry()));
+            meter.increment();
         }
 
         public void recordState(CircuitBreaker.State newState) {
@@ -98,6 +115,10 @@ public class DefaultCircuitBreakerMetricsFactory {
             return new AcquireKey(this.context.name(), state, callStatus, null);
         }
 
+        protected ResultKey createMetricResultKey(CircuitBreaker.State state, CircuitBreakerObservation.CallResult callResult) {
+            return new ResultKey(this.context.name(), state, callResult, null);
+        }
+
         // DO NOT ADD DYNAMIC TAGS IN BUILDER, use metric key instead of metric collision will happen
         protected Gauge.Builder<?> createMetricState(StateKey metricKey, AtomicInteger stateValue) {
             return Gauge.builder("resilient.circuitbreaker.state", stateValue::get)
@@ -117,6 +138,13 @@ public class DefaultCircuitBreakerMetricsFactory {
             return Counter.builder("resilient.circuitbreaker.call.acquire")
                 .baseUnit(BaseUnits.OPERATIONS)
                 .tags(Tags.of(createTags(metricKey.name, metricKey.state.name(), metricKey.status.name(), metricKey.extraTags)));
+        }
+
+        // DO NOT ADD DYNAMIC TAGS IN BUILDER, use metric key instead of metric collision will happen
+        protected Counter.Builder createMetricResult(ResultKey metricKey) {
+            return Counter.builder("resilient.circuitbreaker.call.result")
+                .baseUnit(BaseUnits.OPERATIONS)
+                .tags(Tags.of(createTags(metricKey.name, metricKey.state.name(), metricKey.result.name(), metricKey.extraTags)));
         }
 
         protected ArrayList<Tag> createTags(String name, @Nullable String state, @Nullable String status, @Nullable Tags extraTags) {

--- a/resilient/resilient-kora/src/main/java/io/koraframework/resilient/circuitbreaker/telemetry/impl/DefaultCircuitBreakerObservation.java
+++ b/resilient/resilient-kora/src/main/java/io/koraframework/resilient/circuitbreaker/telemetry/impl/DefaultCircuitBreakerObservation.java
@@ -14,6 +14,8 @@ public class DefaultCircuitBreakerObservation implements CircuitBreakerObservati
 
     protected CircuitBreaker.@Nullable State state;
     protected CircuitBreakerObservation.@Nullable CallAcquireStatus callStatus;
+    protected CircuitBreaker.@Nullable State resultState;
+    protected CircuitBreakerObservation.@Nullable CallResult callResult;
     protected CircuitBreaker.@Nullable State newState;
     @Nullable
     protected Throwable exception;
@@ -31,6 +33,12 @@ public class DefaultCircuitBreakerObservation implements CircuitBreakerObservati
     public void recordCallAcquire(CircuitBreaker.State state, CircuitBreakerObservation.CallAcquireStatus callStatus) {
         this.state = state;
         this.callStatus = callStatus;
+    }
+
+    @Override
+    public void recordCallResult(CircuitBreaker.State state, CircuitBreakerObservation.CallResult callResult) {
+        this.resultState = state;
+        this.callResult = callResult;
     }
 
     @Override
@@ -57,6 +65,10 @@ public class DefaultCircuitBreakerObservation implements CircuitBreakerObservati
         if (this.state != null && this.callStatus != null) {
             this.metrics.recordCallAcquire(this.state, this.callStatus);
             this.logger.logAcquire(this.state, this.callStatus, System.nanoTime() - this.startNanos, this.exception);
+        }
+        if (this.resultState != null && this.callResult != null) {
+            this.metrics.recordCallResult(this.resultState, this.callResult);
+            this.logger.logResult(this.resultState, this.callResult, System.nanoTime() - this.startNanos, this.exception);
         }
     }
 }

--- a/resilient/resilient-kora/src/main/java/io/koraframework/resilient/circuitbreaker/telemetry/impl/NoopCircuitBreakerLoggerFactory.java
+++ b/resilient/resilient-kora/src/main/java/io/koraframework/resilient/circuitbreaker/telemetry/impl/NoopCircuitBreakerLoggerFactory.java
@@ -35,5 +35,11 @@ public final class NoopCircuitBreakerLoggerFactory extends DefaultCircuitBreaker
 
         @Override
         public void logStateChange(CircuitBreaker.State previousState, CircuitBreaker.State newState) {}
+
+        @Override
+        public void logResult(CircuitBreaker.State state,
+                              CircuitBreakerObservation.CallResult callResult,
+                              long processingTimeNanos,
+                              @Nullable Throwable exception) {}
     }
 }

--- a/resilient/resilient-kora/src/main/java/io/koraframework/resilient/circuitbreaker/telemetry/impl/NoopCircuitBreakerMetricsFactory.java
+++ b/resilient/resilient-kora/src/main/java/io/koraframework/resilient/circuitbreaker/telemetry/impl/NoopCircuitBreakerMetricsFactory.java
@@ -26,6 +26,9 @@ public final class NoopCircuitBreakerMetricsFactory extends DefaultCircuitBreake
         public void recordCallAcquire(CircuitBreaker.State state, CircuitBreakerObservation.CallAcquireStatus callStatus) {}
 
         @Override
+        public void recordCallResult(CircuitBreaker.State state, CircuitBreakerObservation.CallResult callResult) {}
+
+        @Override
         public void recordState(CircuitBreaker.State newState) {}
     }
 }

--- a/resilient/resilient-kora/src/main/java/io/koraframework/resilient/circuitbreaker/telemetry/impl/NoopCircuitBreakerObservation.java
+++ b/resilient/resilient-kora/src/main/java/io/koraframework/resilient/circuitbreaker/telemetry/impl/NoopCircuitBreakerObservation.java
@@ -14,6 +14,9 @@ public final class NoopCircuitBreakerObservation implements CircuitBreakerObserv
     public void recordCallAcquire(CircuitBreaker.State state, CallAcquireStatus callStatus) {}
 
     @Override
+    public void recordCallResult(CircuitBreaker.State state, CallResult callResult) {}
+
+    @Override
     public void recordStateChange(CircuitBreaker.State previousState, CircuitBreaker.State newState) {}
 
     @Override

--- a/resilient/resilient-kora/src/test/java/io/koraframework/resilient/circuitbreaker/FixedWindowKoraCircuitBreakerTests.java
+++ b/resilient/resilient-kora/src/test/java/io/koraframework/resilient/circuitbreaker/FixedWindowKoraCircuitBreakerTests.java
@@ -48,7 +48,7 @@ class FixedWindowKoraCircuitBreakerTests extends Assertions {
     void switchFromClosedToOpen() {
         // given
         final CircuitBreakerConfig.NamedConfig config = new $CircuitBreakerConfig_NamedConfig_ConfigValueMapper.NamedConfig_Impl(
-            true, 30, WAIT_IN_OPEN, 3, 10L, 8L, KoraCircuitBreakerPredicate.class.getCanonicalName());
+            true, CircuitBreakerConfig.CircuitBreakerType.FIXED_WINDOW, countBased(10L, null), null, 30, WAIT_IN_OPEN, 3, 8L, KoraCircuitBreakerPredicate.class.getCanonicalName());
         final FixedWindowKoraCircuitBreaker circuitBreaker = new FixedWindowKoraCircuitBreaker("default", config, new KoraCircuitBreakerPredicate(), NoopCircuitBreakerTelemetry.INSTANCE);
 
         // when
@@ -84,7 +84,7 @@ class FixedWindowKoraCircuitBreakerTests extends Assertions {
     void switchFromClosedToOpenForMinimumNumberOfCalls() {
         // given
         final CircuitBreakerConfig.NamedConfig config = new $CircuitBreakerConfig_NamedConfig_ConfigValueMapper.NamedConfig_Impl(
-            true, 100, WAIT_IN_OPEN, 1, 2L, 2L, KoraCircuitBreakerPredicate.class.getCanonicalName());
+            true, CircuitBreakerConfig.CircuitBreakerType.FIXED_WINDOW, countBased(2L, null), null, 100, WAIT_IN_OPEN, 1, 2L, KoraCircuitBreakerPredicate.class.getCanonicalName());
         final FixedWindowKoraCircuitBreaker circuitBreaker = new FixedWindowKoraCircuitBreaker("default", config, new KoraCircuitBreakerPredicate(), NoopCircuitBreakerTelemetry.INSTANCE);
 
         // when
@@ -104,7 +104,7 @@ class FixedWindowKoraCircuitBreakerTests extends Assertions {
     void switchFromClosedToOpenToHalfOpenToOpen() {
         // given
         final CircuitBreakerConfig.NamedConfig config = new $CircuitBreakerConfig_NamedConfig_ConfigValueMapper.NamedConfig_Impl(
-            true, 100, WAIT_IN_OPEN, 2, 2L, 2L, KoraCircuitBreakerPredicate.class.getCanonicalName());
+            true, CircuitBreakerConfig.CircuitBreakerType.FIXED_WINDOW, countBased(2L, null), null, 100, WAIT_IN_OPEN, 2, 2L, KoraCircuitBreakerPredicate.class.getCanonicalName());
         final FixedWindowKoraCircuitBreaker circuitBreaker = new FixedWindowKoraCircuitBreaker("default", config, new KoraCircuitBreakerPredicate(), NoopCircuitBreakerTelemetry.INSTANCE);
 
         // when
@@ -130,7 +130,7 @@ class FixedWindowKoraCircuitBreakerTests extends Assertions {
     void switchFromClosedToOpenToHalfOpenToOpenToHalfOpenToOpen() {
         // given
         final CircuitBreakerConfig.NamedConfig config = new $CircuitBreakerConfig_NamedConfig_ConfigValueMapper.NamedConfig_Impl(
-            true, 100, WAIT_IN_OPEN, 2, 2L, 2L, KoraCircuitBreakerPredicate.class.getCanonicalName());
+            true, CircuitBreakerConfig.CircuitBreakerType.FIXED_WINDOW, countBased(2L, null), null, 100, WAIT_IN_OPEN, 2, 2L, KoraCircuitBreakerPredicate.class.getCanonicalName());
         final FixedWindowKoraCircuitBreaker circuitBreaker = new FixedWindowKoraCircuitBreaker("default", config, new KoraCircuitBreakerPredicate(), NoopCircuitBreakerTelemetry.INSTANCE);
 
         // when
@@ -163,7 +163,7 @@ class FixedWindowKoraCircuitBreakerTests extends Assertions {
     void switchFromClosedToOpenToHalfOpenToOpenToHalfOpenToClosed() {
         // given
         final CircuitBreakerConfig.NamedConfig config = new $CircuitBreakerConfig_NamedConfig_ConfigValueMapper.NamedConfig_Impl(
-            true, 100, WAIT_IN_OPEN, 2, 2L, 2L, KoraCircuitBreakerPredicate.class.getCanonicalName());
+            true, CircuitBreakerConfig.CircuitBreakerType.FIXED_WINDOW, countBased(2L, null), null, 100, WAIT_IN_OPEN, 2, 2L, KoraCircuitBreakerPredicate.class.getCanonicalName());
         final FixedWindowKoraCircuitBreaker circuitBreaker = new FixedWindowKoraCircuitBreaker("default", config, new KoraCircuitBreakerPredicate(), NoopCircuitBreakerTelemetry.INSTANCE);
 
         // when
@@ -200,7 +200,7 @@ class FixedWindowKoraCircuitBreakerTests extends Assertions {
     void switchFromClosedToOpenToHalfOpenToOpenToHalfOpenToClosedComplex() {
         // given
         final CircuitBreakerConfig.NamedConfig config = new $CircuitBreakerConfig_NamedConfig_ConfigValueMapper.NamedConfig_Impl(
-            true, 50, WAIT_IN_OPEN, 2, 4L, 2L, KoraCircuitBreakerPredicate.class.getCanonicalName());
+            true, CircuitBreakerConfig.CircuitBreakerType.FIXED_WINDOW, countBased(4L, null), null, 50, WAIT_IN_OPEN, 2, 2L, KoraCircuitBreakerPredicate.class.getCanonicalName());
         final FixedWindowKoraCircuitBreaker circuitBreaker = new FixedWindowKoraCircuitBreaker("default", config, new KoraCircuitBreakerPredicate(), NoopCircuitBreakerTelemetry.INSTANCE);
 
         // when
@@ -237,7 +237,7 @@ class FixedWindowKoraCircuitBreakerTests extends Assertions {
     void switchFromClosedToOpenToHalfOpenCorrectlyRestoreIgnoredExceptionToOpen() {
         // given
         final CircuitBreakerConfig.NamedConfig config = new $CircuitBreakerConfig_NamedConfig_ConfigValueMapper.NamedConfig_Impl(
-            true, 50, WAIT_IN_OPEN, 2, 4L, 2L, KoraCircuitBreakerPredicate.class.getCanonicalName());
+            true, CircuitBreakerConfig.CircuitBreakerType.FIXED_WINDOW, countBased(4L, null), null, 50, WAIT_IN_OPEN, 2, 2L, KoraCircuitBreakerPredicate.class.getCanonicalName());
         final FixedWindowKoraCircuitBreaker circuitBreaker = new FixedWindowKoraCircuitBreaker("default", config, new CircuitBreakerPredicate() {
             @Override
             public String name() {
@@ -280,7 +280,7 @@ class FixedWindowKoraCircuitBreakerTests extends Assertions {
     void switchFromClosedToOpenToHalfOpenToOpenToHalfOpenToClosedForAccept() {
         // given
         final CircuitBreakerConfig.NamedConfig config = new $CircuitBreakerConfig_NamedConfig_ConfigValueMapper.NamedConfig_Impl(
-            true, 50, WAIT_IN_OPEN, 2, 4L, 2L, KoraCircuitBreakerPredicate.class.getCanonicalName());
+            true, CircuitBreakerConfig.CircuitBreakerType.FIXED_WINDOW, countBased(4L, null), null, 50, WAIT_IN_OPEN, 2, 2L, KoraCircuitBreakerPredicate.class.getCanonicalName());
         final FixedWindowKoraCircuitBreaker circuitBreaker = new FixedWindowKoraCircuitBreaker("default", config, new KoraCircuitBreakerPredicate(), NoopCircuitBreakerTelemetry.INSTANCE);
 
         Callable<Boolean> successCallable = () -> {
@@ -322,7 +322,7 @@ class FixedWindowKoraCircuitBreakerTests extends Assertions {
     void switchFromClosedToOpenToHalfOpenToOpenToHalfOpenWhenPartFailToOpen() {
         // given
         final CircuitBreakerConfig.NamedConfig config = new $CircuitBreakerConfig_NamedConfig_ConfigValueMapper.NamedConfig_Impl(
-            true, 100, WAIT_IN_OPEN, 2, 2L, 2L, KoraCircuitBreakerPredicate.class.getCanonicalName());
+            true, CircuitBreakerConfig.CircuitBreakerType.FIXED_WINDOW, countBased(2L, null), null, 100, WAIT_IN_OPEN, 2, 2L, KoraCircuitBreakerPredicate.class.getCanonicalName());
         final FixedWindowKoraCircuitBreaker circuitBreaker = new FixedWindowKoraCircuitBreaker("default", config, new KoraCircuitBreakerPredicate(), NoopCircuitBreakerTelemetry.INSTANCE);
 
         // when
@@ -359,7 +359,7 @@ class FixedWindowKoraCircuitBreakerTests extends Assertions {
     void switchFromClosedToOpenToHalfOpenToClosed() {
         // given
         final CircuitBreakerConfig.NamedConfig config = new $CircuitBreakerConfig_NamedConfig_ConfigValueMapper.NamedConfig_Impl(
-            true, 100, WAIT_IN_OPEN, 2, 2L, 2L, KoraCircuitBreakerPredicate.class.getCanonicalName());
+            true, CircuitBreakerConfig.CircuitBreakerType.FIXED_WINDOW, countBased(2L, null), null, 100, WAIT_IN_OPEN, 2, 2L, KoraCircuitBreakerPredicate.class.getCanonicalName());
         final FixedWindowKoraCircuitBreaker circuitBreaker = new FixedWindowKoraCircuitBreaker("default", config, new KoraCircuitBreakerPredicate(), NoopCircuitBreakerTelemetry.INSTANCE);
 
         // when
@@ -387,7 +387,7 @@ class FixedWindowKoraCircuitBreakerTests extends Assertions {
     void switchFromOpenToHalfOpenAndValidateAcquireCalls() {
         // given
         final CircuitBreakerConfig.NamedConfig config = new $CircuitBreakerConfig_NamedConfig_ConfigValueMapper.NamedConfig_Impl(
-            true, 100, WAIT_IN_OPEN, 1, 1L, 1L, KoraCircuitBreakerPredicate.class.getCanonicalName());
+            true, CircuitBreakerConfig.CircuitBreakerType.FIXED_WINDOW, countBased(1L, null), null, 100, WAIT_IN_OPEN, 1, 1L, KoraCircuitBreakerPredicate.class.getCanonicalName());
         final FixedWindowKoraCircuitBreaker circuitBreaker = new FixedWindowKoraCircuitBreaker("default", config, new KoraCircuitBreakerPredicate(), NoopCircuitBreakerTelemetry.INSTANCE);
 
         // when
@@ -411,7 +411,7 @@ class FixedWindowKoraCircuitBreakerTests extends Assertions {
     void switchFromClosedToOpenForCustomFailurePredicate() {
         // given
         final CircuitBreakerConfig.NamedConfig config = new $CircuitBreakerConfig_NamedConfig_ConfigValueMapper.NamedConfig_Impl(
-            true, 100, WAIT_IN_OPEN, 1, 1L, 1L, "custom");
+            true, CircuitBreakerConfig.CircuitBreakerType.FIXED_WINDOW, countBased(1L, null), null, 100, WAIT_IN_OPEN, 1, 1L, "custom");
         final FixedWindowKoraCircuitBreaker circuitBreaker = new FixedWindowKoraCircuitBreaker("default", config, new CustomPredicate(), NoopCircuitBreakerTelemetry.INSTANCE);
 
         // when
@@ -430,7 +430,7 @@ class FixedWindowKoraCircuitBreakerTests extends Assertions {
     @Test
     void openToHalfOpenUsesMonotonicTicker() {
         final CircuitBreakerConfig.NamedConfig config = new $CircuitBreakerConfig_NamedConfig_ConfigValueMapper.NamedConfig_Impl(
-            true, 100, WAIT_IN_OPEN, 1, 1L, 1L, KoraCircuitBreakerPredicate.class.getCanonicalName());
+            true, CircuitBreakerConfig.CircuitBreakerType.FIXED_WINDOW, countBased(1L, null), null, 100, WAIT_IN_OPEN, 1, 1L, KoraCircuitBreakerPredicate.class.getCanonicalName());
         var ticker = new AtomicLong();
         final FixedWindowKoraCircuitBreaker circuitBreaker = new FixedWindowKoraCircuitBreaker("default", config, new KoraCircuitBreakerPredicate(), NoopCircuitBreakerTelemetry.INSTANCE, ticker::get);
 
@@ -449,7 +449,7 @@ class FixedWindowKoraCircuitBreakerTests extends Assertions {
     void configValidationRejectsFixedWindowCounterOverflow() {
         var config = new TestCircuitBreakerConfig(Map.of(CircuitBreakerConfig.DEFAULT,
             new $CircuitBreakerConfig_NamedConfig_ConfigValueMapper.NamedConfig_Impl(
-                true, 100, WAIT_IN_OPEN, 1, 0x8000_0000L, 1L, KoraCircuitBreakerPredicate.class.getCanonicalName())));
+                true, CircuitBreakerConfig.CircuitBreakerType.FIXED_WINDOW, countBased(0x8000_0000L, null), null, 100, WAIT_IN_OPEN, 1, 1L, KoraCircuitBreakerPredicate.class.getCanonicalName())));
 
         assertThrows(IllegalArgumentException.class, () -> config.getNamedConfig(CircuitBreakerConfig.DEFAULT));
     }
@@ -458,7 +458,7 @@ class FixedWindowKoraCircuitBreakerTests extends Assertions {
     void configValidationRejectsHalfOpenCounterOverflow() {
         var config = new TestCircuitBreakerConfig(Map.of(CircuitBreakerConfig.DEFAULT,
             new $CircuitBreakerConfig_NamedConfig_ConfigValueMapper.NamedConfig_Impl(
-                true, 100, WAIT_IN_OPEN, 0x1_0000, 1L, 1L, KoraCircuitBreakerPredicate.class.getCanonicalName())));
+                true, CircuitBreakerConfig.CircuitBreakerType.FIXED_WINDOW, countBased(1L, null), null, 100, WAIT_IN_OPEN, 0x1_0000, 1L, KoraCircuitBreakerPredicate.class.getCanonicalName())));
 
         assertThrows(IllegalArgumentException.class, () -> config.getNamedConfig(CircuitBreakerConfig.DEFAULT));
     }
@@ -466,7 +466,7 @@ class FixedWindowKoraCircuitBreakerTests extends Assertions {
     @Test
     void telemetryRecordsCallResults() {
         final CircuitBreakerConfig.NamedConfig config = new $CircuitBreakerConfig_NamedConfig_ConfigValueMapper.NamedConfig_Impl(
-            true, 100, WAIT_IN_OPEN, 1, 1L, 1L, KoraCircuitBreakerPredicate.class.getCanonicalName());
+            true, CircuitBreakerConfig.CircuitBreakerType.FIXED_WINDOW, countBased(1L, null), null, 100, WAIT_IN_OPEN, 1, 1L, KoraCircuitBreakerPredicate.class.getCanonicalName());
         var telemetry = new CountingTelemetry();
         final FixedWindowKoraCircuitBreaker circuitBreaker = new FixedWindowKoraCircuitBreaker("default", config, new KoraCircuitBreakerPredicate(), telemetry);
 
@@ -486,6 +486,10 @@ class FixedWindowKoraCircuitBreakerTests extends Assertions {
         public CircuitBreakerTelemetryConfig telemetry() {
             return null;
         }
+    }
+
+    private static CircuitBreakerConfig.CountBasedConfig countBased(Long windowSize, CircuitBreakerConfig.StripedApproxConfig stripedApprox) {
+        return new $CircuitBreakerConfig_CountBasedConfig_ConfigValueMapper.CountBasedConfig_Impl(windowSize, stripedApprox);
     }
 
     private static final class CountingTelemetry implements CircuitBreakerTelemetry {

--- a/resilient/resilient-kora/src/test/java/io/koraframework/resilient/circuitbreaker/FixedWindowKoraCircuitBreakerTests.java
+++ b/resilient/resilient-kora/src/test/java/io/koraframework/resilient/circuitbreaker/FixedWindowKoraCircuitBreakerTests.java
@@ -1,8 +1,12 @@
 package io.koraframework.resilient.circuitbreaker;
 
 import io.koraframework.resilient.circuitbreaker.exception.CallNotPermittedException;
+import io.koraframework.resilient.circuitbreaker.telemetry.CircuitBreakerObservation;
+import io.koraframework.resilient.circuitbreaker.telemetry.CircuitBreakerTelemetry;
+import io.koraframework.resilient.circuitbreaker.telemetry.CircuitBreakerTelemetryConfig;
 import org.awaitility.Awaitility;
 import org.awaitility.core.ConditionFactory;
+import io.opentelemetry.api.trace.Span;
 import org.jspecify.annotations.NullMarked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -12,10 +16,13 @@ import io.koraframework.resilient.circuitbreaker.telemetry.impl.NoopCircuitBreak
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Map;
 import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 
-class KoraCircuitBreakerTests extends Assertions {
+class FixedWindowKoraCircuitBreakerTests extends Assertions {
 
     private static final Duration WAIT_IN_OPEN = Duration.ofMillis(50);
 
@@ -42,7 +49,7 @@ class KoraCircuitBreakerTests extends Assertions {
         // given
         final CircuitBreakerConfig.NamedConfig config = new $CircuitBreakerConfig_NamedConfig_ConfigValueMapper.NamedConfig_Impl(
             true, 30, WAIT_IN_OPEN, 3, 10L, 8L, KoraCircuitBreakerPredicate.class.getCanonicalName());
-        final KoraCircuitBreaker circuitBreaker = new KoraCircuitBreaker("default", config, new KoraCircuitBreakerPredicate(), NoopCircuitBreakerTelemetry.INSTANCE);
+        final FixedWindowKoraCircuitBreaker circuitBreaker = new FixedWindowKoraCircuitBreaker("default", config, new KoraCircuitBreakerPredicate(), NoopCircuitBreakerTelemetry.INSTANCE);
 
         // when
         assertEquals(State.CLOSED, circuitBreaker.getState());
@@ -78,7 +85,7 @@ class KoraCircuitBreakerTests extends Assertions {
         // given
         final CircuitBreakerConfig.NamedConfig config = new $CircuitBreakerConfig_NamedConfig_ConfigValueMapper.NamedConfig_Impl(
             true, 100, WAIT_IN_OPEN, 1, 2L, 2L, KoraCircuitBreakerPredicate.class.getCanonicalName());
-        final KoraCircuitBreaker circuitBreaker = new KoraCircuitBreaker("default", config, new KoraCircuitBreakerPredicate(), NoopCircuitBreakerTelemetry.INSTANCE);
+        final FixedWindowKoraCircuitBreaker circuitBreaker = new FixedWindowKoraCircuitBreaker("default", config, new KoraCircuitBreakerPredicate(), NoopCircuitBreakerTelemetry.INSTANCE);
 
         // when
         assertEquals(State.CLOSED, circuitBreaker.getState());
@@ -98,7 +105,7 @@ class KoraCircuitBreakerTests extends Assertions {
         // given
         final CircuitBreakerConfig.NamedConfig config = new $CircuitBreakerConfig_NamedConfig_ConfigValueMapper.NamedConfig_Impl(
             true, 100, WAIT_IN_OPEN, 2, 2L, 2L, KoraCircuitBreakerPredicate.class.getCanonicalName());
-        final KoraCircuitBreaker circuitBreaker = new KoraCircuitBreaker("default", config, new KoraCircuitBreakerPredicate(), NoopCircuitBreakerTelemetry.INSTANCE);
+        final FixedWindowKoraCircuitBreaker circuitBreaker = new FixedWindowKoraCircuitBreaker("default", config, new KoraCircuitBreakerPredicate(), NoopCircuitBreakerTelemetry.INSTANCE);
 
         // when
         assertEquals(State.CLOSED, circuitBreaker.getState());
@@ -124,7 +131,7 @@ class KoraCircuitBreakerTests extends Assertions {
         // given
         final CircuitBreakerConfig.NamedConfig config = new $CircuitBreakerConfig_NamedConfig_ConfigValueMapper.NamedConfig_Impl(
             true, 100, WAIT_IN_OPEN, 2, 2L, 2L, KoraCircuitBreakerPredicate.class.getCanonicalName());
-        final KoraCircuitBreaker circuitBreaker = new KoraCircuitBreaker("default", config, new KoraCircuitBreakerPredicate(), NoopCircuitBreakerTelemetry.INSTANCE);
+        final FixedWindowKoraCircuitBreaker circuitBreaker = new FixedWindowKoraCircuitBreaker("default", config, new KoraCircuitBreakerPredicate(), NoopCircuitBreakerTelemetry.INSTANCE);
 
         // when
         assertEquals(State.CLOSED, circuitBreaker.getState());
@@ -157,7 +164,7 @@ class KoraCircuitBreakerTests extends Assertions {
         // given
         final CircuitBreakerConfig.NamedConfig config = new $CircuitBreakerConfig_NamedConfig_ConfigValueMapper.NamedConfig_Impl(
             true, 100, WAIT_IN_OPEN, 2, 2L, 2L, KoraCircuitBreakerPredicate.class.getCanonicalName());
-        final KoraCircuitBreaker circuitBreaker = new KoraCircuitBreaker("default", config, new KoraCircuitBreakerPredicate(), NoopCircuitBreakerTelemetry.INSTANCE);
+        final FixedWindowKoraCircuitBreaker circuitBreaker = new FixedWindowKoraCircuitBreaker("default", config, new KoraCircuitBreakerPredicate(), NoopCircuitBreakerTelemetry.INSTANCE);
 
         // when
         assertEquals(State.CLOSED, circuitBreaker.getState());
@@ -194,7 +201,7 @@ class KoraCircuitBreakerTests extends Assertions {
         // given
         final CircuitBreakerConfig.NamedConfig config = new $CircuitBreakerConfig_NamedConfig_ConfigValueMapper.NamedConfig_Impl(
             true, 50, WAIT_IN_OPEN, 2, 4L, 2L, KoraCircuitBreakerPredicate.class.getCanonicalName());
-        final KoraCircuitBreaker circuitBreaker = new KoraCircuitBreaker("default", config, new KoraCircuitBreakerPredicate(), NoopCircuitBreakerTelemetry.INSTANCE);
+        final FixedWindowKoraCircuitBreaker circuitBreaker = new FixedWindowKoraCircuitBreaker("default", config, new KoraCircuitBreakerPredicate(), NoopCircuitBreakerTelemetry.INSTANCE);
 
         // when
         assertEquals(State.CLOSED, circuitBreaker.getState());
@@ -231,7 +238,7 @@ class KoraCircuitBreakerTests extends Assertions {
         // given
         final CircuitBreakerConfig.NamedConfig config = new $CircuitBreakerConfig_NamedConfig_ConfigValueMapper.NamedConfig_Impl(
             true, 50, WAIT_IN_OPEN, 2, 4L, 2L, KoraCircuitBreakerPredicate.class.getCanonicalName());
-        final KoraCircuitBreaker circuitBreaker = new KoraCircuitBreaker("default", config, new CircuitBreakerPredicate() {
+        final FixedWindowKoraCircuitBreaker circuitBreaker = new FixedWindowKoraCircuitBreaker("default", config, new CircuitBreakerPredicate() {
             @Override
             public String name() {
                 return "kora";
@@ -274,7 +281,7 @@ class KoraCircuitBreakerTests extends Assertions {
         // given
         final CircuitBreakerConfig.NamedConfig config = new $CircuitBreakerConfig_NamedConfig_ConfigValueMapper.NamedConfig_Impl(
             true, 50, WAIT_IN_OPEN, 2, 4L, 2L, KoraCircuitBreakerPredicate.class.getCanonicalName());
-        final KoraCircuitBreaker circuitBreaker = new KoraCircuitBreaker("default", config, new KoraCircuitBreakerPredicate(), NoopCircuitBreakerTelemetry.INSTANCE);
+        final FixedWindowKoraCircuitBreaker circuitBreaker = new FixedWindowKoraCircuitBreaker("default", config, new KoraCircuitBreakerPredicate(), NoopCircuitBreakerTelemetry.INSTANCE);
 
         Callable<Boolean> successCallable = () -> {
             try {
@@ -316,7 +323,7 @@ class KoraCircuitBreakerTests extends Assertions {
         // given
         final CircuitBreakerConfig.NamedConfig config = new $CircuitBreakerConfig_NamedConfig_ConfigValueMapper.NamedConfig_Impl(
             true, 100, WAIT_IN_OPEN, 2, 2L, 2L, KoraCircuitBreakerPredicate.class.getCanonicalName());
-        final KoraCircuitBreaker circuitBreaker = new KoraCircuitBreaker("default", config, new KoraCircuitBreakerPredicate(), NoopCircuitBreakerTelemetry.INSTANCE);
+        final FixedWindowKoraCircuitBreaker circuitBreaker = new FixedWindowKoraCircuitBreaker("default", config, new KoraCircuitBreakerPredicate(), NoopCircuitBreakerTelemetry.INSTANCE);
 
         // when
         assertEquals(State.CLOSED, circuitBreaker.getState());
@@ -353,7 +360,7 @@ class KoraCircuitBreakerTests extends Assertions {
         // given
         final CircuitBreakerConfig.NamedConfig config = new $CircuitBreakerConfig_NamedConfig_ConfigValueMapper.NamedConfig_Impl(
             true, 100, WAIT_IN_OPEN, 2, 2L, 2L, KoraCircuitBreakerPredicate.class.getCanonicalName());
-        final KoraCircuitBreaker circuitBreaker = new KoraCircuitBreaker("default", config, new KoraCircuitBreakerPredicate(), NoopCircuitBreakerTelemetry.INSTANCE);
+        final FixedWindowKoraCircuitBreaker circuitBreaker = new FixedWindowKoraCircuitBreaker("default", config, new KoraCircuitBreakerPredicate(), NoopCircuitBreakerTelemetry.INSTANCE);
 
         // when
         assertEquals(State.CLOSED, circuitBreaker.getState());
@@ -381,7 +388,7 @@ class KoraCircuitBreakerTests extends Assertions {
         // given
         final CircuitBreakerConfig.NamedConfig config = new $CircuitBreakerConfig_NamedConfig_ConfigValueMapper.NamedConfig_Impl(
             true, 100, WAIT_IN_OPEN, 1, 1L, 1L, KoraCircuitBreakerPredicate.class.getCanonicalName());
-        final KoraCircuitBreaker circuitBreaker = new KoraCircuitBreaker("default", config, new KoraCircuitBreakerPredicate(), NoopCircuitBreakerTelemetry.INSTANCE);
+        final FixedWindowKoraCircuitBreaker circuitBreaker = new FixedWindowKoraCircuitBreaker("default", config, new KoraCircuitBreakerPredicate(), NoopCircuitBreakerTelemetry.INSTANCE);
 
         // when
         assertEquals(State.CLOSED, circuitBreaker.getState());
@@ -405,7 +412,7 @@ class KoraCircuitBreakerTests extends Assertions {
         // given
         final CircuitBreakerConfig.NamedConfig config = new $CircuitBreakerConfig_NamedConfig_ConfigValueMapper.NamedConfig_Impl(
             true, 100, WAIT_IN_OPEN, 1, 1L, 1L, "custom");
-        final KoraCircuitBreaker circuitBreaker = new KoraCircuitBreaker("default", config, new CustomPredicate(), NoopCircuitBreakerTelemetry.INSTANCE);
+        final FixedWindowKoraCircuitBreaker circuitBreaker = new FixedWindowKoraCircuitBreaker("default", config, new CustomPredicate(), NoopCircuitBreakerTelemetry.INSTANCE);
 
         // when
         assertEquals(State.CLOSED, circuitBreaker.getState());
@@ -418,5 +425,98 @@ class KoraCircuitBreakerTests extends Assertions {
         // then
         assertFalse(circuitBreaker.tryAcquire()); // closed switched to open
         assertEquals(State.OPEN, circuitBreaker.getState());
+    }
+
+    @Test
+    void openToHalfOpenUsesMonotonicTicker() {
+        final CircuitBreakerConfig.NamedConfig config = new $CircuitBreakerConfig_NamedConfig_ConfigValueMapper.NamedConfig_Impl(
+            true, 100, WAIT_IN_OPEN, 1, 1L, 1L, KoraCircuitBreakerPredicate.class.getCanonicalName());
+        var ticker = new AtomicLong();
+        final FixedWindowKoraCircuitBreaker circuitBreaker = new FixedWindowKoraCircuitBreaker("default", config, new KoraCircuitBreakerPredicate(), NoopCircuitBreakerTelemetry.INSTANCE, ticker::get);
+
+        assertTrue(circuitBreaker.tryAcquire());
+        circuitBreaker.releaseOnError(new IllegalStateException());
+        assertEquals(State.OPEN, circuitBreaker.getState());
+        assertFalse(circuitBreaker.tryAcquire());
+
+        ticker.addAndGet(WAIT_IN_OPEN.toNanos());
+
+        assertTrue(circuitBreaker.tryAcquire());
+        assertEquals(State.HALF_OPEN, circuitBreaker.getState());
+    }
+
+    @Test
+    void configValidationRejectsFixedWindowCounterOverflow() {
+        var config = new TestCircuitBreakerConfig(Map.of(CircuitBreakerConfig.DEFAULT,
+            new $CircuitBreakerConfig_NamedConfig_ConfigValueMapper.NamedConfig_Impl(
+                true, 100, WAIT_IN_OPEN, 1, 0x8000_0000L, 1L, KoraCircuitBreakerPredicate.class.getCanonicalName())));
+
+        assertThrows(IllegalArgumentException.class, () -> config.getNamedConfig(CircuitBreakerConfig.DEFAULT));
+    }
+
+    @Test
+    void configValidationRejectsHalfOpenCounterOverflow() {
+        var config = new TestCircuitBreakerConfig(Map.of(CircuitBreakerConfig.DEFAULT,
+            new $CircuitBreakerConfig_NamedConfig_ConfigValueMapper.NamedConfig_Impl(
+                true, 100, WAIT_IN_OPEN, 0x1_0000, 1L, 1L, KoraCircuitBreakerPredicate.class.getCanonicalName())));
+
+        assertThrows(IllegalArgumentException.class, () -> config.getNamedConfig(CircuitBreakerConfig.DEFAULT));
+    }
+
+    @Test
+    void telemetryRecordsCallResults() {
+        final CircuitBreakerConfig.NamedConfig config = new $CircuitBreakerConfig_NamedConfig_ConfigValueMapper.NamedConfig_Impl(
+            true, 100, WAIT_IN_OPEN, 1, 1L, 1L, KoraCircuitBreakerPredicate.class.getCanonicalName());
+        var telemetry = new CountingTelemetry();
+        final FixedWindowKoraCircuitBreaker circuitBreaker = new FixedWindowKoraCircuitBreaker("default", config, new KoraCircuitBreakerPredicate(), telemetry);
+
+        assertEquals("ok", circuitBreaker.accept(() -> "ok"));
+        assertThrows(IllegalStateException.class, () -> circuitBreaker.accept(() -> {
+            throw new IllegalStateException();
+        }));
+        assertEquals("fallback", circuitBreaker.accept(() -> "ignored", () -> "fallback"));
+
+        assertTrue(telemetry.results.contains(CircuitBreakerObservation.CallResult.SUCCESS));
+        assertTrue(telemetry.results.contains(CircuitBreakerObservation.CallResult.FAILURE));
+        assertTrue(telemetry.results.contains(CircuitBreakerObservation.CallResult.FALLBACK));
+    }
+
+    private record TestCircuitBreakerConfig(Map<String, CircuitBreakerConfig.NamedConfig> circuitbreaker) implements CircuitBreakerConfig {
+        @Override
+        public CircuitBreakerTelemetryConfig telemetry() {
+            return null;
+        }
+    }
+
+    private static final class CountingTelemetry implements CircuitBreakerTelemetry {
+
+        private final ArrayList<CircuitBreakerObservation.CallResult> results = new ArrayList<>();
+
+        @Override
+        public CircuitBreakerObservation observe() {
+            return new CircuitBreakerObservation() {
+                @Override
+                public void recordCallAcquire(State state, CallAcquireStatus callStatus) {}
+
+                @Override
+                public void recordCallResult(State state, CallResult callResult) {
+                    results.add(callResult);
+                }
+
+                @Override
+                public void recordStateChange(State previousState, State newState) {}
+
+                @Override
+                public Span span() {
+                    return Span.getInvalid();
+                }
+
+                @Override
+                public void end() {}
+
+                @Override
+                public void observeError(Throwable e) {}
+            };
+        }
     }
 }

--- a/resilient/resilient-kora/src/test/java/io/koraframework/resilient/circuitbreaker/RingBufferKoraCircuitBreakerTests.java
+++ b/resilient/resilient-kora/src/test/java/io/koraframework/resilient/circuitbreaker/RingBufferKoraCircuitBreakerTests.java
@@ -1,0 +1,383 @@
+package io.koraframework.resilient.circuitbreaker;
+
+import io.koraframework.resilient.circuitbreaker.exception.CallNotPermittedException;
+import io.koraframework.resilient.circuitbreaker.telemetry.CircuitBreakerTelemetryConfig;
+import io.koraframework.resilient.circuitbreaker.telemetry.impl.NoopCircuitBreakerTelemetry;
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionFactory;
+import org.jspecify.annotations.NullMarked;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+
+class RingBufferKoraCircuitBreakerTests extends Assertions {
+
+    private static final Duration WAIT_IN_OPEN = Duration.ofMillis(50);
+
+    @NullMarked
+    static class CustomPredicate implements CircuitBreakerPredicate {
+
+        @Override
+        public String name() {
+            return "custom";
+        }
+
+        @Override
+        public boolean test(Throwable throwable) {
+            return throwable instanceof IllegalStateException;
+        }
+    }
+
+    private static ConditionFactory awaitily() {
+        return Awaitility.await().atMost(Duration.ofSeconds(1)).pollDelay(Duration.ofMillis(5));
+    }
+
+    @Test
+    void managerCreatesRingBufferCircuitBreakerWhenTypeConfigured() {
+        var manager = new KoraCircuitBreakerManager(
+            circuitBreakerConfig(config(4, 2, 50, 2)),
+            List.of(new KoraCircuitBreakerPredicate()),
+            (name, telemetryConfig) -> NoopCircuitBreakerTelemetry.INSTANCE
+        );
+
+        assertInstanceOf(RingBufferKoraCircuitBreaker.class, manager.get(CircuitBreakerConfig.DEFAULT));
+    }
+
+    @Test
+    void snapshotSumsOutcomeCounters() {
+        var circuitBreaker = new RingBufferKoraCircuitBreaker(
+            "default",
+            config(4, 1, 100, 1),
+            ignoredPredicate(),
+            NoopCircuitBreakerTelemetry.INSTANCE
+        );
+
+        circuitBreaker.releaseOnSuccess();
+        circuitBreaker.releaseOnError(new IllegalStateException());
+        var snapshot = circuitBreaker.snapshot();
+
+        assertEquals(1, snapshot.total());
+        assertEquals(0, snapshot.failures());
+        assertEquals(1, snapshot.ignored());
+    }
+
+    @Test
+    void switchFromClosedToOpen() {
+        var circuitBreaker = ringBuffer(config(10, 8, 30, 3));
+
+        assertEquals(CircuitBreaker.State.CLOSED, circuitBreaker.getState());
+        for (int i = 0; i < 7; i++) {
+            assertTrue(circuitBreaker.tryAcquire());
+            circuitBreaker.releaseOnSuccess();
+        }
+        assertTrue(circuitBreaker.tryAcquire());
+        circuitBreaker.releaseOnError(new IllegalStateException());
+        assertTrue(circuitBreaker.tryAcquire());
+        circuitBreaker.releaseOnError(new IllegalStateException());
+        assertEquals(CircuitBreaker.State.CLOSED, circuitBreaker.getState());
+
+        assertTrue(circuitBreaker.tryAcquire());
+        circuitBreaker.releaseOnError(new IllegalStateException());
+
+        assertFalse(circuitBreaker.tryAcquire());
+        assertEquals(CircuitBreaker.State.OPEN, circuitBreaker.getState());
+    }
+
+    @Test
+    void switchFromClosedToOpenForMinimumNumberOfCalls() {
+        var circuitBreaker = ringBuffer(config(2, 2, 100, 1));
+
+        assertTrue(circuitBreaker.tryAcquire());
+        circuitBreaker.releaseOnError(new IllegalStateException());
+        assertEquals(CircuitBreaker.State.CLOSED, circuitBreaker.getState());
+
+        assertTrue(circuitBreaker.tryAcquire());
+        circuitBreaker.releaseOnError(new IllegalStateException());
+
+        assertFalse(circuitBreaker.tryAcquire());
+        assertEquals(CircuitBreaker.State.OPEN, circuitBreaker.getState());
+    }
+
+    @Test
+    void switchFromClosedToOpenToHalfOpenToOpen() {
+        var circuitBreaker = ringBuffer(config(2, 2, 100, 2));
+
+        open(circuitBreaker);
+
+        awaitily().until(circuitBreaker::tryAcquire);
+        assertEquals(CircuitBreaker.State.HALF_OPEN, circuitBreaker.getState());
+        circuitBreaker.releaseOnError(new IllegalStateException());
+
+        assertFalse(circuitBreaker.tryAcquire());
+        assertEquals(CircuitBreaker.State.OPEN, circuitBreaker.getState());
+    }
+
+    @Test
+    void switchFromClosedToOpenToHalfOpenToClosed() {
+        var circuitBreaker = ringBuffer(config(2, 2, 100, 2));
+
+        open(circuitBreaker);
+
+        awaitily().until(circuitBreaker::tryAcquire);
+        assertEquals(CircuitBreaker.State.HALF_OPEN, circuitBreaker.getState());
+        circuitBreaker.releaseOnSuccess();
+        assertTrue(circuitBreaker.tryAcquire());
+        assertFalse(circuitBreaker.tryAcquire());
+        circuitBreaker.releaseOnSuccess();
+
+        assertTrue(circuitBreaker.tryAcquire());
+        assertEquals(CircuitBreaker.State.CLOSED, circuitBreaker.getState());
+    }
+
+    @Test
+    void switchFromClosedToOpenToHalfOpenCorrectlyRestoreIgnoredExceptionToOpen() {
+        var circuitBreaker = new RingBufferKoraCircuitBreaker(
+            "default",
+            config(4, 2, 50, 2),
+            new CircuitBreakerPredicate() {
+                @Override
+                public String name() {
+                    return "kora";
+                }
+
+                @Override
+                public boolean test(Throwable throwable) {
+                    return !(throwable instanceof UncheckedIOException);
+                }
+            },
+            NoopCircuitBreakerTelemetry.INSTANCE
+        );
+
+        open(circuitBreaker);
+
+        awaitily().dontCatchUncaughtExceptions().untilAsserted(() -> assertDoesNotThrow(circuitBreaker::acquire));
+        assertEquals(CircuitBreaker.State.HALF_OPEN, circuitBreaker.getState());
+        circuitBreaker.releaseOnError(new UncheckedIOException(new IOException("OPS")));
+        awaitily().dontCatchUncaughtExceptions().untilAsserted(() -> assertDoesNotThrow(circuitBreaker::acquire));
+        assertEquals(CircuitBreaker.State.HALF_OPEN, circuitBreaker.getState());
+        circuitBreaker.releaseOnError(new UncheckedIOException(new IOException("OPS")));
+
+        assertEquals(CircuitBreaker.State.HALF_OPEN, circuitBreaker.getState());
+        awaitily().dontCatchUncaughtExceptions().untilAsserted(() -> assertDoesNotThrow(circuitBreaker::acquire));
+        circuitBreaker.releaseOnError(new IllegalStateException());
+
+        assertEquals(CircuitBreaker.State.OPEN, circuitBreaker.getState());
+        assertFalse(circuitBreaker.tryAcquire());
+    }
+
+    @Test
+    void switchFromClosedToOpenToHalfOpenToOpenToHalfOpenToClosedForAccept() {
+        var circuitBreaker = ringBuffer(config(4, 2, 50, 2));
+        Callable<Boolean> successCallable = () -> {
+            try {
+                return circuitBreaker.accept(() -> "success") != null;
+            } catch (CallNotPermittedException e) {
+                return false;
+            }
+        };
+        Supplier<Object> failSupplier = () -> {
+            if (true) {
+                throw new IllegalStateException();
+            }
+            return null;
+        };
+
+        assertThrows(IllegalStateException.class, () -> circuitBreaker.accept(failSupplier));
+        assertThrows(IllegalStateException.class, () -> circuitBreaker.accept(failSupplier));
+        assertThrows(CallNotPermittedException.class, () -> circuitBreaker.accept(failSupplier));
+        assertEquals(CircuitBreaker.State.OPEN, circuitBreaker.getState());
+
+        awaitily().until(successCallable);
+        assertEquals(CircuitBreaker.State.HALF_OPEN, circuitBreaker.getState());
+        assertThrows(IllegalStateException.class, () -> circuitBreaker.accept(failSupplier));
+        assertEquals(CircuitBreaker.State.OPEN, circuitBreaker.getState());
+
+        awaitily().until(successCallable);
+        assertEquals(CircuitBreaker.State.HALF_OPEN, circuitBreaker.getState());
+        awaitily().until(successCallable);
+        assertEquals(CircuitBreaker.State.CLOSED, circuitBreaker.getState());
+    }
+
+    @Test
+    void switchFromClosedToOpenForCustomFailurePredicate() {
+        var circuitBreaker = new RingBufferKoraCircuitBreaker(
+            "default",
+            config(true, 1, 1, 100, 1, "custom"),
+            new CustomPredicate(),
+            NoopCircuitBreakerTelemetry.INSTANCE
+        );
+
+        assertTrue(circuitBreaker.tryAcquire());
+        circuitBreaker.releaseOnError(new NullPointerException());
+        assertTrue(circuitBreaker.tryAcquire());
+        assertEquals(CircuitBreaker.State.CLOSED, circuitBreaker.getState());
+        circuitBreaker.releaseOnError(new IllegalStateException());
+
+        assertFalse(circuitBreaker.tryAcquire());
+        assertEquals(CircuitBreaker.State.OPEN, circuitBreaker.getState());
+    }
+
+    @Test
+    void openToHalfOpenUsesMonotonicTicker() {
+        var ticker = new AtomicLong();
+        var circuitBreaker = new RingBufferKoraCircuitBreaker(
+            "default",
+            config(1, 1, 100, 1),
+            new KoraCircuitBreakerPredicate(),
+            NoopCircuitBreakerTelemetry.INSTANCE,
+            ticker::get
+        );
+
+        assertTrue(circuitBreaker.tryAcquire());
+        circuitBreaker.releaseOnError(new IllegalStateException());
+        assertEquals(CircuitBreaker.State.OPEN, circuitBreaker.getState());
+        assertFalse(circuitBreaker.tryAcquire());
+
+        ticker.addAndGet(WAIT_IN_OPEN.toNanos());
+
+        assertTrue(circuitBreaker.tryAcquire());
+        assertEquals(CircuitBreaker.State.HALF_OPEN, circuitBreaker.getState());
+    }
+
+    @Test
+    void disabledCircuitBreakerAlwaysPermitsCalls() {
+        var circuitBreaker = ringBuffer(config(false, 1, 1, 100, 1));
+
+        assertTrue(circuitBreaker.tryAcquire());
+        circuitBreaker.releaseOnError(new IllegalStateException());
+        assertTrue(circuitBreaker.tryAcquire());
+        assertEquals(CircuitBreaker.State.CLOSED, circuitBreaker.getState());
+        assertThrows(IllegalStateException.class, () -> circuitBreaker.accept(() -> {
+            throw new IllegalStateException();
+        }));
+        assertEquals(CircuitBreaker.State.CLOSED, circuitBreaker.getState());
+    }
+
+    @Test
+    void ringBufferEvictsOldOutcomesExactly() {
+        var circuitBreaker = ringBuffer(config(2, 2, 100, 1));
+
+        circuitBreaker.releaseOnError(new IllegalStateException());
+        circuitBreaker.releaseOnSuccess();
+        circuitBreaker.releaseOnSuccess();
+        var snapshot = circuitBreaker.snapshot();
+
+        assertEquals(2, snapshot.total());
+        assertEquals(0, snapshot.failures());
+    }
+
+    @Test
+    void concurrentClosedSuccessRecordingStaysWithinWindow() throws Exception {
+        var windowSize = 64;
+        var circuitBreaker = ringBuffer(config(windowSize, windowSize, 100, 1));
+        var threads = 8;
+        var iterations = 2000;
+        var start = new CountDownLatch(1);
+        var done = new CountDownLatch(threads);
+        var failures = new ArrayList<Throwable>();
+        var executor = Executors.newFixedThreadPool(threads);
+        try {
+            for (int i = 0; i < threads; i++) {
+                executor.execute(() -> {
+                    try {
+                        start.await();
+                        for (int j = 0; j < iterations; j++) {
+                            circuitBreaker.releaseOnSuccess();
+                        }
+                    } catch (Throwable e) {
+                        synchronized (failures) {
+                            failures.add(e);
+                        }
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+
+            start.countDown();
+            assertTrue(done.await(5, TimeUnit.SECONDS));
+        } finally {
+            executor.shutdownNow();
+        }
+
+        assertTrue(failures.isEmpty(), () -> failures.toString());
+        var snapshot = circuitBreaker.snapshot();
+        assertEquals(CircuitBreaker.State.CLOSED, circuitBreaker.getState());
+        assertEquals(windowSize, snapshot.total());
+        assertEquals(0, snapshot.failures());
+    }
+
+    private static void open(RingBufferKoraCircuitBreaker circuitBreaker) {
+        assertEquals(CircuitBreaker.State.CLOSED, circuitBreaker.getState());
+        assertTrue(circuitBreaker.tryAcquire());
+        circuitBreaker.releaseOnError(new IllegalStateException());
+        assertTrue(circuitBreaker.tryAcquire());
+        circuitBreaker.releaseOnError(new IllegalStateException());
+        assertFalse(circuitBreaker.tryAcquire());
+        assertEquals(CircuitBreaker.State.OPEN, circuitBreaker.getState());
+    }
+
+    private static RingBufferKoraCircuitBreaker ringBuffer(CircuitBreakerConfig.NamedConfig config) {
+        return new RingBufferKoraCircuitBreaker("default", config, new KoraCircuitBreakerPredicate(), NoopCircuitBreakerTelemetry.INSTANCE);
+    }
+
+    private static CircuitBreakerConfig.NamedConfig config(long windowSize, long minimumRequiredCalls, int failureRateThreshold, int permittedCallsInHalfOpenState) {
+        return config(true, windowSize, minimumRequiredCalls, failureRateThreshold, permittedCallsInHalfOpenState);
+    }
+
+    private static CircuitBreakerConfig.NamedConfig config(Boolean enabled, long windowSize, long minimumRequiredCalls, int failureRateThreshold, int permittedCallsInHalfOpenState) {
+        return config(enabled, windowSize, minimumRequiredCalls, failureRateThreshold, permittedCallsInHalfOpenState, KoraCircuitBreakerPredicate.class.getCanonicalName());
+    }
+
+    private static CircuitBreakerConfig.NamedConfig config(Boolean enabled,
+                                                           long windowSize,
+                                                           long minimumRequiredCalls,
+                                                           int failureRateThreshold,
+                                                           int permittedCallsInHalfOpenState,
+                                                           String failurePredicateName) {
+        return new $CircuitBreakerConfig_NamedConfig_ConfigValueMapper.NamedConfig_Impl(
+            enabled, CircuitBreakerConfig.CircuitBreakerType.RING_BUFFER, countBased(windowSize, null), null, failureRateThreshold, WAIT_IN_OPEN, permittedCallsInHalfOpenState, minimumRequiredCalls, failurePredicateName
+        );
+    }
+
+    private static CircuitBreakerConfig circuitBreakerConfig(CircuitBreakerConfig.NamedConfig config) {
+        return new TestCircuitBreakerConfig(Map.of(CircuitBreakerConfig.DEFAULT, config));
+    }
+
+    private static CircuitBreakerPredicate ignoredPredicate() {
+        return new CircuitBreakerPredicate() {
+            @Override
+            public String name() {
+                return "ignored";
+            }
+
+            @Override
+            public boolean test(Throwable throwable) {
+                return false;
+            }
+        };
+    }
+
+    private static CircuitBreakerConfig.CountBasedConfig countBased(Long windowSize, CircuitBreakerConfig.StripedApproxConfig stripedApprox) {
+        return new $CircuitBreakerConfig_CountBasedConfig_ConfigValueMapper.CountBasedConfig_Impl(windowSize, stripedApprox);
+    }
+
+    private record TestCircuitBreakerConfig(Map<String, CircuitBreakerConfig.NamedConfig> circuitbreaker) implements CircuitBreakerConfig {
+        @Override
+        public CircuitBreakerTelemetryConfig telemetry() {
+            return null;
+        }
+    }
+}

--- a/resilient/resilient-kora/src/test/java/io/koraframework/resilient/circuitbreaker/StripedApproxKoraCircuitBreakerTests.java
+++ b/resilient/resilient-kora/src/test/java/io/koraframework/resilient/circuitbreaker/StripedApproxKoraCircuitBreakerTests.java
@@ -1,0 +1,572 @@
+package io.koraframework.resilient.circuitbreaker;
+
+import io.koraframework.resilient.circuitbreaker.exception.CallNotPermittedException;
+import io.koraframework.resilient.circuitbreaker.telemetry.CircuitBreakerTelemetryConfig;
+import io.koraframework.resilient.circuitbreaker.telemetry.impl.NoopCircuitBreakerTelemetry;
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionFactory;
+import org.jspecify.annotations.NullMarked;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+
+class StripedApproxKoraCircuitBreakerTests extends Assertions {
+
+    private static final Duration WAIT_IN_OPEN = Duration.ofMillis(50);
+
+    @NullMarked
+    static class CustomPredicate implements CircuitBreakerPredicate {
+
+        @Override
+        public String name() {
+            return "custom";
+        }
+
+        @Override
+        public boolean test(Throwable throwable) {
+            return throwable instanceof IllegalStateException;
+        }
+    }
+
+    private static ConditionFactory awaitily() {
+        return Awaitility.await().atMost(Duration.ofSeconds(1)).pollDelay(Duration.ofMillis(5));
+    }
+
+    @Test
+    void managerCreatesStripedApproxCircuitBreakerWhenTypeConfigured() {
+        var manager = new KoraCircuitBreakerManager(
+            circuitBreakerConfig(stripedConfig(4, 4, 2, 50, 2)),
+            List.of(new KoraCircuitBreakerPredicate()),
+            (name, telemetryConfig) -> NoopCircuitBreakerTelemetry.INSTANCE
+        );
+
+        assertInstanceOf(StripedApproxKoraCircuitBreaker.class, manager.get(CircuitBreakerConfig.DEFAULT));
+    }
+
+    @Test
+    void stripedConfigUsesDefaultStripes() {
+        var namedConfig = new TestCircuitBreakerConfig(Map.of(CircuitBreakerConfig.DEFAULT,
+            config(null, CircuitBreakerConfig.CircuitBreakerType.STRIPED_APPROX, null, 4, 2, 50, 2)
+        )).getNamedConfig(CircuitBreakerConfig.DEFAULT);
+
+        assertEquals(CircuitBreakerConfig.STRIPED_APPROX_DEFAULT_STRIPES, namedConfig.countBased().stripedApprox().stripes());
+    }
+
+    @Test
+    void snapshotSumsOutcomeCounters() {
+        var circuitBreaker = new StripedApproxKoraCircuitBreaker(
+            "default",
+            stripedConfig(1, 4, 1, 100, 1),
+            ignoredPredicate(),
+            NoopCircuitBreakerTelemetry.INSTANCE
+        );
+
+        circuitBreaker.releaseOnSuccess();
+        circuitBreaker.releaseOnError(new IllegalStateException());
+        var snapshot = circuitBreaker.snapshot();
+
+        assertEquals(1, snapshot.total());
+        assertEquals(0, snapshot.failures());
+        assertEquals(1, snapshot.ignored());
+    }
+
+    @Test
+    void switchFromClosedToOpen() {
+        var circuitBreaker = stripedCircuitBreaker(stripedConfig(1, 10, 8, 30, 3));
+
+        assertEquals(CircuitBreaker.State.CLOSED, circuitBreaker.getState());
+        assertTrue(circuitBreaker.tryAcquire());
+        circuitBreaker.releaseOnSuccess();
+        assertTrue(circuitBreaker.tryAcquire());
+        circuitBreaker.releaseOnSuccess();
+        assertTrue(circuitBreaker.tryAcquire());
+        circuitBreaker.releaseOnSuccess();
+        assertTrue(circuitBreaker.tryAcquire());
+        circuitBreaker.releaseOnSuccess();
+        assertTrue(circuitBreaker.tryAcquire());
+        circuitBreaker.releaseOnSuccess();
+        assertTrue(circuitBreaker.tryAcquire());
+        circuitBreaker.releaseOnSuccess();
+        assertTrue(circuitBreaker.tryAcquire());
+        circuitBreaker.releaseOnSuccess();
+        assertTrue(circuitBreaker.tryAcquire());
+        circuitBreaker.releaseOnError(new IllegalStateException());
+        assertTrue(circuitBreaker.tryAcquire());
+        circuitBreaker.releaseOnError(new IllegalStateException());
+        assertEquals(CircuitBreaker.State.CLOSED, circuitBreaker.getState());
+
+        assertTrue(circuitBreaker.tryAcquire());
+        circuitBreaker.releaseOnError(new IllegalStateException());
+        assertFalse(circuitBreaker.tryAcquire());
+        assertEquals(CircuitBreaker.State.OPEN, circuitBreaker.getState());
+    }
+
+    @Test
+    void switchFromClosedToOpenForMinimumNumberOfCalls() {
+        var circuitBreaker = stripedCircuitBreaker(stripedConfig(1, 2, 2, 100, 1));
+
+        assertEquals(CircuitBreaker.State.CLOSED, circuitBreaker.getState());
+        assertTrue(circuitBreaker.tryAcquire());
+        circuitBreaker.releaseOnError(new IllegalStateException());
+        assertEquals(CircuitBreaker.State.CLOSED, circuitBreaker.getState());
+        assertTrue(circuitBreaker.tryAcquire());
+        circuitBreaker.releaseOnError(new IllegalStateException());
+
+        assertFalse(circuitBreaker.tryAcquire());
+        assertEquals(CircuitBreaker.State.OPEN, circuitBreaker.getState());
+    }
+
+    @Test
+    void switchFromClosedToOpenToHalfOpenToOpen() {
+        var circuitBreaker = stripedCircuitBreaker(stripedConfig(1, 2, 2, 100, 2));
+
+        open(circuitBreaker);
+
+        awaitily().until(circuitBreaker::tryAcquire);
+        assertEquals(CircuitBreaker.State.HALF_OPEN, circuitBreaker.getState());
+        circuitBreaker.releaseOnError(new IllegalStateException());
+
+        assertFalse(circuitBreaker.tryAcquire());
+        assertEquals(CircuitBreaker.State.OPEN, circuitBreaker.getState());
+    }
+
+    @Test
+    void switchFromClosedToOpenToHalfOpenToOpenToHalfOpenToOpen() {
+        var circuitBreaker = stripedCircuitBreaker(stripedConfig(1, 2, 2, 100, 2));
+
+        open(circuitBreaker);
+
+        awaitily().until(circuitBreaker::tryAcquire);
+        assertEquals(CircuitBreaker.State.HALF_OPEN, circuitBreaker.getState());
+        circuitBreaker.releaseOnError(new IllegalStateException());
+
+        assertFalse(circuitBreaker.tryAcquire());
+        assertEquals(CircuitBreaker.State.OPEN, circuitBreaker.getState());
+
+        awaitily().until(circuitBreaker::tryAcquire);
+        assertEquals(CircuitBreaker.State.HALF_OPEN, circuitBreaker.getState());
+        circuitBreaker.releaseOnError(new IllegalStateException());
+
+        assertFalse(circuitBreaker.tryAcquire());
+        assertEquals(CircuitBreaker.State.OPEN, circuitBreaker.getState());
+    }
+
+    @Test
+    void switchFromClosedToOpenToHalfOpenToOpenToHalfOpenToClosed() {
+        var circuitBreaker = stripedCircuitBreaker(stripedConfig(1, 2, 2, 100, 2));
+
+        open(circuitBreaker);
+
+        awaitily().until(circuitBreaker::tryAcquire);
+        assertEquals(CircuitBreaker.State.HALF_OPEN, circuitBreaker.getState());
+        circuitBreaker.releaseOnError(new IllegalStateException());
+
+        assertFalse(circuitBreaker.tryAcquire());
+        assertEquals(CircuitBreaker.State.OPEN, circuitBreaker.getState());
+
+        awaitily().until(circuitBreaker::tryAcquire);
+        assertEquals(CircuitBreaker.State.HALF_OPEN, circuitBreaker.getState());
+        circuitBreaker.releaseOnSuccess();
+        assertTrue(circuitBreaker.tryAcquire());
+        assertFalse(circuitBreaker.tryAcquire());
+        assertEquals(CircuitBreaker.State.HALF_OPEN, circuitBreaker.getState());
+        circuitBreaker.releaseOnSuccess();
+
+        assertTrue(circuitBreaker.tryAcquire());
+        assertEquals(CircuitBreaker.State.CLOSED, circuitBreaker.getState());
+    }
+
+    @Test
+    void switchFromClosedToOpenToHalfOpenToOpenToHalfOpenToClosedComplex() {
+        var circuitBreaker = stripedCircuitBreaker(stripedConfig(1, 4, 2, 50, 2));
+
+        open(circuitBreaker);
+
+        awaitily().until(circuitBreaker::tryAcquire);
+        assertEquals(CircuitBreaker.State.HALF_OPEN, circuitBreaker.getState());
+        circuitBreaker.releaseOnError(new IllegalStateException());
+
+        assertFalse(circuitBreaker.tryAcquire());
+        assertEquals(CircuitBreaker.State.OPEN, circuitBreaker.getState());
+
+        awaitily().until(circuitBreaker::tryAcquire);
+        assertEquals(CircuitBreaker.State.HALF_OPEN, circuitBreaker.getState());
+        circuitBreaker.releaseOnSuccess();
+        assertTrue(circuitBreaker.tryAcquire());
+        assertFalse(circuitBreaker.tryAcquire());
+        assertEquals(CircuitBreaker.State.HALF_OPEN, circuitBreaker.getState());
+        circuitBreaker.releaseOnSuccess();
+
+        assertTrue(circuitBreaker.tryAcquire());
+        assertEquals(CircuitBreaker.State.CLOSED, circuitBreaker.getState());
+    }
+
+    @Test
+    void switchFromClosedToOpenToHalfOpenCorrectlyRestoreIgnoredExceptionToOpen() {
+        var circuitBreaker = new StripedApproxKoraCircuitBreaker(
+            "default",
+            stripedConfig(1, 4, 2, 50, 2),
+            new CircuitBreakerPredicate() {
+                @Override
+                public String name() {
+                    return "kora";
+                }
+
+                @Override
+                public boolean test(Throwable throwable) {
+                    return !(throwable instanceof UncheckedIOException);
+                }
+            },
+            NoopCircuitBreakerTelemetry.INSTANCE
+        );
+
+        open(circuitBreaker);
+
+        awaitily().dontCatchUncaughtExceptions().untilAsserted(() -> Assertions.assertDoesNotThrow(circuitBreaker::acquire));
+        assertEquals(CircuitBreaker.State.HALF_OPEN, circuitBreaker.getState());
+        circuitBreaker.releaseOnError(new UncheckedIOException(new IOException("OPS")));
+        awaitily().dontCatchUncaughtExceptions().untilAsserted(() -> Assertions.assertDoesNotThrow(circuitBreaker::acquire));
+        assertEquals(CircuitBreaker.State.HALF_OPEN, circuitBreaker.getState());
+        circuitBreaker.releaseOnError(new UncheckedIOException(new IOException("OPS")));
+
+        assertEquals(CircuitBreaker.State.HALF_OPEN, circuitBreaker.getState());
+        awaitily().dontCatchUncaughtExceptions().untilAsserted(() -> Assertions.assertDoesNotThrow(circuitBreaker::acquire));
+        circuitBreaker.releaseOnError(new IllegalStateException());
+
+        assertEquals(CircuitBreaker.State.OPEN, circuitBreaker.getState());
+        assertFalse(circuitBreaker.tryAcquire());
+    }
+
+    @Test
+    void switchFromClosedToOpenToHalfOpenToOpenToHalfOpenToClosedForAccept() {
+        var circuitBreaker = stripedCircuitBreaker(stripedConfig(1, 4, 2, 50, 2));
+
+        Callable<Boolean> successCallable = () -> {
+            try {
+                return circuitBreaker.accept(() -> "success") != null;
+            } catch (CallNotPermittedException e) {
+                return false;
+            }
+        };
+        Supplier<Object> failSupplier = () -> {
+            if (true) {
+                throw new IllegalStateException();
+            }
+            return null;
+        };
+
+        assertEquals(CircuitBreaker.State.CLOSED, circuitBreaker.getState());
+        assertThrows(IllegalStateException.class, () -> circuitBreaker.accept(failSupplier));
+        assertThrows(IllegalStateException.class, () -> circuitBreaker.accept(failSupplier));
+
+        assertThrows(CallNotPermittedException.class, () -> circuitBreaker.accept(failSupplier));
+        assertEquals(CircuitBreaker.State.OPEN, circuitBreaker.getState());
+
+        awaitily().until(successCallable);
+        assertEquals(CircuitBreaker.State.HALF_OPEN, circuitBreaker.getState());
+
+        assertThrows(IllegalStateException.class, () -> circuitBreaker.accept(failSupplier));
+        assertEquals(CircuitBreaker.State.OPEN, circuitBreaker.getState());
+
+        awaitily().until(successCallable);
+        assertEquals(CircuitBreaker.State.HALF_OPEN, circuitBreaker.getState());
+        awaitily().until(successCallable);
+        assertEquals(CircuitBreaker.State.CLOSED, circuitBreaker.getState());
+    }
+
+    @Test
+    void switchFromClosedToOpenToHalfOpenToOpenToHalfOpenWhenPartFailToOpen() {
+        var circuitBreaker = stripedCircuitBreaker(stripedConfig(1, 2, 2, 100, 2));
+
+        open(circuitBreaker);
+
+        awaitily().until(circuitBreaker::tryAcquire);
+        assertEquals(CircuitBreaker.State.HALF_OPEN, circuitBreaker.getState());
+        circuitBreaker.releaseOnError(new IllegalStateException());
+
+        assertFalse(circuitBreaker.tryAcquire());
+        assertEquals(CircuitBreaker.State.OPEN, circuitBreaker.getState());
+
+        awaitily().until(circuitBreaker::tryAcquire);
+        assertEquals(CircuitBreaker.State.HALF_OPEN, circuitBreaker.getState());
+        circuitBreaker.releaseOnSuccess();
+        assertTrue(circuitBreaker.tryAcquire());
+        assertFalse(circuitBreaker.tryAcquire());
+        assertEquals(CircuitBreaker.State.HALF_OPEN, circuitBreaker.getState());
+        circuitBreaker.releaseOnError(new IllegalStateException());
+
+        assertFalse(circuitBreaker.tryAcquire());
+        assertEquals(CircuitBreaker.State.OPEN, circuitBreaker.getState());
+    }
+
+    @Test
+    void switchFromClosedToOpenToHalfOpenToClosed() {
+        var circuitBreaker = stripedCircuitBreaker(stripedConfig(1, 2, 2, 100, 2));
+
+        open(circuitBreaker);
+
+        awaitily().until(circuitBreaker::tryAcquire);
+        assertEquals(CircuitBreaker.State.HALF_OPEN, circuitBreaker.getState());
+        circuitBreaker.releaseOnSuccess();
+        assertTrue(circuitBreaker.tryAcquire());
+        assertFalse(circuitBreaker.tryAcquire());
+        circuitBreaker.releaseOnSuccess();
+
+        assertTrue(circuitBreaker.tryAcquire());
+        assertEquals(CircuitBreaker.State.CLOSED, circuitBreaker.getState());
+    }
+
+    @Test
+    void switchFromOpenToHalfOpenAndValidateAcquireCalls() {
+        var circuitBreaker = stripedCircuitBreaker(stripedConfig(1, 1, 1, 100, 1));
+
+        assertEquals(CircuitBreaker.State.CLOSED, circuitBreaker.getState());
+        assertTrue(circuitBreaker.tryAcquire());
+        circuitBreaker.releaseOnError(new IllegalStateException());
+        assertFalse(circuitBreaker.tryAcquire());
+        assertEquals(CircuitBreaker.State.OPEN, circuitBreaker.getState());
+
+        awaitily().until(circuitBreaker::tryAcquire);
+        assertEquals(CircuitBreaker.State.HALF_OPEN, circuitBreaker.getState());
+        assertFalse(circuitBreaker.tryAcquire());
+        assertEquals(CircuitBreaker.State.HALF_OPEN, circuitBreaker.getState());
+        circuitBreaker.releaseOnSuccess();
+        assertEquals(CircuitBreaker.State.CLOSED, circuitBreaker.getState());
+        assertTrue(circuitBreaker.tryAcquire());
+    }
+
+    @Test
+    void switchFromClosedToOpenForCustomFailurePredicate() {
+        var circuitBreaker = new StripedApproxKoraCircuitBreaker(
+            "default",
+            config(true, CircuitBreakerConfig.CircuitBreakerType.STRIPED_APPROX, striped(1), 1, 1, 100, 1, "custom"),
+            new CustomPredicate(),
+            NoopCircuitBreakerTelemetry.INSTANCE
+        );
+
+        assertEquals(CircuitBreaker.State.CLOSED, circuitBreaker.getState());
+        assertTrue(circuitBreaker.tryAcquire());
+        circuitBreaker.releaseOnError(new NullPointerException());
+        assertTrue(circuitBreaker.tryAcquire());
+        assertEquals(CircuitBreaker.State.CLOSED, circuitBreaker.getState());
+        circuitBreaker.releaseOnError(new IllegalStateException());
+
+        assertFalse(circuitBreaker.tryAcquire());
+        assertEquals(CircuitBreaker.State.OPEN, circuitBreaker.getState());
+    }
+
+    @Test
+    void openToHalfOpenUsesMonotonicTicker() {
+        var ticker = new AtomicLong();
+        var circuitBreaker = new StripedApproxKoraCircuitBreaker(
+            "default",
+            stripedConfig(1, 1, 1, 100, 1),
+            new KoraCircuitBreakerPredicate(),
+            NoopCircuitBreakerTelemetry.INSTANCE,
+            ticker::get
+        );
+
+        assertTrue(circuitBreaker.tryAcquire());
+        circuitBreaker.releaseOnError(new IllegalStateException());
+        assertEquals(CircuitBreaker.State.OPEN, circuitBreaker.getState());
+        assertFalse(circuitBreaker.tryAcquire());
+
+        ticker.addAndGet(WAIT_IN_OPEN.toNanos());
+
+        assertTrue(circuitBreaker.tryAcquire());
+        assertEquals(CircuitBreaker.State.HALF_OPEN, circuitBreaker.getState());
+    }
+
+    @Test
+    void disabledCircuitBreakerAlwaysPermitsCalls() {
+        var circuitBreaker = stripedCircuitBreaker(config(false, CircuitBreakerConfig.CircuitBreakerType.STRIPED_APPROX, striped(1), 1, 1, 100, 1));
+
+        assertTrue(circuitBreaker.tryAcquire());
+        circuitBreaker.releaseOnError(new IllegalStateException());
+        assertTrue(circuitBreaker.tryAcquire());
+        assertEquals(CircuitBreaker.State.CLOSED, circuitBreaker.getState());
+        assertThrows(IllegalStateException.class, () -> circuitBreaker.accept(() -> {
+            throw new IllegalStateException();
+        }));
+        assertEquals(CircuitBreaker.State.CLOSED, circuitBreaker.getState());
+    }
+
+    @Test
+    void stripeWindowEvictsOldOutcomes() {
+        var circuitBreaker = stripedCircuitBreaker(stripedConfig(1, 2, 2, 100, 1));
+
+        circuitBreaker.releaseOnError(new IllegalStateException());
+        circuitBreaker.releaseOnSuccess();
+        circuitBreaker.releaseOnSuccess();
+        var snapshot = circuitBreaker.snapshot();
+
+        assertEquals(2, snapshot.total());
+        assertEquals(0, snapshot.failures());
+    }
+
+    @Test
+    void stripedApproxCapacityCanBeLargerThanConfiguredWindow() {
+        var circuitBreaker = stripedCircuitBreaker(stripedConfig(4, 10, 10, 100, 1));
+
+        for (int i = 0; i < 12; i++) {
+            circuitBreaker.releaseOnSuccess();
+        }
+
+        var snapshot = circuitBreaker.snapshot();
+        assertTrue(snapshot.total() <= 12);
+        assertTrue(snapshot.total() <= effectiveCapacity(10, 4));
+        assertEquals(0, snapshot.failures());
+    }
+
+    @Test
+    void concurrentClosedSuccessRecordingStaysWithinEffectiveCapacity() throws Exception {
+        var stripes = 8;
+        var windowSize = 64;
+        var circuitBreaker = stripedCircuitBreaker(stripedConfig(stripes, windowSize, windowSize, 100, 1));
+        var threads = 8;
+        var iterations = 2000;
+        var start = new CountDownLatch(1);
+        var done = new CountDownLatch(threads);
+        var failures = new ArrayList<Throwable>();
+        var executor = Executors.newFixedThreadPool(threads);
+        try {
+            for (int i = 0; i < threads; i++) {
+                executor.execute(() -> {
+                    try {
+                        start.await();
+                        for (int j = 0; j < iterations; j++) {
+                            circuitBreaker.releaseOnSuccess();
+                        }
+                    } catch (Throwable e) {
+                        synchronized (failures) {
+                            failures.add(e);
+                        }
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+
+            start.countDown();
+            assertTrue(done.await(5, TimeUnit.SECONDS));
+        } finally {
+            executor.shutdownNow();
+        }
+
+        assertTrue(failures.isEmpty(), () -> failures.toString());
+        var snapshot = circuitBreaker.snapshot();
+        assertEquals(CircuitBreaker.State.CLOSED, circuitBreaker.getState());
+        assertTrue(snapshot.total() > 0);
+        assertTrue(snapshot.total() <= effectiveCapacity(windowSize, stripes));
+        assertEquals(0, snapshot.failures());
+    }
+
+    @Test
+    void configValidationRejectsTooLargeStripedWindowForConfiguredStripes() {
+        var config = new TestCircuitBreakerConfig(Map.of(CircuitBreakerConfig.DEFAULT,
+            config(null, CircuitBreakerConfig.CircuitBreakerType.STRIPED_APPROX, striped(1), 0x1_0000L, 1, 100, 1)
+        ));
+
+        assertThrows(IllegalArgumentException.class, () -> config.getNamedConfig(CircuitBreakerConfig.DEFAULT));
+    }
+
+    @Test
+    void configValidationRejectsTooManyStripes() {
+        var config = new TestCircuitBreakerConfig(Map.of(CircuitBreakerConfig.DEFAULT,
+            config(null, CircuitBreakerConfig.CircuitBreakerType.STRIPED_APPROX, striped(CircuitBreakerConfig.STRIPED_APPROX_MAX_STRIPES + 1), 4, 1, 100, 1)
+        ));
+
+        assertThrows(IllegalArgumentException.class, () -> config.getNamedConfig(CircuitBreakerConfig.DEFAULT));
+    }
+
+    private static void open(StripedApproxKoraCircuitBreaker circuitBreaker) {
+        assertEquals(CircuitBreaker.State.CLOSED, circuitBreaker.getState());
+        assertTrue(circuitBreaker.tryAcquire());
+        circuitBreaker.releaseOnError(new IllegalStateException());
+        assertTrue(circuitBreaker.tryAcquire());
+        circuitBreaker.releaseOnError(new IllegalStateException());
+        assertFalse(circuitBreaker.tryAcquire());
+        assertEquals(CircuitBreaker.State.OPEN, circuitBreaker.getState());
+    }
+
+    private static StripedApproxKoraCircuitBreaker stripedCircuitBreaker(CircuitBreakerConfig.NamedConfig config) {
+        return new StripedApproxKoraCircuitBreaker("default", config, new KoraCircuitBreakerPredicate(), NoopCircuitBreakerTelemetry.INSTANCE);
+    }
+
+    private static CircuitBreakerConfig.NamedConfig stripedConfig(int stripes, long windowSize, long minimumRequiredCalls, int failureRateThreshold, int permittedCallsInHalfOpenState) {
+        return config(true, CircuitBreakerConfig.CircuitBreakerType.STRIPED_APPROX, striped(stripes), windowSize, minimumRequiredCalls, failureRateThreshold, permittedCallsInHalfOpenState);
+    }
+
+    private static CircuitBreakerConfig circuitBreakerConfig(CircuitBreakerConfig.NamedConfig config) {
+        return new TestCircuitBreakerConfig(Map.of(CircuitBreakerConfig.DEFAULT, config));
+    }
+
+    private static CircuitBreakerConfig.NamedConfig config(Boolean enabled,
+                                                           CircuitBreakerConfig.CircuitBreakerType type,
+                                                           CircuitBreakerConfig.StripedApproxConfig stripedApprox,
+                                                           long windowSize,
+                                                           long minimumRequiredCalls,
+                                                           int failureRateThreshold,
+                                                           int permittedCallsInHalfOpenState) {
+        return config(enabled, type, stripedApprox, windowSize, minimumRequiredCalls, failureRateThreshold, permittedCallsInHalfOpenState, KoraCircuitBreakerPredicate.class.getCanonicalName());
+    }
+
+    private static CircuitBreakerConfig.NamedConfig config(Boolean enabled,
+                                                           CircuitBreakerConfig.CircuitBreakerType type,
+                                                           CircuitBreakerConfig.StripedApproxConfig stripedApprox,
+                                                           long windowSize,
+                                                           long minimumRequiredCalls,
+                                                           int failureRateThreshold,
+                                                           int permittedCallsInHalfOpenState,
+                                                           String failurePredicateName) {
+        return new $CircuitBreakerConfig_NamedConfig_ConfigValueMapper.NamedConfig_Impl(
+            enabled, type, countBased(windowSize, stripedApprox), null, failureRateThreshold, WAIT_IN_OPEN, permittedCallsInHalfOpenState, minimumRequiredCalls, failurePredicateName
+        );
+    }
+
+    private static CircuitBreakerConfig.CountBasedConfig countBased(Long windowSize, CircuitBreakerConfig.StripedApproxConfig stripedApprox) {
+        return new $CircuitBreakerConfig_CountBasedConfig_ConfigValueMapper.CountBasedConfig_Impl(windowSize, stripedApprox);
+    }
+
+    private static CircuitBreakerConfig.StripedApproxConfig striped(int stripes) {
+        return new $CircuitBreakerConfig_StripedApproxConfig_ConfigValueMapper.StripedApproxConfig_Impl(stripes);
+    }
+
+    private static int effectiveCapacity(int windowSize, int stripes) {
+        var stripeWindowSize = (windowSize + stripes - 1) / stripes;
+        return stripeWindowSize * stripes;
+    }
+
+    private static CircuitBreakerPredicate ignoredPredicate() {
+        return new CircuitBreakerPredicate() {
+            @Override
+            public String name() {
+                return "ignored";
+            }
+
+            @Override
+            public boolean test(Throwable throwable) {
+                return false;
+            }
+        };
+    }
+
+    private record TestCircuitBreakerConfig(Map<String, CircuitBreakerConfig.NamedConfig> circuitbreaker) implements CircuitBreakerConfig {
+        @Override
+        public CircuitBreakerTelemetryConfig telemetry() {
+            return null;
+        }
+    }
+}

--- a/resilient/resilient-kora/src/test/java/io/koraframework/resilient/circuitbreaker/TimeBasedKoraCircuitBreakerTests.java
+++ b/resilient/resilient-kora/src/test/java/io/koraframework/resilient/circuitbreaker/TimeBasedKoraCircuitBreakerTests.java
@@ -1,0 +1,474 @@
+package io.koraframework.resilient.circuitbreaker;
+
+import io.koraframework.resilient.circuitbreaker.exception.CallNotPermittedException;
+import io.koraframework.resilient.circuitbreaker.telemetry.CircuitBreakerTelemetryConfig;
+import io.koraframework.resilient.circuitbreaker.telemetry.impl.NoopCircuitBreakerTelemetry;
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionFactory;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+
+class TimeBasedKoraCircuitBreakerTests extends Assertions {
+
+    private static final Duration WAIT_IN_OPEN = Duration.ofMillis(50);
+    private static final Duration WINDOW = Duration.ofSeconds(1);
+
+    @NullMarked
+    static class CustomPredicate implements CircuitBreakerPredicate {
+
+        @Override
+        public String name() {
+            return "custom";
+        }
+
+        @Override
+        public boolean test(Throwable throwable) {
+            return throwable instanceof IllegalStateException;
+        }
+    }
+
+    private static ConditionFactory awaitily() {
+        return Awaitility.await().atMost(Duration.ofSeconds(1)).pollDelay(Duration.ofMillis(5));
+    }
+
+    @Test
+    void managerCreatesTimeBasedCircuitBreakerWhenTypeConfigured() {
+        var manager = new KoraCircuitBreakerManager(
+            circuitBreakerConfig(config(WINDOW, 4, 2, 50, 2)),
+            List.of(new KoraCircuitBreakerPredicate()),
+            (name, telemetryConfig) -> NoopCircuitBreakerTelemetry.INSTANCE
+        );
+
+        assertInstanceOf(TimeBasedKoraCircuitBreaker.class, manager.get(CircuitBreakerConfig.DEFAULT));
+    }
+
+    @Test
+    void getNamedConfigMergesTimeBasedDefaults() {
+        var namedConfig = circuitBreakerConfig(config(null, WINDOW, null, 2, 50, 2, null, null, null))
+            .getNamedConfig(CircuitBreakerConfig.DEFAULT);
+
+        assertEquals(CircuitBreakerConfig.TIME_BASED_DEFAULT_SAMPLE_COUNT, namedConfig.timeBased().sampleCount());
+        assertEquals(CircuitBreakerConfig.TIME_BASED_DEFAULT_COUNTER_STRIPES, namedConfig.timeBased().counterStripes());
+        assertEquals(CircuitBreakerConfig.TimeBasedCounterType.ATOMIC, namedConfig.timeBased().counterType());
+    }
+
+    @Test
+    void snapshotSumsOutcomeCounters() {
+        var circuitBreaker = new TimeBasedKoraCircuitBreaker(
+            "default",
+            config(WINDOW, 4, 1, 100, 1),
+            ignoredPredicate(),
+            NoopCircuitBreakerTelemetry.INSTANCE
+        );
+
+        circuitBreaker.releaseOnSuccess();
+        circuitBreaker.releaseOnError(new IllegalStateException());
+        var snapshot = circuitBreaker.snapshot();
+
+        assertEquals(1, snapshot.total());
+        assertEquals(0, snapshot.failures());
+        assertEquals(1, snapshot.ignored());
+    }
+
+    @Test
+    void snapshotDropsExpiredBuckets() {
+        var ticker = new AtomicLong();
+        var circuitBreaker = new TimeBasedKoraCircuitBreaker(
+            "default",
+            config(Duration.ofMillis(100), 2, 1, 100, 1),
+            new KoraCircuitBreakerPredicate(),
+            NoopCircuitBreakerTelemetry.INSTANCE,
+            ticker::get
+        );
+
+        circuitBreaker.releaseOnSuccess();
+        assertEquals(1, circuitBreaker.snapshot().total());
+        assertEquals(0, circuitBreaker.snapshot().failures());
+
+        ticker.addAndGet(Duration.ofMillis(150).toNanos());
+        circuitBreaker.releaseOnSuccess();
+        var snapshot = circuitBreaker.snapshot();
+
+        assertEquals(1, snapshot.total());
+        assertEquals(0, snapshot.failures());
+    }
+
+    @Test
+    void switchFromClosedToOpen() {
+        var circuitBreaker = timeBased(config(WINDOW, 4, 8, 30, 3));
+
+        assertEquals(CircuitBreaker.State.CLOSED, circuitBreaker.getState());
+        for (int i = 0; i < 7; i++) {
+            assertTrue(circuitBreaker.tryAcquire());
+            circuitBreaker.releaseOnSuccess();
+        }
+        assertTrue(circuitBreaker.tryAcquire());
+        circuitBreaker.releaseOnError(new IllegalStateException());
+        assertTrue(circuitBreaker.tryAcquire());
+        circuitBreaker.releaseOnError(new IllegalStateException());
+        assertEquals(CircuitBreaker.State.CLOSED, circuitBreaker.getState());
+
+        assertTrue(circuitBreaker.tryAcquire());
+        circuitBreaker.releaseOnError(new IllegalStateException());
+
+        assertFalse(circuitBreaker.tryAcquire());
+        assertEquals(CircuitBreaker.State.OPEN, circuitBreaker.getState());
+    }
+
+    @Test
+    void switchFromClosedToOpenForMinimumNumberOfCalls() {
+        var circuitBreaker = timeBased(config(WINDOW, 2, 2, 100, 1));
+
+        assertTrue(circuitBreaker.tryAcquire());
+        circuitBreaker.releaseOnError(new IllegalStateException());
+        assertEquals(CircuitBreaker.State.CLOSED, circuitBreaker.getState());
+
+        assertTrue(circuitBreaker.tryAcquire());
+        circuitBreaker.releaseOnError(new IllegalStateException());
+
+        assertFalse(circuitBreaker.tryAcquire());
+        assertEquals(CircuitBreaker.State.OPEN, circuitBreaker.getState());
+    }
+
+    @Test
+    void switchFromClosedToOpenToHalfOpenToOpen() {
+        var circuitBreaker = timeBased(config(WINDOW, 2, 2, 100, 2));
+
+        open(circuitBreaker);
+
+        awaitily().until(circuitBreaker::tryAcquire);
+        assertEquals(CircuitBreaker.State.HALF_OPEN, circuitBreaker.getState());
+        circuitBreaker.releaseOnError(new IllegalStateException());
+
+        assertFalse(circuitBreaker.tryAcquire());
+        assertEquals(CircuitBreaker.State.OPEN, circuitBreaker.getState());
+    }
+
+    @Test
+    void switchFromClosedToOpenToHalfOpenToClosed() {
+        var circuitBreaker = timeBased(config(WINDOW, 2, 2, 100, 2));
+
+        open(circuitBreaker);
+
+        awaitily().until(circuitBreaker::tryAcquire);
+        assertEquals(CircuitBreaker.State.HALF_OPEN, circuitBreaker.getState());
+        circuitBreaker.releaseOnSuccess();
+        assertTrue(circuitBreaker.tryAcquire());
+        assertFalse(circuitBreaker.tryAcquire());
+        circuitBreaker.releaseOnSuccess();
+
+        assertTrue(circuitBreaker.tryAcquire());
+        assertEquals(CircuitBreaker.State.CLOSED, circuitBreaker.getState());
+    }
+
+    @Test
+    void switchFromClosedToOpenToHalfOpenCorrectlyRestoreIgnoredExceptionToOpen() {
+        var circuitBreaker = new TimeBasedKoraCircuitBreaker(
+            "default",
+            config(WINDOW, 4, 2, 50, 2),
+            new CircuitBreakerPredicate() {
+                @Override
+                public String name() {
+                    return "kora";
+                }
+
+                @Override
+                public boolean test(Throwable throwable) {
+                    return !(throwable instanceof UncheckedIOException);
+                }
+            },
+            NoopCircuitBreakerTelemetry.INSTANCE
+        );
+
+        open(circuitBreaker);
+
+        awaitily().dontCatchUncaughtExceptions().untilAsserted(() -> assertDoesNotThrow(circuitBreaker::acquire));
+        assertEquals(CircuitBreaker.State.HALF_OPEN, circuitBreaker.getState());
+        circuitBreaker.releaseOnError(new UncheckedIOException(new IOException("OPS")));
+        awaitily().dontCatchUncaughtExceptions().untilAsserted(() -> assertDoesNotThrow(circuitBreaker::acquire));
+        assertEquals(CircuitBreaker.State.HALF_OPEN, circuitBreaker.getState());
+        circuitBreaker.releaseOnError(new UncheckedIOException(new IOException("OPS")));
+
+        assertEquals(CircuitBreaker.State.HALF_OPEN, circuitBreaker.getState());
+        awaitily().dontCatchUncaughtExceptions().untilAsserted(() -> assertDoesNotThrow(circuitBreaker::acquire));
+        circuitBreaker.releaseOnError(new IllegalStateException());
+
+        assertEquals(CircuitBreaker.State.OPEN, circuitBreaker.getState());
+        assertFalse(circuitBreaker.tryAcquire());
+    }
+
+    @Test
+    void switchFromClosedToOpenToHalfOpenToOpenToHalfOpenToClosedForAccept() {
+        var circuitBreaker = timeBased(config(WINDOW, 4, 2, 50, 2));
+        Callable<Boolean> successCallable = () -> {
+            try {
+                return circuitBreaker.accept(() -> "success") != null;
+            } catch (CallNotPermittedException e) {
+                return false;
+            }
+        };
+        Supplier<Object> failSupplier = () -> {
+            if (true) {
+                throw new IllegalStateException();
+            }
+            return null;
+        };
+
+        assertThrows(IllegalStateException.class, () -> circuitBreaker.accept(failSupplier));
+        assertThrows(IllegalStateException.class, () -> circuitBreaker.accept(failSupplier));
+        assertThrows(CallNotPermittedException.class, () -> circuitBreaker.accept(failSupplier));
+        assertEquals(CircuitBreaker.State.OPEN, circuitBreaker.getState());
+
+        awaitily().until(successCallable);
+        assertEquals(CircuitBreaker.State.HALF_OPEN, circuitBreaker.getState());
+        assertThrows(IllegalStateException.class, () -> circuitBreaker.accept(failSupplier));
+        assertEquals(CircuitBreaker.State.OPEN, circuitBreaker.getState());
+
+        awaitily().until(successCallable);
+        assertEquals(CircuitBreaker.State.HALF_OPEN, circuitBreaker.getState());
+        awaitily().until(successCallable);
+        assertEquals(CircuitBreaker.State.CLOSED, circuitBreaker.getState());
+    }
+
+    @Test
+    void switchFromClosedToOpenForCustomFailurePredicate() {
+        var circuitBreaker = new TimeBasedKoraCircuitBreaker(
+            "default",
+            config(true, WINDOW, 1, 1, 100, 1, "custom"),
+            new CustomPredicate(),
+            NoopCircuitBreakerTelemetry.INSTANCE
+        );
+
+        assertTrue(circuitBreaker.tryAcquire());
+        circuitBreaker.releaseOnError(new NullPointerException());
+        assertTrue(circuitBreaker.tryAcquire());
+        assertEquals(CircuitBreaker.State.CLOSED, circuitBreaker.getState());
+        circuitBreaker.releaseOnError(new IllegalStateException());
+
+        assertFalse(circuitBreaker.tryAcquire());
+        assertEquals(CircuitBreaker.State.OPEN, circuitBreaker.getState());
+    }
+
+    @Test
+    void openToHalfOpenUsesMonotonicTicker() {
+        var ticker = new AtomicLong();
+        var circuitBreaker = new TimeBasedKoraCircuitBreaker(
+            "default",
+            config(WINDOW, 1, 1, 100, 1),
+            new KoraCircuitBreakerPredicate(),
+            NoopCircuitBreakerTelemetry.INSTANCE,
+            ticker::get
+        );
+
+        assertTrue(circuitBreaker.tryAcquire());
+        circuitBreaker.releaseOnError(new IllegalStateException());
+        assertEquals(CircuitBreaker.State.OPEN, circuitBreaker.getState());
+        assertFalse(circuitBreaker.tryAcquire());
+
+        ticker.addAndGet(WAIT_IN_OPEN.toNanos());
+
+        assertTrue(circuitBreaker.tryAcquire());
+        assertEquals(CircuitBreaker.State.HALF_OPEN, circuitBreaker.getState());
+    }
+
+    @Test
+    void disabledCircuitBreakerAlwaysPermitsCalls() {
+        var circuitBreaker = timeBased(config(false, WINDOW, 1, 1, 100, 1));
+
+        assertTrue(circuitBreaker.tryAcquire());
+        circuitBreaker.releaseOnError(new IllegalStateException());
+        assertTrue(circuitBreaker.tryAcquire());
+        assertEquals(CircuitBreaker.State.CLOSED, circuitBreaker.getState());
+        assertThrows(IllegalStateException.class, () -> circuitBreaker.accept(() -> {
+            throw new IllegalStateException();
+        }));
+        assertEquals(CircuitBreaker.State.CLOSED, circuitBreaker.getState());
+    }
+
+    @Test
+    void longAdderCounterTypeRecordsOutcomes() {
+        var circuitBreaker = timeBased(config(WINDOW, 4, 1, 100, 1, CircuitBreakerConfig.TimeBasedCounterType.LONG_ADDER));
+
+        circuitBreaker.releaseOnSuccess();
+        circuitBreaker.releaseOnError(new IllegalStateException());
+        var snapshot = circuitBreaker.snapshot();
+
+        assertEquals(2, snapshot.total());
+        assertEquals(1, snapshot.failures());
+    }
+
+    @Test
+    void concurrentClosedSuccessRecordingDoesNotAllocateWindowPerCall() throws Exception {
+        var circuitBreaker = timeBased(config(Duration.ofSeconds(5), 16, 1, 100, 1));
+        var threads = 8;
+        var iterations = 2000;
+        var start = new CountDownLatch(1);
+        var done = new CountDownLatch(threads);
+        var executor = Executors.newFixedThreadPool(threads);
+        try {
+            for (int i = 0; i < threads; i++) {
+                executor.execute(() -> {
+                    try {
+                        start.await();
+                        for (int j = 0; j < iterations; j++) {
+                            circuitBreaker.releaseOnSuccess();
+                        }
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+
+            start.countDown();
+            assertTrue(done.await(5, TimeUnit.SECONDS));
+        } finally {
+            executor.shutdownNow();
+        }
+
+        var snapshot = circuitBreaker.snapshot();
+        assertEquals(CircuitBreaker.State.CLOSED, circuitBreaker.getState());
+        assertEquals((long) threads * iterations, snapshot.total());
+        assertEquals(0, snapshot.failures());
+    }
+
+    private static void open(TimeBasedKoraCircuitBreaker circuitBreaker) {
+        assertEquals(CircuitBreaker.State.CLOSED, circuitBreaker.getState());
+        assertTrue(circuitBreaker.tryAcquire());
+        circuitBreaker.releaseOnError(new IllegalStateException());
+        assertTrue(circuitBreaker.tryAcquire());
+        circuitBreaker.releaseOnError(new IllegalStateException());
+        assertFalse(circuitBreaker.tryAcquire());
+        assertEquals(CircuitBreaker.State.OPEN, circuitBreaker.getState());
+    }
+
+    private static TimeBasedKoraCircuitBreaker timeBased(CircuitBreakerConfig.NamedConfig config) {
+        return new TimeBasedKoraCircuitBreaker("default", config, new KoraCircuitBreakerPredicate(), NoopCircuitBreakerTelemetry.INSTANCE);
+    }
+
+    private static CircuitBreakerConfig.NamedConfig config(Duration windowDuration,
+                                                           int sampleCount,
+                                                           long minimumRequiredCalls,
+                                                           int failureRateThreshold,
+                                                           int permittedCallsInHalfOpenState) {
+        return config(true, windowDuration, sampleCount, minimumRequiredCalls, failureRateThreshold, permittedCallsInHalfOpenState);
+    }
+
+    private static CircuitBreakerConfig.NamedConfig config(Duration windowDuration,
+                                                           int sampleCount,
+                                                           long minimumRequiredCalls,
+                                                           int failureRateThreshold,
+                                                           int permittedCallsInHalfOpenState,
+                                                           CircuitBreakerConfig.TimeBasedCounterType counterType) {
+        return config(true, windowDuration, sampleCount, minimumRequiredCalls, failureRateThreshold, permittedCallsInHalfOpenState, counterType);
+    }
+
+    private static CircuitBreakerConfig.NamedConfig config(Boolean enabled,
+                                                           Duration windowDuration,
+                                                           int sampleCount,
+                                                           long minimumRequiredCalls,
+                                                           int failureRateThreshold,
+                                                           int permittedCallsInHalfOpenState) {
+        return config(enabled, windowDuration, sampleCount, minimumRequiredCalls, failureRateThreshold, permittedCallsInHalfOpenState, CircuitBreakerConfig.TimeBasedCounterType.ATOMIC);
+    }
+
+    private static CircuitBreakerConfig.NamedConfig config(Boolean enabled,
+                                                           Duration windowDuration,
+                                                           int sampleCount,
+                                                           long minimumRequiredCalls,
+                                                           int failureRateThreshold,
+                                                           int permittedCallsInHalfOpenState,
+                                                           CircuitBreakerConfig.TimeBasedCounterType counterType) {
+        return config(enabled, windowDuration, sampleCount, minimumRequiredCalls, failureRateThreshold, permittedCallsInHalfOpenState, counterType, KoraCircuitBreakerPredicate.class.getCanonicalName());
+    }
+
+    private static CircuitBreakerConfig.NamedConfig config(Boolean enabled,
+                                                           Duration windowDuration,
+                                                           int sampleCount,
+                                                           long minimumRequiredCalls,
+                                                           int failureRateThreshold,
+                                                           int permittedCallsInHalfOpenState,
+                                                           String failurePredicateName) {
+        return config(enabled, windowDuration, sampleCount, minimumRequiredCalls, failureRateThreshold, permittedCallsInHalfOpenState, CircuitBreakerConfig.TimeBasedCounterType.ATOMIC, failurePredicateName);
+    }
+
+    private static CircuitBreakerConfig.NamedConfig config(Boolean enabled,
+                                                           Duration windowDuration,
+                                                           int sampleCount,
+                                                           long minimumRequiredCalls,
+                                                           int failureRateThreshold,
+                                                           int permittedCallsInHalfOpenState,
+                                                           CircuitBreakerConfig.TimeBasedCounterType counterType,
+                                                           String failurePredicateName) {
+        return config(enabled, windowDuration, sampleCount, minimumRequiredCalls, failureRateThreshold, permittedCallsInHalfOpenState, 4, counterType, failurePredicateName);
+    }
+
+    private static CircuitBreakerConfig.NamedConfig config(@Nullable Boolean enabled,
+                                                           @Nullable Duration windowDuration,
+                                                           @Nullable Integer sampleCount,
+                                                           long minimumRequiredCalls,
+                                                           int failureRateThreshold,
+                                                           int permittedCallsInHalfOpenState,
+                                                           @Nullable Integer counterStripes,
+                                                           CircuitBreakerConfig.@Nullable TimeBasedCounterType counterType,
+                                                           @Nullable String failurePredicateName) {
+        return new $CircuitBreakerConfig_NamedConfig_ConfigValueMapper.NamedConfig_Impl(
+            enabled,
+            CircuitBreakerConfig.CircuitBreakerType.TIME_BASED,
+            null,
+            timeBased(windowDuration, sampleCount, counterStripes, counterType),
+            failureRateThreshold,
+            WAIT_IN_OPEN,
+            permittedCallsInHalfOpenState,
+            minimumRequiredCalls,
+            failurePredicateName == null ? KoraCircuitBreakerPredicate.class.getCanonicalName() : failurePredicateName
+        );
+    }
+
+    private static CircuitBreakerConfig.TimeBasedConfig timeBased(@Nullable Duration windowDuration,
+                                                                  @Nullable Integer sampleCount,
+                                                                  @Nullable Integer counterStripes,
+                                                                  CircuitBreakerConfig.@Nullable TimeBasedCounterType counterType) {
+        return new $CircuitBreakerConfig_TimeBasedConfig_ConfigValueMapper.TimeBasedConfig_Impl(windowDuration, sampleCount, counterStripes, counterType);
+    }
+
+    private static CircuitBreakerConfig circuitBreakerConfig(CircuitBreakerConfig.NamedConfig config) {
+        return new TestCircuitBreakerConfig(Map.of(CircuitBreakerConfig.DEFAULT, config));
+    }
+
+    private static CircuitBreakerPredicate ignoredPredicate() {
+        return new CircuitBreakerPredicate() {
+            @Override
+            public String name() {
+                return "ignored";
+            }
+
+            @Override
+            public boolean test(Throwable throwable) {
+                return false;
+            }
+        };
+    }
+
+    private record TestCircuitBreakerConfig(Map<String, CircuitBreakerConfig.NamedConfig> circuitbreaker) implements CircuitBreakerConfig {
+        @Override
+        public CircuitBreakerTelemetryConfig telemetry() {
+            return null;
+        }
+    }
+}

--- a/resilient/resilient-symbol-processor/src/test/kotlin/io/koraframework/resilient/circuitbreaker/CircuitBreakerTests.kt
+++ b/resilient/resilient-symbol-processor/src/test/kotlin/io/koraframework/resilient/circuitbreaker/CircuitBreakerTests.kt
@@ -29,7 +29,7 @@ class CircuitBreakerTests {
         val config: CircuitBreakerConfig.NamedConfig = `$CircuitBreakerConfig_NamedConfig_ConfigValueMapper`.NamedConfig_Impl(
             true, 50, WAIT_IN_OPEN, 2, 4L, 2L, KoraCircuitBreakerPredicate::class.java.canonicalName
         )
-        val circuitBreaker = KoraCircuitBreaker("default", config, KoraCircuitBreakerPredicate(), NoopCircuitBreakerTelemetry.INSTANCE)
+        val circuitBreaker = FixedWindowKoraCircuitBreaker("default", config, KoraCircuitBreakerPredicate(), NoopCircuitBreakerTelemetry.INSTANCE)
 
         val successCallable = Callable {
             try {

--- a/resilient/resilient-symbol-processor/src/test/kotlin/io/koraframework/resilient/circuitbreaker/CircuitBreakerTests.kt
+++ b/resilient/resilient-symbol-processor/src/test/kotlin/io/koraframework/resilient/circuitbreaker/CircuitBreakerTests.kt
@@ -23,11 +23,15 @@ class CircuitBreakerTests {
         return await().atMost(Duration.ofSeconds(1)).pollDelay(Duration.ofMillis(5))
     }
 
+    private fun countBased(windowSize: Long?, stripedApprox: CircuitBreakerConfig.StripedApproxConfig?): CircuitBreakerConfig.CountBasedConfig {
+        return `$CircuitBreakerConfig_CountBasedConfig_ConfigValueMapper`.CountBasedConfig_Impl(windowSize, stripedApprox)
+    }
+
     @Test
     fun switchFromClosedToOpenToHalfOpenToOpenToHalfOpenToClosedForAccept() {
         // given
         val config: CircuitBreakerConfig.NamedConfig = `$CircuitBreakerConfig_NamedConfig_ConfigValueMapper`.NamedConfig_Impl(
-            true, 50, WAIT_IN_OPEN, 2, 4L, 2L, KoraCircuitBreakerPredicate::class.java.canonicalName
+            true, CircuitBreakerConfig.CircuitBreakerType.FIXED_WINDOW, countBased(4L, null), null, 50, WAIT_IN_OPEN, 2, 2L, KoraCircuitBreakerPredicate::class.java.canonicalName
         )
         val circuitBreaker = FixedWindowKoraCircuitBreaker("default", config, KoraCircuitBreakerPredicate(), NoopCircuitBreakerTelemetry.INSTANCE)
 

--- a/resilient/resilient-symbol-processor/src/test/kotlin/io/koraframework/resilient/symbol/processor/aop/testdata/AppWithConfig.kt
+++ b/resilient/resilient-symbol-processor/src/test/kotlin/io/koraframework/resilient/symbol/processor/aop/testdata/AppWithConfig.kt
@@ -21,7 +21,7 @@ interface AppWithConfig : ConfigValueMapperModule, CircuitBreakerModule, RetryMo
             resilient {
               circuitbreaker {
                 default {
-                  slidingWindowSize = 1
+                  windowSize = 1
                   minimumRequiredCalls = 1
                   failureRateThreshold = 100
                   permittedCallsInHalfOpenState = 1

--- a/resilient/resilient-symbol-processor/src/test/kotlin/io/koraframework/resilient/symbol/processor/aop/testdata/AppWithConfig.kt
+++ b/resilient/resilient-symbol-processor/src/test/kotlin/io/koraframework/resilient/symbol/processor/aop/testdata/AppWithConfig.kt
@@ -21,7 +21,13 @@ interface AppWithConfig : ConfigValueMapperModule, CircuitBreakerModule, RetryMo
             resilient {
               circuitbreaker {
                 default {
-                  windowSize = 1
+                  type = STRIPED_APPROX
+                  countBased {
+                    windowSize = 1
+                    stripedApprox {
+                      stripes = 1
+                    }
+                  }
                   minimumRequiredCalls = 1
                   failureRateThreshold = 100
                   permittedCallsInHalfOpenState = 1


### PR DESCRIPTION
Add advanced CircuitBreaker implementations and config model:

- Add `STRIPED_APPROX` count-based CB for high-concurrency approximate windows.
- Add `RING_BUFFER` count-based CB with global sequence and slot-level CAS for stronger last-N semantics.
- Add `TIME_BASED` CB backed by LeapArray time buckets.
- Add `countBased { windowSize, stripedApprox { stripes } }` config section.
- Add `timeBased { windowDuration, sampleCount, counterStripes, counterType }` config section.
- Add `LONG_ADDER` counter mode for time-based CB as opt-in high-contention mode.
- Update tests for fixed, striped, ring buffer, and time-based behavior.