### PR TITLE
Added `clientConfig` for single OpenAPI client config path as default behavior

### DIFF
--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/CodegenParams.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/CodegenParams.java
@@ -15,6 +15,7 @@ public class CodegenParams {
     public static final String ENABLE_VALIDATION = "enableServerValidation";
     public static final String DISCRIMINATOR_CASE_SENSITIVE = "discriminatorCaseSensitive";
     public static final String PRIMARY_AUTH = "primaryAuth";
+    public static final String CLIENT_CONFIG = "clientConfig";
     public static final String CLIENT_CONFIG_PREFIX = "clientConfigPrefix";
     public static final String SECURITY_CONFIG_PREFIX = "securityConfigPrefix";
     public static final String CLIENT_TAGS = "tags";
@@ -33,6 +34,7 @@ public class CodegenParams {
     public boolean enableValidation = false;
     public boolean authAsMethodArgument = false;
     public @Nullable String primaryAuth = null;
+    public @Nullable String clientConfig = null;
     public @Nullable String clientConfigPrefix = null;
     public String securityConfigPrefix = null;
     public Map<String, KoraCodegen.TagClient> clientTags = new HashMap<>();
@@ -51,7 +53,8 @@ public class CodegenParams {
         cliOptions.add(CliOption.newString(CODEGEN_MODE, "Generation mode (one of java, reactive or kotlin)"));
         cliOptions.add(CliOption.newString(SECURITY_CONFIG_PREFIX, "Config prefix for security config parsers"));
         cliOptions.add(CliOption.newString(PRIMARY_AUTH, "Specify primary HTTP client securityScheme if multiple are available for method"));
-        cliOptions.add(CliOption.newString(CLIENT_CONFIG_PREFIX, "Generated client config prefix"));
+        cliOptions.add(CliOption.newString(CLIENT_CONFIG, "Generated client config path"));
+        cliOptions.add(CliOption.newString(CLIENT_CONFIG_PREFIX, "Generated client config prefix for per-client config paths"));
         cliOptions.add(CliOption.newString(CLIENT_TAGS, "Json containing http client tags configuration for apis"));
         cliOptions.add(CliOption.newString(INTERCEPTORS, "Json containing interceptors for HTTP server/client"));
         cliOptions.add(CliOption.newBoolean(ENABLE_VALIDATION, "Generate validation related annotation on models and controllers"));
@@ -103,6 +106,9 @@ public class CodegenParams {
         }
         if (additionalProperties.containsKey(AUTH_AS_METHOD_ARGUMENT)) {
             params.authAsMethodArgument = Boolean.parseBoolean(additionalProperties.get(AUTH_AS_METHOD_ARGUMENT).toString());
+        }
+        if (additionalProperties.containsKey(CLIENT_CONFIG)) {
+            params.clientConfig = additionalProperties.get(CLIENT_CONFIG).toString();
         }
         if (additionalProperties.containsKey(CLIENT_CONFIG_PREFIX)) {
             params.clientConfigPrefix = additionalProperties.get(CLIENT_CONFIG_PREFIX).toString();

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/KoraCodegen.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/KoraCodegen.java
@@ -100,6 +100,7 @@ public class KoraCodegen extends DefaultCodegen {
     public void processOpts() {
         super.processOpts();
         params = CodegenParams.parse(additionalProperties);
+        validateClientConfig();
         switch (params.codegenMode) {
             case JAVA_CLIENT -> {
                 modelTemplateFiles.put("javaModel.mustache", ".java");
@@ -231,6 +232,29 @@ public class KoraCodegen extends DefaultCodegen {
         }
 
         this.sanitizeConfig();
+    }
+
+    private void validateClientConfig() {
+        if (!params.codegenMode.isClient() || params.clientConfig != null && !params.clientConfig.isBlank() || params.clientConfigPrefix != null && !params.clientConfigPrefix.isBlank()) {
+            return;
+        }
+
+        var fileName = Optional.ofNullable(inputSpec)
+            .map(FilenameUtils::getBaseName)
+            .filter(s -> !s.isBlank())
+            .orElse("openapi");
+        var suggestedName = camelize(fileName, CamelizeOption.LOWERCASE_FIRST_CHAR);
+        throw new IllegalArgumentException(
+            "clientConfig is required for " + params.codegenMode.getMode()
+            + ". Create client config path, for example: httpClient." + suggestedName
+        );
+    }
+
+    private String clientConfigPath(String clientName) {
+        if (params.clientConfigPrefix != null && !params.clientConfigPrefix.isBlank()) {
+            return params.clientConfigPrefix + "." + StringUtils.uncapitalize(clientName);
+        }
+        return params.clientConfig;
     }
 
     private String getUpperSnakeCase(String value, Locale locale) {
@@ -1881,5 +1905,14 @@ public class KoraCodegen extends DefaultCodegen {
 
     @Override
     public void postProcess() {
+        if (!params.codegenMode.isClient() || operationsByClassName.isEmpty()) {
+            return;
+        }
+
+        var clients = operationsByClassName.keySet().stream()
+            .sorted()
+            .map(clientName -> "  - " + clientName + " -> " + clientConfigPath(clientName) + " (configPath)")
+            .collect(Collectors.joining("\n"));
+        LOGGER.info("Generated Kora OpenAPI HTTP clients and config paths:\n{}", clients);
     }
 }

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientApiGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientApiGenerator.java
@@ -335,8 +335,11 @@ public class ClientApiGenerator extends AbstractJavaGenerator<OperationsMap> {
 
     private AnnotationSpec buildHttpClientAnnotation(OperationsMap ctx) {
         var httpClientAnnotation = AnnotationSpec.builder(Classes.httpClient);
-        if (params.clientConfigPrefix != null) {
-            httpClientAnnotation.addMember("value", "$S", params.clientConfigPrefix + "." + ctx.get("classname"));
+        if (params.clientConfig != null || params.clientConfigPrefix != null) {
+            var configPath = params.clientConfigPrefix != null
+                ? params.clientConfigPrefix + "." + StringUtils.uncapitalize(ctx.get("classname").toString())
+                : params.clientConfig;
+            httpClientAnnotation.addMember("value", "$S", configPath);
         }
         var tag = ctx.get("baseName").toString();
         var clientTag = params.clientTags.get(tag);

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ClientApiGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ClientApiGenerator.kt
@@ -138,8 +138,11 @@ class ClientApiGenerator() : AbstractKotlinGenerator<OperationsMap>() {
 
     private fun buildHttpClientAnnotation(ctx: OperationsMap): AnnotationSpec {
         val httpClientAnnotation = AnnotationSpec.builder(Classes.httpClient.asKt())
-        params.clientConfigPrefix?.let {
-            httpClientAnnotation.addMember("value = %S", it + "." + ctx.get("classname"))
+        params.clientConfigPrefix?.let { clientConfigPrefix ->
+            val configPath = clientConfigPrefix + "." + StringUtils.uncapitalize(ctx.get("classname").toString())
+            httpClientAnnotation.addMember("value = %S", configPath)
+        } ?: params.clientConfig?.let { clientConfig ->
+            httpClientAnnotation.addMember("value = %S", clientConfig)
         }
         val tag = ctx.get("baseName").toString()
         val clientTag = params.clientTags[tag]

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/BaseOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/BaseOpenapiTest.java
@@ -23,6 +23,10 @@ public abstract class BaseOpenapiTest {
             @Nullable
             public String implicitHeadersRegex;
             public boolean defaultDelegate;
+            @Nullable
+            public String clientConfig = "test";
+            @Nullable
+            public String clientConfigPrefix;
 
             public Options setAuthAsArg(boolean authAsArg) {
                 this.authAsArg = authAsArg;
@@ -49,6 +53,16 @@ public abstract class BaseOpenapiTest {
                 return this;
             }
 
+            public Options setClientConfig(@Nullable String clientConfig) {
+                this.clientConfig = clientConfig;
+                return this;
+            }
+
+            public Options setClientConfigPrefix(@Nullable String clientConfigPrefix) {
+                this.clientConfigPrefix = clientConfigPrefix;
+                return this;
+            }
+
             @Override
             public String toString() {
                 return "Options{" +
@@ -57,6 +71,8 @@ public abstract class BaseOpenapiTest {
                        ", implicitHeaders=" + implicitHeaders +
                        ", implicitHeadersRegex=" + implicitHeadersRegex +
                        ", defaultDelegate=" + defaultDelegate +
+                       ", clientConfig='" + clientConfig + '\'' +
+                       ", clientConfigPrefix='" + clientConfigPrefix + '\'' +
                        '}';
             }
         }
@@ -151,8 +167,14 @@ public abstract class BaseOpenapiTest {
             .addAdditionalProperty("authAsMethodArgument", options.authAsArg)
             .addAdditionalProperty("implicitHeaders", options.implicitHeaders)
             .addAdditionalProperty("requestInDelegateParams", options.includeServerRequest)
-            .addAdditionalProperty("requestInDelegateParams", options.includeServerRequest)
-            .addAdditionalProperty("clientConfigPrefix", "test");
+            .addAdditionalProperty("requestInDelegateParams", options.includeServerRequest);
+
+        if (options.clientConfig != null) {
+            configurator.addAdditionalProperty("clientConfig", options.clientConfig);
+        }
+        if (options.clientConfigPrefix != null) {
+            configurator.addAdditionalProperty("clientConfigPrefix", options.clientConfigPrefix);
+        }
 
         if (options.defaultDelegate) {
             configurator.addAdditionalProperty("delegateMethodBodyMode", "throwException");

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientJavaOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientJavaOpenapiTest.java
@@ -1,7 +1,12 @@
 package io.koraframework.openapi.generator;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+
+import java.nio.file.Files;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class HttpClientJavaOpenapiTest extends BaseJavaOpenapiTest {
     @ParameterizedTest
@@ -13,5 +18,71 @@ public class HttpClientJavaOpenapiTest extends BaseJavaOpenapiTest {
             params.spec(),
             params.options()
         );
+    }
+
+    @Test
+    void clientConfigIsUsedAsSingleConfigPath() throws Exception {
+        var files = generate(
+            "petstoreV3_single_config",
+            "java-client",
+            getClass().getResource("/example/petstoreV3.yaml").toExternalForm(),
+            new SwaggerParams.Options().setClientConfig("httpClient.petstoreV3")
+        );
+
+        var content = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().endsWith("Api.java"))
+            .filter(path -> {
+                try {
+                    return Files.readString(path).contains("@HttpClient");
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            })
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(content.contains("value = \"httpClient.petstoreV3\""));
+        assertFalse(content.contains("httpClient.petstoreV3."));
+    }
+
+    @Test
+    void clientConfigPrefixAppendsLowerCamelClientName() throws Exception {
+        var files = generate(
+            "petstoreV3_prefix_config",
+            "java-client",
+            getClass().getResource("/example/petstoreV3.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+                .setClientConfig(null)
+                .setClientConfigPrefix("httpClient")
+        );
+
+        var content = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().endsWith("Api.java"))
+            .filter(path -> {
+                try {
+                    return Files.readString(path).contains("@HttpClient");
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            })
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(content.contains("value = \"httpClient.petsApi\""));
+    }
+
+    @Test
+    void clientConfigIsRequiredWhenPrefixIsMissing() {
+        var e = assertThrows(IllegalArgumentException.class, () -> generate(
+            "petstoreV3_missing_config",
+            "java-client",
+            getClass().getResource("/example/petstoreV3.yaml").toExternalForm(),
+            new SwaggerParams.Options().setClientConfig(null)
+        ));
+
+        assertTrue(e.getMessage().contains("clientConfig is required for java-client"));
+        assertTrue(e.getMessage().contains("httpClient.petstoreV3"));
     }
 }

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientKotlinOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientKotlinOpenapiTest.java
@@ -1,7 +1,12 @@
 package io.koraframework.openapi.generator;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+
+import java.nio.file.Files;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class HttpClientKotlinOpenapiTest extends BaseKotlinOpenapiTest {
     @ParameterizedTest
@@ -13,5 +18,71 @@ public class HttpClientKotlinOpenapiTest extends BaseKotlinOpenapiTest {
             params.spec(),
             params.options()
         );
+    }
+
+    @Test
+    void clientConfigIsUsedAsSingleConfigPath() throws Exception {
+        var files = generate(
+            "petstoreV3_single_config",
+            "kotlin-client",
+            getClass().getResource("/example/petstoreV3.yaml").toExternalForm(),
+            new SwaggerParams.Options().setClientConfig("httpClient.petstoreV3")
+        );
+
+        var content = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().endsWith("Api.kt"))
+            .filter(path -> {
+                try {
+                    return Files.readString(path).contains("@HttpClient");
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            })
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(content.contains("value = \"httpClient.petstoreV3\""));
+        assertFalse(content.contains("httpClient.petstoreV3."));
+    }
+
+    @Test
+    void clientConfigPrefixAppendsLowerCamelClientName() throws Exception {
+        var files = generate(
+            "petstoreV3_prefix_config",
+            "kotlin-client",
+            getClass().getResource("/example/petstoreV3.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+                .setClientConfig(null)
+                .setClientConfigPrefix("httpClient")
+        );
+
+        var content = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().endsWith("Api.kt"))
+            .filter(path -> {
+                try {
+                    return Files.readString(path).contains("@HttpClient");
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            })
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(content.contains("value = \"httpClient.petsApi\""));
+    }
+
+    @Test
+    void clientConfigIsRequiredWhenPrefixIsMissing() {
+        var e = assertThrows(IllegalArgumentException.class, () -> generate(
+            "petstoreV3_missing_config",
+            "kotlin-client",
+            getClass().getResource("/example/petstoreV3.yaml").toExternalForm(),
+            new SwaggerParams.Options().setClientConfig(null)
+        ));
+
+        assertTrue(e.getMessage().contains("clientConfig is required for kotlin-client"));
+        assertTrue(e.getMessage().contains("httpClient.petstoreV3"));
     }
 }


### PR DESCRIPTION
- Add `clientConfig` for single OpenAPI client config path
- Keep old per-client behavior via `clientConfigPrefix` generator option
- Log generated clients with their final `(configPath)`

---

## Конфигурация клиента

### `clientConfig`

`clientConfig` задаёт новое поведение по умолчанию и определяет единый путь конфигурации для всего OpenAPI-файла.

Параметр обязателен при генерации `java-client` и `kotlin-client`, если не указан `clientConfigPrefix`.

Если не заданы ни `clientConfig`, ни `clientConfigPrefix`, генерация должна завершаться ошибкой с подсказкой рекомендуемого пути:

```text
httpClient.<ИмяOpenApiФайлаВCamelCase>
```

### `clientConfigPrefix`

`clientConfigPrefix` включает старое поведение через явно указанный флаг или параметр.

Путь конфигурации строится по следующему шаблону:

```text
<clientConfigPrefix>.<generatedClientName>
```

Имя сгенерированного клиента должно быть приведено к `lowerCamelCase`.

Пример:

```text
httpClient.petsApi
```

### Удалённый параметр

`clientConfigByTag` полностью удалён.

### Логирование результата генерации

В конце генерации необходимо вывести список сгенерированных HTTP-клиентов и соответствующих им путей конфигурации:

```text
Generated Kora OpenAPI HTTP clients and config paths:
- PetsApi -> httpClient.petsApi (configPath)
```
