### PR TITLE
Added OpenAPI generator HTTP client shared interface for same model different status codes

### DIFF
--- a/http/http-client-common/src/main/java/io/koraframework/http/client/common/annotation/ResponseCodeMapper.java
+++ b/http/http-client-common/src/main/java/io/koraframework/http/client/common/annotation/ResponseCodeMapper.java
@@ -52,7 +52,6 @@ public @interface ResponseCodeMapper {
      * <hr>
      * <b>English</b>: Specifies the implementation of the handler to be registered
      */
-    @SuppressWarnings("rawtypes")
     Class<? extends HttpClientResponseMapper> mapper() default HttpClientResponseMapper.class;
 
     @Retention(RetentionPolicy.RUNTIME)

--- a/openapi/openapi-generator/build.gradle
+++ b/openapi/openapi-generator/build.gradle
@@ -80,6 +80,7 @@ sourceSets {
             addOpenapiDir("petstoreV3_nullable_enable_json_nullable")
             addOpenapiDir("petstoreV3_request_parameters")
             addOpenapiDir("petstoreV3_responses")
+            addOpenapiDir("petstoreV3_same_response_model")
             addOpenapiDir("petstoreV3_security_all")
             addOpenapiDir("petstoreV3_security_all_auth_arg")
             addOpenapiDir("petstoreV3_security_multi")

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ApiResponseGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ApiResponseGenerator.java
@@ -24,13 +24,18 @@ public class ApiResponseGenerator extends AbstractJavaGenerator<OperationsMap> {
                 var t = TypeSpec.interfaceBuilder(responseClassName)
                     .addAnnotation(generated())
                     .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.SEALED);
-                var sharedResponses = sharedResponses(ctx, responseClassName, operation.responses);
+                var sharedResponses = params.codegenMode.isClient()
+                    ? sharedResponses(ctx, responseClassName, operation.responses)
+                    : Map.<String, SharedResponse>of();
                 for (var sharedResponse : sharedResponses.values()) {
                     t.addType(sharedResponse.type);
                 }
                 for (var response : operation.responses) {
                     var codeResponseName = responseClassName.nestedClass(capitalize(operation.operationId) + (response.isDefault ? "Default" : response.code) + "ApiResponse");
-                    t.addType(response(ctx, codeResponseName, response, sharedResponses.get(response.dataType)));
+                    var sharedResponse = response.dataType == null
+                        ? null
+                        : sharedResponses.get(response.dataType);
+                    t.addType(response(ctx, codeResponseName, response, sharedResponse));
                 }
                 b.addType(t.build());
             }

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ApiResponseGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ApiResponseGenerator.java
@@ -99,7 +99,7 @@ public class ApiResponseGenerator extends AbstractJavaGenerator<OperationsMap> {
             var className = responseClassName.nestedClass(responseClassName.simpleName().replaceAll("ApiResponse$", "") + sanitizeSharedResponseName(dataType) + "ApiResponse");
             var type = TypeSpec.interfaceBuilder(className)
                 .addAnnotation(generated())
-                .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.NON_SEALED)
+                .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.SEALED)
                 .addSuperinterface(responseClassName)
                 .addMethod(MethodSpec.methodBuilder("content")
                     .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ApiResponseGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ApiResponseGenerator.java
@@ -1,10 +1,13 @@
 package io.koraframework.openapi.generator.javagen;
 
 import com.palantir.javapoet.*;
+import org.openapitools.codegen.CodegenModel;
 import org.openapitools.codegen.CodegenResponse;
 import org.openapitools.codegen.model.OperationsMap;
 
 import javax.lang.model.element.Modifier;
+import java.util.*;
+import java.util.stream.Collectors;
 
 public class ApiResponseGenerator extends AbstractJavaGenerator<OperationsMap> {
     @Override
@@ -16,14 +19,18 @@ public class ApiResponseGenerator extends AbstractJavaGenerator<OperationsMap> {
         for (var operation : ctx.getOperations().getOperation()) {
             var responseClassName = className.nestedClass(capitalize(operation.operationId) + "ApiResponse");
             if (operation.responses.size() == 1) {
-                b.addType(response(ctx, responseClassName, operation.responses.getFirst()));
+                b.addType(response(ctx, responseClassName, operation.responses.getFirst(), null));
             } else {
                 var t = TypeSpec.interfaceBuilder(responseClassName)
                     .addAnnotation(generated())
                     .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.SEALED);
+                var sharedResponses = sharedResponses(ctx, responseClassName, operation.responses);
+                for (var sharedResponse : sharedResponses.values()) {
+                    t.addType(sharedResponse.type);
+                }
                 for (var response : operation.responses) {
                     var codeResponseName = responseClassName.nestedClass(capitalize(operation.operationId) + (response.isDefault ? "Default" : response.code) + "ApiResponse");
-                    t.addType(response(ctx, codeResponseName, response));
+                    t.addType(response(ctx, codeResponseName, response, sharedResponses.get(response.dataType)));
                 }
                 b.addType(t.build());
             }
@@ -32,13 +39,13 @@ public class ApiResponseGenerator extends AbstractJavaGenerator<OperationsMap> {
         return JavaFile.builder(apiPackage, b.build()).build();
     }
 
-    private TypeSpec response(OperationsMap ctx, ClassName name, CodegenResponse response) {
+    private TypeSpec response(OperationsMap ctx, ClassName name, CodegenResponse response, SharedResponse sharedResponse) {
         var t = TypeSpec.recordBuilder(name)
             .addAnnotation(generated())
             .addJavadoc("%s (status code %s)".formatted(response.message, response.code))
             .addModifiers(Modifier.PUBLIC, Modifier.STATIC);
         if (name.enclosingClassName().enclosingClassName() != null) {
-            t.addSuperinterface(name.enclosingClassName());
+            t.addSuperinterface(sharedResponse == null ? name.enclosingClassName() : sharedResponse.className);
         }
         var c = MethodSpec.constructorBuilder()
             .addModifiers(Modifier.PUBLIC);
@@ -53,7 +60,109 @@ public class ApiResponseGenerator extends AbstractJavaGenerator<OperationsMap> {
             c.addParameter(ClassName.get(String.class), header.nameInCamelCase);
         }
 
+        if (sharedResponse != null && sharedResponse.statusCodeMethod != null && (!response.isDefault || !"statusCode".equals(sharedResponse.statusCodeMethod))) {
+            var method = MethodSpec.methodBuilder(sharedResponse.statusCodeMethod)
+                .addAnnotation(Override.class)
+                .addModifiers(Modifier.PUBLIC)
+                .returns(TypeName.INT);
+            if (response.isDefault) {
+                method.addStatement("return this.statusCode");
+            } else {
+                method.addStatement("return $L", response.code);
+            }
+            t.addMethod(method.build());
+        }
         return t.recordConstructor(c.build()).build();
     }
 
+    private Map<String, SharedResponse> sharedResponses(OperationsMap ctx, ClassName responseClassName, List<CodegenResponse> responses) {
+        var responseByDataType = responses.stream()
+            .filter(response -> response.dataType != null)
+            .collect(Collectors.groupingBy(response -> response.dataType, LinkedHashMap::new, Collectors.toList()));
+        var result = new HashMap<String, SharedResponse>();
+        for (var entry : responseByDataType.entrySet()) {
+            if (entry.getValue().size() < 2) {
+                continue;
+            }
+            var dataType = entry.getKey();
+            var contentType = asType(entry.getValue().getFirst());
+            var model = model(dataType);
+            var occupiedNames = model == null
+                ? Set.<String>of()
+                : model.vars.stream().map(property -> property.name).collect(Collectors.toSet());
+            var statusCodeMethod = statusCodeMethod(occupiedNames);
+            var className = responseClassName.nestedClass(responseClassName.simpleName().replaceAll("ApiResponse$", "") + sanitizeSharedResponseName(dataType) + "ApiResponse");
+            var type = TypeSpec.interfaceBuilder(className)
+                .addAnnotation(generated())
+                .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.NON_SEALED)
+                .addSuperinterface(responseClassName)
+                .addMethod(MethodSpec.methodBuilder("content")
+                    .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+                    .returns(contentType)
+                    .build());
+            if (model != null) {
+                for (var property : model.vars) {
+                    if ("content".equals(property.name) || Objects.equals(property.name, statusCodeMethod)) {
+                        continue;
+                    }
+                    type.addMethod(MethodSpec.methodBuilder(property.name)
+                        .addModifiers(Modifier.PUBLIC, Modifier.DEFAULT)
+                        .returns(asType(property))
+                        .addStatement("return this.content().$N()", property.name)
+                        .build());
+                }
+            }
+            if (statusCodeMethod != null) {
+                type.addMethod(MethodSpec.methodBuilder(statusCodeMethod)
+                    .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+                    .returns(TypeName.INT)
+                    .build());
+            }
+            result.put(dataType, new SharedResponse(className, type.build(), statusCodeMethod));
+        }
+        return result;
+    }
+
+    private CodegenModel model(String dataType) {
+        var model = models.get(dataType);
+        if (model != null && !model.getModels().isEmpty()) {
+            return model.getModels().getFirst().getModel();
+        }
+        for (var modelMap : models.values()) {
+            if (modelMap.getModels().isEmpty()) {
+                continue;
+            }
+            var codegenModel = modelMap.getModels().getFirst().getModel();
+            if (dataType.equals(codegenModel.classname)) {
+                return codegenModel;
+            }
+        }
+        return null;
+    }
+
+    private static String sanitizeSharedResponseName(String dataType) {
+        var name = dataType.replaceAll("[^a-zA-Z0-9]", "");
+        if (name.isBlank()) {
+            return "Content";
+        }
+        return capitalize(name);
+    }
+
+    private static String statusCodeMethod(Set<String> occupiedNames) {
+        var candidates = List.of("statusCode", "httpStatusCode", "statusCodeMethod", "httpStatusCodeMethod");
+        for (var candidate : candidates) {
+            if (!occupiedNames.contains(candidate)) {
+                return candidate;
+            }
+        }
+        for (var candidate : candidates) {
+            var underscored = "_" + candidate;
+            if (!occupiedNames.contains(underscored)) {
+                return underscored;
+            }
+        }
+        return null;
+    }
+
+    private record SharedResponse(ClassName className, TypeSpec type, String statusCodeMethod) {}
 }

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ApiResponseGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ApiResponseGenerator.java
@@ -2,6 +2,7 @@ package io.koraframework.openapi.generator.javagen;
 
 import com.palantir.javapoet.*;
 import org.openapitools.codegen.CodegenModel;
+import org.openapitools.codegen.CodegenProperty;
 import org.openapitools.codegen.CodegenResponse;
 import org.openapitools.codegen.model.OperationsMap;
 
@@ -112,7 +113,7 @@ public class ApiResponseGenerator extends AbstractJavaGenerator<OperationsMap> {
                     }
                     type.addMethod(MethodSpec.methodBuilder(property.name)
                         .addModifiers(Modifier.PUBLIC, Modifier.DEFAULT)
-                        .returns(asType(property))
+                        .returns(fieldType(property))
                         .addStatement("return this.content().$N()", property.name)
                         .build());
                 }
@@ -143,6 +144,17 @@ public class ApiResponseGenerator extends AbstractJavaGenerator<OperationsMap> {
             }
         }
         return null;
+    }
+
+    private TypeName fieldType(CodegenProperty field) {
+        var type = asType(field);
+        if (field.isNullable && !field.required) {
+            return ParameterizedTypeName.get(Classes.jsonNullable, type.box());
+        } else if (!field.required || field.isNullable) {
+            return type.box().annotated(AnnotationSpec.builder(Classes.nullable).build());
+        } else {
+            return type;
+        }
     }
 
     private static String sanitizeSharedResponseName(String dataType) {

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientResponseMapperGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientResponseMapperGenerator.java
@@ -34,8 +34,7 @@ public class ClientResponseMapperGenerator extends AbstractJavaGenerator<Operati
             .addAnnotation(Classes.component)
             .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
             .addSuperinterface(ParameterizedTypeName.get(Classes.httpClientResponseMapper, responseType));
-        var constructor = MethodSpec.constructorBuilder()
-            .addModifiers(Modifier.PUBLIC);
+        MethodSpec.Builder constructor = null;
         if (response.dataType != null) {
             var mapperType = ParameterizedTypeName.get(Classes.httpClientResponseMapper, asType(response));
             b.addField(mapperType, "delegate", Modifier.PRIVATE, Modifier.FINAL);
@@ -43,7 +42,9 @@ public class ClientResponseMapperGenerator extends AbstractJavaGenerator<Operati
             if (isContentJson(response.getContent())) {
                 mapperParam.addAnnotation(jsonAnnotation());
             }
-            constructor.addParameter(mapperParam.build())
+            constructor = MethodSpec.constructorBuilder()
+                .addModifiers(Modifier.PUBLIC)
+                .addParameter(mapperParam.build())
                 .addStatement("this.delegate = delegate");
         }
 
@@ -87,8 +88,10 @@ public class ClientResponseMapperGenerator extends AbstractJavaGenerator<Operati
             newArgs.add(header.name);
         }
 
-        return b
-            .addMethod(constructor.build())
-            .addMethod(apply.addStatement("return new $T($L)", responseWithCodeType, newArgs.build()).build()).build();
+        if (constructor != null) {
+            b.addMethod(constructor.build());
+        }
+
+        return b.addMethod(apply.addStatement("return new $T($L)", responseWithCodeType, newArgs.build()).build()).build();
     }
 }

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ApiResponseGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ApiResponseGenerator.kt
@@ -1,7 +1,9 @@
 package io.koraframework.openapi.generator.kotlingen
 
 import com.squareup.kotlinpoet.*
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import org.openapitools.codegen.CodegenModel
+import org.openapitools.codegen.CodegenProperty
 import org.openapitools.codegen.CodegenResponse
 import org.openapitools.codegen.model.OperationsMap
 
@@ -104,7 +106,7 @@ class ApiResponseGenerator : AbstractKotlinGenerator<OperationsMap>() {
                 model?.vars.orEmpty().forEach { property ->
                     if (property.name != "content" && property.name != statusCodeProperty) {
                         type.addProperty(
-                            PropertySpec.builder(property.name, asType(property).asKt())
+                            PropertySpec.builder(property.name, fieldType(property))
                                 .getter(FunSpec.getterBuilder().addStatement("return content.%N", property.name).build())
                                 .build()
                         )
@@ -127,6 +129,15 @@ class ApiResponseGenerator : AbstractKotlinGenerator<OperationsMap>() {
             .filter { it.models.isNotEmpty() }
             .map { it.models.first().model }
             .firstOrNull { it.classname == dataType }
+    }
+
+    private fun fieldType(field: CodegenProperty): TypeName {
+        val type = asType(field).asKt()
+        return when {
+            field.isNullable && !field.required -> Classes.jsonNullable.asKt().parameterizedBy(type)
+            !field.required || field.isNullable -> type.copy(nullable = true)
+            else -> type
+        }
     }
 
     private fun sanitizeSharedResponseName(dataType: String): String {

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ApiResponseGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ApiResponseGenerator.kt
@@ -1,6 +1,7 @@
 package io.koraframework.openapi.generator.kotlingen
 
 import com.squareup.kotlinpoet.*
+import org.openapitools.codegen.CodegenModel
 import org.openapitools.codegen.CodegenResponse
 import org.openapitools.codegen.model.OperationsMap
 
@@ -12,18 +13,20 @@ class ApiResponseGenerator : AbstractKotlinGenerator<OperationsMap>() {
         for (operation in ctx.operations.operation) {
             val responseClassName = className.nestedClass(capitalize(operation.operationId) + "ApiResponse")
             if (operation.responses.size == 1) {
-                b.addType(response(ctx, responseClassName, operation.responses.single()))
+                b.addType(response(ctx, responseClassName, operation.responses.single(), null))
             } else {
                 val t = TypeSpec.interfaceBuilder(responseClassName)
                     .addAnnotation(generated())
                     .addModifiers(KModifier.SEALED)
+                val sharedResponses = sharedResponses(responseClassName, operation.responses)
+                sharedResponses.values.forEach { t.addType(it.type) }
                 for (response in operation.responses) {
                     val codeResponseClassName = if (response.isDefault)
                         capitalize(operation.operationId) + "DefaultApiResponse"
                     else
                         capitalize(operation.operationId) + response.code + "ApiResponse"
                     val codeResponseName = responseClassName.nestedClass(codeResponseClassName)
-                    t.addType(response(ctx, codeResponseName, response))
+                    t.addType(response(ctx, codeResponseName, response, sharedResponses[response.dataType]))
                 }
                 b.addType(t.build())
             }
@@ -31,7 +34,7 @@ class ApiResponseGenerator : AbstractKotlinGenerator<OperationsMap>() {
         return FileSpec.get(apiPackage, b.build())
     }
 
-    private fun response(ctx: OperationsMap, name: ClassName, response: CodegenResponse): TypeSpec {
+    private fun response(ctx: OperationsMap, name: ClassName, response: CodegenResponse, sharedResponse: SharedResponse?): TypeSpec {
         val t = TypeSpec.classBuilder(name)
             .addAnnotation(generated())
             .addKdoc("${response.message} (status code ${response.code})")
@@ -39,17 +42,27 @@ class ApiResponseGenerator : AbstractKotlinGenerator<OperationsMap>() {
             t.addModifiers(KModifier.DATA)
         }
         if (name.enclosingClassName()?.enclosingClassName() != null) {
-            t.addSuperinterface(name.enclosingClassName()!!)
+            t.addSuperinterface(sharedResponse?.className ?: name.enclosingClassName()!!)
         }
         val c = FunSpec.constructorBuilder()
         if (response.isDefault) {
             c.addParameter("statusCode", INT)
-            t.addProperty(PropertySpec.builder("statusCode", INT).initializer("statusCode").build())
+            val statusCodeProperty = PropertySpec.builder("statusCode", INT)
+                .initializer("statusCode")
+            if (sharedResponse?.statusCodeProperty == "statusCode") {
+                statusCodeProperty.addModifiers(KModifier.OVERRIDE)
+            }
+            t.addProperty(statusCodeProperty.build())
         }
         response.dataType?.let {
             val type = asType(response).asKt()
             c.addParameter("content", type)
-            t.addProperty(PropertySpec.builder("content", type).initializer("content").build())
+            val contentProperty = PropertySpec.builder("content", type)
+                .initializer("content")
+            if (sharedResponse != null) {
+                contentProperty.addModifiers(KModifier.OVERRIDE)
+            }
+            t.addProperty(contentProperty.build())
         }
         for (header in response.headers) {
             var type: TypeName = String::class.asClassName() // todo Some header decoding maybe? We can do it
@@ -59,6 +72,83 @@ class ApiResponseGenerator : AbstractKotlinGenerator<OperationsMap>() {
             c.addParameter(header.name, type)
             t.addProperty(PropertySpec.builder(header.name, type).initializer(header.name).build())
         }
+        if (sharedResponse?.statusCodeProperty != null && (!response.isDefault || sharedResponse.statusCodeProperty != "statusCode")) {
+            val property = PropertySpec.builder(sharedResponse.statusCodeProperty, INT)
+                .addModifiers(KModifier.OVERRIDE)
+                .getter(
+                    FunSpec.getterBuilder()
+                        .addStatement("return %L", if (response.isDefault) "statusCode" else response.code)
+                        .build()
+                )
+                .build()
+            t.addProperty(property)
+        }
         return t.primaryConstructor(c.build()).build()
     }
+
+    private fun sharedResponses(responseClassName: ClassName, responses: List<CodegenResponse>): Map<String, SharedResponse> {
+        return responses.asSequence()
+            .filter { it.dataType != null }
+            .groupBy { it.dataType }
+            .filterValues { it.size > 1 }
+            .mapValues { (dataType, responsesByType) ->
+                val contentType = asType(responsesByType.first()).asKt()
+                val model = model(dataType)
+                val occupiedNames = model?.vars.orEmpty().map { it.name }.toSet()
+                val statusCodeProperty = statusCodeProperty(occupiedNames)
+                val className = responseClassName.nestedClass(responseClassName.simpleName.removeSuffix("ApiResponse") + sanitizeSharedResponseName(dataType) + "ApiResponse")
+                val type = TypeSpec.interfaceBuilder(className)
+                    .addAnnotation(generated())
+                    .addSuperinterface(responseClassName)
+                    .addProperty(PropertySpec.builder("content", contentType).build())
+                model?.vars.orEmpty().forEach { property ->
+                    if (property.name != "content" && property.name != statusCodeProperty) {
+                        type.addProperty(
+                            PropertySpec.builder(property.name, asType(property).asKt())
+                                .getter(FunSpec.getterBuilder().addStatement("return content.%N", property.name).build())
+                                .build()
+                        )
+                    }
+                }
+                if (statusCodeProperty != null) {
+                    type.addProperty(PropertySpec.builder(statusCodeProperty, INT).build())
+                }
+                SharedResponse(className, type.build(), statusCodeProperty)
+            }
+    }
+
+    private fun model(dataType: String): CodegenModel? {
+        val model = models[dataType]
+        if (model != null && model.models.isNotEmpty()) {
+            return model.models.first().model
+        }
+        return models.values
+            .asSequence()
+            .filter { it.models.isNotEmpty() }
+            .map { it.models.first().model }
+            .firstOrNull { it.classname == dataType }
+    }
+
+    private fun sanitizeSharedResponseName(dataType: String): String {
+        val name = dataType.replace(Regex("[^a-zA-Z0-9]"), "")
+        return if (name.isBlank()) "Content" else capitalize(name)
+    }
+
+    private fun statusCodeProperty(occupiedNames: Set<String>): String? {
+        val candidates = listOf("statusCode", "httpStatusCode", "statusCodeMethod", "httpStatusCodeMethod")
+        for (candidate in candidates) {
+            if (!occupiedNames.contains(candidate)) {
+                return candidate
+            }
+        }
+        for (candidate in candidates) {
+            val underscored = "_$candidate"
+            if (!occupiedNames.contains(underscored)) {
+                return underscored
+            }
+        }
+        return null
+    }
+
+    private data class SharedResponse(val className: ClassName, val type: TypeSpec, val statusCodeProperty: String?)
 }

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ApiResponseGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ApiResponseGenerator.kt
@@ -18,7 +18,7 @@ class ApiResponseGenerator : AbstractKotlinGenerator<OperationsMap>() {
                 val t = TypeSpec.interfaceBuilder(responseClassName)
                     .addAnnotation(generated())
                     .addModifiers(KModifier.SEALED)
-                val sharedResponses = sharedResponses(responseClassName, operation.responses)
+                val sharedResponses = if (params.codegenMode.isClient) sharedResponses(responseClassName, operation.responses) else emptyMap()
                 sharedResponses.values.forEach { t.addType(it.type) }
                 for (response in operation.responses) {
                     val codeResponseClassName = if (response.isDefault)

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/BaseOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/BaseOpenapiTest.java
@@ -100,6 +100,7 @@ public abstract class BaseOpenapiTest {
             "/example/petstoreV3_security_oauth.yaml",
             "/example/petstoreV3_security_multi.yaml",
             "/example/petstoreV3_single_response.yaml",
+            "/example/petstoreV3_same_response_model.yaml",
             "/example/petstoreV3_responses.yaml",
             "/example/petstoreV3_types.yaml",
             "/example/petstoreV3_validation.yaml",

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientJavaOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientJavaOpenapiTest.java
@@ -101,7 +101,7 @@ public class HttpClientJavaOpenapiTest extends BaseJavaOpenapiTest {
             .findFirst()
             .orElseThrow());
 
-        assertTrue(content.contains("non-sealed interface GetErrorsModelErrorApiResponse extends GetErrorsApiResponse"));
+        assertTrue(content.contains("sealed interface GetErrorsModelErrorApiResponse extends GetErrorsApiResponse"));
         assertTrue(content.contains("ModelError content()"));
         assertTrue(content.contains("default String message()"));
         assertTrue(content.contains("int _statusCode()"));

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientJavaOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientJavaOpenapiTest.java
@@ -85,4 +85,27 @@ public class HttpClientJavaOpenapiTest extends BaseJavaOpenapiTest {
         assertTrue(e.getMessage().contains("clientConfig is required for java-client"));
         assertTrue(e.getMessage().contains("httpClient.petstoreV3"));
     }
+
+    @Test
+    void sameResponseModelGetsSharedInterface() throws Exception {
+        var files = generate(
+            "petstoreV3_same_response_model",
+            "java-client",
+            getClass().getResource("/example/petstoreV3_same_response_model.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+        );
+
+        var content = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().endsWith("ApiResponses.java"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(content.contains("non-sealed interface GetErrorsModelErrorApiResponse extends GetErrorsApiResponse"));
+        assertTrue(content.contains("ModelError content()"));
+        assertTrue(content.contains("default String message()"));
+        assertTrue(content.contains("int _statusCode()"));
+        assertTrue(content.contains("record GetErrors400ApiResponse(ModelError content) implements GetErrorsModelErrorApiResponse"));
+        assertTrue(content.contains("return 400"));
+    }
 }

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientJavaOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientJavaOpenapiTest.java
@@ -104,8 +104,10 @@ public class HttpClientJavaOpenapiTest extends BaseJavaOpenapiTest {
         assertTrue(content.contains("sealed interface GetErrorsModelErrorApiResponse extends GetErrorsApiResponse"));
         assertTrue(content.contains("ModelError content()"));
         assertTrue(content.contains("default String message()"));
+        assertTrue(content.contains("default @Nullable String details()"));
         assertTrue(content.contains("int _statusCode()"));
         assertTrue(content.contains("record GetErrors400ApiResponse(ModelError content) implements GetErrorsModelErrorApiResponse"));
         assertTrue(content.contains("return 400"));
+        assertTrue(content.contains("return this.content().details()"));
     }
 }

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientKotlinOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientKotlinOpenapiTest.java
@@ -85,4 +85,28 @@ public class HttpClientKotlinOpenapiTest extends BaseKotlinOpenapiTest {
         assertTrue(e.getMessage().contains("clientConfig is required for kotlin-client"));
         assertTrue(e.getMessage().contains("httpClient.petstoreV3"));
     }
+
+    @Test
+    void sameResponseModelGetsSharedInterface() throws Exception {
+        var files = generate(
+            "petstoreV3_same_response_model",
+            "kotlin-client",
+            getClass().getResource("/example/petstoreV3_same_response_model.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+        );
+
+        var content = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().endsWith("ApiResponses.kt"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(content.contains("public interface GetErrorsModelErrorApiResponse : GetErrorsApiResponse"));
+        assertTrue(content.contains("public val content: ModelError"));
+        assertTrue(content.contains("public val message: String"));
+        assertTrue(content.contains("public val _statusCode: Int"));
+        assertTrue(content.contains("public data class GetErrors400ApiResponse("));
+        assertTrue(content.contains(": GetErrorsModelErrorApiResponse"));
+        assertTrue(content.contains("get() = 400"));
+    }
 }

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientKotlinOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientKotlinOpenapiTest.java
@@ -104,9 +104,11 @@ public class HttpClientKotlinOpenapiTest extends BaseKotlinOpenapiTest {
         assertTrue(content.contains("public interface GetErrorsModelErrorApiResponse : GetErrorsApiResponse"));
         assertTrue(content.contains("public val content: ModelError"));
         assertTrue(content.contains("public val message: String"));
+        assertTrue(content.contains("public val details: String?"));
         assertTrue(content.contains("public val _statusCode: Int"));
         assertTrue(content.contains("public data class GetErrors400ApiResponse("));
         assertTrue(content.contains(": GetErrorsModelErrorApiResponse"));
         assertTrue(content.contains("get() = 400"));
+        assertTrue(content.contains("get() = content.details"));
     }
 }

--- a/openapi/openapi-generator/src/test/resources/example/petstoreV3_same_response_model.yaml
+++ b/openapi/openapi-generator/src/test/resources/example/petstoreV3_same_response_model.yaml
@@ -46,3 +46,5 @@ components:
           format: int32
         message:
           type: string
+        details:
+          type: string

--- a/openapi/openapi-generator/src/test/resources/example/petstoreV3_same_response_model.yaml
+++ b/openapi/openapi-generator/src/test/resources/example/petstoreV3_same_response_model.yaml
@@ -1,0 +1,48 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Same response model
+paths:
+  /errors:
+    get:
+      operationId: getErrors
+      tags:
+        - errors
+      responses:
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+components:
+  schemas:
+    Error:
+      type: object
+      required:
+        - statusCode
+        - httpStatusCode
+        - statusCodeMethod
+        - httpStatusCodeMethod
+        - message
+      properties:
+        statusCode:
+          type: integer
+          format: int32
+        httpStatusCode:
+          type: integer
+          format: int32
+        statusCodeMethod:
+          type: integer
+          format: int32
+        httpStatusCodeMethod:
+          type: integer
+          format: int32
+        message:
+          type: string


### PR DESCRIPTION
- Adds shared response interfaces when multiple status codes return the same OpenAPI model. The generated interface exposes common model fields plus a status-code accessor, so callers can handle grouped responses without switching over every concrete status response.
- Status accessor names are selected with collision fallback:
- statusCode, httpStatusCode, statusCodeMethod, httpStatusCodeMethod, then the same names with _ prefix.
- Also adds Java/Kotlin coverage with a same-response-model fixture, including renamed model lookup like Error -> ModelError.

Merge after #711

---

```java
@Generated("io.koraframework.openapi.generator.javagen.ApiResponseGenerator")
public interface ErrorsApiResponses {
  @Generated("io.koraframework.openapi.generator.javagen.ApiResponseGenerator")
  sealed interface GetErrorsApiResponse {
    @Generated("io.koraframework.openapi.generator.javagen.ApiResponseGenerator")
    sealed interface GetErrorsModelErrorApiResponse extends GetErrorsApiResponse {
      ModelError content();

      int _statusCode();
    }

    /**
     * Bad request (status code 400)
     */
    @Generated("io.koraframework.openapi.generator.javagen.ApiResponseGenerator")
    record GetErrors400ApiResponse(ModelError content) implements GetErrorsModelErrorApiResponse {
      @Override
      public int _statusCode() {
        return 400;
      }
    }

    /**
     * Server error (status code 500)
     */
    @Generated("io.koraframework.openapi.generator.javagen.ApiResponseGenerator")
    record GetErrors500ApiResponse(ModelError content) implements GetErrorsModelErrorApiResponse {
      @Override
      public int _statusCode() {
        return 500;
      }
    }
  }
}
```