### PR TITLE
Added `@DefaultComponent` support for `@Component` classes

### DIFF
--- a/core/common/src/main/java/io/koraframework/common/annotation/DefaultComponent.java
+++ b/core/common/src/main/java/io/koraframework/common/annotation/DefaultComponent.java
@@ -10,7 +10,7 @@ import java.lang.annotation.Target;
  * если другой такой же тип с таким же {@link Tag} не найдет в графе зависимостей контейнера.
  * Является Singleton, то есть дает гарантию, что у класса будет всего один экземпляр класса.
  * <hr>
- * <b>English</b>: Indicates that the annotated factory provides the default component for injection, will be used
+ * <b>English</b>: Indicates that the annotated factory or component provides the default component for injection, will be used
  * if another component of the same type with the same {@link Tag} is not found in the container's dependency graph.
  * Is Singleton, that is, it provides a guarantee that the class will have only one instance of the class.
  * <br>
@@ -28,7 +28,7 @@ import java.lang.annotation.Target;
  *  }
  * </pre>
  */
-@Target(ElementType.METHOD)
+@Target({ElementType.METHOD, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface DefaultComponent {
 

--- a/core/kora-app-annotation-processor/src/main/java/io/koraframework/kora/app/annotation/processor/declaration/ComponentDeclaration.java
+++ b/core/kora-app-annotation-processor/src/main/java/io/koraframework/kora/app/annotation/processor/declaration/ComponentDeclaration.java
@@ -90,6 +90,11 @@ public sealed interface ComponentDeclaration {
         }
 
         @Override
+        public boolean isDefault() {
+            return AnnotationUtils.findAnnotation(this.typeElement, CommonClassNames.defaultComponent) != null;
+        }
+
+        @Override
         public String declarationString() {
             return "component  " + TypeName.get(type);
         }

--- a/core/kora-app-annotation-processor/src/test/java/io/koraframework/kora/app/annotation/processor/ConflictResolutionTest.java
+++ b/core/kora-app-annotation-processor/src/test/java/io/koraframework/kora/app/annotation/processor/ConflictResolutionTest.java
@@ -74,4 +74,188 @@ public class ConflictResolutionTest extends AbstractKoraAppTest {
         assertThat(g.get(draw.getNodes().get(0))).isInstanceOf(this.compileResult.loadClass("TestImpl2"));
     }
 
+    @Test
+    public void testDefaultComponentAnnotatedComponentUsedWhenNoOverride() throws ClassNotFoundException {
+        var draw = compile("""
+            public interface TestInterface {}
+            """, """
+            @Component
+            @DefaultComponent
+            public class DefaultTestImpl implements TestInterface {}
+            """, """
+            @KoraApp
+            public interface ExampleApplication {
+                @Root
+                default Object root(TestInterface t) {return t;}
+            }
+            """);
+        assertThat(draw.getNodes()).hasSize(2);
+
+        var defaultImpl = this.compileResult.loadClass("DefaultTestImpl");
+        var g = draw.init();
+        assertThat(draw.getNodes())
+            .extracting(g::get)
+            .anySatisfy(value -> assertThat(value).isInstanceOf(defaultImpl));
+    }
+
+    @Test
+    public void testDefaultComponentAnnotatedComponentOverrideByComponentClass() throws ClassNotFoundException {
+        var draw = compile("""
+            public interface TestInterface {}
+            """, """
+            @Component
+            @DefaultComponent
+            public class DefaultTestImpl implements TestInterface {}
+            """, """
+            @Component
+            public class OverrideTestImpl implements TestInterface {}
+            """, """
+            @KoraApp
+            public interface ExampleApplication {
+                @Root
+                default Object root(TestInterface t) {return t;}
+            }
+            """);
+        assertThat(draw.getNodes()).hasSize(2);
+
+        var defaultImpl = this.compileResult.loadClass("DefaultTestImpl");
+        var overrideImpl = this.compileResult.loadClass("OverrideTestImpl");
+        var g = draw.init();
+        assertThat(draw.getNodes())
+            .extracting(g::get)
+            .anySatisfy(value -> assertThat(value).isInstanceOf(overrideImpl))
+            .noneSatisfy(value -> assertThat(value).isInstanceOf(defaultImpl));
+    }
+
+    @Test
+    public void testDefaultComponentAnnotatedComponentOverrideByFactoryMethod() throws ClassNotFoundException {
+        var draw = compile("""
+            public interface TestInterface {}
+            """, """
+            @Component
+            @DefaultComponent
+            public class DefaultTestImpl implements TestInterface {}
+            """, """
+            public class OverrideTestImpl implements TestInterface {}
+            """, """
+            @KoraApp
+            public interface ExampleApplication {
+                @Root
+                default Object root(TestInterface t) {return t;}
+
+                default OverrideTestImpl testImpl() { return new OverrideTestImpl(); }
+            }
+            """);
+        assertThat(draw.getNodes()).hasSize(2);
+
+        var defaultImpl = this.compileResult.loadClass("DefaultTestImpl");
+        var overrideImpl = this.compileResult.loadClass("OverrideTestImpl");
+        var g = draw.init();
+        assertThat(draw.getNodes())
+            .extracting(g::get)
+            .anySatisfy(value -> assertThat(value).isInstanceOf(overrideImpl))
+            .noneSatisfy(value -> assertThat(value).isInstanceOf(defaultImpl));
+    }
+
+    @Test
+    public void testDefaultComponentAnnotatedComponentOverrideBySameTagOnly() throws ClassNotFoundException {
+        var draw = compile("""
+            public interface TestInterface {}
+            """, """
+            public final class DefaultTag {}
+            """, """
+            public final class OverrideTag {}
+            """, """
+            @Component
+            @DefaultComponent
+            @Tag(DefaultTag.class)
+            public class DefaultTestImpl implements TestInterface {}
+            """, """
+            @Component
+            @Tag(OverrideTag.class)
+            public class OverrideTestImpl implements TestInterface {}
+            """, """
+            @KoraApp
+            public interface ExampleApplication {
+                @Root
+                default Object root(@Tag(DefaultTag.class) TestInterface t) {return t;}
+            }
+            """);
+        assertThat(draw.getNodes()).hasSize(2);
+
+        var defaultImpl = this.compileResult.loadClass("DefaultTestImpl");
+        var overrideImpl = this.compileResult.loadClass("OverrideTestImpl");
+        var g = draw.init();
+        assertThat(draw.getNodes())
+            .extracting(g::get)
+            .anySatisfy(value -> assertThat(value).isInstanceOf(defaultImpl))
+            .noneSatisfy(value -> assertThat(value).isInstanceOf(overrideImpl));
+    }
+
+    @Test
+    public void testDefaultComponentAnnotatedComponentOverrideByComponentClassWithSameTag() throws ClassNotFoundException {
+        var draw = compile("""
+            public interface TestInterface {}
+            """, """
+            public final class TestTag {}
+            """, """
+            @Component
+            @DefaultComponent
+            @Tag(TestTag.class)
+            public class DefaultTestImpl implements TestInterface {}
+            """, """
+            @Component
+            @Tag(TestTag.class)
+            public class OverrideTestImpl implements TestInterface {}
+            """, """
+            @KoraApp
+            public interface ExampleApplication {
+                @Root
+                default Object root(@Tag(TestTag.class) TestInterface t) {return t;}
+            }
+            """);
+        assertThat(draw.getNodes()).hasSize(2);
+
+        var defaultImpl = this.compileResult.loadClass("DefaultTestImpl");
+        var overrideImpl = this.compileResult.loadClass("OverrideTestImpl");
+        var g = draw.init();
+        assertThat(draw.getNodes())
+            .extracting(g::get)
+            .anySatisfy(value -> assertThat(value).isInstanceOf(overrideImpl))
+            .noneSatisfy(value -> assertThat(value).isInstanceOf(defaultImpl));
+    }
+
+    @Test
+    public void testDefaultComponentAnnotatedComponentOverrideByConditionalComponent() throws ClassNotFoundException {
+        var draw = compile("""
+            public interface TestInterface {}
+            """, """
+            @Component
+            @DefaultComponent
+            public class DefaultTestImpl implements TestInterface {}
+            """, """
+            @Component
+            @Conditional(tag = io.koraframework.kora.app.annotation.processor.ConditionalComponentTest.MatchesCondition.class)
+            public class OverrideTestImpl implements TestInterface {}
+            """, """
+            @KoraApp
+            public interface ExampleApplication {
+                @Root
+                default Object root(TestInterface t) {return t;}
+
+                @Tag(io.koraframework.kora.app.annotation.processor.ConditionalComponentTest.MatchesCondition.class)
+                default GraphCondition matches() { return new io.koraframework.kora.app.annotation.processor.ConditionalComponentTest.MatchesCondition(); }
+            }
+            """);
+        assertThat(draw.getNodes()).hasSize(3);
+
+        var defaultImpl = this.compileResult.loadClass("DefaultTestImpl");
+        var overrideImpl = this.compileResult.loadClass("OverrideTestImpl");
+        var g = draw.init();
+        assertThat(draw.getNodes())
+            .extracting(g::get)
+            .anySatisfy(value -> assertThat(value).isInstanceOf(overrideImpl))
+            .noneSatisfy(value -> assertThat(value).isInstanceOf(defaultImpl));
+    }
+
 }

--- a/core/kora-app-symbol-processor/src/main/kotlin/io/koraframework/kora/app/ksp/declaration/ComponentDeclaration.kt
+++ b/core/kora-app-symbol-processor/src/main/kotlin/io/koraframework/kora/app/ksp/declaration/ComponentDeclaration.kt
@@ -93,6 +93,7 @@ sealed interface ComponentDeclaration {
     ) : ComponentDeclaration {
         override val source get() = this.constructor
         override fun declarationString() = "component  " + classDeclaration.qualifiedName?.asString().toString()
+        override fun isDefault(): Boolean = classDeclaration.findAnnotation(CommonClassNames.defaultComponent) != null
     }
 
     data class FromExtensionComponent(

--- a/core/kora-app-symbol-processor/src/test/kotlin/io/koraframework/kora/app/ksp/ConflictResolutionTest.kt
+++ b/core/kora-app-symbol-processor/src/test/kotlin/io/koraframework/kora/app/ksp/ConflictResolutionTest.kt
@@ -1,9 +1,9 @@
 package io.koraframework.kora.app.ksp
 
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import io.koraframework.ksp.common.AbstractSymbolProcessorTest
 
-class ConflictResolutionTest : AbstractSymbolProcessorTest() {
+class ConflictResolutionTest : AbstractKoraAppProcessorTest() {
     @Test
     fun testMultipleComponentSameType() {
         compile0(listOf(KoraAppProcessorProvider()),
@@ -81,5 +81,215 @@ class ConflictResolutionTest : AbstractSymbolProcessorTest() {
         )
 
         compileResult.assertSuccess()
+    }
+
+    @Test
+    fun testDefaultComponentAnnotatedComponentUsedWhenNoOverride() {
+        val draw = compile(
+            """
+            interface TestInterface
+            """,
+            """
+            @Component
+            @DefaultComponent
+            class DefaultTestImpl : TestInterface
+            """,
+            """
+            @KoraApp
+            interface ExampleApplication {
+                @Root
+                fun root(t: TestInterface): Any = t
+            }
+            """
+        )
+        assertThat(draw.nodes).hasSize(2)
+
+        val defaultImpl = loadClass("DefaultTestImpl")
+        val graph = draw.init()
+        val values = draw.nodes.map { graph.get(it) }
+        assertThat(values).anyMatch { defaultImpl.isInstance(it) }
+    }
+
+    @Test
+    fun testDefaultComponentAnnotatedComponentOverrideByComponentClass() {
+        val draw = compile(
+            """
+            interface TestInterface
+            """,
+            """
+            @Component
+            @DefaultComponent
+            class DefaultTestImpl : TestInterface
+            """,
+            """
+            @Component
+            class OverrideTestImpl : TestInterface
+            """,
+            """
+            @KoraApp
+            interface ExampleApplication {
+                @Root
+                fun root(t: TestInterface): Any = t
+            }
+            """
+        )
+        assertThat(draw.nodes).hasSize(2)
+
+        val defaultImpl = loadClass("DefaultTestImpl")
+        val overrideImpl = loadClass("OverrideTestImpl")
+        val graph = draw.init()
+        val values = draw.nodes.map { graph.get(it) }
+        assertThat(values).anyMatch { overrideImpl.isInstance(it) }
+        assertThat(values).noneMatch { defaultImpl.isInstance(it) }
+    }
+
+    @Test
+    fun testDefaultComponentAnnotatedComponentOverrideByFactoryMethod() {
+        val draw = compile(
+            """
+            interface TestInterface
+            """,
+            """
+            @Component
+            @DefaultComponent
+            class DefaultTestImpl : TestInterface
+            """,
+            """
+            class OverrideTestImpl : TestInterface
+            """,
+            """
+            @KoraApp
+            interface ExampleApplication {
+                @Root
+                fun root(t: TestInterface): Any = t
+
+                fun testImpl() = OverrideTestImpl()
+            }
+            """
+        )
+        assertThat(draw.nodes).hasSize(2)
+
+        val defaultImpl = loadClass("DefaultTestImpl")
+        val overrideImpl = loadClass("OverrideTestImpl")
+        val graph = draw.init()
+        val values = draw.nodes.map { graph.get(it) }
+        assertThat(values).anyMatch { overrideImpl.isInstance(it) }
+        assertThat(values).noneMatch { defaultImpl.isInstance(it) }
+    }
+
+    @Test
+    fun testDefaultComponentAnnotatedComponentOverrideBySameTagOnly() {
+        val draw = compile(
+            """
+            interface TestInterface
+            """,
+            """
+            class DefaultTag
+            """,
+            """
+            class OverrideTag
+            """,
+            """
+            @Component
+            @DefaultComponent
+            @Tag(DefaultTag::class)
+            class DefaultTestImpl : TestInterface
+            """,
+            """
+            @Component
+            @Tag(OverrideTag::class)
+            class OverrideTestImpl : TestInterface
+            """,
+            """
+            @KoraApp
+            interface ExampleApplication {
+                @Root
+                fun root(@Tag(DefaultTag::class) t: TestInterface): Any = t
+            }
+            """
+        )
+        assertThat(draw.nodes).hasSize(2)
+
+        val defaultImpl = loadClass("DefaultTestImpl")
+        val overrideImpl = loadClass("OverrideTestImpl")
+        val graph = draw.init()
+        val values = draw.nodes.map { graph.get(it) }
+        assertThat(values).anyMatch { defaultImpl.isInstance(it) }
+        assertThat(values).noneMatch { overrideImpl.isInstance(it) }
+    }
+
+    @Test
+    fun testDefaultComponentAnnotatedComponentOverrideByComponentClassWithSameTag() {
+        val draw = compile(
+            """
+            interface TestInterface
+            """,
+            """
+            class TestTag
+            """,
+            """
+            @Component
+            @DefaultComponent
+            @Tag(TestTag::class)
+            class DefaultTestImpl : TestInterface
+            """,
+            """
+            @Component
+            @Tag(TestTag::class)
+            class OverrideTestImpl : TestInterface
+            """,
+            """
+            @KoraApp
+            interface ExampleApplication {
+                @Root
+                fun root(@Tag(TestTag::class) t: TestInterface): Any = t
+            }
+            """
+        )
+        assertThat(draw.nodes).hasSize(2)
+
+        val defaultImpl = loadClass("DefaultTestImpl")
+        val overrideImpl = loadClass("OverrideTestImpl")
+        val graph = draw.init()
+        val values = draw.nodes.map { graph.get(it) }
+        assertThat(values).anyMatch { overrideImpl.isInstance(it) }
+        assertThat(values).noneMatch { defaultImpl.isInstance(it) }
+    }
+
+    @Test
+    fun testDefaultComponentAnnotatedComponentOverrideByConditionalComponent() {
+        val draw = compile(
+            """
+            interface TestInterface
+            """,
+            """
+            @Component
+            @DefaultComponent
+            class DefaultTestImpl : TestInterface
+            """,
+            """
+            @Component
+            @Conditional(tag = io.koraframework.kora.app.ksp.ConditionalComponentTest.MatchesCondition::class)
+            class OverrideTestImpl : TestInterface
+            """,
+            """
+            @KoraApp
+            interface ExampleApplication {
+                @Root
+                fun root(t: TestInterface): Any = t
+
+                @Tag(io.koraframework.kora.app.ksp.ConditionalComponentTest.MatchesCondition::class)
+                fun matches(): GraphCondition = io.koraframework.kora.app.ksp.ConditionalComponentTest.MatchesCondition()
+            }
+            """
+        )
+        assertThat(draw.nodes).hasSize(3)
+
+        val defaultImpl = loadClass("DefaultTestImpl")
+        val overrideImpl = loadClass("OverrideTestImpl")
+        val graph = draw.init()
+        val values = draw.nodes.map { graph.get(it) }
+        assertThat(values).anyMatch { overrideImpl.isInstance(it) }
+        assertThat(values).noneMatch { defaultImpl.isInstance(it) }
     }
 }


### PR DESCRIPTION
- Added `@DefaultComponent` support for `@Component` classes via `@Target(TYPE)`.
- Updated Java annotation processor and KSP to treat annotated components as default declarations.
- Added Java and KSP conflict-resolution tests for:
  - default component usage without override
  - override by `@Component`
  - override by factory method
  - tag-specific override behavior
  - conditional component override