### PR TITLE
Added OpenAPI Generator `rawBodyMode` and `object` field improved generation handling

### DIFF
--- a/http/http-client-common/src/main/java/io/koraframework/http/client/common/request/mapper/HttpClientRequestMapperModule.java
+++ b/http/http-client-common/src/main/java/io/koraframework/http/client/common/request/mapper/HttpClientRequestMapperModule.java
@@ -4,6 +4,7 @@ import io.koraframework.common.annotation.DefaultComponent;
 import io.koraframework.common.annotation.Tag;
 import io.koraframework.http.client.common.request.HttpClientRequestMapper;
 import io.koraframework.http.common.body.HttpBody;
+import io.koraframework.http.common.body.HttpBodyOutput;
 import io.koraframework.json.common.JsonWriter;
 import io.koraframework.json.common.annotation.Json;
 
@@ -14,6 +15,11 @@ public interface HttpClientRequestMapperModule {
     @DefaultComponent
     default HttpClientRequestMapper<byte[]> httpClientRequestByteArrayMapper() {
         return (body) -> HttpBody.octetStream(body);
+    }
+
+    @DefaultComponent
+    default HttpClientRequestMapper<HttpBodyOutput> httpClientRequestBodyOutputMapper() {
+        return body -> body;
     }
 
     @DefaultComponent

--- a/http/http-client-common/src/main/java/io/koraframework/http/client/common/response/HttpClientResponseMapperModule.java
+++ b/http/http-client-common/src/main/java/io/koraframework/http/client/common/response/HttpClientResponseMapperModule.java
@@ -5,6 +5,7 @@ import io.koraframework.common.annotation.DefaultComponent;
 import io.koraframework.http.client.common.response.mapper.HttpClientEitherResponseMapper;
 import io.koraframework.http.client.common.response.mapper.JsonHttpClientResponseMapper;
 import io.koraframework.http.common.HttpResponseEntity;
+import io.koraframework.http.common.body.HttpBodyInput;
 import io.koraframework.json.common.JsonReader;
 import io.koraframework.json.common.annotation.Json;
 
@@ -38,6 +39,11 @@ public interface HttpClientResponseMapperModule {
                 return ByteBuffer.wrap(body.asInputStream().readAllBytes());
             }
         };
+    }
+
+    @DefaultComponent
+    default HttpClientResponseMapper<HttpBodyInput> httpClientResponseBodyInputMapper() {
+        return HttpClientResponse::body;
     }
 
     @DefaultComponent

--- a/http/http-server-common/src/main/java/io/koraframework/http/server/common/request/mapper/HttpServerRequestMapperModule.java
+++ b/http/http-server-common/src/main/java/io/koraframework/http/server/common/request/mapper/HttpServerRequestMapperModule.java
@@ -1,6 +1,7 @@
 package io.koraframework.http.server.common.request.mapper;
 
 import io.koraframework.common.annotation.DefaultComponent;
+import io.koraframework.http.common.body.HttpBodyInput;
 import io.koraframework.http.common.form.FormMultipart;
 import io.koraframework.http.common.form.FormUrlEncoded;
 import io.koraframework.http.server.common.request.HttpServerRequest;
@@ -17,6 +18,11 @@ public interface HttpServerRequestMapperModule {
     @DefaultComponent
     default HttpServerRequestMapper<HttpServerRequest> noopHttpServerRequestMapper() {
         return (r) -> r;
+    }
+
+    @DefaultComponent
+    default HttpServerRequestMapper<HttpBodyInput> httpBodyInputHttpServerRequestMapper() {
+        return HttpServerRequest::body;
     }
 
     @DefaultComponent

--- a/http/http-server-common/src/main/java/io/koraframework/http/server/common/response/mapper/HttpServerResponseMapperModule.java
+++ b/http/http-server-common/src/main/java/io/koraframework/http/server/common/response/mapper/HttpServerResponseMapperModule.java
@@ -3,6 +3,7 @@ package io.koraframework.http.server.common.response.mapper;
 import io.koraframework.common.annotation.DefaultComponent;
 import io.koraframework.http.common.HttpResponseEntity;
 import io.koraframework.http.common.body.HttpBody;
+import io.koraframework.http.common.body.HttpBodyOutput;
 import io.koraframework.http.server.common.response.HttpServerResponse;
 import io.koraframework.http.server.common.response.HttpServerResponseMapper;
 import io.koraframework.json.common.JsonWriter;
@@ -25,6 +26,11 @@ public interface HttpServerResponseMapperModule {
     @DefaultComponent
     default HttpServerResponseMapper<byte[]> byteArrayHttpServerResponseMapper() {
         return (request, r) -> HttpServerResponse.of(200, HttpBody.octetStream(r));
+    }
+
+    @DefaultComponent
+    default HttpServerResponseMapper<HttpBodyOutput> httpBodyOutputHttpServerResponseMapper() {
+        return (request, r) -> HttpServerResponse.of(200, r);
     }
 
     @DefaultComponent

--- a/openapi/openapi-generator/build.gradle
+++ b/openapi/openapi-generator/build.gradle
@@ -81,6 +81,7 @@ sourceSets {
             addOpenapiDir("petstoreV3_request_parameters")
             addOpenapiDir("petstoreV3_responses")
             addOpenapiDir("petstoreV3_same_response_model")
+            addOpenapiDir("petstoreV3_bare_object")
             addOpenapiDir("petstoreV3_security_all")
             addOpenapiDir("petstoreV3_security_all_auth_arg")
             addOpenapiDir("petstoreV3_security_multi")

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/AbstractGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/AbstractGenerator.java
@@ -60,6 +60,7 @@ public abstract class AbstractGenerator<C, R> {
         public static final ClassName httpBody = ClassName.get("io.koraframework.http.common.body", "HttpBody");
         public static final ClassName formMultipart = ClassName.get("io.koraframework.http.common.form", "FormMultipart");
         public static final ClassName formPart = formMultipart.nestedClass("FormPart");
+        public static final ClassName httpBodyInput = ClassName.get("io.koraframework.http.common.body", "HttpBodyInput");
         public static final ClassName httpBodyOutput = ClassName.get("io.koraframework.http.common.body", "HttpBodyOutput");
 
         // Client
@@ -143,6 +144,9 @@ public abstract class AbstractGenerator<C, R> {
     }
 
     public TypeName asType(OperationsMap ctx, CodegenOperation operation, CodegenParameter param) {
+        if (param.isBodyParam && isBareObject(param)) {
+            return requestBodyType();
+        }
         if (param.getSchema() != null) {
             return asType(param.getSchema());
         }
@@ -186,6 +190,9 @@ public abstract class AbstractGenerator<C, R> {
             if (rs.isFile) {
                 return ArrayTypeName.of(TypeName.BYTE);
             }
+            if (isBareObject(rs)) {
+                return responseBodyType();
+            }
         }
         if (schema.getIsModel() && schema instanceof CodegenModel c) {
             return ClassName.get(modelPackage, c.getClassname());
@@ -200,6 +207,9 @@ public abstract class AbstractGenerator<C, R> {
             return ParameterizedTypeName.get(ClassName.get(List.class), asType(schema.getItems()).box());
         }
         if (schema.getIsMap()) {
+            if (schema.getAdditionalProperties() == null) {
+                return ClassName.get(Object.class);
+            }
             return ParameterizedTypeName.get(ClassName.get(Map.class), ClassName.get(String.class), asType(schema.getAdditionalProperties()).box());
         }
         if (schema.getIsModel()) {
@@ -290,5 +300,31 @@ public abstract class AbstractGenerator<C, R> {
             return ClassName.get(modelPackage, schema.getDataType());
         }
         throw new IllegalArgumentException(schema.toString());
+    }
+
+    protected TypeName requestBodyType() {
+        if (params.rawBodyMode == CodegenParams.RawBodyMode.BYTES) {
+            return ArrayTypeName.of(TypeName.BYTE);
+        }
+        return params.codegenMode.isClient()
+            ? Classes.httpBodyOutput
+            : Classes.httpBodyInput;
+    }
+
+    protected TypeName responseBodyType() {
+        if (params.rawBodyMode == CodegenParams.RawBodyMode.BYTES) {
+            return ArrayTypeName.of(TypeName.BYTE);
+        }
+        return params.codegenMode.isClient()
+            ? Classes.httpBodyInput
+            : Classes.httpBodyOutput;
+    }
+
+    protected boolean isBareObject(IJsonSchemaValidationProperties schema) {
+        return "Object".equals(schema.getDataType())
+               || schema.getIsMap() && schema.getAdditionalProperties() == null
+               || schema instanceof CodegenProperty p && p.isFreeFormObject
+               || schema instanceof CodegenParameter cp && cp.isFreeFormObject
+               || schema instanceof CodegenResponse r && r.isFreeFormObject;
     }
 }

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/AbstractGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/AbstractGenerator.java
@@ -144,7 +144,7 @@ public abstract class AbstractGenerator<C, R> {
     }
 
     public TypeName asType(OperationsMap ctx, CodegenOperation operation, CodegenParameter param) {
-        if (param.isBodyParam && isBareObject(param)) {
+        if (param.isBodyParam && isBareObject(param) && params.rawBodyMode != CodegenParams.RawBodyMode.OBJECT) {
             return requestBodyType();
         }
         if (param.getSchema() != null) {
@@ -190,7 +190,7 @@ public abstract class AbstractGenerator<C, R> {
             if (rs.isFile) {
                 return ArrayTypeName.of(TypeName.BYTE);
             }
-            if (isBareObject(rs)) {
+            if (isBareObject(rs) && params.rawBodyMode != CodegenParams.RawBodyMode.OBJECT) {
                 return responseBodyType();
             }
         }
@@ -306,6 +306,9 @@ public abstract class AbstractGenerator<C, R> {
         if (params.rawBodyMode == CodegenParams.RawBodyMode.BYTES) {
             return ArrayTypeName.of(TypeName.BYTE);
         }
+        if (params.rawBodyMode == CodegenParams.RawBodyMode.OBJECT) {
+            return ClassName.get(Object.class);
+        }
         return params.codegenMode.isClient()
             ? Classes.httpBodyOutput
             : Classes.httpBodyInput;
@@ -314,6 +317,9 @@ public abstract class AbstractGenerator<C, R> {
     protected TypeName responseBodyType() {
         if (params.rawBodyMode == CodegenParams.RawBodyMode.BYTES) {
             return ArrayTypeName.of(TypeName.BYTE);
+        }
+        if (params.rawBodyMode == CodegenParams.RawBodyMode.OBJECT) {
+            return ClassName.get(Object.class);
         }
         return params.codegenMode.isClient()
             ? Classes.httpBodyInput
@@ -326,5 +332,9 @@ public abstract class AbstractGenerator<C, R> {
                || schema instanceof CodegenProperty p && p.isFreeFormObject
                || schema instanceof CodegenParameter cp && cp.isFreeFormObject
                || schema instanceof CodegenResponse r && r.isFreeFormObject;
+    }
+
+    protected boolean requiresJsonMapper(IJsonSchemaValidationProperties schema) {
+        return !isBareObject(schema) || params.rawBodyMode == CodegenParams.RawBodyMode.OBJECT;
     }
 }

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/CodegenParams.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/CodegenParams.java
@@ -29,6 +29,7 @@ public class CodegenParams {
     public static final String IMPLICIT_HEADERS = "implicitHeaders";
     public static final String IMPLICIT_HEADERS_REGEX = "implicitHeadersRegex";
     public static final String FORCE_INCLUDE_OPTIONAL = "forceIncludeOptional";
+    public static final String RAW_BODY_MODE = "rawBodyMode";
     
     public CodegenMode codegenMode = CodegenMode.JAVA_CLIENT;
     public boolean enableValidation = false;
@@ -47,6 +48,7 @@ public class CodegenParams {
     public boolean implicitHeaders = false;
     public @Nullable Pattern implicitHeadersRegex = null;
     public boolean forceIncludeOptional = false;
+    public RawBodyMode rawBodyMode = RawBodyMode.BYTES;
 
     static List<CliOption> cliOptions() {
         var cliOptions = new ArrayList<CliOption>();
@@ -65,6 +67,7 @@ public class CodegenParams {
         cliOptions.add(CliOption.newString(PREFIX_PATH, "Path prefix for HTTP Server controllers"));
         cliOptions.add(CliOption.newString(DELEGATE_METHOD_BODY_MODE, "Delegate method generation mode"));
         cliOptions.add(CliOption.newString(FORCE_INCLUDE_OPTIONAL, "If enabled forces Nullable and NonRequired fields to be included ALWAYS even if null, can't be enabled with enableJsonNullable simultaneously"));
+        cliOptions.add(CliOption.newString(RAW_BODY_MODE, "Bare object request and response body mode (one of BYTES, RAW)"));
         return cliOptions;
     }
 
@@ -143,6 +146,18 @@ public class CodegenParams {
         if (additionalProperties.containsKey(FORCE_INCLUDE_OPTIONAL)) {
             params.forceIncludeOptional = Boolean.parseBoolean(additionalProperties.get(FORCE_INCLUDE_OPTIONAL).toString());
         }
+        if (additionalProperties.containsKey(RAW_BODY_MODE)) {
+            params.rawBodyMode = RawBodyMode.of(additionalProperties.get(RAW_BODY_MODE).toString());
+        }
         return params;
+    }
+
+    public enum RawBodyMode {
+        BYTES,
+        RAW;
+
+        public static RawBodyMode of(String value) {
+            return RawBodyMode.valueOf(value.toUpperCase(Locale.ROOT));
+        }
     }
 }

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/CodegenParams.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/CodegenParams.java
@@ -67,7 +67,7 @@ public class CodegenParams {
         cliOptions.add(CliOption.newString(PREFIX_PATH, "Path prefix for HTTP Server controllers"));
         cliOptions.add(CliOption.newString(DELEGATE_METHOD_BODY_MODE, "Delegate method generation mode"));
         cliOptions.add(CliOption.newString(FORCE_INCLUDE_OPTIONAL, "If enabled forces Nullable and NonRequired fields to be included ALWAYS even if null, can't be enabled with enableJsonNullable simultaneously"));
-        cliOptions.add(CliOption.newString(RAW_BODY_MODE, "Bare object request and response body mode (one of BYTES, RAW)"));
+        cliOptions.add(CliOption.newString(RAW_BODY_MODE, "Bare object request and response body mode (one of BYTES, BODY, OBJECT)"));
         return cliOptions;
     }
 
@@ -154,7 +154,8 @@ public class CodegenParams {
 
     public enum RawBodyMode {
         BYTES,
-        RAW;
+        BODY,
+        OBJECT;
 
         public static RawBodyMode of(String value) {
             return RawBodyMode.valueOf(value.toUpperCase(Locale.ROOT));

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/AbstractJavaGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/AbstractJavaGenerator.java
@@ -233,7 +233,7 @@ public abstract class AbstractJavaGenerator<C> extends AbstractGenerator<C, Java
             b.add("@return ");
             for (var i = 0; i < operation.responses.size(); i++) {
                 if (i > 0) {
-                    b.add(" or ");
+                    b.add("\n        ");
                 }
                 var response = operation.responses.get(i);
                 b.add(Objects.requireNonNullElse(response.message, ""));
@@ -245,13 +245,6 @@ public abstract class AbstractJavaGenerator<C> extends AbstractGenerator<C, Java
         }
         if (operation.isDeprecated) {
             b.add("@deprecated\n");
-        }
-        for (var response : operation.responses) {
-            b.add("@return ")
-                .add(response.message)
-                .add(" (status code ")
-                .add(response.code)
-                .add(")\n");
         }
         if (operation.externalDocs != null) {
             b.add("@see <a href=\"" + operation.externalDocs.getUrl() + "\">" + operation.summary + " Documentation</a>");

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/AbstractJavaGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/AbstractJavaGenerator.java
@@ -109,7 +109,7 @@ public abstract class AbstractJavaGenerator<C> extends AbstractGenerator<C, Java
                 .addMember("value", "$S", param.baseName)
                 .build());
         }
-        if (param.isBodyParam && KoraCodegen.isContentJson(param)) {
+        if (param.isBodyParam && KoraCodegen.isContentJson(param) && !isBareObject(param)) {
             b.addAnnotation(jsonAnnotation());
         }
         if (params.codegenMode.isServer() && params.enableValidation) {
@@ -208,6 +208,7 @@ public abstract class AbstractJavaGenerator<C> extends AbstractGenerator<C, Java
         if (operation.notes != null) {
             b.add(operation.notes).add("\n");
         }
+        b.add("\n");
         for (var param : operation.allParams) {
             if (!param.isFormParam) {
                 b.add("@param ").add(param.paramName).add(" ");
@@ -227,6 +228,20 @@ public abstract class AbstractJavaGenerator<C> extends AbstractGenerator<C, Java
                 }
                 b.add("\n");
             }
+        }
+        if (!operation.responses.isEmpty()) {
+            b.add("@return ");
+            for (var i = 0; i < operation.responses.size(); i++) {
+                if (i > 0) {
+                    b.add(" or ");
+                }
+                var response = operation.responses.get(i);
+                b.add(Objects.requireNonNullElse(response.message, ""));
+                b.add(" (status code ");
+                b.add(response.isDefault ? "default" : response.code);
+                b.add(")");
+            }
+            b.add("\n");
         }
         if (operation.isDeprecated) {
             b.add("@deprecated\n");

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/AbstractJavaGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/AbstractJavaGenerator.java
@@ -109,7 +109,7 @@ public abstract class AbstractJavaGenerator<C> extends AbstractGenerator<C, Java
                 .addMember("value", "$S", param.baseName)
                 .build());
         }
-        if (param.isBodyParam && KoraCodegen.isContentJson(param) && !isBareObject(param)) {
+        if (param.isBodyParam && KoraCodegen.isContentJson(param) && requiresJsonMapper(param)) {
             b.addAnnotation(jsonAnnotation());
         }
         if (params.codegenMode.isServer() && params.enableValidation) {

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientResponseMapperGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientResponseMapperGenerator.java
@@ -39,7 +39,7 @@ public class ClientResponseMapperGenerator extends AbstractJavaGenerator<Operati
             var mapperType = ParameterizedTypeName.get(Classes.httpClientResponseMapper, asType(response));
             b.addField(mapperType, "delegate", Modifier.PRIVATE, Modifier.FINAL);
             var mapperParam = ParameterSpec.builder(mapperType, "delegate");
-            if (isContentJson(response.getContent())) {
+            if (isContentJson(response.getContent()) && !isBareObject(response)) {
                 mapperParam.addAnnotation(jsonAnnotation());
             }
             constructor = MethodSpec.constructorBuilder()

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientResponseMapperGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientResponseMapperGenerator.java
@@ -39,7 +39,7 @@ public class ClientResponseMapperGenerator extends AbstractJavaGenerator<Operati
             var mapperType = ParameterizedTypeName.get(Classes.httpClientResponseMapper, asType(response));
             b.addField(mapperType, "delegate", Modifier.PRIVATE, Modifier.FINAL);
             var mapperParam = ParameterSpec.builder(mapperType, "delegate");
-            if (isContentJson(response.getContent()) && !isBareObject(response)) {
+            if (isContentJson(response.getContent()) && requiresJsonMapper(response)) {
                 mapperParam.addAnnotation(jsonAnnotation());
             }
             constructor = MethodSpec.constructorBuilder()

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ServerResponseMapperGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ServerResponseMapperGenerator.java
@@ -40,7 +40,7 @@ public class ServerResponseMapperGenerator extends AbstractJavaGenerator<Operati
                 var mapperName = "response" + response.code + "Delegate";
                 b.addField(mapperType, mapperName, Modifier.PRIVATE, Modifier.FINAL);
                 var param = ParameterSpec.builder(mapperType, mapperName);
-                if (KoraCodegen.isContentJson(response.getContent())) {
+                if (KoraCodegen.isContentJson(response.getContent()) && !isBareObject(response)) {
                     param.addAnnotation(Classes.json);
                 }
                 constructor.addParameter(param.build());

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ServerResponseMapperGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ServerResponseMapperGenerator.java
@@ -40,7 +40,7 @@ public class ServerResponseMapperGenerator extends AbstractJavaGenerator<Operati
                 var mapperName = "response" + response.code + "Delegate";
                 b.addField(mapperType, mapperName, Modifier.PRIVATE, Modifier.FINAL);
                 var param = ParameterSpec.builder(mapperType, mapperName);
-                if (KoraCodegen.isContentJson(response.getContent()) && !isBareObject(response)) {
+                if (KoraCodegen.isContentJson(response.getContent()) && requiresJsonMapper(response)) {
                     param.addAnnotation(Classes.json);
                 }
                 constructor.addParameter(param.build());

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/AbstractKotlinGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/AbstractKotlinGenerator.kt
@@ -145,7 +145,7 @@ abstract class AbstractKotlinGenerator<C : Any> : AbstractGenerator<C, FileSpec>
                     .build()
             )
 
-            param.isBodyParam && KoraCodegen.isContentJson(param) -> b.addAnnotation(
+            param.isBodyParam && KoraCodegen.isContentJson(param) && !isBareObject(param) -> b.addAnnotation(
                 AnnotationSpec.builder(Classes.json.asKt())
                     .build()
             )
@@ -275,13 +275,17 @@ abstract class AbstractKotlinGenerator<C : Any> : AbstractGenerator<C, FileSpec>
         com.palantir.javapoet.ClassName.get("java.util", "Map") -> Map::class.asClassName()
         com.palantir.javapoet.ClassName.get("java.util", "Set") -> Set::class.asClassName()
         com.palantir.javapoet.ClassName.get("java.lang", "String") -> String::class.asClassName()
+        com.palantir.javapoet.ClassName.get("java.lang", "Object") -> ANY
+        com.palantir.javapoet.ClassName.get("java.math", "BigDecimal") -> java.math.BigDecimal::class.asClassName()
+        com.palantir.javapoet.ClassName.get("io.koraframework.http.common.body", "HttpBodyInput") -> ClassName("io.koraframework.http.common.body", "HttpBodyInput")
+        com.palantir.javapoet.ClassName.get("io.koraframework.http.common.body", "HttpBodyOutput") -> ClassName("io.koraframework.http.common.body", "HttpBodyOutput")
         com.palantir.javapoet.TypeName.INT.box() -> INT
         com.palantir.javapoet.TypeName.LONG.box() -> LONG
         com.palantir.javapoet.TypeName.SHORT.box() -> SHORT
         com.palantir.javapoet.TypeName.BYTE.box() -> BYTE
         com.palantir.javapoet.TypeName.DOUBLE.box() -> DOUBLE
-        com.palantir.javapoet.TypeName.FLOAT.box() -> FLOAT
-        com.palantir.javapoet.TypeName.BOOLEAN.box() -> BOOLEAN
+        com.palantir.javapoet.TypeName.FLOAT.box() -> BOOLEAN
+        com.palantir.javapoet.TypeName.BOOLEAN.box() -> FLOAT
         else -> ClassName(packageName(), simpleNames())
     }
 

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/AbstractKotlinGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/AbstractKotlinGenerator.kt
@@ -145,7 +145,7 @@ abstract class AbstractKotlinGenerator<C : Any> : AbstractGenerator<C, FileSpec>
                     .build()
             )
 
-            param.isBodyParam && KoraCodegen.isContentJson(param) && !isBareObject(param) -> b.addAnnotation(
+            param.isBodyParam && KoraCodegen.isContentJson(param) && requiresJsonMapper(param) -> b.addAnnotation(
                 AnnotationSpec.builder(Classes.json.asKt())
                     .build()
             )

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/AbstractKotlinGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/AbstractKotlinGenerator.kt
@@ -257,12 +257,18 @@ abstract class AbstractKotlinGenerator<C : Any> : AbstractGenerator<C, FileSpec>
         if (operation.isDeprecated) {
             b.add("@deprecated\n")
         }
-        for (response in operation.responses) {
+        if (operation.responses.isNotEmpty()) {
             b.add("@return ")
-                .add(response.message)
-                .add(" (status code ")
-                .add(response.code)
-                .add(")\n")
+            for ((index, response) in operation.responses.withIndex()) {
+                if (index > 0) {
+                    b.add("\n        ")
+                }
+                b.add(response.message ?: "")
+                    .add(" (status code ")
+                    .add(if (response.isDefault) "default" else response.code)
+                    .add(")")
+            }
+            b.add("\n")
         }
         if (operation.externalDocs != null) {
             b.add("@see <a href=\"" + operation.externalDocs.url + "\">" + operation.summary + " Documentation</a>")

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ClientResponseMapperGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ClientResponseMapperGenerator.kt
@@ -33,7 +33,7 @@ class ClientResponseMapperGenerator : AbstractKotlinGenerator<OperationsMap>() {
             val mapperType = Classes.httpClientResponseMapper.asKt().parameterizedBy(asType(response).asKt())
             b.addProperty(PropertySpec.builder("delegate", mapperType).initializer("delegate").build())
             val mapperParam = ParameterSpec.builder("delegate", mapperType)
-            if (KoraCodegen.isContentJson(response.content)) {
+            if (KoraCodegen.isContentJson(response.content) && !isBareObject(response)) {
                 mapperParam.addAnnotation(jsonAnnotation())
             }
             constructor.addParameter(mapperParam.build())

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ClientResponseMapperGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ClientResponseMapperGenerator.kt
@@ -33,7 +33,7 @@ class ClientResponseMapperGenerator : AbstractKotlinGenerator<OperationsMap>() {
             val mapperType = Classes.httpClientResponseMapper.asKt().parameterizedBy(asType(response).asKt())
             b.addProperty(PropertySpec.builder("delegate", mapperType).initializer("delegate").build())
             val mapperParam = ParameterSpec.builder("delegate", mapperType)
-            if (KoraCodegen.isContentJson(response.content) && !isBareObject(response)) {
+            if (KoraCodegen.isContentJson(response.content) && requiresJsonMapper(response)) {
                 mapperParam.addAnnotation(jsonAnnotation())
             }
             constructor.addParameter(mapperParam.build())

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ModelGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ModelGenerator.kt
@@ -137,9 +137,11 @@ class ModelGenerator : AbstractKotlinGenerator<ModelsMap>() {
                 enumModel.isString = enumSource.isString
                 enumModel.isLong = enumSource.isLong
                 enumModel.isInteger = enumSource.isInteger
-                enumModel.isDouble = enumSource.isDouble
-                enumModel.isFloat = enumSource.isFloat
                 enumModel.isBoolean = enumSource.isBoolean
+                enumModel.isFloat = enumSource.isFloat
+                enumModel.isDouble = enumSource.isDouble
+                enumModel.isDecimal = enumSource.isDecimal
+                enumModel.isNumber = enumSource.isNumber
                 val enumTypeSpec = buildEnum(ctx, enumModel)
                 b.addType(enumTypeSpec)
                 fieldType = ClassName(modelPackage, model.getClassname(), enumModel.name)
@@ -385,6 +387,9 @@ class ModelGenerator : AbstractKotlinGenerator<ModelsMap>() {
         }
         if (model.isInteger || "Integer" == model.dataType) {
             return INT
+        }
+        if ("BigDecimal" == model.dataType) {
+            return java.math.BigDecimal::class.asClassName()
         }
         if (model.isDouble || "Double" == model.dataType) {
             return DOUBLE

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ServerResponseMappersGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ServerResponseMappersGenerator.kt
@@ -36,7 +36,7 @@ class ServerResponseMappersGenerator : AbstractKotlinGenerator<OperationsMap>() 
                 val mapperName = "response" + response.code + "Delegate"
                 b.addProperty(PropertySpec.builder(mapperName, mapperType).initializer(mapperName).build())
                 val param = ParameterSpec.builder(mapperName, mapperType)
-                if (KoraCodegen.isContentJson(response.content)) {
+                if (KoraCodegen.isContentJson(response.content) && !isBareObject(response)) {
                     param.addAnnotation(Classes.json.asKt())
                 }
                 constructor.addParameter(param.build())

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ServerResponseMappersGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ServerResponseMappersGenerator.kt
@@ -36,7 +36,7 @@ class ServerResponseMappersGenerator : AbstractKotlinGenerator<OperationsMap>() 
                 val mapperName = "response" + response.code + "Delegate"
                 b.addProperty(PropertySpec.builder(mapperName, mapperType).initializer(mapperName).build())
                 val param = ParameterSpec.builder(mapperName, mapperType)
-                if (KoraCodegen.isContentJson(response.content) && !isBareObject(response)) {
+                if (KoraCodegen.isContentJson(response.content) && requiresJsonMapper(response)) {
                     param.addAnnotation(Classes.json.asKt())
                 }
                 constructor.addParameter(param.build())

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/BaseOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/BaseOpenapiTest.java
@@ -26,6 +26,8 @@ public abstract class BaseOpenapiTest {
             public String implicitHeadersRegex;
             public boolean defaultDelegate;
             @Nullable
+            public String rawBodyMode;
+            @Nullable
             public String clientConfig = "test";
             @Nullable
             public String clientConfigPrefix;
@@ -55,6 +57,11 @@ public abstract class BaseOpenapiTest {
                 return this;
             }
 
+            public Options setRawBodyMode(@Nullable String rawBodyMode) {
+                this.rawBodyMode = rawBodyMode;
+                return this;
+            }
+
             public Options setClientConfig(@Nullable String clientConfig) {
                 this.clientConfig = clientConfig;
                 return this;
@@ -73,6 +80,7 @@ public abstract class BaseOpenapiTest {
                        ", implicitHeaders=" + implicitHeaders +
                        ", implicitHeadersRegex=" + implicitHeadersRegex +
                        ", defaultDelegate=" + defaultDelegate +
+                       ", rawBodyMode='" + rawBodyMode + '\'' +
                        ", clientConfig='" + clientConfig + '\'' +
                        ", clientConfigPrefix='" + clientConfigPrefix + '\'' +
                        '}';
@@ -103,6 +111,7 @@ public abstract class BaseOpenapiTest {
             "/example/petstoreV3_security_multi.yaml",
             "/example/petstoreV3_single_response.yaml",
             "/example/petstoreV3_same_response_model.yaml",
+            "/example/petstoreV3_bare_object.yaml",
             "/example/petstoreV3_responses.yaml",
             "/example/petstoreV3_types.yaml",
             "/example/petstoreV3_validation.yaml",
@@ -177,6 +186,9 @@ public abstract class BaseOpenapiTest {
         }
         if (options.clientConfigPrefix != null) {
             configurator.addAdditionalProperty("clientConfigPrefix", options.clientConfigPrefix);
+        }
+        if (options.rawBodyMode != null) {
+            configurator.addAdditionalProperty("rawBodyMode", options.rawBodyMode);
         }
 
         if (options.defaultDelegate) {

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/BaseOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/BaseOpenapiTest.java
@@ -142,6 +142,27 @@ public abstract class BaseOpenapiTest {
         return result.toArray(SwaggerParams[]::new);
     }
 
+    protected static long countJavadocReturnTags(String content) {
+        return content.lines()
+            .filter(line -> line.contains("* @return "))
+            .count();
+    }
+
+    protected static boolean containsMultilineStoreInventoryReturn(String content) {
+        var lines = content.lines().toList();
+        for (int i = 0; i < lines.size() - 3; i++) {
+            if (lines.get(i).contains("@return Stored payload (status code 200)")
+                && lines.get(i + 1).contains("Validation error (status code 400)")
+                && lines.get(i + 2).contains("Validation error (status code 404)")
+                && lines.get(i + 3).contains("Unknown server error (status code 500)")) {
+                return !lines.get(i).contains(" or ")
+                       && !lines.get(i + 1).contains("@return")
+                       && !lines.get(i + 2).contains("@return")
+                       && !lines.get(i + 3).contains("@return");
+            }
+        }
+        return false;
+    }
 
     protected final List<File> generate(String name, String mode, String spec, SwaggerParams.Options options) throws Exception {
         var dir = openapiSourcesDir.toAbsolutePath().toString();

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientJavaOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientJavaOpenapiTest.java
@@ -272,4 +272,110 @@ public class HttpClientJavaOpenapiTest extends BaseJavaOpenapiTest {
         assertTrue(optionalArgsContent.contains("public PetsApiListPetsOptArgs withIntOptional(Integer intOptional)"));
         assertTrue(optionalArgsContent.contains("return this;"));
     }
+
+    @Test
+    void bareObjectPropertiesAreGeneratedAsObject() throws Exception {
+        var files = generate(
+            "petstoreV3_bare_object_bytes_default",
+            "java-client",
+            getClass().getResource("/example/petstoreV3_bare_object.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+        );
+
+        var content = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("Pet.java"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(content.contains("public record Pet(long id, Object metadata, @Nullable Object optionalMetadata)"));
+        assertTrue(content.contains("public Pet withMetadata(Object metadata)"));
+        assertTrue(content.contains("public Pet withOptionalMetadata(@Nullable Object optionalMetadata)"));
+    }
+
+    @Test
+    void bareObjectRequestAndResponseAreGeneratedAsRawHttpBodyTypes() throws Exception {
+        var files = generate(
+            "petstoreV3_bare_object_raw",
+            "java-client",
+            getClass().getResource("/example/petstoreV3_bare_object.yaml").toExternalForm(),
+            new SwaggerParams.Options().setRawBodyMode("RAW")
+        );
+
+        var apiContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_raw"))
+            .filter(path -> path.getFileName().toString().equals("DefaultApi.java"))
+            .findFirst()
+            .orElseThrow());
+        var responsesContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_raw"))
+            .filter(path -> path.getFileName().toString().equals("DefaultApiResponses.java"))
+            .findFirst()
+            .orElseThrow());
+        var responseMapperContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_raw"))
+            .filter(path -> path.getFileName().toString().equals("DefaultApiClientResponseMappers.java"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(apiContent.contains("StoreInventoryApiResponse storeInventory(HttpBodyOutput body)"));
+        assertTrue(apiContent.contains("RawObjectApiResponse rawObject(HttpBodyOutput body)"));
+        assertTrue(responsesContent.contains("sealed interface StoreInventoryApiResponse"));
+        assertTrue(responsesContent.contains("record StoreInventory200ApiResponse("));
+        assertTrue(responsesContent.contains("HttpBodyInput content) implements StoreInventoryObjectApiResponse"));
+        assertTrue(responsesContent.contains("StoreInventory400ApiResponse"));
+        assertTrue(responsesContent.contains("ErrorMessage"));
+        assertTrue(responsesContent.contains("implements StoreInventory"));
+        assertTrue(responsesContent.contains("record StoreInventory500ApiResponse("));
+        assertTrue(responsesContent.contains("HttpBodyInput content) implements StoreInventoryObjectApiResponse"));
+        assertTrue(responsesContent.contains("sealed interface RawObjectApiResponse"));
+        assertTrue(responsesContent.contains("record RawObject200ApiResponse("));
+        assertTrue(responsesContent.contains("HttpBodyInput content) implements RawObjectObjectApiResponse"));
+        assertTrue(responsesContent.contains("record RawObject400ApiResponse("));
+        assertTrue(responsesContent.contains("record RawObject500ApiResponse("));
+        assertTrue(responseMapperContent.contains("private final HttpClientResponseMapper<HttpBodyInput> delegate"));
+        assertTrue(responseMapperContent.contains("private final HttpClientResponseMapper<ErrorMessage> delegate"));
+        assertFalse(responseMapperContent.contains("@Json HttpClientResponseMapper<HttpBodyInput>"));
+    }
+
+    @Test
+    void bareObjectRequestAndResponseUseByteArrayByDefault() throws Exception {
+        var files = generate(
+            "petstoreV3_bare_object_bytes_default",
+            "java-client",
+            getClass().getResource("/example/petstoreV3_bare_object.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+        );
+
+        var apiContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_bytes_default"))
+            .filter(path -> path.getFileName().toString().equals("DefaultApi.java"))
+            .findFirst()
+            .orElseThrow());
+        var responsesContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_bytes_default"))
+            .filter(path -> path.getFileName().toString().equals("DefaultApiResponses.java"))
+            .findFirst()
+            .orElseThrow());
+        var responseMapperContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_bytes_default"))
+            .filter(path -> path.getFileName().toString().equals("DefaultApiClientResponseMappers.java"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(apiContent.contains("StoreInventoryApiResponse storeInventory(byte[] body)"));
+        assertTrue(apiContent.contains("RawObjectApiResponse rawObject(byte[] body)"));
+        assertTrue(responsesContent.contains("record StoreInventory200ApiResponse(byte[] content)"));
+        assertTrue(responsesContent.contains("record StoreInventory500ApiResponse(byte[] content)"));
+        assertTrue(responsesContent.contains("record RawObject200ApiResponse(byte[] content)"));
+        assertTrue(responsesContent.contains("record RawObject400ApiResponse(byte[] content)"));
+        assertTrue(responsesContent.contains("record RawObject500ApiResponse(byte[] content)"));
+        assertTrue(responseMapperContent.contains("private final HttpClientResponseMapper<byte[]> delegate"));
+    }
 }

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientJavaOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientJavaOpenapiTest.java
@@ -323,6 +323,8 @@ public class HttpClientJavaOpenapiTest extends BaseJavaOpenapiTest {
 
         assertTrue(apiContent.contains("StoreInventoryApiResponse storeInventory(HttpBodyOutput body)"));
         assertTrue(apiContent.contains("RawObjectApiResponse rawObject(HttpBodyOutput body)"));
+        assertEquals(3, countJavadocReturnTags(apiContent));
+        assertTrue(containsMultilineStoreInventoryReturn(apiContent));
         assertTrue(responsesContent.contains("sealed interface StoreInventoryApiResponse"));
         assertTrue(responsesContent.contains("record StoreInventory200ApiResponse("));
         assertTrue(responsesContent.contains("HttpBodyInput content) implements StoreInventoryObjectApiResponse"));

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientJavaOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientJavaOpenapiTest.java
@@ -294,29 +294,29 @@ public class HttpClientJavaOpenapiTest extends BaseJavaOpenapiTest {
     }
 
     @Test
-    void bareObjectRequestAndResponseAreGeneratedAsRawHttpBodyTypes() throws Exception {
+    void bareObjectRequestAndResponseAreGeneratedAsHttpBodyTypes() throws Exception {
         var files = generate(
-            "petstoreV3_bare_object_raw",
+            "petstoreV3_bare_object_body",
             "java-client",
             getClass().getResource("/example/petstoreV3_bare_object.yaml").toExternalForm(),
-            new SwaggerParams.Options().setRawBodyMode("RAW")
+            new SwaggerParams.Options().setRawBodyMode("BODY")
         );
 
         var apiContent = Files.readString(files.stream()
             .map(java.io.File::toPath)
-            .filter(path -> path.toString().contains("petstoreV3_bare_object_raw"))
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_body"))
             .filter(path -> path.getFileName().toString().equals("DefaultApi.java"))
             .findFirst()
             .orElseThrow());
         var responsesContent = Files.readString(files.stream()
             .map(java.io.File::toPath)
-            .filter(path -> path.toString().contains("petstoreV3_bare_object_raw"))
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_body"))
             .filter(path -> path.getFileName().toString().equals("DefaultApiResponses.java"))
             .findFirst()
             .orElseThrow());
         var responseMapperContent = Files.readString(files.stream()
             .map(java.io.File::toPath)
-            .filter(path -> path.toString().contains("petstoreV3_bare_object_raw"))
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_body"))
             .filter(path -> path.getFileName().toString().equals("DefaultApiClientResponseMappers.java"))
             .findFirst()
             .orElseThrow());
@@ -339,6 +339,44 @@ public class HttpClientJavaOpenapiTest extends BaseJavaOpenapiTest {
         assertTrue(responseMapperContent.contains("private final HttpClientResponseMapper<HttpBodyInput> delegate"));
         assertTrue(responseMapperContent.contains("private final HttpClientResponseMapper<ErrorMessage> delegate"));
         assertFalse(responseMapperContent.contains("@Json HttpClientResponseMapper<HttpBodyInput>"));
+    }
+
+    @Test
+    void bareObjectRequestAndResponseAreGeneratedAsObjectTypes() throws Exception {
+        var files = generate(
+            "petstoreV3_bare_object_object",
+            "java-client",
+            getClass().getResource("/example/petstoreV3_bare_object.yaml").toExternalForm(),
+            new SwaggerParams.Options().setRawBodyMode("OBJECT")
+        );
+
+        var apiContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_object"))
+            .filter(path -> path.getFileName().toString().equals("DefaultApi.java"))
+            .findFirst()
+            .orElseThrow());
+        var responsesContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_object"))
+            .filter(path -> path.getFileName().toString().equals("DefaultApiResponses.java"))
+            .findFirst()
+            .orElseThrow());
+        var responseMapperContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_object"))
+            .filter(path -> path.getFileName().toString().equals("DefaultApiClientResponseMappers.java"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(apiContent.contains("StoreInventoryApiResponse storeInventory(@Json Object body)"));
+        assertTrue(apiContent.contains("RawObjectApiResponse rawObject(@Json Object body)"));
+        assertTrue(responsesContent.contains("record StoreInventory200ApiResponse(Object content)"));
+        assertTrue(responsesContent.contains("record StoreInventory500ApiResponse(Object content)"));
+        assertTrue(responsesContent.contains("record RawObject200ApiResponse(Object content)"));
+        assertTrue(responsesContent.contains("record RawObject400ApiResponse(Object content)"));
+        assertTrue(responsesContent.contains("record RawObject500ApiResponse(Object content)"));
+        assertTrue(responseMapperContent.contains("@Json HttpClientResponseMapper<Object> delegate"));
     }
 
     @Test

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientKotlinOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientKotlinOpenapiTest.java
@@ -111,4 +111,116 @@ public class HttpClientKotlinOpenapiTest extends BaseKotlinOpenapiTest {
         assertTrue(content.contains("get() = 400"));
         assertTrue(content.contains("get() = content.details"));
     }
+
+    @Test
+    void enumValueTypesSupportDouble() throws Exception {
+        var files = generate(
+            "petstoreV3_enum",
+            "kotlin-client",
+            getClass().getResource("/example/petstoreV3_enum.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+        );
+
+        var content = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("Pet.kt"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(content.contains("public enum class NonReqDoubleEnum private constructor("));
+        assertTrue(content.contains("public val `value`: Double"));
+        assertTrue(content.contains("`delegate`: io.koraframework.json.common.JsonWriter<Double>"));
+        assertTrue(content.contains("`delegate`: io.koraframework.json.common.JsonReader<Double>"));
+    }
+
+    @Test
+    void bareObjectRequestAndResponseAreGeneratedAsRawHttpBodyTypes() throws Exception {
+        var files = generate(
+            "petstoreV3_bare_object_raw",
+            "kotlin-client",
+            getClass().getResource("/example/petstoreV3_bare_object.yaml").toExternalForm(),
+            new SwaggerParams.Options().setRawBodyMode("RAW")
+        );
+
+        var apiContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_raw"))
+            .filter(path -> path.getFileName().toString().equals("DefaultApi.kt"))
+            .findFirst()
+            .orElseThrow());
+        var responsesContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_raw"))
+            .filter(path -> path.getFileName().toString().equals("DefaultApiResponses.kt"))
+            .findFirst()
+            .orElseThrow());
+        var modelContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_raw"))
+            .filter(path -> path.getFileName().toString().equals("Pet.kt"))
+            .findFirst()
+            .orElseThrow());
+        var errorContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_raw"))
+            .filter(path -> path.getFileName().toString().equals("ErrorMessage.kt"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(apiContent.contains("public fun storeInventory(body: HttpBodyOutput): DefaultApiResponses.StoreInventoryApiResponse"));
+        assertTrue(apiContent.contains("public fun rawObject(body: HttpBodyOutput): DefaultApiResponses.RawObjectApiResponse"));
+        assertTrue(responsesContent.contains("public sealed interface StoreInventoryApiResponse"));
+        assertTrue(responsesContent.contains("public data class StoreInventory200ApiResponse("));
+        assertTrue(responsesContent.contains("public val content: HttpBodyInput"));
+        assertTrue(responsesContent.contains("public data class StoreInventory400ApiResponse("));
+        assertTrue(responsesContent.contains("public val content: ErrorMessage"));
+        assertTrue(responsesContent.contains("public data class StoreInventory500ApiResponse("));
+        assertTrue(responsesContent.contains("public val content: HttpBodyInput"));
+        assertTrue(responsesContent.contains("public sealed interface RawObjectApiResponse"));
+        assertTrue(responsesContent.contains("public data class RawObject200ApiResponse("));
+        assertTrue(responsesContent.contains("public data class RawObject400ApiResponse("));
+        assertTrue(responsesContent.contains("public data class RawObject500ApiResponse("));
+        assertTrue(modelContent.contains("public data class Pet("));
+        assertTrue(modelContent.contains("public val metadata: Any"));
+        assertTrue(modelContent.contains("public val optionalMetadata: Any? = null"));
+        assertTrue(errorContent.contains("public data class ErrorMessage("));
+        assertTrue(errorContent.contains("public val message: String"));
+    }
+
+    @Test
+    void bareObjectRequestAndResponseUseByteArrayByDefault() throws Exception {
+        var files = generate(
+            "petstoreV3_bare_object_bytes_default",
+            "kotlin-client",
+            getClass().getResource("/example/petstoreV3_bare_object.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+        );
+
+        var apiContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_bytes_default"))
+            .filter(path -> path.getFileName().toString().equals("DefaultApi.kt"))
+            .findFirst()
+            .orElseThrow());
+        var responsesContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_bytes_default"))
+            .filter(path -> path.getFileName().toString().equals("DefaultApiResponses.kt"))
+            .findFirst()
+            .orElseThrow());
+        var responseMapperContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_bytes_default"))
+            .filter(path -> path.getFileName().toString().equals("DefaultApiClientResponseMappers.kt"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(apiContent.contains("public fun storeInventory(body: ByteArray): DefaultApiResponses.StoreInventoryApiResponse"));
+        assertTrue(apiContent.contains("public fun rawObject(body: ByteArray): DefaultApiResponses.RawObjectApiResponse"));
+        assertTrue(responsesContent.contains("public val content: ByteArray"));
+        assertTrue(responsesContent.contains("public data class RawObject200ApiResponse("));
+        assertTrue(responsesContent.contains("public data class RawObject400ApiResponse("));
+        assertTrue(responsesContent.contains("public data class RawObject500ApiResponse("));
+        assertTrue(responseMapperContent.contains("HttpClientResponseMapper<ByteArray>"));
+    }
 }

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientKotlinOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientKotlinOpenapiTest.java
@@ -169,6 +169,8 @@ public class HttpClientKotlinOpenapiTest extends BaseKotlinOpenapiTest {
 
         assertTrue(apiContent.contains("public fun storeInventory(body: HttpBodyOutput): DefaultApiResponses.StoreInventoryApiResponse"));
         assertTrue(apiContent.contains("public fun rawObject(body: HttpBodyOutput): DefaultApiResponses.RawObjectApiResponse"));
+        assertEquals(3, countJavadocReturnTags(apiContent));
+        assertTrue(containsMultilineStoreInventoryReturn(apiContent));
         assertTrue(responsesContent.contains("public sealed interface StoreInventoryApiResponse"));
         assertTrue(responsesContent.contains("public data class StoreInventory200ApiResponse("));
         assertTrue(responsesContent.contains("public val content: HttpBodyInput"));

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientKotlinOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientKotlinOpenapiTest.java
@@ -134,35 +134,35 @@ public class HttpClientKotlinOpenapiTest extends BaseKotlinOpenapiTest {
     }
 
     @Test
-    void bareObjectRequestAndResponseAreGeneratedAsRawHttpBodyTypes() throws Exception {
+    void bareObjectRequestAndResponseAreGeneratedAsHttpBodyTypes() throws Exception {
         var files = generate(
-            "petstoreV3_bare_object_raw",
+            "petstoreV3_bare_object_body",
             "kotlin-client",
             getClass().getResource("/example/petstoreV3_bare_object.yaml").toExternalForm(),
-            new SwaggerParams.Options().setRawBodyMode("RAW")
+            new SwaggerParams.Options().setRawBodyMode("BODY")
         );
 
         var apiContent = Files.readString(files.stream()
             .map(java.io.File::toPath)
-            .filter(path -> path.toString().contains("petstoreV3_bare_object_raw"))
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_body"))
             .filter(path -> path.getFileName().toString().equals("DefaultApi.kt"))
             .findFirst()
             .orElseThrow());
         var responsesContent = Files.readString(files.stream()
             .map(java.io.File::toPath)
-            .filter(path -> path.toString().contains("petstoreV3_bare_object_raw"))
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_body"))
             .filter(path -> path.getFileName().toString().equals("DefaultApiResponses.kt"))
             .findFirst()
             .orElseThrow());
         var modelContent = Files.readString(files.stream()
             .map(java.io.File::toPath)
-            .filter(path -> path.toString().contains("petstoreV3_bare_object_raw"))
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_body"))
             .filter(path -> path.getFileName().toString().equals("Pet.kt"))
             .findFirst()
             .orElseThrow());
         var errorContent = Files.readString(files.stream()
             .map(java.io.File::toPath)
-            .filter(path -> path.toString().contains("petstoreV3_bare_object_raw"))
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_body"))
             .filter(path -> path.getFileName().toString().equals("ErrorMessage.kt"))
             .findFirst()
             .orElseThrow());
@@ -185,6 +185,45 @@ public class HttpClientKotlinOpenapiTest extends BaseKotlinOpenapiTest {
         assertTrue(modelContent.contains("public val optionalMetadata: Any? = null"));
         assertTrue(errorContent.contains("public data class ErrorMessage("));
         assertTrue(errorContent.contains("public val message: String"));
+    }
+
+    @Test
+    void bareObjectRequestAndResponseAreGeneratedAsObjectTypes() throws Exception {
+        var files = generate(
+            "petstoreV3_bare_object_object",
+            "kotlin-client",
+            getClass().getResource("/example/petstoreV3_bare_object.yaml").toExternalForm(),
+            new SwaggerParams.Options().setRawBodyMode("OBJECT")
+        );
+
+        var apiContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_object"))
+            .filter(path -> path.getFileName().toString().equals("DefaultApi.kt"))
+            .findFirst()
+            .orElseThrow());
+        var responsesContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_object"))
+            .filter(path -> path.getFileName().toString().equals("DefaultApiResponses.kt"))
+            .findFirst()
+            .orElseThrow());
+        var responseMapperContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_object"))
+            .filter(path -> path.getFileName().toString().equals("DefaultApiClientResponseMappers.kt"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(apiContent.contains("body: Any"));
+        assertTrue(apiContent.contains("DefaultApiResponses.StoreInventoryApiResponse"));
+        assertTrue(apiContent.contains("DefaultApiResponses.RawObjectApiResponse"));
+        assertTrue(responsesContent.contains("public val content: Any"));
+        assertTrue(responsesContent.contains("public data class RawObject200ApiResponse("));
+        assertTrue(responsesContent.contains("public data class RawObject400ApiResponse("));
+        assertTrue(responsesContent.contains("public data class RawObject500ApiResponse("));
+        assertTrue(responseMapperContent.contains("HttpClientResponseMapper<Any>"));
+        assertTrue(responseMapperContent.contains("@Json"));
     }
 
     @Test

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpServerJavaOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpServerJavaOpenapiTest.java
@@ -47,4 +47,92 @@ public class HttpServerJavaOpenapiTest extends BaseJavaOpenapiTest {
         assertTrue(delegateContent.contains("* @param body Pet object that needs to be added to the store (required)"));
         assertTrue(delegateContent.contains("* @return Invalid input (status code 405)"));
     }
+
+    @Test
+    void bareObjectRequestAndResponseAreGeneratedAsRawHttpBodyTypes() throws Exception {
+        var files = generate(
+            "petstoreV3_bare_object_raw",
+            "java-server",
+            getClass().getResource("/example/petstoreV3_bare_object.yaml").toExternalForm(),
+            new SwaggerParams.Options().setRawBodyMode("RAW")
+        );
+
+        var controllerContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_raw"))
+            .filter(path -> path.getFileName().toString().equals("DefaultApiController.java"))
+            .findFirst()
+            .orElseThrow());
+        var delegateContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_raw"))
+            .filter(path -> path.getFileName().toString().equals("DefaultApiDelegate.java"))
+            .findFirst()
+            .orElseThrow());
+        var responsesContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_raw"))
+            .filter(path -> path.getFileName().toString().equals("DefaultApiResponses.java"))
+            .findFirst()
+            .orElseThrow());
+        var responseMapperContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_raw"))
+            .filter(path -> path.getFileName().toString().equals("DefaultApiServerResponseMappers.java"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(controllerContent.contains("StoreInventoryApiResponse storeInventory(HttpBodyInput body)"));
+        assertTrue(delegateContent.contains("StoreInventoryApiResponse storeInventory(HttpBodyInput body)"));
+        assertTrue(controllerContent.contains("RawObjectApiResponse rawObject(HttpBodyInput body)"));
+        assertTrue(delegateContent.contains("RawObjectApiResponse rawObject(HttpBodyInput body)"));
+        assertTrue(responsesContent.contains("record StoreInventory200ApiResponse("));
+        assertTrue(responsesContent.contains("HttpBodyOutput content) implements StoreInventoryApiResponse"));
+        assertTrue(responsesContent.contains("record StoreInventory400ApiResponse(ErrorMessage content) implements StoreInventoryApiResponse"));
+        assertTrue(responsesContent.contains("record StoreInventory500ApiResponse("));
+        assertTrue(responsesContent.contains("record RawObject200ApiResponse("));
+        assertTrue(responsesContent.contains("HttpBodyOutput content) implements RawObjectApiResponse"));
+        assertTrue(responsesContent.contains("record RawObject400ApiResponse("));
+        assertTrue(responsesContent.contains("record RawObject500ApiResponse("));
+        assertTrue(responseMapperContent.contains("HttpServerResponseMapper<HttpResponseEntity<HttpBodyOutput>> response200Delegate"));
+        assertTrue(responseMapperContent.contains("HttpServerResponseMapper<HttpResponseEntity<ErrorMessage>> response400Delegate"));
+    }
+
+    @Test
+    void bareObjectRequestAndResponseUseByteArrayByDefault() throws Exception {
+        var files = generate(
+            "petstoreV3_bare_object_bytes_default",
+            "java-server",
+            getClass().getResource("/example/petstoreV3_bare_object.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+        );
+
+        var controllerContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_bytes_default"))
+            .filter(path -> path.getFileName().toString().equals("DefaultApiController.java"))
+            .findFirst()
+            .orElseThrow());
+        var responsesContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_bytes_default"))
+            .filter(path -> path.getFileName().toString().equals("DefaultApiResponses.java"))
+            .findFirst()
+            .orElseThrow());
+        var responseMapperContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_bytes_default"))
+            .filter(path -> path.getFileName().toString().equals("DefaultApiServerResponseMappers.java"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(controllerContent.contains("StoreInventoryApiResponse storeInventory(byte[] body)"));
+        assertTrue(controllerContent.contains("RawObjectApiResponse rawObject(byte[] body)"));
+        assertTrue(responsesContent.contains("record StoreInventory200ApiResponse(byte[] content) implements StoreInventoryApiResponse"));
+        assertTrue(responsesContent.contains("record StoreInventory500ApiResponse(byte[] content) implements StoreInventoryApiResponse"));
+        assertTrue(responsesContent.contains("record RawObject200ApiResponse(byte[] content) implements RawObjectApiResponse"));
+        assertTrue(responsesContent.contains("record RawObject400ApiResponse(byte[] content) implements RawObjectApiResponse"));
+        assertTrue(responsesContent.contains("record RawObject500ApiResponse(byte[] content) implements RawObjectApiResponse"));
+        assertTrue(responseMapperContent.contains("HttpServerResponseMapper<HttpResponseEntity<byte[]>> response200Delegate"));
+    }
 }

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpServerJavaOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpServerJavaOpenapiTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.nio.file.Files;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class HttpServerJavaOpenapiTest extends BaseJavaOpenapiTest {
     @ParameterizedTest
@@ -86,6 +86,9 @@ public class HttpServerJavaOpenapiTest extends BaseJavaOpenapiTest {
         assertTrue(delegateContent.contains("StoreInventoryApiResponse storeInventory(HttpBodyInput body)"));
         assertTrue(controllerContent.contains("RawObjectApiResponse rawObject(HttpBodyInput body)"));
         assertTrue(delegateContent.contains("RawObjectApiResponse rawObject(HttpBodyInput body)"));
+        assertEquals(3, countJavadocReturnTags(controllerContent));
+        assertEquals(3, countJavadocReturnTags(delegateContent));
+        assertTrue(containsMultilineStoreInventoryReturn(controllerContent));
         assertTrue(responsesContent.contains("record StoreInventory200ApiResponse("));
         assertTrue(responsesContent.contains("HttpBodyOutput content) implements StoreInventoryApiResponse"));
         assertTrue(responsesContent.contains("record StoreInventory400ApiResponse(ErrorMessage content) implements StoreInventoryApiResponse"));

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpServerJavaOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpServerJavaOpenapiTest.java
@@ -49,35 +49,35 @@ public class HttpServerJavaOpenapiTest extends BaseJavaOpenapiTest {
     }
 
     @Test
-    void bareObjectRequestAndResponseAreGeneratedAsRawHttpBodyTypes() throws Exception {
+    void bareObjectRequestAndResponseAreGeneratedAsHttpBodyTypes() throws Exception {
         var files = generate(
-            "petstoreV3_bare_object_raw",
+            "petstoreV3_bare_object_body",
             "java-server",
             getClass().getResource("/example/petstoreV3_bare_object.yaml").toExternalForm(),
-            new SwaggerParams.Options().setRawBodyMode("RAW")
+            new SwaggerParams.Options().setRawBodyMode("BODY")
         );
 
         var controllerContent = Files.readString(files.stream()
             .map(java.io.File::toPath)
-            .filter(path -> path.toString().contains("petstoreV3_bare_object_raw"))
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_body"))
             .filter(path -> path.getFileName().toString().equals("DefaultApiController.java"))
             .findFirst()
             .orElseThrow());
         var delegateContent = Files.readString(files.stream()
             .map(java.io.File::toPath)
-            .filter(path -> path.toString().contains("petstoreV3_bare_object_raw"))
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_body"))
             .filter(path -> path.getFileName().toString().equals("DefaultApiDelegate.java"))
             .findFirst()
             .orElseThrow());
         var responsesContent = Files.readString(files.stream()
             .map(java.io.File::toPath)
-            .filter(path -> path.toString().contains("petstoreV3_bare_object_raw"))
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_body"))
             .filter(path -> path.getFileName().toString().equals("DefaultApiResponses.java"))
             .findFirst()
             .orElseThrow());
         var responseMapperContent = Files.readString(files.stream()
             .map(java.io.File::toPath)
-            .filter(path -> path.toString().contains("petstoreV3_bare_object_raw"))
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_body"))
             .filter(path -> path.getFileName().toString().equals("DefaultApiServerResponseMappers.java"))
             .findFirst()
             .orElseThrow());
@@ -96,6 +96,52 @@ public class HttpServerJavaOpenapiTest extends BaseJavaOpenapiTest {
         assertTrue(responsesContent.contains("record RawObject500ApiResponse("));
         assertTrue(responseMapperContent.contains("HttpServerResponseMapper<HttpResponseEntity<HttpBodyOutput>> response200Delegate"));
         assertTrue(responseMapperContent.contains("HttpServerResponseMapper<HttpResponseEntity<ErrorMessage>> response400Delegate"));
+    }
+
+    @Test
+    void bareObjectRequestAndResponseAreGeneratedAsObjectTypes() throws Exception {
+        var files = generate(
+            "petstoreV3_bare_object_object",
+            "java-server",
+            getClass().getResource("/example/petstoreV3_bare_object.yaml").toExternalForm(),
+            new SwaggerParams.Options().setRawBodyMode("OBJECT")
+        );
+
+        var controllerContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_object"))
+            .filter(path -> path.getFileName().toString().equals("DefaultApiController.java"))
+            .findFirst()
+            .orElseThrow());
+        var delegateContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_object"))
+            .filter(path -> path.getFileName().toString().equals("DefaultApiDelegate.java"))
+            .findFirst()
+            .orElseThrow());
+        var responsesContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_object"))
+            .filter(path -> path.getFileName().toString().equals("DefaultApiResponses.java"))
+            .findFirst()
+            .orElseThrow());
+        var responseMapperContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_object"))
+            .filter(path -> path.getFileName().toString().equals("DefaultApiServerResponseMappers.java"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(controllerContent.contains("StoreInventoryApiResponse storeInventory(@Json Object body)"));
+        assertTrue(delegateContent.contains("StoreInventoryApiResponse storeInventory(@Json Object body)"));
+        assertTrue(controllerContent.contains("RawObjectApiResponse rawObject(@Json Object body)"));
+        assertTrue(delegateContent.contains("RawObjectApiResponse rawObject(@Json Object body)"));
+        assertTrue(responsesContent.contains("record StoreInventory200ApiResponse(Object content) implements StoreInventoryApiResponse"));
+        assertTrue(responsesContent.contains("record StoreInventory500ApiResponse(Object content) implements StoreInventoryApiResponse"));
+        assertTrue(responsesContent.contains("record RawObject200ApiResponse(Object content) implements RawObjectApiResponse"));
+        assertTrue(responsesContent.contains("record RawObject400ApiResponse(Object content) implements RawObjectApiResponse"));
+        assertTrue(responsesContent.contains("record RawObject500ApiResponse(Object content) implements RawObjectApiResponse"));
+        assertTrue(responseMapperContent.contains("@Json HttpServerResponseMapper<HttpResponseEntity<Object>> response200Delegate"));
     }
 
     @Test

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpServerKotlinOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpServerKotlinOpenapiTest.java
@@ -1,7 +1,12 @@
 package io.koraframework.openapi.generator;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+
+import java.nio.file.Files;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class HttpServerKotlinOpenapiTest extends BaseKotlinOpenapiTest {
     @ParameterizedTest
@@ -13,5 +18,89 @@ public class HttpServerKotlinOpenapiTest extends BaseKotlinOpenapiTest {
             params.spec(),
             params.options()
         );
+    }
+
+    @Test
+    void bareObjectRequestAndResponseAreGeneratedAsRawHttpBodyTypes() throws Exception {
+        var files = generate(
+            "petstoreV3_bare_object_raw",
+            "kotlin-server",
+            getClass().getResource("/example/petstoreV3_bare_object.yaml").toExternalForm(),
+            new SwaggerParams.Options().setRawBodyMode("RAW")
+        );
+
+        var controllerContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_raw"))
+            .filter(path -> path.getFileName().toString().equals("DefaultApiController.kt"))
+            .findFirst()
+            .orElseThrow());
+        var delegateContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_raw"))
+            .filter(path -> path.getFileName().toString().equals("DefaultApiDelegate.kt"))
+            .findFirst()
+            .orElseThrow());
+        var responsesContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_raw"))
+            .filter(path -> path.getFileName().toString().equals("DefaultApiResponses.kt"))
+            .findFirst()
+            .orElseThrow());
+        var responseMapperContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_raw"))
+            .filter(path -> path.getFileName().toString().equals("DefaultApiServerResponseMappers.kt"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(controllerContent.contains("public fun storeInventory(body: HttpBodyInput): DefaultApiResponses.StoreInventoryApiResponse"));
+        assertTrue(delegateContent.contains("public fun storeInventory(body: HttpBodyInput): DefaultApiResponses.StoreInventoryApiResponse"));
+        assertTrue(controllerContent.contains("public fun rawObject(body: HttpBodyInput): DefaultApiResponses.RawObjectApiResponse"));
+        assertTrue(delegateContent.contains("public fun rawObject(body: HttpBodyInput): DefaultApiResponses.RawObjectApiResponse"));
+        assertTrue(responsesContent.contains("public val content: HttpBodyOutput"));
+        assertTrue(responsesContent.contains("public data class RawObject200ApiResponse("));
+        assertTrue(responsesContent.contains("public data class RawObject400ApiResponse("));
+        assertTrue(responsesContent.contains("public data class RawObject500ApiResponse("));
+        assertTrue(responsesContent.contains("public val content: ErrorMessage"));
+        assertTrue(responseMapperContent.contains("HttpServerResponseMapper<HttpResponseEntity<HttpBodyOutput>>"));
+        assertTrue(responseMapperContent.contains("HttpServerResponseMapper<HttpResponseEntity<ErrorMessage>>"));
+    }
+
+    @Test
+    void bareObjectRequestAndResponseUseByteArrayByDefault() throws Exception {
+        var files = generate(
+            "petstoreV3_bare_object_bytes_default",
+            "kotlin-server",
+            getClass().getResource("/example/petstoreV3_bare_object.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+        );
+
+        var controllerContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_bytes_default"))
+            .filter(path -> path.getFileName().toString().equals("DefaultApiController.kt"))
+            .findFirst()
+            .orElseThrow());
+        var responsesContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_bytes_default"))
+            .filter(path -> path.getFileName().toString().equals("DefaultApiResponses.kt"))
+            .findFirst()
+            .orElseThrow());
+        var responseMapperContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_bytes_default"))
+            .filter(path -> path.getFileName().toString().equals("DefaultApiServerResponseMappers.kt"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(controllerContent.contains("public fun storeInventory(body: ByteArray): DefaultApiResponses.StoreInventoryApiResponse"));
+        assertTrue(controllerContent.contains("public fun rawObject(body: ByteArray): DefaultApiResponses.RawObjectApiResponse"));
+        assertTrue(responsesContent.contains("public val content: ByteArray"));
+        assertTrue(responsesContent.contains("public data class RawObject200ApiResponse("));
+        assertTrue(responsesContent.contains("public data class RawObject400ApiResponse("));
+        assertTrue(responsesContent.contains("public data class RawObject500ApiResponse("));
+        assertTrue(responseMapperContent.contains("HttpServerResponseMapper<HttpResponseEntity<ByteArray>>"));
     }
 }

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpServerKotlinOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpServerKotlinOpenapiTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.nio.file.Files;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class HttpServerKotlinOpenapiTest extends BaseKotlinOpenapiTest {
     @ParameterizedTest
@@ -58,6 +58,9 @@ public class HttpServerKotlinOpenapiTest extends BaseKotlinOpenapiTest {
         assertTrue(delegateContent.contains("public fun storeInventory(body: HttpBodyInput): DefaultApiResponses.StoreInventoryApiResponse"));
         assertTrue(controllerContent.contains("public fun rawObject(body: HttpBodyInput): DefaultApiResponses.RawObjectApiResponse"));
         assertTrue(delegateContent.contains("public fun rawObject(body: HttpBodyInput): DefaultApiResponses.RawObjectApiResponse"));
+        assertEquals(3, countJavadocReturnTags(controllerContent));
+        assertEquals(3, countJavadocReturnTags(delegateContent));
+        assertTrue(containsMultilineStoreInventoryReturn(controllerContent));
         assertTrue(responsesContent.contains("public val content: HttpBodyOutput"));
         assertTrue(responsesContent.contains("public data class RawObject200ApiResponse("));
         assertTrue(responsesContent.contains("public data class RawObject400ApiResponse("));

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpServerKotlinOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpServerKotlinOpenapiTest.java
@@ -21,35 +21,35 @@ public class HttpServerKotlinOpenapiTest extends BaseKotlinOpenapiTest {
     }
 
     @Test
-    void bareObjectRequestAndResponseAreGeneratedAsRawHttpBodyTypes() throws Exception {
+    void bareObjectRequestAndResponseAreGeneratedAsHttpBodyTypes() throws Exception {
         var files = generate(
-            "petstoreV3_bare_object_raw",
+            "petstoreV3_bare_object_body",
             "kotlin-server",
             getClass().getResource("/example/petstoreV3_bare_object.yaml").toExternalForm(),
-            new SwaggerParams.Options().setRawBodyMode("RAW")
+            new SwaggerParams.Options().setRawBodyMode("BODY")
         );
 
         var controllerContent = Files.readString(files.stream()
             .map(java.io.File::toPath)
-            .filter(path -> path.toString().contains("petstoreV3_bare_object_raw"))
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_body"))
             .filter(path -> path.getFileName().toString().equals("DefaultApiController.kt"))
             .findFirst()
             .orElseThrow());
         var delegateContent = Files.readString(files.stream()
             .map(java.io.File::toPath)
-            .filter(path -> path.toString().contains("petstoreV3_bare_object_raw"))
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_body"))
             .filter(path -> path.getFileName().toString().equals("DefaultApiDelegate.kt"))
             .findFirst()
             .orElseThrow());
         var responsesContent = Files.readString(files.stream()
             .map(java.io.File::toPath)
-            .filter(path -> path.toString().contains("petstoreV3_bare_object_raw"))
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_body"))
             .filter(path -> path.getFileName().toString().equals("DefaultApiResponses.kt"))
             .findFirst()
             .orElseThrow());
         var responseMapperContent = Files.readString(files.stream()
             .map(java.io.File::toPath)
-            .filter(path -> path.toString().contains("petstoreV3_bare_object_raw"))
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_body"))
             .filter(path -> path.getFileName().toString().equals("DefaultApiServerResponseMappers.kt"))
             .findFirst()
             .orElseThrow());
@@ -65,6 +65,54 @@ public class HttpServerKotlinOpenapiTest extends BaseKotlinOpenapiTest {
         assertTrue(responsesContent.contains("public val content: ErrorMessage"));
         assertTrue(responseMapperContent.contains("HttpServerResponseMapper<HttpResponseEntity<HttpBodyOutput>>"));
         assertTrue(responseMapperContent.contains("HttpServerResponseMapper<HttpResponseEntity<ErrorMessage>>"));
+    }
+
+    @Test
+    void bareObjectRequestAndResponseAreGeneratedAsObjectTypes() throws Exception {
+        var files = generate(
+            "petstoreV3_bare_object_object",
+            "kotlin-server",
+            getClass().getResource("/example/petstoreV3_bare_object.yaml").toExternalForm(),
+            new SwaggerParams.Options().setRawBodyMode("OBJECT")
+        );
+
+        var controllerContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_object"))
+            .filter(path -> path.getFileName().toString().equals("DefaultApiController.kt"))
+            .findFirst()
+            .orElseThrow());
+        var delegateContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_object"))
+            .filter(path -> path.getFileName().toString().equals("DefaultApiDelegate.kt"))
+            .findFirst()
+            .orElseThrow());
+        var responsesContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_object"))
+            .filter(path -> path.getFileName().toString().equals("DefaultApiResponses.kt"))
+            .findFirst()
+            .orElseThrow());
+        var responseMapperContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.toString().contains("petstoreV3_bare_object_object"))
+            .filter(path -> path.getFileName().toString().equals("DefaultApiServerResponseMappers.kt"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(controllerContent.contains("body: Any"));
+        assertTrue(delegateContent.contains("body: Any"));
+        assertTrue(controllerContent.contains("DefaultApiResponses.StoreInventoryApiResponse"));
+        assertTrue(delegateContent.contains("DefaultApiResponses.StoreInventoryApiResponse"));
+        assertTrue(controllerContent.contains("DefaultApiResponses.RawObjectApiResponse"));
+        assertTrue(delegateContent.contains("DefaultApiResponses.RawObjectApiResponse"));
+        assertTrue(responsesContent.contains("public val content: Any"));
+        assertTrue(responsesContent.contains("public data class RawObject200ApiResponse("));
+        assertTrue(responsesContent.contains("public data class RawObject400ApiResponse("));
+        assertTrue(responsesContent.contains("public data class RawObject500ApiResponse("));
+        assertTrue(responseMapperContent.contains("HttpServerResponseMapper<HttpResponseEntity<Any>>"));
+        assertTrue(responseMapperContent.contains("@Json"));
     }
 
     @Test

--- a/openapi/openapi-generator/src/test/resources/example/petstoreV3_bare_object.yaml
+++ b/openapi/openapi-generator/src/test/resources/example/petstoreV3_bare_object.yaml
@@ -1,0 +1,104 @@
+openapi: 3.0.3
+
+info:
+  title: PetStore with bare object
+  version: 1.0.0
+
+paths:
+  /store/inventory:
+    get:
+      summary: Returns pet inventories by status
+      operationId: getInventory
+      responses:
+        '200':
+          description: A page of pet
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+    post:
+      summary: Stores any inventory payload
+      operationId: storeInventory
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: Stored payload
+          content:
+            application/json:
+              schema:
+                type: object
+        '400':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorMessage"
+        '404':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorMessage"
+        '500':
+          description: Unknown server error
+          content:
+            application/json:
+              schema:
+                type: object
+  /store/raw-object:
+    post:
+      summary: Exchanges any raw object payload
+      operationId: rawObject
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: Raw object response
+          content:
+            application/json:
+              schema:
+                type: object
+        '400':
+          description: Raw object validation error
+          content:
+            application/json:
+              schema:
+                type: object
+        '500':
+          description: Raw object server error
+          content:
+            application/json:
+              schema:
+                type: object
+
+components:
+  schemas:
+    ErrorMessage:
+      type: object
+      required:
+        - message
+      properties:
+        message:
+          type: string
+    Pet:
+      type: object
+      required:
+        - id
+        - metadata
+      properties:
+        id:
+          type: integer
+          format: int64
+        metadata:
+          type: object
+        optionalMetadata:
+          type: object


### PR DESCRIPTION
- Add `rawBodyMode` for bare OpenAPI `object` request/response bodies.
- Default mode is `BYTES`, generating `byte[]` / `ByteArray` for top-level bare object bodies. `RAW` mode generates HTTP body abstractions instead: `HttpBodyOutput` / `HttpBodyInput` depending on client/server direction.
- Also keeps nested model `object` fields as `Object` / `Any`, adds HTTP body mappers, and covers Java/Kotlin client/server generation with bare object request/response tests.

Merge after #712 

---

Client:

```java
  @HttpRoute(
      method = "POST",
      path = "/store/raw-object"
  )
  DefaultApiResponses.RawObjectApiResponse rawObject(@Header HttpHeaders additionalHeaders, byte[] body); // or HttpBodyOutput body
```

```java
 @Generated("io.koraframework.openapi.generator.javagen.ApiResponseGenerator")
  sealed interface RawObjectApiResponse {
    @Generated("io.koraframework.openapi.generator.javagen.ApiResponseGenerator")
    non-sealed interface RawObjectObjectApiResponse extends RawObjectApiResponse {
      byte[] content(); // or HttpBodyInput content

      int statusCode();
    }

    /**
     * Raw object response (status code 200)
     */
    @Generated("io.koraframework.openapi.generator.javagen.ApiResponseGenerator")
    record RawObject200ApiResponse(byte[] content) implements RawObjectObjectApiResponse {
      @Override
      public int statusCode() {
        return 200;
      }
    }

    /**
     * Raw object server error (status code 500)
     */
    @Generated("io.koraframework.openapi.generator.javagen.ApiResponseGenerator")
    record RawObject500ApiResponse(byte[] content) implements RawObjectObjectApiResponse {
      @Override
      public int statusCode() {
        return 500;
      }
    }
  }
```

---

Server:

```java
  @HttpRoute(
      method = "POST",
      path = "/store/raw-object"
  )
  DefaultApiResponses.RawObjectApiResponse rawObject(HttpHeaders _headers, byte[] body) throws Exception; // or HttpBodyInput body
```

```java
  @Generated("io.koraframework.openapi.generator.javagen.ApiResponseGenerator")
  sealed interface RawObjectApiResponse {
    /**
     * Raw object response (status code 200)
     */
    @Generated("io.koraframework.openapi.generator.javagen.ApiResponseGenerator")
    record RawObject200ApiResponse(byte[] content) implements RawObjectApiResponse { // or HttpBodyOutput content
    }

    /**
     * Raw object server error (status code 500)
     */
    @Generated("io.koraframework.openapi.generator.javagen.ApiResponseGenerator")
    record RawObject500ApiResponse(byte[] content) implements RawObjectApiResponse { // or HttpBodyOutput content
    }
  }
```