### PR TITLE
Added Caffeine cache telemetry with Redis-aligned contracts

### DIFF
--- a/cache/cache-annotation-processor/src/main/java/io/koraframework/cache/annotation/processor/CacheAnnotationProcessor.java
+++ b/cache/cache-annotation-processor/src/main/java/io/koraframework/cache/annotation/processor/CacheAnnotationProcessor.java
@@ -29,6 +29,7 @@ public class CacheAnnotationProcessor extends AbstractKoraProcessor {
     private static final ClassName CAFFEINE_CACHE_FACTORY = ClassName.get("io.koraframework.cache.caffeine", "CaffeineCacheFactory");
     private static final ClassName CAFFEINE_CACHE_CONFIG = ClassName.get("io.koraframework.cache.caffeine", "CaffeineCacheConfig");
     private static final ClassName CAFFEINE_CACHE_IMPL = ClassName.get("io.koraframework.cache.caffeine", "AbstractCaffeineCache");
+    private static final ClassName CAFFEINE_TELEMETRY_FACTORY = ClassName.get("io.koraframework.cache.caffeine.telemetry", "CaffeineCacheTelemetryFactory");
 
     private static final ClassName REDIS_TELEMETRY_FACTORY = ClassName.get("io.koraframework.cache.redis.telemetry", "RedisCacheTelemetryFactory");
     private static final ClassName REDIS_CACHE = ClassName.get("io.koraframework.cache.redis", "RedisCache");
@@ -315,7 +316,8 @@ public class CacheAnnotationProcessor extends AbstractKoraProcessor {
                     .addAnnotation(TagUtils.makeAnnotationSpec(ClassName.get(cacheImpl)))
                     .build())
                 .addParameter(CAFFEINE_CACHE_FACTORY, "factory")
-                .addStatement("return new $T(config, factory)", cacheImplName)
+                .addParameter(CAFFEINE_TELEMETRY_FACTORY, "telemetryFactory")
+                .addStatement("return new $T(config, factory, telemetryFactory)", cacheImplName)
                 .returns(TypeName.get(cacheImpl.asType()))
                 .build();
         }
@@ -365,7 +367,8 @@ public class CacheAnnotationProcessor extends AbstractKoraProcessor {
                 .addModifiers(Modifier.PUBLIC)
                 .addParameter(CAFFEINE_CACHE_CONFIG, "config")
                 .addParameter(CAFFEINE_CACHE_FACTORY, "factory")
-                .addStatement("super($S, config, factory)", configPath)
+                .addParameter(CAFFEINE_TELEMETRY_FACTORY, "telemetryFactory")
+                .addStatement("super($S, config, factory, telemetryFactory)", configPath)
                 .build();
         }
 

--- a/cache/cache-annotation-processor/src/test/java/io/koraframework/cache/annotation/processor/CacheOptionalTests.java
+++ b/cache/cache-annotation-processor/src/test/java/io/koraframework/cache/annotation/processor/CacheOptionalTests.java
@@ -40,7 +40,7 @@ public class CacheOptionalTests extends AbstractCacheAnnotationProcessorTests im
         compileResult.assertSuccess();
 
         var cache = newObject("$DummyCache_Impl", CacheRunner.getCaffeineConfig(),
-            caffeineCacheFactory(null));
+            caffeineCacheFactory(null), defaultCaffeineCacheTelemetryFactory(null, null, null, null));
         assertThat(cache).isNotNull();
 
         var service = newObject("$CacheableSync__AopProxy", cache);
@@ -83,10 +83,10 @@ public class CacheOptionalTests extends AbstractCacheAnnotationProcessorTests im
         compileResult.assertSuccess();
 
         var cache1 = newObject("$DummyCache1_Impl", CacheRunner.getCaffeineConfig(),
-            caffeineCacheFactory(null));
+            caffeineCacheFactory(null), defaultCaffeineCacheTelemetryFactory(null, null, null, null));
         assertThat(cache1).isNotNull();
         var cache2 = newObject("$DummyCache2_Impl", CacheRunner.getCaffeineConfig(),
-            caffeineCacheFactory(null));
+            caffeineCacheFactory(null), defaultCaffeineCacheTelemetryFactory(null, null, null, null));
         assertThat(cache2).isNotNull();
 
         var service = newObject("$CacheableSync__AopProxy", cache1, cache2);
@@ -123,7 +123,7 @@ public class CacheOptionalTests extends AbstractCacheAnnotationProcessorTests im
         compileResult.assertSuccess();
 
         var cache = newObject("$DummyCache_Impl", CacheRunner.getCaffeineConfig(),
-            caffeineCacheFactory(null));
+            caffeineCacheFactory(null), defaultCaffeineCacheTelemetryFactory(null, null, null, null));
         assertThat(cache).isNotNull();
 
         var service = newObject("$CacheableSync__AopProxy", cache);
@@ -166,10 +166,10 @@ public class CacheOptionalTests extends AbstractCacheAnnotationProcessorTests im
         compileResult.assertSuccess();
 
         var cache1 = newObject("$DummyCache1_Impl", CacheRunner.getCaffeineConfig(),
-            caffeineCacheFactory(null));
+            caffeineCacheFactory(null), defaultCaffeineCacheTelemetryFactory(null, null, null, null));
         assertThat(cache1).isNotNull();
         var cache2 = newObject("$DummyCache2_Impl", CacheRunner.getCaffeineConfig(),
-            caffeineCacheFactory(null));
+            caffeineCacheFactory(null), defaultCaffeineCacheTelemetryFactory(null, null, null, null));
         assertThat(cache2).isNotNull();
 
         var service = newObject("$CacheableSync__AopProxy", cache1, cache2);
@@ -206,7 +206,7 @@ public class CacheOptionalTests extends AbstractCacheAnnotationProcessorTests im
         compileResult.assertSuccess();
 
         var cache = newObject("$DummyCache_Impl", CacheRunner.getCaffeineConfig(),
-            caffeineCacheFactory(null));
+            caffeineCacheFactory(null), defaultCaffeineCacheTelemetryFactory(null, null, null, null));
         assertThat(cache).isNotNull();
 
         var service = newObject("$CacheableSync__AopProxy", cache);
@@ -249,10 +249,10 @@ public class CacheOptionalTests extends AbstractCacheAnnotationProcessorTests im
         compileResult.assertSuccess();
 
         var cache1 = newObject("$DummyCache1_Impl", CacheRunner.getCaffeineConfig(),
-            caffeineCacheFactory(null));
+            caffeineCacheFactory(null), defaultCaffeineCacheTelemetryFactory(null, null, null, null));
         assertThat(cache1).isNotNull();
         var cache2 = newObject("$DummyCache2_Impl", CacheRunner.getCaffeineConfig(),
-            caffeineCacheFactory(null));
+            caffeineCacheFactory(null), defaultCaffeineCacheTelemetryFactory(null, null, null, null));
         assertThat(cache2).isNotNull();
 
         var service = newObject("$CacheableSync__AopProxy", cache1, cache2);
@@ -295,10 +295,10 @@ public class CacheOptionalTests extends AbstractCacheAnnotationProcessorTests im
         compileResult.assertSuccess();
 
         var cache1 = newObject("$DummyCache1_Impl", CacheRunner.getCaffeineConfig(),
-            caffeineCacheFactory(null));
+            caffeineCacheFactory(null), defaultCaffeineCacheTelemetryFactory(null, null, null, null));
         assertThat(cache1).isNotNull();
         var cache2 = newObject("$DummyCache2_Impl", CacheRunner.getCaffeineConfig(),
-            caffeineCacheFactory(null));
+            caffeineCacheFactory(null), defaultCaffeineCacheTelemetryFactory(null, null, null, null));
         assertThat(cache2).isNotNull();
 
         var service = newObject("$CacheableSync__AopProxy", cache1, cache2);
@@ -341,10 +341,10 @@ public class CacheOptionalTests extends AbstractCacheAnnotationProcessorTests im
         compileResult.assertSuccess();
 
         var cache1 = newObject("$DummyCache1_Impl", CacheRunner.getCaffeineConfig(),
-            caffeineCacheFactory(null));
+            caffeineCacheFactory(null), defaultCaffeineCacheTelemetryFactory(null, null, null, null));
         assertThat(cache1).isNotNull();
         var cache2 = newObject("$DummyCache2_Impl", CacheRunner.getCaffeineConfig(),
-            caffeineCacheFactory(null));
+            caffeineCacheFactory(null), defaultCaffeineCacheTelemetryFactory(null, null, null, null));
         assertThat(cache2).isNotNull();
 
         var service = newObject("$CacheableSync__AopProxy", cache1, cache2);

--- a/cache/cache-annotation-processor/src/test/java/io/koraframework/cache/annotation/processor/CacheRunner.java
+++ b/cache/cache-annotation-processor/src/test/java/io/koraframework/cache/annotation/processor/CacheRunner.java
@@ -1,8 +1,10 @@
 package io.koraframework.cache.annotation.processor;
 
-import io.koraframework.cache.caffeine.$CaffeineCacheConfig_CaffeineTelemetryConfig_CaffeineLoggingConfig_ConfigValueMapper;
-import io.koraframework.cache.caffeine.$CaffeineCacheConfig_CaffeineTelemetryConfig_CaffeineMetricsConfig_ConfigValueMapper;
 import io.koraframework.cache.caffeine.CaffeineCacheConfig;
+import io.koraframework.cache.caffeine.telemetry.CaffeineCacheTelemetryConfig;
+import io.koraframework.cache.caffeine.telemetry.$CaffeineCacheTelemetryConfig_CaffeineCacheLoggingConfig_ConfigValueMapper;
+import io.koraframework.cache.caffeine.telemetry.$CaffeineCacheTelemetryConfig_CaffeineCacheMetricsConfig_ConfigValueMapper;
+import io.koraframework.cache.caffeine.telemetry.$CaffeineCacheTelemetryConfig_CaffeineCacheTracingConfig_ConfigValueMapper;
 import io.koraframework.cache.redis.*;
 import io.koraframework.cache.redis.RedisCacheClient;
 import io.koraframework.cache.redis.telemetry.*;
@@ -22,13 +24,14 @@ final class CacheRunner {
 
     public static CaffeineCacheConfig getCaffeineConfig() {
         var config = Mockito.mock(CaffeineCacheConfig.class);
-        var telemetry = Mockito.mock(CaffeineCacheConfig.CaffeineTelemetryConfig.class);
+        var telemetry = Mockito.mock(CaffeineCacheTelemetryConfig.class);
         when(config.telemetry()).thenReturn(telemetry);
         when(config.maximumSize()).thenReturn(100_000L);
         when(config.expireAfterAccess()).thenReturn(null);
         when(config.expireAfterWrite()).thenReturn(null);
-        when(telemetry.metrics()).thenReturn(new $CaffeineCacheConfig_CaffeineTelemetryConfig_CaffeineMetricsConfig_ConfigValueMapper.CaffeineMetricsConfig_Defaults());
-        when(telemetry.logging()).thenReturn(new $CaffeineCacheConfig_CaffeineTelemetryConfig_CaffeineLoggingConfig_ConfigValueMapper.CaffeineLoggingConfig_Defaults());
+        when(telemetry.metrics()).thenReturn(new $CaffeineCacheTelemetryConfig_CaffeineCacheMetricsConfig_ConfigValueMapper.CaffeineCacheMetricsConfig_Defaults());
+        when(telemetry.logging()).thenReturn(new $CaffeineCacheTelemetryConfig_CaffeineCacheLoggingConfig_ConfigValueMapper.CaffeineCacheLoggingConfig_Defaults());
+        when(telemetry.tracing()).thenReturn(new $CaffeineCacheTelemetryConfig_CaffeineCacheTracingConfig_ConfigValueMapper.CaffeineCacheTracingConfig_Defaults());
         return config;
     }
 

--- a/cache/cache-annotation-processor/src/test/java/io/koraframework/cache/annotation/processor/SyncCacheAopTests.java
+++ b/cache/cache-annotation-processor/src/test/java/io/koraframework/cache/annotation/processor/SyncCacheAopTests.java
@@ -41,7 +41,7 @@ class SyncCacheAopTests implements CaffeineCacheModule {
             final Constructor<?> cacheConstructor = cacheClass.getDeclaredConstructors()[0];
             cacheConstructor.setAccessible(true);
             cache = (DummyCache21) cacheConstructor.newInstance(CacheRunner.getCaffeineConfig(),
-                caffeineCacheFactory(null));
+                caffeineCacheFactory(null), defaultCaffeineCacheTelemetryFactory(null, null, null, null));
 
             var serviceClass = classLoader.loadClass(CACHED_SERVICE);
             if (serviceClass == null) {

--- a/cache/cache-annotation-processor/src/test/java/io/koraframework/cache/annotation/processor/SyncCacheManyAopTests.java
+++ b/cache/cache-annotation-processor/src/test/java/io/koraframework/cache/annotation/processor/SyncCacheManyAopTests.java
@@ -50,7 +50,7 @@ class SyncCacheManyAopTests implements CaffeineCacheModule, RedisCacheModule {
             final Constructor<?> cacheConstructor1 = cacheClass1.getDeclaredConstructors()[0];
             cacheConstructor1.setAccessible(true);
             cache1 = (DummyCache21) cacheConstructor1.newInstance(CacheRunner.getCaffeineConfig(),
-                caffeineCacheFactory(null));
+                caffeineCacheFactory(null), defaultCaffeineCacheTelemetryFactory(null, null, null, null));
 
             var cacheClass2 = classLoader.loadClass(CACHED_IMPL_2);
             if (cacheClass2 == null) {

--- a/cache/cache-annotation-processor/src/test/java/io/koraframework/cache/annotation/processor/SyncCacheOneAopTests.java
+++ b/cache/cache-annotation-processor/src/test/java/io/koraframework/cache/annotation/processor/SyncCacheOneAopTests.java
@@ -41,7 +41,7 @@ class SyncCacheOneAopTests implements CaffeineCacheModule {
             final Constructor<?> cacheConstructor = cacheClass.getDeclaredConstructors()[0];
             cacheConstructor.setAccessible(true);
             cache = (DummyCache11) cacheConstructor.newInstance(CacheRunner.getCaffeineConfig(),
-                caffeineCacheFactory(null));
+                caffeineCacheFactory(null), defaultCaffeineCacheTelemetryFactory(null, null, null, null));
 
             var serviceClass = classLoader.loadClass(CACHED_SERVICE);
             if (serviceClass == null) {

--- a/cache/cache-annotation-processor/src/test/java/io/koraframework/cache/annotation/processor/SyncCacheOneManyAopTests.java
+++ b/cache/cache-annotation-processor/src/test/java/io/koraframework/cache/annotation/processor/SyncCacheOneManyAopTests.java
@@ -48,7 +48,7 @@ class SyncCacheOneManyAopTests implements CaffeineCacheModule, RedisCacheModule 
             final Constructor<?> cacheConstructor1 = cacheClass1.getDeclaredConstructors()[0];
             cacheConstructor1.setAccessible(true);
             cache1 = (DummyCache11) cacheConstructor1.newInstance(CacheRunner.getCaffeineConfig(),
-                caffeineCacheFactory(null));
+                caffeineCacheFactory(null), defaultCaffeineCacheTelemetryFactory(null, null, null, null));
 
             var cacheClass2 = classLoader.loadClass(CACHED_IMPL_2);
             if (cacheClass2 == null) {

--- a/cache/cache-annotation-processor/src/test/java/io/koraframework/cache/annotation/processor/SyncCacheOneManySyncAopTests.java
+++ b/cache/cache-annotation-processor/src/test/java/io/koraframework/cache/annotation/processor/SyncCacheOneManySyncAopTests.java
@@ -45,7 +45,7 @@ class SyncCacheOneManySyncAopTests implements CaffeineCacheModule, RedisCacheMod
             final Constructor<?> cacheConstructor1 = cacheClass1.getDeclaredConstructors()[0];
             cacheConstructor1.setAccessible(true);
             cache1 = (DummyCache11) cacheConstructor1.newInstance(CacheRunner.getCaffeineConfig(),
-                caffeineCacheFactory(null));
+                caffeineCacheFactory(null), defaultCaffeineCacheTelemetryFactory(null, null, null, null));
 
             var cacheClass2 = classLoader.loadClass(CACHED_IMPL_2);
             if (cacheClass2 == null) {
@@ -55,7 +55,7 @@ class SyncCacheOneManySyncAopTests implements CaffeineCacheModule, RedisCacheMod
             final Constructor<?> cacheConstructor2 = cacheClass2.getDeclaredConstructors()[0];
             cacheConstructor2.setAccessible(true);
             cache2 = (DummyCache13) cacheConstructor2.newInstance(CacheRunner.getCaffeineConfig(),
-                caffeineCacheFactory(null));
+                caffeineCacheFactory(null), defaultCaffeineCacheTelemetryFactory(null, null, null, null));
 
             var serviceClass = classLoader.loadClass(CACHED_SERVICE);
             if (serviceClass == null) {

--- a/cache/cache-caffeine/src/main/java/io/koraframework/cache/caffeine/AbstractCaffeineCache.java
+++ b/cache/cache-caffeine/src/main/java/io/koraframework/cache/caffeine/AbstractCaffeineCache.java
@@ -1,33 +1,32 @@
 package io.koraframework.cache.caffeine;
 
 import com.github.benmanes.caffeine.cache.Cache;
+import io.koraframework.cache.caffeine.telemetry.CaffeineCacheTelemetry;
+import io.koraframework.cache.caffeine.telemetry.CaffeineCacheTelemetryFactory;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.slf4j.helpers.NOPLogger;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 
+import static io.koraframework.cache.caffeine.telemetry.CaffeineCacheTelemetry.Operation.*;
+
 @NullMarked
 public abstract class AbstractCaffeineCache<K, V> implements CaffeineCache<K, V> {
 
-    private final String cacheName;
     private final Cache<K, V> caffeine;
-    private final Logger logger;
+    private final CaffeineCacheTelemetry telemetry;
 
     protected AbstractCaffeineCache(String cacheConfigPath,
                                     CaffeineCacheConfig config,
-                                    CaffeineCacheFactory factory) {
-        this.cacheName = cacheConfigPath;
+                                    CaffeineCacheFactory factory,
+                                    CaffeineCacheTelemetryFactory telemetryFactory) {
         this.caffeine = factory.build(cacheConfigPath, config);
-        this.logger = config.telemetry().logging().enabled()
-            ? LoggerFactory.getLogger(getClass())
-            : NOPLogger.NOP_LOGGER;
+        this.telemetry = telemetryFactory.get(cacheConfigPath, getClass(), config.telemetry());
     }
 
     @Override
@@ -37,25 +36,18 @@ public abstract class AbstractCaffeineCache<K, V> implements CaffeineCache<K, V>
             return null;
         }
 
-        V value = caffeine.getIfPresent(key);
-        if (value == null) {
-            if (logger.isTraceEnabled()) {
-                logger.atTrace()
-                    .addKeyValue("cacheName", cacheName)
-                    .addKeyValue("operation", "GET")
-                    .addKeyValue("key", key)
-                    .log("Caffeine Cache operation didn't retrieved value");
-            }
-        } else {
-            if (logger.isDebugEnabled()) {
-                logger.atDebug()
-                    .addKeyValue("cacheName", cacheName)
-                    .addKeyValue("operation", "GET")
-                    .addKeyValue("key", key)
-                    .log("Caffeine Cache operation retrieved value");
-            }
+        var observation = this.telemetry.observe(GET);
+        observation.observeKey(key);
+        try {
+            var value = caffeine.getIfPresent(key);
+            observation.observeValue(value);
+            return value;
+        } catch (Exception e) {
+            observation.observeError(e);
+            throw e;
+        } finally {
+            observation.end();
         }
-        return value;
     }
 
     @Override
@@ -64,107 +56,77 @@ public abstract class AbstractCaffeineCache<K, V> implements CaffeineCache<K, V>
             return Collections.emptyMap();
         }
 
-        var values = caffeine.getAllPresent(keys);
-        if (logger.isTraceEnabled()) {
-            logger.atTrace()
-                .addKeyValue("cacheName", cacheName)
-                .addKeyValue("operation", "GET_MANY")
-                .addKeyValue("keys", keys.size())
-                .addKeyValue("values", values.size())
-                .log("Caffeine Cache operation completed");
+        var observation = this.telemetry.observe(GET_MANY);
+        observation.observeKeys(keys);
+        try {
+            var values = caffeine.getAllPresent(keys);
+            observation.observeValues(values);
+            return values;
+        } catch (Exception e) {
+            observation.observeError(e);
+            throw e;
+        } finally {
+            observation.end();
         }
-        return values;
     }
 
     @Override
     public Map<K, V> getAll() {
-        var values = Collections.unmodifiableMap(caffeine.asMap());
-        if (logger.isTraceEnabled()) {
-            logger.atTrace()
-                .addKeyValue("cacheName", cacheName)
-                .addKeyValue("operation", "GET_ALL")
-                .addKeyValue("values", values.size())
-                .log("Caffeine Cache operation completed");
+        var observation = this.telemetry.observe(GET_ALL);
+        try {
+            var values = Collections.unmodifiableMap(caffeine.asMap());
+            observation.observeValues(values);
+            return values;
+        } catch (Exception e) {
+            observation.observeError(e);
+            throw e;
+        } finally {
+            observation.end();
         }
-        return values;
     }
 
     @Override
     public V computeIfAbsent(K key, Function<K, @Nullable V> mappingFunction) {
         if (key == null) {
-            if (logger.isTraceEnabled()) {
-                logger.atTrace()
-                    .addKeyValue("cacheName", cacheName)
-                    .addKeyValue("operation", "COMPUTE_IF_ABSENT")
-                    .log("Caffeine Cache operation empty key provided, executing mapping function...");
-            }
             return mappingFunction.apply(key);
         }
 
-        if (logger.isTraceEnabled()) {
-            logger.atTrace()
-                .addKeyValue("cacheName", cacheName)
-                .addKeyValue("operation", "COMPUTE_IF_ABSENT")
-                .addKeyValue("key", key)
-                .log("Caffeine Cache operation started...");
+        var observation = this.telemetry.observe(COMPUTE_IF_ABSENT);
+        observation.observeKey(key);
+        try {
+            var value = caffeine.get(key, mappingFunction);
+            observation.observeValue(value);
+            return value;
+        } catch (Exception e) {
+            observation.observeError(e);
+            throw e;
+        } finally {
+            observation.end();
         }
-
-        var value = caffeine.get(key, mappingFunction);
-        if (value == null) {
-            if (logger.isTraceEnabled()) {
-                logger.atTrace()
-                    .addKeyValue("cacheName", cacheName)
-                    .addKeyValue("operation", "COMPUTE_IF_ABSENT")
-                    .addKeyValue("key", key)
-                    .log("Caffeine Cache operation completed without any value");
-            }
-        } else {
-            if (logger.isTraceEnabled()) {
-                logger.atTrace()
-                    .addKeyValue("cacheName", cacheName)
-                    .addKeyValue("operation", "COMPUTE_IF_ABSENT")
-                    .addKeyValue("key", key)
-                    .log("Caffeine Cache operation completed with value");
-            }
-        }
-        return value;
     }
 
     @SuppressWarnings("unchecked")
     @Override
     public Map<K, V> computeIfAbsent(Collection<K> keys, Function<Set<K>, Map<K, V>> mappingFunction) {
         if (keys == null || keys.isEmpty()) {
-            if (logger.isTraceEnabled()) {
-                logger.atTrace()
-                    .addKeyValue("cacheName", cacheName)
-                    .addKeyValue("operation", "COMPUTE_IF_ABSENT_MANY")
-                    .log("Caffeine Cache operation empty keys provided, executing mapping function...");
-            }
             return mappingFunction.apply(Collections.emptySet());
         }
 
-        if (logger.isTraceEnabled()) {
-            logger.atTrace()
-                .addKeyValue("cacheName", cacheName)
-                .addKeyValue("operation", "COMPUTE_IF_ABSENT_MANY")
-                .addKeyValue("keys", keys.size())
-                .log("Caffeine Cache operation started...");
+        var observation = this.telemetry.observe(COMPUTE_IF_ABSENT_MANY);
+        observation.observeKeys(keys);
+        try {
+            var value = caffeine.getAll(keys, ks -> mappingFunction.apply((Set<K>) ks));
+            if (value == null) {
+                value = Collections.emptyMap();
+            }
+            observation.observeValues(value);
+            return value;
+        } catch (Exception e) {
+            observation.observeError(e);
+            throw e;
+        } finally {
+            observation.end();
         }
-
-        var value = caffeine.getAll(keys, ks -> mappingFunction.apply((Set<K>) ks));
-        if (value == null) {
-            value = Collections.emptyMap();
-        }
-
-        if (logger.isTraceEnabled()) {
-            logger.atTrace()
-                .addKeyValue("cacheName", cacheName)
-                .addKeyValue("operation", "COMPUTE_IF_ABSENT_MANY")
-                .addKeyValue("keys", keys.size())
-                .addKeyValue("values", value.size())
-                .log("Caffeine Cache operation completed");
-        }
-        return value;
     }
 
     public V put(K key, V value) {
@@ -172,15 +134,18 @@ public abstract class AbstractCaffeineCache<K, V> implements CaffeineCache<K, V>
             return value;
         }
 
-        caffeine.put(key, value);
-        if (logger.isTraceEnabled()) {
-            logger.atTrace()
-                .addKeyValue("cacheName", cacheName)
-                .addKeyValue("operation", "PUT")
-                .addKeyValue("key", key)
-                .log("Caffeine Cache operation completed");
+        var observation = this.telemetry.observe(PUT);
+        observation.observeKey(key);
+        observation.observeValue(value);
+        try {
+            caffeine.put(key, value);
+            return value;
+        } catch (Exception e) {
+            observation.observeError(e);
+            throw e;
+        } finally {
+            observation.end();
         }
-        return value;
     }
 
     @Override
@@ -189,16 +154,18 @@ public abstract class AbstractCaffeineCache<K, V> implements CaffeineCache<K, V>
             return Collections.emptyMap();
         }
 
-        caffeine.putAll(keyAndValues);
-        if (logger.isTraceEnabled()) {
-            logger.atTrace()
-                .addKeyValue("cacheName", cacheName)
-                .addKeyValue("operation", "PUT_MANY")
-                .addKeyValue("keys", keyAndValues.size())
-                .log("Caffeine Cache operation completed");
+        var observation = this.telemetry.observe(PUT_MANY);
+        observation.observeKeys(keyAndValues.keySet());
+        observation.observeValues(keyAndValues);
+        try {
+            caffeine.putAll(keyAndValues);
+            return keyAndValues;
+        } catch (Exception e) {
+            observation.observeError(e);
+            throw e;
+        } finally {
+            observation.end();
         }
-
-        return keyAndValues;
     }
 
     @Override
@@ -207,13 +174,15 @@ public abstract class AbstractCaffeineCache<K, V> implements CaffeineCache<K, V>
             return;
         }
 
-        caffeine.invalidate(key);
-        if (logger.isTraceEnabled()) {
-            logger.atTrace()
-                .addKeyValue("cacheName", cacheName)
-                .addKeyValue("operation", "INVALIDATE")
-                .addKeyValue("key", key)
-                .log("Caffeine Cache operation completed");
+        var observation = this.telemetry.observe(INVALIDATE);
+        observation.observeKey(key);
+        try {
+            caffeine.invalidate(key);
+        } catch (Exception e) {
+            observation.observeError(e);
+            throw e;
+        } finally {
+            observation.end();
         }
     }
 
@@ -223,24 +192,29 @@ public abstract class AbstractCaffeineCache<K, V> implements CaffeineCache<K, V>
             return;
         }
 
-        caffeine.invalidateAll(keys);
-        if (logger.isTraceEnabled()) {
-            logger.atTrace()
-                .addKeyValue("cacheName", cacheName)
-                .addKeyValue("operation", "INVALIDATE_MANY")
-                .addKeyValue("keys", keys.size())
-                .log("Caffeine Cache operation completed");
+        var observation = this.telemetry.observe(INVALIDATE_MANY);
+        observation.observeKeys(keys);
+        try {
+            caffeine.invalidateAll(keys);
+        } catch (Exception e) {
+            observation.observeError(e);
+            throw e;
+        } finally {
+            observation.end();
         }
     }
 
     @Override
     public void invalidateAll() {
-        caffeine.invalidateAll();
-        if (logger.isDebugEnabled()) {
-            logger.atDebug()
-                .addKeyValue("cacheName", cacheName)
-                .addKeyValue("operation", "INVALIDATE_ALL")
-                .log("Caffeine Cache operation completed");
+        var observation = this.telemetry.observe(INVALIDATE_ALL);
+        try {
+            observation.observeKeys(List.of());
+            caffeine.invalidateAll();
+        } catch (Exception e) {
+            observation.observeError(e);
+            throw e;
+        } finally {
+            observation.end();
         }
     }
 }

--- a/cache/cache-caffeine/src/main/java/io/koraframework/cache/caffeine/CaffeineCacheConfig.java
+++ b/cache/cache-caffeine/src/main/java/io/koraframework/cache/caffeine/CaffeineCacheConfig.java
@@ -1,12 +1,11 @@
 package io.koraframework.cache.caffeine;
 
 
+import io.koraframework.cache.caffeine.telemetry.CaffeineCacheTelemetryConfig;
 import io.koraframework.config.common.annotation.ConfigMapper;
-import io.koraframework.telemetry.common.TelemetryConfig;
 import org.jspecify.annotations.Nullable;
 
 import java.time.Duration;
-import java.util.Map;
 
 @ConfigMapper
 public interface CaffeineCacheConfig {
@@ -24,28 +23,5 @@ public interface CaffeineCacheConfig {
     @Nullable
     Integer initialSize();
 
-    CaffeineTelemetryConfig telemetry();
-
-    @ConfigMapper
-    interface CaffeineTelemetryConfig {
-
-        CaffeineMetricsConfig metrics();
-
-        CaffeineLoggingConfig logging();
-
-        @ConfigMapper
-        interface CaffeineLoggingConfig extends TelemetryConfig.LoggingConfig {}
-
-        @ConfigMapper
-        interface CaffeineMetricsConfig {
-
-            default boolean enabled() {
-                return false;
-            }
-
-            default Map<String, String> tags() {
-                return Map.of();
-            }
-        }
-    }
+    CaffeineCacheTelemetryConfig telemetry();
 }

--- a/cache/cache-caffeine/src/main/java/io/koraframework/cache/caffeine/CaffeineCacheModule.java
+++ b/cache/cache-caffeine/src/main/java/io/koraframework/cache/caffeine/CaffeineCacheModule.java
@@ -1,7 +1,12 @@
 package io.koraframework.cache.caffeine;
 
+import io.koraframework.cache.caffeine.telemetry.CaffeineCacheTelemetryFactory;
+import io.koraframework.cache.caffeine.telemetry.impl.DefaultCaffeineCacheLoggerFactory;
+import io.koraframework.cache.caffeine.telemetry.impl.DefaultCaffeineCacheMetricsFactory;
+import io.koraframework.cache.caffeine.telemetry.impl.DefaultCaffeineCacheTelemetryFactory;
 import io.koraframework.common.annotation.DefaultComponent;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.opentelemetry.api.trace.Tracer;
 import org.jspecify.annotations.Nullable;
 
 public interface CaffeineCacheModule {
@@ -9,5 +14,13 @@ public interface CaffeineCacheModule {
     @DefaultComponent
     default CaffeineCacheFactory caffeineCacheFactory(@Nullable MeterRegistry meterRegistry) {
         return new CaffeineFactory(meterRegistry);
+    }
+
+    @DefaultComponent
+    default CaffeineCacheTelemetryFactory defaultCaffeineCacheTelemetryFactory(@Nullable Tracer tracer,
+                                                                              @Nullable MeterRegistry meterRegistry,
+                                                                              @Nullable DefaultCaffeineCacheLoggerFactory loggerFactory,
+                                                                              @Nullable DefaultCaffeineCacheMetricsFactory metricsFactory) {
+        return new DefaultCaffeineCacheTelemetryFactory(tracer, meterRegistry, loggerFactory, metricsFactory);
     }
 }

--- a/cache/cache-caffeine/src/main/java/io/koraframework/cache/caffeine/telemetry/CaffeineCacheObservation.java
+++ b/cache/cache-caffeine/src/main/java/io/koraframework/cache/caffeine/telemetry/CaffeineCacheObservation.java
@@ -1,0 +1,17 @@
+package io.koraframework.cache.caffeine.telemetry;
+
+import io.koraframework.common.telemetry.Observation;
+
+import java.util.Collection;
+import java.util.Map;
+
+public interface CaffeineCacheObservation extends Observation {
+
+    void observeKey(Object key);
+
+    void observeValue(Object value);
+
+    void observeKeys(Collection<?> keys);
+
+    void observeValues(Map<?, ?> keyToValue);
+}

--- a/cache/cache-caffeine/src/main/java/io/koraframework/cache/caffeine/telemetry/CaffeineCacheTelemetry.java
+++ b/cache/cache-caffeine/src/main/java/io/koraframework/cache/caffeine/telemetry/CaffeineCacheTelemetry.java
@@ -1,0 +1,26 @@
+package io.koraframework.cache.caffeine.telemetry;
+
+public interface CaffeineCacheTelemetry {
+
+    CaffeineCacheObservation observe(Operation operation);
+
+    enum Operation {
+        GET,
+        GET_MANY,
+        GET_ALL,
+        PUT,
+        PUT_MANY,
+        COMPUTE_IF_ABSENT,
+        COMPUTE_IF_ABSENT_MANY,
+        INVALIDATE,
+        INVALIDATE_MANY,
+        INVALIDATE_ALL;
+
+        public boolean hasCacheResult() {
+            return switch (this) {
+                case GET, GET_MANY, GET_ALL, COMPUTE_IF_ABSENT, COMPUTE_IF_ABSENT_MANY -> true;
+                default -> false;
+            };
+        }
+    }
+}

--- a/cache/cache-caffeine/src/main/java/io/koraframework/cache/caffeine/telemetry/CaffeineCacheTelemetryConfig.java
+++ b/cache/cache-caffeine/src/main/java/io/koraframework/cache/caffeine/telemetry/CaffeineCacheTelemetryConfig.java
@@ -1,0 +1,26 @@
+package io.koraframework.cache.caffeine.telemetry;
+
+import io.koraframework.config.common.annotation.ConfigMapper;
+import io.koraframework.telemetry.common.TelemetryConfig;
+
+@ConfigMapper
+public interface CaffeineCacheTelemetryConfig extends TelemetryConfig {
+
+    @Override
+    CaffeineCacheLoggingConfig logging();
+
+    @Override
+    CaffeineCacheTracingConfig tracing();
+
+    @Override
+    CaffeineCacheMetricsConfig metrics();
+
+    @ConfigMapper
+    interface CaffeineCacheTracingConfig extends TelemetryConfig.TracingConfig {}
+
+    @ConfigMapper
+    interface CaffeineCacheLoggingConfig extends TelemetryConfig.LoggingConfig {}
+
+    @ConfigMapper
+    interface CaffeineCacheMetricsConfig extends TelemetryConfig.MetricsConfig {}
+}

--- a/cache/cache-caffeine/src/main/java/io/koraframework/cache/caffeine/telemetry/CaffeineCacheTelemetryFactory.java
+++ b/cache/cache-caffeine/src/main/java/io/koraframework/cache/caffeine/telemetry/CaffeineCacheTelemetryFactory.java
@@ -1,0 +1,6 @@
+package io.koraframework.cache.caffeine.telemetry;
+
+public interface CaffeineCacheTelemetryFactory {
+
+    CaffeineCacheTelemetry get(String cacheConfigPath, Class<?> cacheImpl, CaffeineCacheTelemetryConfig config);
+}

--- a/cache/cache-caffeine/src/main/java/io/koraframework/cache/caffeine/telemetry/impl/DefaultCaffeineCacheLoggerFactory.java
+++ b/cache/cache-caffeine/src/main/java/io/koraframework/cache/caffeine/telemetry/impl/DefaultCaffeineCacheLoggerFactory.java
@@ -1,0 +1,80 @@
+package io.koraframework.cache.caffeine.telemetry.impl;
+
+import io.koraframework.cache.caffeine.telemetry.CaffeineCacheTelemetry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+
+public class DefaultCaffeineCacheLoggerFactory {
+
+    public static final DefaultCaffeineCacheLoggerFactory INSTANCE = new DefaultCaffeineCacheLoggerFactory();
+
+    public DefaultCaffeineCacheLogger create(DefaultCaffeineCacheTelemetry.TelemetryContext context) {
+        var logger = LoggerFactory.getLogger(context.cacheImplCanonicalName());
+        return new DefaultCaffeineCacheLogger(logger, context);
+    }
+
+    public static class DefaultCaffeineCacheLogger {
+
+        protected final Logger logger;
+        protected final DefaultCaffeineCacheTelemetry.TelemetryContext context;
+
+        public DefaultCaffeineCacheLogger(Logger logger, DefaultCaffeineCacheTelemetry.TelemetryContext context) {
+            this.logger = logger;
+            this.context = context;
+        }
+
+        public void logStart(CaffeineCacheTelemetry.Operation operation, Object key) {
+            if (this.logger.isDebugEnabled()) {
+                this.logger.atTrace()
+                    .addKeyValue("operation", operation)
+                    .addKeyValue("cacheConfigPath", this.context.cacheConfigPath())
+                    .addKeyValue("cacheImpl", this.context.cacheImplCanonicalName())
+                    .addKeyValue("key", key)
+                    .log("Caffeine Cache operation started");
+            }
+        }
+
+        public void logStart(CaffeineCacheTelemetry.Operation operation, Collection<?> keys) {
+            if (this.logger.isTraceEnabled()) {
+                this.logger.atTrace()
+                    .addKeyValue("operation", operation)
+                    .addKeyValue("cacheConfigPath", this.context.cacheConfigPath())
+                    .addKeyValue("cacheImpl", this.context.cacheImplCanonicalName())
+                    .addKeyValue("keys", keys.size())
+                    .log("Caffeine Cache operation started");
+            }
+        }
+
+        public void logEnd(CaffeineCacheTelemetry.Operation operation, Throwable error) {
+            if (this.logger.isWarnEnabled()) {
+                this.logger.atWarn()
+                    .addKeyValue("operation", operation)
+                    .addKeyValue("cacheConfigPath", this.context.cacheConfigPath())
+                    .addKeyValue("cacheImpl", this.context.cacheImplCanonicalName())
+                    .log("Caffeine Cache operation failed due to: {}", error.getMessage());
+            }
+        }
+
+        public void logEnd(CaffeineCacheTelemetry.Operation operation, int retrieved, int missed) {
+            if (this.logger.isTraceEnabled()) {
+                var builder = retrieved > 0
+                    ? this.logger.atDebug()
+                    : this.logger.atTrace();
+
+                builder
+                    .addKeyValue("operation", operation)
+                    .addKeyValue("cacheConfigPath", this.context.cacheConfigPath())
+                    .addKeyValue("cacheImpl", this.context.cacheImplCanonicalName());
+
+                if (operation.hasCacheResult()) {
+                    builder.addKeyValue("retrieved", retrieved);
+                    builder.addKeyValue("missed", missed);
+                }
+
+                builder.log("Caffeine Cache operation completed");
+            }
+        }
+    }
+}

--- a/cache/cache-caffeine/src/main/java/io/koraframework/cache/caffeine/telemetry/impl/DefaultCaffeineCacheMetricsFactory.java
+++ b/cache/cache-caffeine/src/main/java/io/koraframework/cache/caffeine/telemetry/impl/DefaultCaffeineCacheMetricsFactory.java
@@ -1,8 +1,17 @@
 package io.koraframework.cache.caffeine.telemetry.impl;
 
 import io.koraframework.cache.caffeine.telemetry.CaffeineCacheTelemetry;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Timer;
+import io.opentelemetry.semconv.ErrorAttributes;
 import org.jspecify.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 public class DefaultCaffeineCacheMetricsFactory {
 
@@ -13,6 +22,9 @@ public class DefaultCaffeineCacheMetricsFactory {
     }
 
     public static class DefaultCaffeineCacheMetrics {
+
+        protected static final String TAG_OPERATION = "operation";
+        protected static final String TAG_ORIGIN = "origin";
 
         public record DurationKey(CaffeineCacheTelemetry.Operation operation,
                                   @Nullable Class<? extends Throwable> errorType,
@@ -43,6 +55,9 @@ public class DefaultCaffeineCacheMetricsFactory {
             }
         }
 
+        protected final ConcurrentMap<DurationKey, Timer> operationDurationCache = new ConcurrentHashMap<>();
+        protected final ConcurrentMap<RatioKey, Counter> ratioCounterCache = new ConcurrentHashMap<>();
+
         protected final DefaultCaffeineCacheTelemetry.TelemetryContext context;
 
         public DefaultCaffeineCacheMetrics(DefaultCaffeineCacheTelemetry.TelemetryContext context) {
@@ -51,10 +66,92 @@ public class DefaultCaffeineCacheMetricsFactory {
 
         public void reportCommandTook(CaffeineCacheTelemetry.Operation operation,
                                       long startedRecordsHandleInNanos,
-                                      @Nullable Throwable error) {}
+                                      @Nullable Throwable error) {
+            // Intentionally empty: Caffeine metrics are exported by the Caffeine inner metrics exporter.
+        }
 
         public void reportRatioChange(CaffeineCacheTelemetry.Operation operation,
                                       RatioType ratioType,
-                                      int change) {}
+                                      int change) {
+            // Intentionally empty: Caffeine metrics are exported by the Caffeine inner metrics exporter.
+        }
+
+        protected DurationKey createMetricOperationDurationKey(CaffeineCacheTelemetry.Operation operation, @Nullable Throwable error) {
+            if (error instanceof CompletionException ce && ce.getCause() != null) {
+                error = ce.getCause();
+            }
+            var errorType = error == null ? null : error.getClass();
+            return new DurationKey(operation, errorType, null);
+        }
+
+        protected RatioKey createMetricRatioCounterKey(CaffeineCacheTelemetry.Operation operation, RatioType ratioType) {
+            return new RatioKey(operation, ratioType, null);
+        }
+
+        // DO NOT ADD DYNAMIC TAGS IN BUILDER, use metric key instead of metric collision will happen
+        protected Timer.Builder createMetricOperationDuration(DurationKey metricKey,
+                                                              CaffeineCacheTelemetry.Operation operation,
+                                                              @Nullable Throwable error) {
+            var extraTags = 0;
+            if (metricKey.extraTags != null) {
+                for (Tag _ : metricKey.extraTags) {
+                    extraTags++;
+                }
+            }
+            var errorValue = error == null ? "" : error.getClass().getCanonicalName();
+            var tags = new ArrayList<Tag>(6 + context.config().metrics().tags().size() + extraTags);
+            tags.add(Tag.of(DefaultCaffeineCacheTelemetry.SYSTEM_CONFIG_PATH, context.cacheConfigPath()));
+            tags.add(Tag.of(DefaultCaffeineCacheTelemetry.SYSTEM_NAME_SIMPLE, context.cacheImplSimpleName()));
+            tags.add(Tag.of(DefaultCaffeineCacheTelemetry.SYSTEM_NAME_CANONICAL, context.cacheImplCanonicalName()));
+            tags.add(Tag.of(TAG_ORIGIN, "caffeine"));
+            for (var e : context.config().metrics().tags().entrySet()) {
+                tags.add(Tag.of(e.getKey(), e.getValue()));
+            }
+
+            // dynamic tags from cache key
+            tags.add(Tag.of(TAG_OPERATION, operation.name()));
+            tags.add(Tag.of(ErrorAttributes.ERROR_TYPE.getKey(), errorValue));
+            if (metricKey.extraTags != null) {
+                for (Tag extraTag : metricKey.extraTags) {
+                    tags.add(extraTag);
+                }
+            }
+
+            return Timer.builder("cache.operation.duration")
+                .serviceLevelObjectives(context.config().metrics().slo())
+                .tags(Tags.of(tags));
+        }
+
+        // DO NOT ADD DYNAMIC TAGS IN BUILDER, use metric key instead of metric collision will happen
+        protected Counter.Builder createMetricRatioCounter(RatioKey metricKey,
+                                                           CaffeineCacheTelemetry.Operation operation,
+                                                           RatioType ratioType) {
+            var extraTags = 0;
+            if (metricKey.extraTags != null) {
+                for (Tag _ : metricKey.extraTags) {
+                    extraTags++;
+                }
+            }
+            var tags = new ArrayList<Tag>(6 + context.config().metrics().tags().size() + extraTags);
+            tags.add(Tag.of(DefaultCaffeineCacheTelemetry.SYSTEM_CONFIG_PATH, context.cacheConfigPath()));
+            tags.add(Tag.of(DefaultCaffeineCacheTelemetry.SYSTEM_NAME_SIMPLE, context.cacheImplSimpleName()));
+            tags.add(Tag.of(DefaultCaffeineCacheTelemetry.SYSTEM_NAME_CANONICAL, context.cacheImplCanonicalName()));
+            tags.add(Tag.of(TAG_ORIGIN, "caffeine"));
+            for (var e : context.config().metrics().tags().entrySet()) {
+                tags.add(Tag.of(e.getKey(), e.getValue()));
+            }
+
+            // dynamic tags from cache key
+            tags.add(Tag.of(TAG_OPERATION, operation.name()));
+            tags.add(Tag.of("type", ratioType.value));
+            if (metricKey.extraTags != null) {
+                for (Tag extraTag : metricKey.extraTags) {
+                    tags.add(extraTag);
+                }
+            }
+
+            return Counter.builder("cache.ratio")
+                .tags(Tags.of(tags));
+        }
     }
 }

--- a/cache/cache-caffeine/src/main/java/io/koraframework/cache/caffeine/telemetry/impl/DefaultCaffeineCacheMetricsFactory.java
+++ b/cache/cache-caffeine/src/main/java/io/koraframework/cache/caffeine/telemetry/impl/DefaultCaffeineCacheMetricsFactory.java
@@ -1,0 +1,60 @@
+package io.koraframework.cache.caffeine.telemetry.impl;
+
+import io.koraframework.cache.caffeine.telemetry.CaffeineCacheTelemetry;
+import io.micrometer.core.instrument.Tags;
+import org.jspecify.annotations.Nullable;
+
+public class DefaultCaffeineCacheMetricsFactory {
+
+    public static final DefaultCaffeineCacheMetricsFactory INSTANCE = new DefaultCaffeineCacheMetricsFactory();
+
+    public DefaultCaffeineCacheMetrics create(DefaultCaffeineCacheTelemetry.TelemetryContext context) {
+        return new DefaultCaffeineCacheMetrics(context);
+    }
+
+    public static class DefaultCaffeineCacheMetrics {
+
+        public record DurationKey(CaffeineCacheTelemetry.Operation operation,
+                                  @Nullable Class<? extends Throwable> errorType,
+                                  @Nullable Tags extraTags) {
+
+            public DurationKey withExtraTags(Tags tags) {
+                return new DurationKey(operation, errorType, tags);
+            }
+        }
+
+        public record RatioKey(CaffeineCacheTelemetry.Operation operation,
+                               RatioType ratioType,
+                               @Nullable Tags extraTags) {
+
+            public RatioKey withExtraTags(Tags tags) {
+                return new RatioKey(operation, ratioType, tags);
+            }
+        }
+
+        public enum RatioType {
+            HIT("hit"),
+            MISS("miss");
+
+            public final String value;
+
+            RatioType(String value) {
+                this.value = value;
+            }
+        }
+
+        protected final DefaultCaffeineCacheTelemetry.TelemetryContext context;
+
+        public DefaultCaffeineCacheMetrics(DefaultCaffeineCacheTelemetry.TelemetryContext context) {
+            this.context = context;
+        }
+
+        public void reportCommandTook(CaffeineCacheTelemetry.Operation operation,
+                                      long startedRecordsHandleInNanos,
+                                      @Nullable Throwable error) {}
+
+        public void reportRatioChange(CaffeineCacheTelemetry.Operation operation,
+                                      RatioType ratioType,
+                                      int change) {}
+    }
+}

--- a/cache/cache-caffeine/src/main/java/io/koraframework/cache/caffeine/telemetry/impl/DefaultCaffeineCacheObservation.java
+++ b/cache/cache-caffeine/src/main/java/io/koraframework/cache/caffeine/telemetry/impl/DefaultCaffeineCacheObservation.java
@@ -1,0 +1,87 @@
+package io.koraframework.cache.caffeine.telemetry.impl;
+
+import io.koraframework.cache.caffeine.telemetry.CaffeineCacheObservation;
+import io.koraframework.cache.caffeine.telemetry.CaffeineCacheTelemetry;
+import io.opentelemetry.api.trace.Span;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Collection;
+import java.util.Map;
+
+public class DefaultCaffeineCacheObservation implements CaffeineCacheObservation {
+
+    protected final CaffeineCacheTelemetry.Operation operation;
+    protected final DefaultCaffeineCacheLoggerFactory.DefaultCaffeineCacheLogger logger;
+
+    @Nullable
+    protected Throwable error;
+    @Nullable
+    protected Object value;
+    @Nullable
+    protected Map<?, ?> values;
+    @Nullable
+    protected Object key;
+    @Nullable
+    protected Collection<?> keys;
+
+    public DefaultCaffeineCacheObservation(CaffeineCacheTelemetry.Operation operation,
+                                           DefaultCaffeineCacheLoggerFactory.DefaultCaffeineCacheLogger logger) {
+        this.operation = operation;
+        this.logger = logger;
+    }
+
+    @Override
+    public void observeKey(Object key) {
+        this.key = key;
+        this.logger.logStart(this.operation, key);
+    }
+
+    @Override
+    public void observeKeys(Collection<?> keys) {
+        this.keys = keys;
+        this.logger.logStart(this.operation, keys);
+    }
+
+    @Override
+    public void observeValue(Object value) {
+        this.value = value;
+    }
+
+    @Override
+    public void observeValues(Map<?, ?> keyToValue) {
+        this.values = keyToValue;
+    }
+
+    @Override
+    public Span span() {
+        return Span.getInvalid();
+    }
+
+    @Override
+    public void end() {
+        if (error != null) {
+            return;
+        }
+
+        var retrieved = 0;
+        var missed = 0;
+        if (operation.hasCacheResult()) {
+            if (value != null) {
+                retrieved = 1;
+            } else if (values != null && !values.isEmpty()) {
+                retrieved = values.size();
+            } else if (key != null) {
+                missed = 1;
+            } else if (keys != null) {
+                missed = keys.size();
+            }
+        }
+        logger.logEnd(operation, retrieved, missed);
+    }
+
+    @Override
+    public void observeError(Throwable e) {
+        this.error = e;
+        this.logger.logEnd(operation, e);
+    }
+}

--- a/cache/cache-caffeine/src/main/java/io/koraframework/cache/caffeine/telemetry/impl/DefaultCaffeineCacheTelemetry.java
+++ b/cache/cache-caffeine/src/main/java/io/koraframework/cache/caffeine/telemetry/impl/DefaultCaffeineCacheTelemetry.java
@@ -1,0 +1,59 @@
+package io.koraframework.cache.caffeine.telemetry.impl;
+
+import io.koraframework.cache.caffeine.telemetry.*;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.opentelemetry.api.trace.Tracer;
+
+public class DefaultCaffeineCacheTelemetry implements CaffeineCacheTelemetry {
+
+    public record TelemetryContext(CaffeineCacheTelemetryConfig config,
+                                   boolean isTracingEnabled,
+                                   boolean isMetricsEnabled,
+                                   MeterRegistry meterRegistry,
+                                   Tracer tracer,
+                                   String cacheConfigPath,
+                                   String cacheImplCanonicalName,
+                                   String cacheImplSimpleName) {
+
+        public static final TelemetryContext EMPTY = new TelemetryContext(new $CaffeineCacheTelemetryConfig_ConfigValueMapper.CaffeineCacheTelemetryConfig_Impl(
+            new $CaffeineCacheTelemetryConfig_CaffeineCacheLoggingConfig_ConfigValueMapper.CaffeineCacheLoggingConfig_Defaults(),
+            new $CaffeineCacheTelemetryConfig_CaffeineCacheTracingConfig_ConfigValueMapper.CaffeineCacheTracingConfig_Defaults(),
+            new $CaffeineCacheTelemetryConfig_CaffeineCacheMetricsConfig_ConfigValueMapper.CaffeineCacheMetricsConfig_Defaults()
+        ), false, false, DefaultCaffeineCacheTelemetryFactory.NOOP_METER_REGISTRY, DefaultCaffeineCacheTelemetryFactory.NOOP_TRACER, "", "", "");
+    }
+
+    public static final String SYSTEM_CONFIG_PATH = "system.config";
+    public static final String SYSTEM_NAME_SIMPLE = "system.name.simple";
+    public static final String SYSTEM_NAME_CANONICAL = "system.name.canonical";
+
+    protected final TelemetryContext context;
+    protected final DefaultCaffeineCacheLoggerFactory.DefaultCaffeineCacheLogger logger;
+
+    public DefaultCaffeineCacheTelemetry(String cacheConfigPath,
+                                         Class<?> cacheImpl,
+                                         CaffeineCacheTelemetryConfig config,
+                                         Tracer tracer,
+                                         MeterRegistry meterRegistry,
+                                         DefaultCaffeineCacheMetricsFactory metricsFactory,
+                                         DefaultCaffeineCacheLoggerFactory loggerFactory) {
+        var isTracingEnabled = config.tracing().enabled() && tracer != DefaultCaffeineCacheTelemetryFactory.NOOP_TRACER;
+        var isMetricsEnabled = config.metrics().enabled() && meterRegistry != DefaultCaffeineCacheTelemetryFactory.NOOP_METER_REGISTRY;
+
+        this.context = new TelemetryContext(config,
+            isTracingEnabled,
+            isMetricsEnabled,
+            meterRegistry,
+            tracer,
+            cacheConfigPath,
+            cacheImpl.getCanonicalName(),
+            cacheImpl.getSimpleName()
+        );
+
+        this.logger = loggerFactory.create(this.context);
+    }
+
+    @Override
+    public CaffeineCacheObservation observe(Operation operation) {
+        return new DefaultCaffeineCacheObservation(operation, logger);
+    }
+}

--- a/cache/cache-caffeine/src/main/java/io/koraframework/cache/caffeine/telemetry/impl/DefaultCaffeineCacheTelemetryFactory.java
+++ b/cache/cache-caffeine/src/main/java/io/koraframework/cache/caffeine/telemetry/impl/DefaultCaffeineCacheTelemetryFactory.java
@@ -1,0 +1,76 @@
+package io.koraframework.cache.caffeine.telemetry.impl;
+
+import io.koraframework.cache.caffeine.telemetry.CaffeineCacheTelemetry;
+import io.koraframework.cache.caffeine.telemetry.CaffeineCacheTelemetryConfig;
+import io.koraframework.cache.caffeine.telemetry.CaffeineCacheTelemetryFactory;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.api.trace.TracerProvider;
+import org.jspecify.annotations.Nullable;
+
+public class DefaultCaffeineCacheTelemetryFactory implements CaffeineCacheTelemetryFactory {
+
+    public static final Tracer NOOP_TRACER = TracerProvider.noop().get("caffeine");
+    public static final MeterRegistry NOOP_METER_REGISTRY = new CompositeMeterRegistry();
+
+    @Nullable
+    private final Tracer tracer;
+    @Nullable
+    private final MeterRegistry meterRegistry;
+    @Nullable
+    private final DefaultCaffeineCacheLoggerFactory loggerFactory;
+    @Nullable
+    private final DefaultCaffeineCacheMetricsFactory metricsFactory;
+
+    public DefaultCaffeineCacheTelemetryFactory(@Nullable Tracer tracer,
+                                                @Nullable MeterRegistry meterRegistry,
+                                                @Nullable DefaultCaffeineCacheLoggerFactory loggerFactory,
+                                                @Nullable DefaultCaffeineCacheMetricsFactory metricsFactory) {
+        this.tracer = tracer;
+        this.meterRegistry = meterRegistry;
+        this.loggerFactory = loggerFactory;
+        this.metricsFactory = metricsFactory;
+    }
+
+    @Override
+    public CaffeineCacheTelemetry get(String cacheConfigPath, Class<?> cacheImpl, CaffeineCacheTelemetryConfig config) {
+        var traceEnabled = this.tracer != null && config.tracing().enabled();
+        var metricEnabled = this.meterRegistry != null && config.metrics().enabled();
+        if (!traceEnabled && !metricEnabled && !config.logging().enabled()) {
+            return NoopCaffeineCacheTelemetry.INSTANCE;
+        }
+
+        var tracer = traceEnabled ? this.tracer : NOOP_TRACER;
+        var meterRegistry = metricEnabled ? this.meterRegistry : NOOP_METER_REGISTRY;
+        final DefaultCaffeineCacheMetricsFactory enabledMetricsFactory;
+        if (metricEnabled) {
+            enabledMetricsFactory = this.metricsFactory != null
+                ? this.metricsFactory
+                : DefaultCaffeineCacheMetricsFactory.INSTANCE;
+        } else {
+            enabledMetricsFactory = NoopCaffeineCacheMetricsFactory.INSTANCE;
+        }
+
+        final DefaultCaffeineCacheLoggerFactory enabledLoggerFactory;
+        if (config.logging().enabled()) {
+            enabledLoggerFactory = this.loggerFactory != null
+                ? this.loggerFactory
+                : DefaultCaffeineCacheLoggerFactory.INSTANCE;
+        } else {
+            enabledLoggerFactory = NoopCaffeineCacheLoggerFactory.INSTANCE;
+        }
+
+        return build(cacheConfigPath, cacheImpl, config, tracer, meterRegistry, enabledMetricsFactory, enabledLoggerFactory);
+    }
+
+    protected CaffeineCacheTelemetry build(String cacheConfigPath,
+                                           Class<?> cacheImpl,
+                                           CaffeineCacheTelemetryConfig config,
+                                           Tracer tracer,
+                                           MeterRegistry meterRegistry,
+                                           DefaultCaffeineCacheMetricsFactory metricsFactory,
+                                           DefaultCaffeineCacheLoggerFactory loggerFactory) {
+        return new DefaultCaffeineCacheTelemetry(cacheConfigPath, cacheImpl, config, tracer, meterRegistry, metricsFactory, loggerFactory);
+    }
+}

--- a/cache/cache-caffeine/src/main/java/io/koraframework/cache/caffeine/telemetry/impl/NoopCaffeineCacheLoggerFactory.java
+++ b/cache/cache-caffeine/src/main/java/io/koraframework/cache/caffeine/telemetry/impl/NoopCaffeineCacheLoggerFactory.java
@@ -1,0 +1,22 @@
+package io.koraframework.cache.caffeine.telemetry.impl;
+
+import org.slf4j.helpers.NOPLogger;
+
+public final class NoopCaffeineCacheLoggerFactory extends DefaultCaffeineCacheLoggerFactory {
+
+    public static final NoopCaffeineCacheLoggerFactory INSTANCE = new NoopCaffeineCacheLoggerFactory();
+
+    private NoopCaffeineCacheLoggerFactory() {}
+
+    @Override
+    public DefaultCaffeineCacheLogger create(DefaultCaffeineCacheTelemetry.TelemetryContext context) {
+        return new NoopCaffeineCacheLogger();
+    }
+
+    private static final class NoopCaffeineCacheLogger extends DefaultCaffeineCacheLogger {
+
+        private NoopCaffeineCacheLogger() {
+            super(NOPLogger.NOP_LOGGER, DefaultCaffeineCacheTelemetry.TelemetryContext.EMPTY);
+        }
+    }
+}

--- a/cache/cache-caffeine/src/main/java/io/koraframework/cache/caffeine/telemetry/impl/NoopCaffeineCacheMetricsFactory.java
+++ b/cache/cache-caffeine/src/main/java/io/koraframework/cache/caffeine/telemetry/impl/NoopCaffeineCacheMetricsFactory.java
@@ -1,0 +1,13 @@
+package io.koraframework.cache.caffeine.telemetry.impl;
+
+public final class NoopCaffeineCacheMetricsFactory extends DefaultCaffeineCacheMetricsFactory {
+
+    public static final NoopCaffeineCacheMetricsFactory INSTANCE = new NoopCaffeineCacheMetricsFactory();
+
+    private NoopCaffeineCacheMetricsFactory() {}
+
+    @Override
+    public DefaultCaffeineCacheMetrics create(DefaultCaffeineCacheTelemetry.TelemetryContext context) {
+        return new DefaultCaffeineCacheMetrics(DefaultCaffeineCacheTelemetry.TelemetryContext.EMPTY);
+    }
+}

--- a/cache/cache-caffeine/src/main/java/io/koraframework/cache/caffeine/telemetry/impl/NoopCaffeineCacheObservation.java
+++ b/cache/cache-caffeine/src/main/java/io/koraframework/cache/caffeine/telemetry/impl/NoopCaffeineCacheObservation.java
@@ -1,0 +1,37 @@
+package io.koraframework.cache.caffeine.telemetry.impl;
+
+import io.koraframework.cache.caffeine.telemetry.CaffeineCacheObservation;
+import io.opentelemetry.api.trace.Span;
+
+import java.util.Collection;
+import java.util.Map;
+
+public final class NoopCaffeineCacheObservation implements CaffeineCacheObservation {
+
+    public static final NoopCaffeineCacheObservation INSTANCE = new NoopCaffeineCacheObservation();
+
+    private NoopCaffeineCacheObservation() {}
+
+    @Override
+    public void observeKey(Object key) {}
+
+    @Override
+    public void observeValue(Object value) {}
+
+    @Override
+    public void observeKeys(Collection<?> keys) {}
+
+    @Override
+    public void observeValues(Map<?, ?> keyToValue) {}
+
+    @Override
+    public void observeError(Throwable e) {}
+
+    @Override
+    public void end() {}
+
+    @Override
+    public Span span() {
+        return Span.getInvalid();
+    }
+}

--- a/cache/cache-caffeine/src/main/java/io/koraframework/cache/caffeine/telemetry/impl/NoopCaffeineCacheTelemetry.java
+++ b/cache/cache-caffeine/src/main/java/io/koraframework/cache/caffeine/telemetry/impl/NoopCaffeineCacheTelemetry.java
@@ -1,0 +1,16 @@
+package io.koraframework.cache.caffeine.telemetry.impl;
+
+import io.koraframework.cache.caffeine.telemetry.CaffeineCacheObservation;
+import io.koraframework.cache.caffeine.telemetry.CaffeineCacheTelemetry;
+
+public final class NoopCaffeineCacheTelemetry implements CaffeineCacheTelemetry {
+
+    public static final NoopCaffeineCacheTelemetry INSTANCE = new NoopCaffeineCacheTelemetry();
+
+    private NoopCaffeineCacheTelemetry() {}
+
+    @Override
+    public CaffeineCacheObservation observe(Operation operation) {
+        return NoopCaffeineCacheObservation.INSTANCE;
+    }
+}

--- a/cache/cache-caffeine/src/main/java/module-info.java
+++ b/cache/cache-caffeine/src/main/java/module-info.java
@@ -10,4 +10,6 @@ module kora.cache.caffeine {
     requires transitive kora.cache.common;
 
     exports io.koraframework.cache.caffeine;
+    exports io.koraframework.cache.caffeine.telemetry;
+    exports io.koraframework.cache.caffeine.telemetry.impl;
 }

--- a/cache/cache-caffeine/src/test/java/io/koraframework/cache/caffeine/CacheRunner.java
+++ b/cache/cache-caffeine/src/test/java/io/koraframework/cache/caffeine/CacheRunner.java
@@ -1,5 +1,9 @@
 package io.koraframework.cache.caffeine;
 
+import io.koraframework.cache.caffeine.telemetry.CaffeineCacheTelemetryConfig;
+import io.koraframework.cache.caffeine.telemetry.$CaffeineCacheTelemetryConfig_CaffeineCacheLoggingConfig_ConfigValueMapper;
+import io.koraframework.cache.caffeine.telemetry.$CaffeineCacheTelemetryConfig_CaffeineCacheMetricsConfig_ConfigValueMapper;
+import io.koraframework.cache.caffeine.telemetry.$CaffeineCacheTelemetryConfig_CaffeineCacheTracingConfig_ConfigValueMapper;
 import io.koraframework.cache.caffeine.testdata.DummyCache;
 import org.junit.jupiter.api.Assertions;
 import org.mockito.Mockito;
@@ -9,48 +13,19 @@ import static org.mockito.Mockito.when;
 abstract class CacheRunner extends Assertions implements CaffeineCacheModule {
     public static CaffeineCacheConfig getConfig() {
         var config = Mockito.mock(CaffeineCacheConfig.class);
-        var telemetry = Mockito.mock(CaffeineCacheConfig.CaffeineTelemetryConfig.class);
+        var telemetry = Mockito.mock(CaffeineCacheTelemetryConfig.class);
         when(config.telemetry()).thenReturn(telemetry);
         when(config.maximumSize()).thenReturn(100_000L);
         when(config.expireAfterAccess()).thenReturn(null);
         when(config.expireAfterWrite()).thenReturn(null);
-        when(telemetry.metrics()).thenReturn(new $CaffeineCacheConfig_CaffeineTelemetryConfig_CaffeineMetricsConfig_ConfigValueMapper.CaffeineMetricsConfig_Defaults());
-        when(telemetry.logging()).thenReturn(new $CaffeineCacheConfig_CaffeineTelemetryConfig_CaffeineLoggingConfig_ConfigValueMapper.CaffeineLoggingConfig_Defaults());
+        when(telemetry.metrics()).thenReturn(new $CaffeineCacheTelemetryConfig_CaffeineCacheMetricsConfig_ConfigValueMapper.CaffeineCacheMetricsConfig_Defaults());
+        when(telemetry.logging()).thenReturn(new $CaffeineCacheTelemetryConfig_CaffeineCacheLoggingConfig_ConfigValueMapper.CaffeineCacheLoggingConfig_Defaults());
+        when(telemetry.tracing()).thenReturn(new $CaffeineCacheTelemetryConfig_CaffeineCacheTracingConfig_ConfigValueMapper.CaffeineCacheTracingConfig_Defaults());
         return config;
     }
-//    public static CaffeineCacheConfig getConfig() {
-//        return new CaffeineCacheConfig() {
-//            @Nullable
-//            @Override
-//            public Duration expireAfterWrite() {
-//                return null;
-//            }
-//
-//            @Nullable
-//            @Override
-//            public Duration expireAfterAccess() {
-//                return null;
-//            }
-//
-//            @Nullable
-//            @Override
-//            public Integer initialSize() {
-//                return null;
-//            }
-//
-//            @Override
-//            public CaffeineTelemetryConfig telemetry() {
-//                return new $CaffeineCacheConfig_CaffeineTelemetryConfig_ConfigValueMapper.CaffeineTelemetryConfig_Impl(
-//                    new $CaffeineCacheConfig_CaffeineTelemetryConfig_CaffeineMetricsConfig_ConfigValueMapper.CaffeineMetricsConfig_Defaults(),
-//                    new $CaffeineCacheConfig_CaffeineTelemetryConfig_CaffeineLoggingConfig_ConfigValueMapper.CaffeineLoggingConfig_Defaults()
-//                );
-//            }
-//        };
-//    }
-
     protected DummyCache createCache() {
         try {
-            return new DummyCache(getConfig(), caffeineCacheFactory(null));
+            return new DummyCache(getConfig(), caffeineCacheFactory(null), defaultCaffeineCacheTelemetryFactory(null, null, null, null));
         } catch (Exception e) {
             throw new IllegalStateException(e);
         }

--- a/cache/cache-caffeine/src/test/java/io/koraframework/cache/caffeine/testdata/DummyCache.java
+++ b/cache/cache-caffeine/src/test/java/io/koraframework/cache/caffeine/testdata/DummyCache.java
@@ -3,10 +3,11 @@ package io.koraframework.cache.caffeine.testdata;
 import io.koraframework.cache.caffeine.AbstractCaffeineCache;
 import io.koraframework.cache.caffeine.CaffeineCacheConfig;
 import io.koraframework.cache.caffeine.CaffeineCacheFactory;
+import io.koraframework.cache.caffeine.telemetry.CaffeineCacheTelemetryFactory;
 
 public final class DummyCache extends AbstractCaffeineCache<String, String> {
 
-    public DummyCache(CaffeineCacheConfig config, CaffeineCacheFactory factory) {
-        super("dummy", config, factory);
+    public DummyCache(CaffeineCacheConfig config, CaffeineCacheFactory factory, CaffeineCacheTelemetryFactory telemetryFactory) {
+        super("dummy", config, factory, telemetryFactory);
     }
 }

--- a/cache/cache-symbol-processor/src/main/kotlin/io/koraframework/cache/symbol/processor/CacheSymbolProcessor.kt
+++ b/cache/cache-symbol-processor/src/main/kotlin/io/koraframework/cache/symbol/processor/CacheSymbolProcessor.kt
@@ -41,6 +41,7 @@ class CacheSymbolProcessor(
         private val CAFFEINE_CACHE_FACTORY = ClassName("io.koraframework.cache.caffeine", "CaffeineCacheFactory")
         private val CAFFEINE_CACHE_CONFIG = ClassName("io.koraframework.cache.caffeine", "CaffeineCacheConfig")
         private val CAFFEINE_CACHE_IMPL = ClassName("io.koraframework.cache.caffeine", "AbstractCaffeineCache")
+        private val CAFFEINE_TELEMETRY_FACTORY = ClassName("io.koraframework.cache.caffeine.telemetry", "CaffeineCacheTelemetryFactory")
 
         private val REDIS_TELEMETRY_FACTORY = ClassName("io.koraframework.cache.redis.telemetry", "RedisCacheTelemetryFactory")
         private val REDIS_CACHE = ClassName("io.koraframework.cache.redis", "RedisCache")
@@ -256,7 +257,8 @@ class CacheSymbolProcessor(
                             .build()
                     )
                     .addParameter("factory", CAFFEINE_CACHE_FACTORY)
-                    .addStatement("return %T(config, factory)", cacheImplName)
+                    .addParameter("telemetryFactory", CAFFEINE_TELEMETRY_FACTORY)
+                    .addStatement("return %T(config, factory, telemetryFactory)", cacheImplName)
                     .returns(cacheTypeName)
                     .build()
             }
@@ -307,6 +309,7 @@ class CacheSymbolProcessor(
                 FunSpec.constructorBuilder()
                     .addParameter("config", CAFFEINE_CACHE_CONFIG)
                     .addParameter("factory", CAFFEINE_CACHE_FACTORY)
+                    .addParameter("telemetryFactory", CAFFEINE_TELEMETRY_FACTORY)
                     .build()
             }
 
@@ -421,10 +424,9 @@ class CacheSymbolProcessor(
             ?.findValueNoDefault<String>("value")!!
 
         return when (cacheType.rawType) {
-            CAFFEINE_CACHE -> CodeBlock.of("%S, config, factory", configPath)
+            CAFFEINE_CACHE -> CodeBlock.of("%S, config, factory, telemetryFactory", configPath)
             REDIS_CACHE -> CodeBlock.of("%S, config, redisClient, telemetryFactory, keyMapper, valueMapper", configPath)
             else -> throw IllegalArgumentException("Unknown cache type: ${cacheType.rawType}")
         }
     }
 }
-

--- a/cache/cache-symbol-processor/src/test/kotlin/io/koraframework/cache/symbol/processor/CacheRunner.kt
+++ b/cache/cache-symbol-processor/src/test/kotlin/io/koraframework/cache/symbol/processor/CacheRunner.kt
@@ -1,9 +1,10 @@
 package io.koraframework.cache.symbol.processor
 
-import io.koraframework.cache.caffeine.`$CaffeineCacheConfig_CaffeineTelemetryConfig_CaffeineLoggingConfig_ConfigValueMapper`
-import io.koraframework.cache.caffeine.`$CaffeineCacheConfig_CaffeineTelemetryConfig_CaffeineMetricsConfig_ConfigValueMapper`
 import io.koraframework.cache.caffeine.CaffeineCacheConfig
-import io.koraframework.cache.caffeine.CaffeineCacheConfig.CaffeineTelemetryConfig
+import io.koraframework.cache.caffeine.telemetry.CaffeineCacheTelemetryConfig
+import io.koraframework.cache.caffeine.telemetry.`$CaffeineCacheTelemetryConfig_CaffeineCacheLoggingConfig_ConfigValueMapper`
+import io.koraframework.cache.caffeine.telemetry.`$CaffeineCacheTelemetryConfig_CaffeineCacheMetricsConfig_ConfigValueMapper`
+import io.koraframework.cache.caffeine.telemetry.`$CaffeineCacheTelemetryConfig_CaffeineCacheTracingConfig_ConfigValueMapper`
 import io.koraframework.cache.redis.*
 import io.koraframework.cache.redis.RedisCacheClient
 import io.koraframework.cache.redis.telemetry.`$RedisCacheTelemetryConfig_ConfigValueMapper`
@@ -25,13 +26,14 @@ class CacheRunner {
 
         fun getCaffeineConfig(): CaffeineCacheConfig {
             val config = Mockito.mock(CaffeineCacheConfig::class.java)
-            val telemetry = Mockito.mock(CaffeineTelemetryConfig::class.java)
+            val telemetry = Mockito.mock(CaffeineCacheTelemetryConfig::class.java)
             `when`(config.telemetry()).thenReturn(telemetry)
             `when`(config.maximumSize()).thenReturn(100000L)
             `when`(config.expireAfterAccess()).thenReturn(null)
             `when`(config.expireAfterWrite()).thenReturn(null)
-            `when`(telemetry.metrics()).thenReturn(`$CaffeineCacheConfig_CaffeineTelemetryConfig_CaffeineMetricsConfig_ConfigValueMapper`.CaffeineMetricsConfig_Defaults())
-            `when`(telemetry.logging()).thenReturn(`$CaffeineCacheConfig_CaffeineTelemetryConfig_CaffeineLoggingConfig_ConfigValueMapper`.CaffeineLoggingConfig_Defaults())
+            `when`(telemetry.metrics()).thenReturn(`$CaffeineCacheTelemetryConfig_CaffeineCacheMetricsConfig_ConfigValueMapper`.CaffeineCacheMetricsConfig_Defaults())
+            `when`(telemetry.logging()).thenReturn(`$CaffeineCacheTelemetryConfig_CaffeineCacheLoggingConfig_ConfigValueMapper`.CaffeineCacheLoggingConfig_Defaults())
+            `when`(telemetry.tracing()).thenReturn(`$CaffeineCacheTelemetryConfig_CaffeineCacheTracingConfig_ConfigValueMapper`.CaffeineCacheTracingConfig_Defaults())
             return config
         }
 

--- a/cache/cache-symbol-processor/src/test/kotlin/io/koraframework/cache/symbol/processor/SyncCacheAopTests.kt
+++ b/cache/cache-symbol-processor/src/test/kotlin/io/koraframework/cache/symbol/processor/SyncCacheAopTests.kt
@@ -37,7 +37,8 @@ class SyncCacheAopTests : CaffeineCacheModule {
             val cacheClass = classLoader.loadClass(CACHE_CLASS) ?: throw IllegalArgumentException("Expected class not found: $CACHE_CLASS")
             cache = cacheClass.constructors[0].newInstance(
                 CacheRunner.getCaffeineConfig(),
-                caffeineCacheFactory(null)
+                caffeineCacheFactory(null),
+                defaultCaffeineCacheTelemetryFactory(null, null, null, null)
             ) as DummyCache21
 
             val serviceClass = classLoader.loadClass(SERVICE_CLASS) ?: throw IllegalArgumentException("Expected class not found: $SERVICE_CLASS")

--- a/cache/cache-symbol-processor/src/test/kotlin/io/koraframework/cache/symbol/processor/SyncCacheManyAopTests.kt
+++ b/cache/cache-symbol-processor/src/test/kotlin/io/koraframework/cache/symbol/processor/SyncCacheManyAopTests.kt
@@ -45,7 +45,8 @@ class SyncCacheManyAopTests : CaffeineCacheModule, RedisCacheModule {
             val cache1Class = classLoader.loadClass(CACHE1_CLASS) ?: throw IllegalArgumentException("Expected class not found: $CACHE1_CLASS")
             cache1 = cache1Class.constructors[0].newInstance(
                 CacheRunner.getCaffeineConfig(),
-                caffeineCacheFactory(null)
+                caffeineCacheFactory(null),
+                defaultCaffeineCacheTelemetryFactory(null, null, null, null)
             ) as DummyCache21
 
             val cache2Class = classLoader.loadClass(CACHE2_CLASS) ?: throw IllegalArgumentException("Expected class not found: $CACHE2_CLASS")

--- a/cache/cache-symbol-processor/src/test/kotlin/io/koraframework/cache/symbol/processor/SyncCacheOneAopTests.kt
+++ b/cache/cache-symbol-processor/src/test/kotlin/io/koraframework/cache/symbol/processor/SyncCacheOneAopTests.kt
@@ -36,7 +36,8 @@ class SyncCacheOneAopTests : CaffeineCacheModule {
             val cacheClass = classLoader.loadClass(CACHE_CLASS) ?: throw IllegalArgumentException("Expected class not found: $CACHE_CLASS")
             cache = cacheClass.constructors[0].newInstance(
                 CacheRunner.getCaffeineConfig(),
-                caffeineCacheFactory(null)
+                caffeineCacheFactory(null),
+                defaultCaffeineCacheTelemetryFactory(null, null, null, null)
             ) as DummyCache11
 
             val serviceClass = classLoader.loadClass(SERVICE_CLASS) ?: throw IllegalArgumentException("Expected class not found: $SERVICE_CLASS")

--- a/cache/cache-symbol-processor/src/test/kotlin/io/koraframework/cache/symbol/processor/SyncCacheOneManyAopTests.kt
+++ b/cache/cache-symbol-processor/src/test/kotlin/io/koraframework/cache/symbol/processor/SyncCacheOneManyAopTests.kt
@@ -42,7 +42,8 @@ class SyncCacheOneManyAopTests : CaffeineCacheModule, RedisCacheModule {
             val cache1Class = classLoader.loadClass(CACHE1_CLASS) ?: throw IllegalArgumentException("Expected class not found: $CACHE1_CLASS")
             cache1 = cache1Class.constructors[0].newInstance(
                 CacheRunner.getCaffeineConfig(),
-                caffeineCacheFactory(null)
+                caffeineCacheFactory(null),
+                defaultCaffeineCacheTelemetryFactory(null, null, null, null)
             ) as DummyCache11
 
             val cache = mutableMapOf<ByteBuffer?, ByteBuffer?>()


### PR DESCRIPTION
- adds `CaffeineCacheTelemetry`, Observation, Config, Factory, and default/noop implementations;
- moves `AbstractCaffeineCache` logging through telemetry observation;
- keeps Caffeine tracing lightweight with `Span.getInvalid()` by default;
- keeps default `Caffeine metrics` as an empty factory;
- introduces enum-based cache operations for both Caffeine and Redis telemetry;
- updates Java/KSP cache processors to inject `CaffeineCacheTelemetryFactory`;
- updates tests for new constructor and telemetry contracts.