### PR TITLE
Updated Redis cache telemetry operation handling

### DIFF
--- a/cache/cache-redis-lettuce/src/main/java/io/koraframework/cache/redis/AbstractRedisCache.java
+++ b/cache/cache-redis-lettuce/src/main/java/io/koraframework/cache/redis/AbstractRedisCache.java
@@ -16,6 +16,8 @@ import java.util.concurrent.CompletionException;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static io.koraframework.cache.redis.telemetry.RedisCacheTelemetry.Operation.*;
+
 public abstract class AbstractRedisCache<K, V> implements RedisCache<K, V> {
 
     private final Logger logger;
@@ -70,7 +72,7 @@ public abstract class AbstractRedisCache<K, V> implements RedisCache<K, V> {
             return null;
         }
 
-        var observation = this.telemetry.observe("GET");
+        var observation = this.telemetry.observe(GET);
         return ScopedValue
             .where(Observation.VALUE, observation)
             .where(OpentelemetryContext.VALUE, Context.current().with(observation.span()))
@@ -103,7 +105,7 @@ public abstract class AbstractRedisCache<K, V> implements RedisCache<K, V> {
             return Collections.emptyMap();
         }
 
-        var observation = this.telemetry.observe("GET_MANY");
+        var observation = this.telemetry.observe(GET_MANY);
         return ScopedValue
             .where(Observation.VALUE, observation)
             .where(OpentelemetryContext.VALUE, Context.current().with(observation.span()))
@@ -148,7 +150,7 @@ public abstract class AbstractRedisCache<K, V> implements RedisCache<K, V> {
             return null;
         }
 
-        var observation = this.telemetry.observe("PUT");
+        var observation = this.telemetry.observe(PUT);
         return ScopedValue
             .where(Observation.VALUE, observation)
             .where(OpentelemetryContext.VALUE, Context.current().with(observation.span()))
@@ -182,7 +184,7 @@ public abstract class AbstractRedisCache<K, V> implements RedisCache<K, V> {
             return Collections.emptyMap();
         }
 
-        var observation = this.telemetry.observe("PUT_MANY");
+        var observation = this.telemetry.observe(PUT_MANY);
         return ScopedValue
             .where(Observation.VALUE, observation)
             .where(OpentelemetryContext.VALUE, Context.current().with(observation.span()))
@@ -229,7 +231,7 @@ public abstract class AbstractRedisCache<K, V> implements RedisCache<K, V> {
             return mappingFunction.apply(key);
         }
 
-        var observation = this.telemetry.observe("COMPUTE_IF_ABSENT");
+        var observation = this.telemetry.observe(COMPUTE_IF_ABSENT);
         return ScopedValue
             .where(Observation.VALUE, observation)
             .where(OpentelemetryContext.VALUE, Context.current().with(observation.span()))
@@ -286,7 +288,7 @@ public abstract class AbstractRedisCache<K, V> implements RedisCache<K, V> {
             return mappingFunction.apply(Collections.emptySet());
         }
 
-        var observation = this.telemetry.observe("COMPUTE_IF_ABSENT_MANY");
+        var observation = this.telemetry.observe(COMPUTE_IF_ABSENT_MANY);
         return ScopedValue
             .where(Observation.VALUE, observation)
             .where(OpentelemetryContext.VALUE, Context.current().with(observation.span()))
@@ -314,6 +316,7 @@ public abstract class AbstractRedisCache<K, V> implements RedisCache<K, V> {
                     } catch (Exception e) {
                         observation.observeError(e);
                     }
+                    observation.observeValues(fromCache);
 
                     if (fromCache.size() == keys.size()) {
                         return fromCache;
@@ -346,7 +349,6 @@ public abstract class AbstractRedisCache<K, V> implements RedisCache<K, V> {
                         }
                     }
                     fromCache.putAll(values);
-                    observation.observeValues(fromCache);
                     return fromCache;
                 } catch (CompletionException e) {
                     observation.observeError(e.getCause());
@@ -366,7 +368,7 @@ public abstract class AbstractRedisCache<K, V> implements RedisCache<K, V> {
             return;
         }
 
-        var observation = this.telemetry.observe("INVALIDATE");
+        var observation = this.telemetry.observe(INVALIDATE);
         ScopedValue
             .where(Observation.VALUE, observation)
             .where(OpentelemetryContext.VALUE, Context.current().with(observation.span()))
@@ -391,7 +393,7 @@ public abstract class AbstractRedisCache<K, V> implements RedisCache<K, V> {
             return;
         }
 
-        var observation = this.telemetry.observe("INVALIDATE_MANY");
+        var observation = this.telemetry.observe(INVALIDATE_MANY);
         ScopedValue
             .where(Observation.VALUE, observation)
             .where(OpentelemetryContext.VALUE, Context.current().with(observation.span()))
@@ -415,7 +417,7 @@ public abstract class AbstractRedisCache<K, V> implements RedisCache<K, V> {
 
     @Override
     public void invalidateAll() {
-        var observation = this.telemetry.observe("INVALIDATE_ALL");
+        var observation = this.telemetry.observe(INVALIDATE_ALL);
         ScopedValue
             .where(Observation.VALUE, observation)
             .where(OpentelemetryContext.VALUE, Context.current().with(observation.span()))

--- a/cache/cache-redis-lettuce/src/main/java/io/koraframework/cache/redis/telemetry/RedisCacheTelemetry.java
+++ b/cache/cache-redis-lettuce/src/main/java/io/koraframework/cache/redis/telemetry/RedisCacheTelemetry.java
@@ -2,5 +2,25 @@ package io.koraframework.cache.redis.telemetry;
 
 public interface RedisCacheTelemetry {
 
-    RedisCacheObservation observe(String operation);
+    RedisCacheObservation observe(Operation operation);
+
+    enum Operation {
+        GET,
+        GET_MANY,
+        GET_ALL,
+        PUT,
+        PUT_MANY,
+        COMPUTE_IF_ABSENT,
+        COMPUTE_IF_ABSENT_MANY,
+        INVALIDATE,
+        INVALIDATE_MANY,
+        INVALIDATE_ALL;
+
+        public boolean hasCacheResult() {
+            return switch (this) {
+                case GET, GET_MANY, GET_ALL, COMPUTE_IF_ABSENT, COMPUTE_IF_ABSENT_MANY -> true;
+                default -> false;
+            };
+        }
+    }
 }

--- a/cache/cache-redis-lettuce/src/main/java/io/koraframework/cache/redis/telemetry/impl/DefaultRedisCacheLoggerFactory.java
+++ b/cache/cache-redis-lettuce/src/main/java/io/koraframework/cache/redis/telemetry/impl/DefaultRedisCacheLoggerFactory.java
@@ -1,5 +1,6 @@
 package io.koraframework.cache.redis.telemetry.impl;
 
+import io.koraframework.cache.redis.telemetry.RedisCacheTelemetry;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,7 +26,7 @@ public class DefaultRedisCacheLoggerFactory {
             this.context = context;
         }
 
-        public void logStart(String operation, Object key) {
+        public void logStart(RedisCacheTelemetry.Operation operation, Object key) {
             if (this.logger.isTraceEnabled()) {
                 this.logger.atTrace()
                     .addKeyValue("operation", operation)
@@ -36,7 +37,7 @@ public class DefaultRedisCacheLoggerFactory {
             }
         }
 
-        public void logStart(String operation, Collection<?> keys) {
+        public void logStart(RedisCacheTelemetry.Operation operation, Collection<?> keys) {
             if (this.logger.isTraceEnabled()) {
                 this.logger.atTrace()
                     .addKeyValue("operation", operation)
@@ -47,7 +48,7 @@ public class DefaultRedisCacheLoggerFactory {
             }
         }
 
-        public void logEnd(String operation, long startedInNanos, @Nullable Throwable error) {
+        public void logEnd(RedisCacheTelemetry.Operation operation, long startedInNanos, @Nullable Throwable error) {
             if (error == null) {
                 this.logEnd(operation, startedInNanos, 0, 0);
                 return;
@@ -63,7 +64,7 @@ public class DefaultRedisCacheLoggerFactory {
             }
         }
 
-        public void logEnd(String operation, long startedInNanos, int retrieved, int missed) {
+        public void logEnd(RedisCacheTelemetry.Operation operation, long startedInNanos, int retrieved, int missed) {
             if (this.logger.isDebugEnabled()) {
                 var builder = retrieved > 0
                     ? this.logger.atDebug()
@@ -75,7 +76,7 @@ public class DefaultRedisCacheLoggerFactory {
                     .addKeyValue("cacheImpl", this.context.cacheImplCanonicalName())
                     .addKeyValue("processingTime", (System.nanoTime() - startedInNanos) / 1_000_000);
 
-                if (operation.startsWith("GET")) {
+                if (operation.hasCacheResult()) {
                     builder.addKeyValue("retrieved", retrieved);
                     builder.addKeyValue("missed", missed);
                 }

--- a/cache/cache-redis-lettuce/src/main/java/io/koraframework/cache/redis/telemetry/impl/DefaultRedisCacheMetricsFactory.java
+++ b/cache/cache-redis-lettuce/src/main/java/io/koraframework/cache/redis/telemetry/impl/DefaultRedisCacheMetricsFactory.java
@@ -1,5 +1,6 @@
 package io.koraframework.cache.redis.telemetry.impl;
 
+import io.koraframework.cache.redis.telemetry.RedisCacheTelemetry;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
@@ -26,7 +27,7 @@ public class DefaultRedisCacheMetricsFactory {
         protected static final String TAG_OPERATION = "operation";
         protected static final String TAG_ORIGIN = "origin";
 
-        public record DurationKey(String operation,
+        public record DurationKey(RedisCacheTelemetry.Operation operation,
                                   @Nullable Class<? extends Throwable> errorType,
                                   @Nullable Tags extraTags) {
 
@@ -35,7 +36,7 @@ public class DefaultRedisCacheMetricsFactory {
             }
         }
 
-        public record RatioKey(String operation,
+        public record RatioKey(RedisCacheTelemetry.Operation operation,
                                RatioType ratioType,
                                @Nullable Tags extraTags) {
 
@@ -64,7 +65,7 @@ public class DefaultRedisCacheMetricsFactory {
             this.context = context;
         }
 
-        public void reportCommandTook(String operation,
+        public void reportCommandTook(RedisCacheTelemetry.Operation operation,
                                       long startedRecordsHandleInNanos,
                                       @Nullable Throwable error) {
             var took = System.nanoTime() - startedRecordsHandleInNanos;
@@ -78,7 +79,7 @@ public class DefaultRedisCacheMetricsFactory {
             meter.record(took, TimeUnit.NANOSECONDS);
         }
 
-        public void reportRatioChange(String operation,
+        public void reportRatioChange(RedisCacheTelemetry.Operation operation,
                                       RatioType ratioType,
                                       int change) {
             var key = createMetricRatioCounterKey(operation, ratioType);
@@ -90,7 +91,7 @@ public class DefaultRedisCacheMetricsFactory {
             meter.increment(change);
         }
 
-        protected DurationKey createMetricOperationDurationKey(String operation, @Nullable Throwable error) {
+        protected DurationKey createMetricOperationDurationKey(RedisCacheTelemetry.Operation operation, @Nullable Throwable error) {
             if (error instanceof CompletionException ce && ce.getCause() != null) {
                 error = ce.getCause();
             }
@@ -98,13 +99,13 @@ public class DefaultRedisCacheMetricsFactory {
             return new DurationKey(operation, errorType, null);
         }
 
-        protected RatioKey createMetricRatioCounterKey(String operation, RatioType ratioType) {
+        protected RatioKey createMetricRatioCounterKey(RedisCacheTelemetry.Operation operation, RatioType ratioType) {
             return new RatioKey(operation, ratioType, null);
         }
 
         // DO NOT ADD DYNAMIC TAGS IN BUILDER, use metric key instead of metric collision will happen
         protected Timer.Builder createMetricOperationDuration(DurationKey metricKey,
-                                                              String operation,
+                                                              RedisCacheTelemetry.Operation operation,
                                                               @Nullable Throwable error) {
             var extraTags = 0;
             if (metricKey.extraTags != null) {
@@ -123,7 +124,7 @@ public class DefaultRedisCacheMetricsFactory {
             }
 
             // dynamic tags from cache key
-            tags.add(Tag.of(TAG_OPERATION, operation));
+            tags.add(Tag.of(TAG_OPERATION, operation.name()));
             tags.add(Tag.of(ErrorAttributes.ERROR_TYPE.getKey(), errorValue));
             if (metricKey.extraTags != null) {
                 for (Tag extraTag : metricKey.extraTags) {
@@ -138,7 +139,7 @@ public class DefaultRedisCacheMetricsFactory {
 
         // DO NOT ADD DYNAMIC TAGS IN BUILDER, use metric key instead of metric collision will happen
         protected Counter.Builder createMetricRatioCounter(RatioKey metricKey,
-                                                           String operation,
+                                                           RedisCacheTelemetry.Operation operation,
                                                            RatioType ratioType) {
             var extraTags = 0;
             if (metricKey.extraTags != null) {
@@ -156,7 +157,7 @@ public class DefaultRedisCacheMetricsFactory {
             }
 
             // dynamic tags from cache key
-            tags.add(Tag.of(TAG_OPERATION, operation));
+            tags.add(Tag.of(TAG_OPERATION, operation.name()));
             tags.add(Tag.of("type", ratioType.value));
             if (metricKey.extraTags != null) {
                 for (Tag extraTag : metricKey.extraTags) {

--- a/cache/cache-redis-lettuce/src/main/java/io/koraframework/cache/redis/telemetry/impl/DefaultRedisCacheObservation.java
+++ b/cache/cache-redis-lettuce/src/main/java/io/koraframework/cache/redis/telemetry/impl/DefaultRedisCacheObservation.java
@@ -1,6 +1,7 @@
 package io.koraframework.cache.redis.telemetry.impl;
 
 import io.koraframework.cache.redis.telemetry.RedisCacheObservation;
+import io.koraframework.cache.redis.telemetry.RedisCacheTelemetry;
 import io.koraframework.cache.redis.telemetry.impl.DefaultRedisCacheMetricsFactory.DefaultRedisCacheMetrics.RatioType;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.StatusCode;
@@ -13,7 +14,7 @@ public class DefaultRedisCacheObservation implements RedisCacheObservation {
 
     protected final long operationStarted = System.nanoTime();
 
-    protected final String operation;
+    protected final RedisCacheTelemetry.Operation operation;
     protected final DefaultRedisCacheTelemetry.TelemetryContext context;
     protected final DefaultRedisCacheLoggerFactory.DefaultRedisCacheLogger logger;
     protected final DefaultRedisCacheMetricsFactory.DefaultRedisCacheMetrics metrics;
@@ -30,7 +31,7 @@ public class DefaultRedisCacheObservation implements RedisCacheObservation {
     @Nullable
     protected Collection<?> keys;
 
-    public DefaultRedisCacheObservation(String operation,
+    public DefaultRedisCacheObservation(RedisCacheTelemetry.Operation operation,
                                         DefaultRedisCacheTelemetry.TelemetryContext context,
                                         DefaultRedisCacheLoggerFactory.DefaultRedisCacheLogger logger,
                                         DefaultRedisCacheMetricsFactory.DefaultRedisCacheMetrics metrics,
@@ -83,7 +84,7 @@ public class DefaultRedisCacheObservation implements RedisCacheObservation {
 
         var retrieved = 0;
         var missed = 0;
-        if (operation.startsWith("GET")) {
+        if (operation.hasCacheResult()) {
             if (value != null) {
                 metrics.reportRatioChange(operation, RatioType.HIT, 1);
                 retrieved = 1;

--- a/cache/cache-redis-lettuce/src/main/java/io/koraframework/cache/redis/telemetry/impl/DefaultRedisCacheTelemetry.java
+++ b/cache/cache-redis-lettuce/src/main/java/io/koraframework/cache/redis/telemetry/impl/DefaultRedisCacheTelemetry.java
@@ -61,17 +61,17 @@ public class DefaultRedisCacheTelemetry implements RedisCacheTelemetry {
     }
 
     @Override
-    public RedisCacheObservation observe(String operation) {
+    public RedisCacheObservation observe(Operation operation) {
         var span = (context.isTracingEnabled())
             ? this.createSpan(operation).startSpan()
             : Span.getInvalid();
         return new DefaultRedisCacheObservation(operation, context, logger, metrics, span);
     }
 
-    protected SpanBuilder createSpan(String operation) {
+    protected SpanBuilder createSpan(Operation operation) {
         var span = this.context.tracer().spanBuilder("cache.operation")
             .setSpanKind(SpanKind.INTERNAL)
-            .setAttribute(TAG_OPERATION, operation)
+            .setAttribute(TAG_OPERATION, operation.name())
             .setAttribute(SYSTEM_CONFIG_PATH, this.context.cacheConfigPath())
             .setAttribute(SYSTEM_NAME_SIMPLE, this.context.cacheImplSimpleName())
             .setAttribute(SYSTEM_NAME_CANONICAL, this.context.cacheImplCanonicalName())

--- a/cache/cache-redis-lettuce/src/main/java/io/koraframework/cache/redis/telemetry/impl/NoopRedisCacheLoggerFactory.java
+++ b/cache/cache-redis-lettuce/src/main/java/io/koraframework/cache/redis/telemetry/impl/NoopRedisCacheLoggerFactory.java
@@ -1,5 +1,6 @@
 package io.koraframework.cache.redis.telemetry.impl;
 
+import io.koraframework.cache.redis.telemetry.RedisCacheTelemetry;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.helpers.NOPLogger;
 
@@ -25,22 +26,22 @@ public final class NoopRedisCacheLoggerFactory extends DefaultRedisCacheLoggerFa
         }
 
         @Override
-        public void logStart(String operation, Object key) {
+        public void logStart(RedisCacheTelemetry.Operation operation, Object key) {
 
         }
 
         @Override
-        public void logStart(String operation, Collection<?> keys) {
+        public void logStart(RedisCacheTelemetry.Operation operation, Collection<?> keys) {
 
         }
 
         @Override
-        public void logEnd(String operation, long startedInNanos, @Nullable Throwable error) {
+        public void logEnd(RedisCacheTelemetry.Operation operation, long startedInNanos, @Nullable Throwable error) {
 
         }
 
         @Override
-        public void logEnd(String operation, long startedInNanos, int retrieved, int missed) {
+        public void logEnd(RedisCacheTelemetry.Operation operation, long startedInNanos, int retrieved, int missed) {
 
         }
     }

--- a/cache/cache-redis-lettuce/src/main/java/io/koraframework/cache/redis/telemetry/impl/NoopRedisCacheMetricsFactory.java
+++ b/cache/cache-redis-lettuce/src/main/java/io/koraframework/cache/redis/telemetry/impl/NoopRedisCacheMetricsFactory.java
@@ -1,5 +1,6 @@
 package io.koraframework.cache.redis.telemetry.impl;
 
+import io.koraframework.cache.redis.telemetry.RedisCacheTelemetry;
 import org.jspecify.annotations.Nullable;
 
 public final class NoopRedisCacheMetricsFactory extends DefaultRedisCacheMetricsFactory {
@@ -22,12 +23,12 @@ public final class NoopRedisCacheMetricsFactory extends DefaultRedisCacheMetrics
         }
 
         @Override
-        public void reportCommandTook(String operation, long startedRecordsHandleInNanos, @Nullable Throwable error) {
+        public void reportCommandTook(RedisCacheTelemetry.Operation operation, long startedRecordsHandleInNanos, @Nullable Throwable error) {
             // do nothing
         }
 
         @Override
-        public void reportRatioChange(String operation, RatioType ratioType, int change) {
+        public void reportRatioChange(RedisCacheTelemetry.Operation operation, RatioType ratioType, int change) {
             // do nothing
         }
     }

--- a/cache/cache-redis-lettuce/src/main/java/io/koraframework/cache/redis/telemetry/impl/NoopRedisCacheTelemetry.java
+++ b/cache/cache-redis-lettuce/src/main/java/io/koraframework/cache/redis/telemetry/impl/NoopRedisCacheTelemetry.java
@@ -10,7 +10,7 @@ public final class NoopRedisCacheTelemetry implements RedisCacheTelemetry {
     private NoopRedisCacheTelemetry() {}
 
     @Override
-    public RedisCacheObservation observe(String operation) {
+    public RedisCacheObservation observe(Operation operation) {
         return NoopRedisCacheObservation.INSTANCE;
     }
 }


### PR DESCRIPTION
Updates Redis cache telemetry operation handling:
- replaces string operation checks with `RedisCacheTelemetry.Operation` enum;
- adds `GET_ALL` for operation symmetry;
- unifies cache-result detection via `Operation#hasCacheResult()`;
- includes `COMPUTE_IF_ABSENT` and `COMPUTE_IF_ABSENT_MANY` in cache-result telemetry;
- reports `COMPUTE_IF_ABSENT_MANY` cache hits before merging computed values.