### PR TITLE
added macros aliases support and more macros and one-to-many mapping

### DIFF
--- a/database/database-annotation-processor/src/main/java/io/koraframework/database/annotation/processor/QueryMacrosParser.java
+++ b/database/database-annotation-processor/src/main/java/io/koraframework/database/annotation/processor/QueryMacrosParser.java
@@ -30,11 +30,14 @@ final class QueryMacrosParser {
         this.types = types;
     }
 
-    record Field(Element field, String column, String path, boolean isId) {}
+    record Field(Element field, String column, String rawColumn, String path, String targetPath, boolean isId) {}
 
-    record Target(DeclaredType type, String name, String column) {}
+    record Target(DeclaredType type, String name, String column, String columnPrefix) {}
+
+    record Command(String target, String command, String alias) {}
 
     public String parse(String sqlWithSyntax, DeclaredType repositoryType, ExecutableElement method) {
+        var aliases = collectAliases(sqlWithSyntax, repositoryType, method);
         var sqlBuilder = new StringBuilder();
         var prevCmdIndex = 0;
         while (true) {
@@ -46,14 +49,59 @@ final class QueryMacrosParser {
             var cmdIndexEnd = sqlWithSyntax.indexOf(MACROS_END, cmdIndexStart);
             var targetAndCmdAsStr = sqlWithSyntax.substring(cmdIndexStart + 2, cmdIndexEnd);
 
-            var substitution = getSubstitution(targetAndCmdAsStr, repositoryType, method);
+            var substitution = getSubstitution(targetAndCmdAsStr, repositoryType, method, aliases);
             sqlBuilder.append(sqlWithSyntax, prevCmdIndex, cmdIndexStart).append(substitution);
 
             prevCmdIndex = cmdIndexEnd + 1;
         }
     }
 
-    private List<Field> getPathField(ExecutableElement method, DeclaredType target, String rootPath, String columnPrefix) {
+    private Map<String, String> collectAliases(String sqlWithSyntax, DeclaredType repositoryType, ExecutableElement method) {
+        var aliases = new HashMap<String, String>();
+        var prevCmdIndex = 0;
+        while (true) {
+            var cmdIndexStart = sqlWithSyntax.indexOf(MACROS_START, prevCmdIndex);
+            if (cmdIndexStart == -1) {
+                return aliases;
+            }
+
+            var cmdIndexEnd = sqlWithSyntax.indexOf(MACROS_END, cmdIndexStart);
+            var targetAndCmdAsStr = sqlWithSyntax.substring(cmdIndexStart + 2, cmdIndexEnd);
+            var command = parseCommand(targetAndCmdAsStr, method);
+            if ("table".equals(command.command()) && command.alias() != null) {
+                getTarget(command.target(), repositoryType, method);
+                aliases.put(command.target(), command.alias());
+            }
+
+            prevCmdIndex = cmdIndexEnd + 1;
+        }
+    }
+
+    private Command parseCommand(String targetAndCommand, ExecutableElement method) {
+        var targetAndCmd = targetAndCommand.split("#", 2);
+        if (targetAndCmd.length == 1) {
+            throw new ProcessingErrorException("Can't extract query marcos and target from: " + targetAndCommand, method);
+        }
+
+        var target = targetAndCmd[0].strip();
+        var selectors = targetAndCmd[1].split("-=", 2);
+        if (selectors.length == 1) {
+            selectors = targetAndCmd[1].split("=", 2);
+        }
+
+        var commandAsStr = selectors[0].strip();
+        var lowerCommand = commandAsStr.toLowerCase(Locale.ROOT);
+        if (lowerCommand.startsWith("table as ")) {
+            var alias = commandAsStr.substring("table as ".length()).strip();
+            if (alias.isEmpty()) {
+                throw new ProcessingErrorException("Table alias is empty in query marcos: " + targetAndCommand, method);
+            }
+            return new Command(target, "table", alias);
+        }
+        return new Command(target, lowerCommand, null);
+    }
+
+    private List<Field> getPathField(ExecutableElement method, DeclaredType target, String rootPath, String rootTargetPath, String columnPrefix) {
         final JdbcNativeType nativeType = JdbcNativeTypes.findNativeType(TypeName.get(target));
         if (nativeType != null) {
             throw new ProcessingErrorException("Can't process argument '" + rootPath + "' as macros cause it is Native Type: " + target, method);
@@ -69,33 +117,36 @@ final class QueryMacrosParser {
             var embedded = AnnotationUtils.findAnnotation(field, DbUtils.EMBEDDED_ANNOTATION);
             if (embedded != null) {
                 if (field.asType() instanceof DeclaredType dt) {
+                    if (CommonUtils.isCollection(dt)) {
+                        dt = (DeclaredType) MethodUtils.getGenericType(dt).orElseThrow();
+                    }
                     var prefix = Objects.requireNonNullElse(AnnotationUtils.parseAnnotationValueWithoutDefault(embedded, "value"), "");
-                    for (var f : getPathField(method, dt, path, prefix)) {
-                        result.add(new Field(f.field(), f.column(), f.path(), isId));
+                    var targetPath = rootTargetPath.isEmpty()
+                        ? field.getSimpleName().toString()
+                        : rootTargetPath + "." + field.getSimpleName().toString();
+                    for (var f : getPathField(method, dt, path, targetPath, columnPrefix + prefix)) {
+                        result.add(new Field(f.field(), f.column(), f.rawColumn(), f.path(), f.targetPath(), isId || f.isId()));
                     }
                 } else {
                     throw new IllegalArgumentException("@Embedded annotation placed on field that can't be embedded: " + target);
                 }
             } else {
-                var columnName = getColumnName(target, field, columnPrefix);
-                result.add(new Field(field, columnName, path, isId));
+                var rawColumnName = getColumnName(target, field);
+                var columnName = columnPrefix.isBlank() ? rawColumnName : columnPrefix + rawColumnName;
+                result.add(new Field(field, columnName, rawColumnName, path, rootTargetPath, isId));
             }
         }
         return result;
     }
 
-    private String getColumnName(DeclaredType target, Element field, String columnPrefix) {
+    private String getColumnName(DeclaredType target, Element field) {
         var column = AnnotationUtils.findAnnotation(field, DbUtils.COLUMN_ANNOTATION);
         var columnName = AnnotationUtils.<String>parseAnnotationValueWithoutDefault(column, "value");
         if (columnName == null || columnName.isEmpty()) {
             var nameConverter = CommonUtils.getNameConverter(EntityUtils.SNAKE_CASE_NAME_CONVERTER, ((TypeElement) target.asElement()));
-            return columnPrefix.isBlank()
-                ? nameConverter.convert(field.getSimpleName().toString())
-                : columnPrefix + nameConverter.convert(field.getSimpleName().toString());
+            return nameConverter.convert(field.getSimpleName().toString());
         }
-        return (columnPrefix.isBlank())
-            ? columnName
-            : columnPrefix + columnName;
+        return columnName;
     }
 
     private Set<String> getCommandSelectorPaths(DeclaredType type, String rootPath, String selects) {
@@ -147,30 +198,31 @@ final class QueryMacrosParser {
     private List<Field> getFields(ExecutableElement method, Target target) {
         final JdbcNativeType nativeType = JdbcNativeTypes.findNativeType(TypeName.get(target.type()));
         if (nativeType != null && target.column() != null) {
-            return List.of(new Field(null, target.column(), target.name(), false));
+            return List.of(new Field(null, target.column(), target.column(), target.name(), target.name(), false));
         }
 
-        return getPathField(method, target.type(), target.name(), "");
+        return getPathField(method, target.type(), target.name(), target.name(), target.columnPrefix());
     }
 
-    private String getSubstitution(String targetAndCommand, DeclaredType repositoryType, ExecutableElement method) {
+    private String getSubstitution(String targetAndCommand, DeclaredType repositoryType, ExecutableElement method, Map<String, String> aliases) {
         try {
-            var targetAndCmd = targetAndCommand.split("#");
+            var targetAndCmd = targetAndCommand.split("#", 2);
             if (targetAndCmd.length == 1) {
                 throw new ProcessingErrorException("Can't extract query marcos and target from: " + targetAndCommand, method);
             }
 
             var target = getTarget(targetAndCmd[0].strip(), repositoryType, method);
-            var selectors = targetAndCmd[1].split("-=");
+            var command = parseCommand(targetAndCommand, method);
+            var selectors = targetAndCmd[1].split("-=", 2);
             final boolean include;
             if (selectors.length == 1) {
                 include = true;
-                selectors = targetAndCmd[1].split("=");
+                selectors = targetAndCmd[1].split("=", 2);
             } else {
                 include = false;
             }
 
-            var commandAsStr = selectors[0].strip().toLowerCase();
+            var commandAsStr = command.command();
 
             var paths = (selectors.length != 1)
                 ? getCommandSelectorPaths(target.type(), target.name(), selectors[1])
@@ -193,9 +245,17 @@ final class QueryMacrosParser {
                     return nameConverter.convert(target.type().asElement().getSimpleName().toString());
                 });
             return switch (commandAsStr) {
-                case "table" -> tableName;
+                case "table" -> command.alias() == null
+                    ? tableName
+                    : tableName + " " + command.alias();
                 case "selects" -> fields.stream()
+                    .map(f -> selectExpression(f, aliases))
+                    .collect(Collectors.joining(", "));
+                case "columns" -> fields.stream()
                     .map(Field::column)
+                    .collect(Collectors.joining(", "));
+                case "values" -> fields.stream()
+                    .map(f -> ":" + f.path())
                     .collect(Collectors.joining(", "));
                 case "inserts" -> {
                     var tableAndColumnPrefix = fields.stream()
@@ -213,7 +273,7 @@ final class QueryMacrosParser {
                     .map(f -> f.column() + " = :" + f.path())
                     .collect(Collectors.joining(", "));
                 case "where" -> fields.stream()
-                    .map(f -> f.column() + " = :" + f.path())
+                    .map(f -> columnReference(f, aliases) + " = :" + f.path())
                     .collect(Collectors.joining(" AND "));
                 default -> throw new ProcessingErrorException("Unknown query marcos specified: " + targetAndCommand, method);
             };
@@ -223,12 +283,36 @@ final class QueryMacrosParser {
         }
     }
 
+    private String selectExpression(Field field, Map<String, String> aliases) {
+        var reference = columnReference(field, aliases);
+        if (aliases.containsKey(field.targetPath()) && !field.column().equals(field.rawColumn())) {
+            return reference + " AS " + field.column();
+        }
+        return reference;
+    }
+
+    private String columnReference(Field field, Map<String, String> aliases) {
+        var alias = aliases.get(field.targetPath());
+        if (alias == null) {
+            return field.column();
+        }
+        return alias + "." + field.rawColumn();
+    }
 
     private Target getTarget(String targetName, DeclaredType repositoryType, ExecutableElement method) {
+        var path = Arrays.stream(targetName.split("\\."))
+            .map(String::strip)
+            .filter(s -> !s.isBlank())
+            .toList();
+        if (path.isEmpty()) {
+            throw new ProcessingErrorException("Macros command unspecified target received: " + targetName, method);
+        }
+
         var methodType = (ExecutableType) this.types.asMemberOf(repositoryType, method);
 
         TypeMirror targetMirror = null;
-        if (TARGET_RETURN.equals(targetName)) {
+        var rootTargetName = path.get(0);
+        if (TARGET_RETURN.equals(rootTargetName)) {
             if (MethodUtils.isVoid(method)) {
                 throw new ProcessingErrorException("Macros command specified 'return' target, but return value is type Void", method);
             } else if (method.getReturnType().toString().equals(DbUtils.UPDATE_COUNT.canonicalName())) {
@@ -252,17 +336,17 @@ final class QueryMacrosParser {
             var parameters = method.getParameters();
             for (int i = 0; i < parameters.size(); i++) {
                 var parameter = parameters.get(i);
-                if (parameter.getSimpleName().contentEquals(targetName)) {
+                if (parameter.getSimpleName().contentEquals(rootTargetName)) {
                     targetMirror = methodType.getParameterTypes().get(i);
                 }
             }
 
             if (targetMirror == null) {
-                var genericTarget = getTypeParameterTarget(repositoryType, method, targetName);
+                var genericTarget = getTypeParameterTarget(repositoryType, method, rootTargetName);
                 if (genericTarget != null) {
                     return genericTarget;
                 }
-                throw new ProcessingErrorException("Macros command unspecified target received: " + targetName, method);
+                throw new ProcessingErrorException("Macros command unspecified target received: " + rootTargetName, method);
             }
 
             if (CommonUtils.isCollection(targetMirror) || CommonUtils.isOptional(targetMirror)) {
@@ -274,10 +358,34 @@ final class QueryMacrosParser {
         }
 
         if (targetMirror instanceof DeclaredType dt) {
-            return new Target(dt, targetName, getColumnName(method, targetName, targetMirror));
+            var target = new Target(dt, rootTargetName, getColumnName(method, rootTargetName, targetMirror), "");
+            for (int i = 1; i < path.size(); i++) {
+                target = getChildTarget(method, target, path.get(i));
+            }
+            return target;
         } else {
             throw new ProcessingErrorException("Macros command unprocessable target type: " + targetName, method);
         }
+    }
+
+    private Target getChildTarget(ExecutableElement method, Target target, String childName) {
+        for (var field : getFields(target.type())) {
+            if (!field.getSimpleName().contentEquals(childName)) {
+                continue;
+            }
+            if (field.asType() instanceof DeclaredType dt) {
+                if (CommonUtils.isCollection(dt)) {
+                    dt = (DeclaredType) MethodUtils.getGenericType(dt).orElseThrow();
+                }
+                var embedded = AnnotationUtils.findAnnotation(field, DbUtils.EMBEDDED_ANNOTATION);
+                var prefix = embedded == null
+                    ? ""
+                    : Objects.requireNonNullElse(AnnotationUtils.parseAnnotationValueWithoutDefault(embedded, "value"), "");
+                return new Target(dt, target.name() + "." + childName, null, target.columnPrefix() + prefix);
+            }
+            throw new ProcessingErrorException("Macros command unprocessable target type: " + target.name() + "." + childName, method);
+        }
+        throw new ProcessingErrorException("Field '" + childName + "' not found, but was present in query marcos target: " + target.name(), method);
     }
 
     private Target getTypeParameterTarget(DeclaredType repositoryType, ExecutableElement method, String targetName) {
@@ -289,7 +397,7 @@ final class QueryMacrosParser {
                 && typeVariable.asElement().getSimpleName().contentEquals(targetName)) {
                 var type = methodType.getParameterTypes().get(i);
                 if (type instanceof DeclaredType dt) {
-                    return new Target(dt, parameter.getSimpleName().toString(), getColumnName(method, targetName, type));
+                    return new Target(dt, parameter.getSimpleName().toString(), getColumnName(method, targetName, type), "");
                 }
                 throw new ProcessingErrorException("Macros command unprocessable target type: " + targetName, method);
             }
@@ -300,7 +408,7 @@ final class QueryMacrosParser {
                 if (typeParameter.getSimpleName().contentEquals(targetName)) {
                     var type = this.types.asMemberOf(repositoryType, typeParameter);
                     if (type instanceof DeclaredType dt) {
-                        return new Target(dt, targetName, getColumnName(method, targetName, type));
+                        return new Target(dt, targetName, getColumnName(method, targetName, type), "");
                     }
                     throw new ProcessingErrorException("Macros command unprocessable target type: " + targetName, method);
                 }
@@ -311,7 +419,7 @@ final class QueryMacrosParser {
             if (typeParameter.getSimpleName().contentEquals(targetName)) {
                 var type = this.types.asMemberOf(repositoryType, typeParameter);
                 if (type instanceof DeclaredType dt) {
-                    return new Target(dt, targetName, getColumnName(method, targetName, type));
+                    return new Target(dt, targetName, getColumnName(method, targetName, type), "");
                 }
                 throw new ProcessingErrorException("Macros command unprocessable target type: " + targetName, method);
             }

--- a/database/database-annotation-processor/src/main/java/io/koraframework/database/annotation/processor/entity/DbEntity.java
+++ b/database/database-annotation-processor/src/main/java/io/koraframework/database/annotation/processor/entity/DbEntity.java
@@ -4,12 +4,15 @@ import com.palantir.javapoet.CodeBlock;
 import com.palantir.javapoet.TypeName;
 import io.koraframework.annotation.processor.common.AnnotationUtils;
 import io.koraframework.annotation.processor.common.CommonUtils;
+import io.koraframework.annotation.processor.common.MethodUtils;
+import io.koraframework.annotation.processor.common.ProcessingErrorException;
 import io.koraframework.annotation.processor.common.RecordUtils;
 import io.koraframework.database.annotation.processor.DbUtils;
 import io.koraframework.database.annotation.processor.EntityUtils;
 import org.jspecify.annotations.Nullable;
 
 import javax.lang.model.element.*;
+import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Types;
@@ -36,11 +39,15 @@ public class DbEntity {
             .<Column>flatMap(ef -> {
                 if (ef instanceof SimpleEntityField simple) {
                     return Stream.of(new ColumnImpl(simple));
-                } else {
-                    var embedded = (EmbeddedEntityField) ef;
+                } else if (ef instanceof EmbeddedEntityField embedded) {
                     return embedded.fields()
                         .stream()
                         .map(ColumnImpl::new);
+                } else {
+                    var embedded = (EmbeddedCollectionEntityField) ef;
+                    return embedded.fields()
+                        .stream()
+                        .map(f -> new ColumnImpl(embedded, f));
                 }
             })
             .toList();
@@ -58,6 +65,51 @@ public class DbEntity {
         return this.typeElement;
     }
 
+    public boolean hasEmbeddedCollection() {
+        return this.entityFields.stream().anyMatch(EmbeddedCollectionEntityField.class::isInstance);
+    }
+
+    public List<EmbeddedCollectionEntityField> embeddedCollections() {
+        return this.entityFields.stream()
+            .filter(EmbeddedCollectionEntityField.class::isInstance)
+            .map(EmbeddedCollectionEntityField.class::cast)
+            .toList();
+    }
+
+    public List<Column> rootIdColumns() {
+        return this.columns.stream()
+            .filter(c -> !(c.entityField() instanceof EmbeddedCollectionEntityField))
+            .filter(c -> AnnotationUtils.isAnnotationPresent(c.element(), DbUtils.ID_ANNOTATION))
+            .toList();
+    }
+
+    public String rootFieldsDescription() {
+        return this.entityFields.stream()
+            .filter(e -> !(e instanceof EmbeddedCollectionEntityField))
+            .map(e -> {
+                if (e instanceof SimpleEntityField simple) {
+                    return simple.element().getSimpleName() + " (" + simple.typeMirror() + ")";
+                }
+                var embedded = (EmbeddedEntityField) e;
+                return embedded.element().getSimpleName() + " (" + embedded.typeMirror() + ")";
+            })
+            .collect(Collectors.joining(", "));
+    }
+
+    public Element rootErrorElement() {
+        var rootField = this.entityFields.stream()
+            .filter(e -> !(e instanceof EmbeddedCollectionEntityField))
+            .findFirst()
+            .orElse(null);
+        if (rootField == null) {
+            return this.typeElement;
+        }
+        if (rootField instanceof EmbeddedEntityField embedded && embedded.typeMirror() instanceof DeclaredType declaredType) {
+            return declaredType.asElement();
+        }
+        return rootField.element();
+    }
+
     public CodeBlock buildInstance(String variableName) {
         return switch (entityType) {
             case RECORD -> {
@@ -71,6 +123,8 @@ public class DbEntity {
                     if (entityField instanceof SimpleEntityField simple) {
                         b.add("$N", simple.element().getSimpleName());
                     } else if (entityField instanceof EmbeddedEntityField embedded) {
+                        b.add("$N", embedded.parent().element().getSimpleName());
+                    } else if (entityField instanceof EmbeddedCollectionEntityField embedded) {
                         b.add("$N", embedded.parent().element().getSimpleName());
                     }
                 }
@@ -86,6 +140,9 @@ public class DbEntity {
                     } else if (entityField instanceof EmbeddedEntityField embedded) {
                         var setter = "set" + CommonUtils.capitalize(embedded.element().getSimpleName().toString());
                         b.addStatement("$N.$N($L)", variableName, setter, embedded.buildInstance());
+                    } else if (entityField instanceof EmbeddedCollectionEntityField embedded) {
+                        var setter = "set" + CommonUtils.capitalize(embedded.element().getSimpleName().toString());
+                        b.addStatement("$N.$N($N)", variableName, setter, embedded.parent().element().getSimpleName());
                     }
                 }
                 yield b.build();
@@ -124,6 +181,30 @@ public class DbEntity {
                 } else {
                     b.add("\n");
                 }
+            } else if (entityField instanceof EmbeddedCollectionEntityField embedded) {
+                var collectionName = embedded.parent().element().getSimpleName();
+                b.addStatement("var $N = new $T<$T>()", collectionName, ArrayList.class, TypeName.get(embedded.elementTypeMirror()));
+                b.add("if (");
+                for (int j = 0; j < embedded.fields().size(); j++) {
+                    var field = embedded.fields().get(j);
+                    if (j > 0) {
+                        b.add(" && ");
+                    }
+                    b.add("$N == null", field.variableName());
+                }
+                b.add(") {$>\n");
+                b.add("// no joined rows for collection\n");
+                b.add("$<\n} else {$>\n");
+                for (int j = 0; j < embedded.fields().size(); j++) {
+                    var field = embedded.fields().get(j);
+                    if (!field.nullable()) {
+                        b.beginControlFlow("if ($N == null)", field.variableName())
+                            .addStatement("throw new $T($S)", NullPointerException.class, "Field %s is not nullable, but column %s is null".formatted(field.element().getSimpleName(), field.columnName()))
+                            .endControlFlow();
+                    }
+                }
+                b.addStatement("$N.add($L)", collectionName, embedded.buildElementInstance());
+                b.add("$<\n}\n");
             }
         }
 
@@ -177,6 +258,20 @@ public class DbEntity {
                 f.nullable,
                 f.parent.accessor() + "()." + f.element.getSimpleName().toString(), // todo,
                 f.parent
+            );
+        }
+
+        public ColumnImpl(EmbeddedCollectionEntityField embedded, EmbeddedCollectionEntityField.Field f) {
+            this(
+                f.element(),
+                f.typeMirror(),
+                f.parent().element.getSimpleName() + "." + f.element.getSimpleName(),
+                f.variableName(),
+                f.columnName(),
+                new String[]{f.parent.element.getSimpleName().toString(), f.element.getSimpleName().toString()},
+                f.nullable,
+                f.parent.accessor() + "()." + f.element.getSimpleName().toString(),
+                embedded
             );
         }
 
@@ -237,6 +332,38 @@ public class DbEntity {
         }
     }
 
+    public record EmbeddedCollectionEntityField(SimpleEntityField parent, TypeMirror typeMirror, TypeMirror elementTypeMirror, VariableElement element, List<Field> fields) implements EntityField {
+
+        @Override
+        public String accessor() {
+            return parent.accessor();
+        }
+
+        public CodeBlock buildElementInstance() {
+            var eb = CodeBlock.builder();
+            eb.add("new $T(", TypeName.get(this.elementTypeMirror())).indent().add("\n");
+            for (int j = 0; j < this.fields().size(); j++) {
+                var field = this.fields().get(j);
+                if (j > 0) {
+                    eb.add(",\n");
+                }
+                eb.add("$N", field.variableName());
+            }
+            eb.unindent().add("\n)");
+            return eb.build();
+        }
+
+        public String recordAccessor() {
+            return this.parent.accessor() + "()";
+        }
+
+        public record Field(SimpleEntityField parent, VariableElement element, TypeMirror typeMirror, String columnName, DtoType entityType, boolean nullable) {
+            public String variableName() {
+                return parent.element.getSimpleName() + "_" + element.getSimpleName().toString();
+            }
+        }
+    }
+
 
     public static DbEntity parseEntity(Types types, TypeMirror typeMirror) {
         var typeElement = (TypeElement) types.asElement(typeMirror);
@@ -269,7 +396,27 @@ public class DbEntity {
                     return field;
                 }
                 var prefix = Objects.requireNonNullElse(AnnotationUtils.parseAnnotationValueWithoutDefault(embedded, "value"), "");
+                if (CommonUtils.isCollection(fieldType)) {
+                    var elementType = MethodUtils.getGenericType(fieldType)
+                        .orElseThrow(() -> new ProcessingErrorException("Embedded collection field should declare element type", fieldElement));
+                    var entity = parseEntity(types, elementType);
+                    if (entity == null) {
+                        throw new ProcessingErrorException("Embedded collection field should be of data type", fieldElement);
+                    }
+                    var embeddedFields = new ArrayList<EmbeddedCollectionEntityField.Field>();
+                    for (var entityField : entity.entityFields) {
+                        boolean isNullableEmbedded = isNullableRecordField(entityField.element(), entity.typeElement);
+                        String prefixEmbedded = prefix + ((SimpleEntityField) entityField).columnName();
+                        embeddedFields.add(new EmbeddedCollectionEntityField.Field(
+                            field, entityField.element(), entityField.typeMirror(), prefixEmbedded, DtoType.RECORD, isNullableEmbedded
+                        ));
+                    }
+                    return new EmbeddedCollectionEntityField(field, fieldType, elementType, fieldElement, embeddedFields);
+                }
                 var entity = parseEntity(types, fieldType);
+                if (entity == null) {
+                    throw new ProcessingErrorException("Embedded field should be of data type", fieldElement);
+                }
                 var embeddedFields = new ArrayList<EmbeddedEntityField.Field>();
                 for (var entityField : entity.entityFields) {
                     boolean isNullableEmbedded = isNullableField || isNullableRecordField(entityField.element(), entity.typeElement);
@@ -353,7 +500,28 @@ public class DbEntity {
                     sink.accept(simpleField);
                 } else {
                     var prefix = Objects.requireNonNullElse(AnnotationUtils.parseAnnotationValueWithoutDefault(embedded, "value"), "");
+                    if (CommonUtils.isCollection(fieldType)) {
+                        var elementType = MethodUtils.getGenericType(fieldType)
+                            .orElseThrow(() -> new ProcessingErrorException("Embedded collection field should declare element type", fieldElement));
+                        var entity = parseEntity(types, elementType);
+                        if (entity == null) {
+                            throw new ProcessingErrorException("Embedded collection field should be of data type", fieldElement);
+                        }
+                        var embeddedFields = new ArrayList<EmbeddedCollectionEntityField.Field>();
+                        for (var entityField : entity.entityFields) {
+                            boolean isNullableEmbedded = isNullableRecordField(entityField.element(), entity.typeElement);
+                            String prefixEmbedded = prefix + ((SimpleEntityField) entityField).columnName();
+                            embeddedFields.add(new EmbeddedCollectionEntityField.Field(
+                                simpleField, entityField.element(), entityField.typeMirror(), prefixEmbedded, DtoType.RECORD, isNullableEmbedded
+                            ));
+                        }
+                        sink.accept(new EmbeddedCollectionEntityField(simpleField, fieldType, elementType, fieldElement, embeddedFields));
+                        return;
+                    }
                     var entity = parseEntity(types, fieldType);
+                    if (entity == null) {
+                        throw new ProcessingErrorException("Embedded field should be of data type", fieldElement);
+                    }
                     var embeddedFields = new ArrayList<EmbeddedEntityField.Field>();
                     for (var entityField : entity.entityFields) {
                         boolean isNullableEmbedded = isNullableField || isNullableRecordField(entityField.element(), entity.typeElement);

--- a/database/database-annotation-processor/src/main/java/io/koraframework/database/annotation/processor/jdbc/JdbcEntityGenerator.java
+++ b/database/database-annotation-processor/src/main/java/io/koraframework/database/annotation/processor/jdbc/JdbcEntityGenerator.java
@@ -4,6 +4,7 @@ import com.palantir.javapoet.*;
 import io.koraframework.annotation.processor.common.AnnotationUtils;
 import io.koraframework.annotation.processor.common.CommonClassNames;
 import io.koraframework.annotation.processor.common.NameUtils;
+import io.koraframework.annotation.processor.common.ProcessingErrorException;
 import io.koraframework.database.annotation.processor.DbEntityReadHelper;
 import io.koraframework.database.annotation.processor.entity.DbEntity;
 
@@ -16,6 +17,7 @@ import java.io.IOException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 
 public class JdbcEntityGenerator {
@@ -70,6 +72,11 @@ public class JdbcEntityGenerator {
 
 
     public void generateListResultSetMapper(DbEntity entity) throws IOException {
+        if (entity.hasEmbeddedCollection()) {
+            generateAggregatingListResultSetMapper(entity);
+            return;
+        }
+
         var mapperClassName = listJdbcResultSetMapperName(entity.typeElement());
 
         var type = TypeSpec.classBuilder(mapperClassName)
@@ -100,6 +107,68 @@ public class JdbcEntityGenerator {
         type.addMethod(constructor.build());
         type.addMethod(apply.build());
 
+
+        JavaFile.builder(mapperClassName.packageName(), type.build()).build().writeTo(this.filer);
+    }
+
+    private void generateAggregatingListResultSetMapper(DbEntity entity) throws IOException {
+        var collections = entity.embeddedCollections();
+        if (collections.size() != 1) {
+            throw new ProcessingErrorException("Only one @Embedded collection field is supported in JdbcResultSetMapper: " + entity.typeElement(), collections.get(1).element());
+        }
+        var rootIdColumns = entity.rootIdColumns();
+        if (rootIdColumns.isEmpty()) {
+            throw new ProcessingErrorException("@Id field is required for one-to-many JdbcResultSetMapper root. Entity: " + entity.typeElement()
+                                               + "; root fields: " + entity.rootFieldsDescription()
+                                               + "; add @Id to one of root fields or to a field inside embedded root type, not to @Embedded collection element only.", entity.rootErrorElement());
+        }
+        var collection = collections.get(0);
+        var mapperClassName = listJdbcResultSetMapperName(entity.typeElement());
+
+        var type = TypeSpec.classBuilder(mapperClassName)
+            .addOriginatingElement(entity.typeElement())
+            .addAnnotation(AnnotationUtils.generated(JdbcEntityGenerator.class))
+            .addSuperinterface(ParameterizedTypeName.get(
+                JdbcTypes.RESULT_SET_MAPPER, ParameterizedTypeName.get(ClassName.get(List.class), TypeName.get(entity.typeMirror()))
+            ))
+            .addModifiers(Modifier.PUBLIC, Modifier.FINAL);
+        var constructor = MethodSpec.constructorBuilder().addModifiers(Modifier.PUBLIC);
+
+        var apply = MethodSpec.methodBuilder("apply")
+            .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+            .addParameter(TypeName.get(ResultSet.class), "_rs")
+            .addException(TypeName.get(SQLException.class))
+            .returns(ParameterizedTypeName.get(ClassName.get(List.class), TypeName.get(entity.typeMirror())));
+        apply.addCode("if (!_rs.next()) {\n  return $T.of();\n}\n", List.class);
+        apply.addCode(this.readColumnIds(entity));
+        var row = this.rowMapperGenerator.readEntity("_row", entity);
+        row.enrich(type, constructor);
+        apply.addCode("var _result = new $T<$T>();\n", ArrayList.class, entity.typeMirror());
+        apply.addCode("var _index = new $T<$T<$T>, $T>();\n", LinkedHashMap.class, List.class, Object.class, entity.typeMirror());
+        apply.addCode("do {$>\n");
+        apply.addCode(row.block());
+        var key = CodeBlock.builder();
+        key.add("$T<$T> _key = $T.of(", List.class, Object.class, List.class);
+        for (int i = 0; i < rootIdColumns.size(); i++) {
+            if (i > 0) {
+                key.add(", ");
+            }
+            key.add("$N", rootIdColumns.get(i).variableName());
+        }
+        key.add(");\n");
+        apply.addCode(key.build());
+        apply.addCode("var _existing = _index.get(_key);\n");
+        apply.addCode("if (_existing == null) {$>\n");
+        apply.addCode("_index.put(_key, _row);\n");
+        apply.addCode("_result.add(_row);\n");
+        apply.addCode("$<\n} else {$>\n");
+        apply.addCode("_existing.$L.addAll(_row.$L);\n", collection.recordAccessor(), collection.recordAccessor());
+        apply.addCode("$<\n}\n");
+        apply.addCode("$<\n} while (_rs.next());\n");
+        apply.addCode("return _result;\n");
+
+        type.addMethod(constructor.build());
+        type.addMethod(apply.build());
 
         JavaFile.builder(mapperClassName.packageName(), type.build()).build().writeTo(this.filer);
     }

--- a/database/database-annotation-processor/src/test/java/io/koraframework/database/common/annotation/processor/jdbc/JdbcExtensionTest.java
+++ b/database/database-annotation-processor/src/test/java/io/koraframework/database/common/annotation/processor/jdbc/JdbcExtensionTest.java
@@ -4,11 +4,14 @@ import io.koraframework.annotation.processor.common.AbstractAnnotationProcessorT
 import io.koraframework.common.annotation.Tag;
 import io.koraframework.database.annotation.processor.RepositoryAnnotationProcessor;
 import io.koraframework.database.annotation.processor.jdbc.JdbcEntityAnnotationProcessor;
+import io.koraframework.database.jdbc.mapper.result.JdbcResultSetMapper;
 import io.koraframework.database.jdbc.mapper.result.JdbcRowMapper;
 import io.koraframework.kora.app.annotation.processor.KoraAppProcessor;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
+import java.sql.ResultSet;
 import java.util.List;
 import java.util.function.Predicate;
 
@@ -27,6 +30,52 @@ public class JdbcExtensionTest extends AbstractAnnotationProcessorTest {
                 import io.koraframework.common.annotation.Mapping;
                 import java.sql.*;
                 """;
+    }
+
+    @Test
+    public void testOneToManyListResultSetMapperGenerated() throws Exception {
+        compile(List.of(new JdbcEntityAnnotationProcessor()),
+            """
+            import io.koraframework.database.common.annotation.*;
+            import io.koraframework.database.jdbc.annotation.EntityJdbc;
+            @Table("users")
+            record User(@Id String id, String name) {}
+            """,
+            """
+            import io.koraframework.database.common.annotation.*;
+            @Table("orders")
+            record Order(@Id String id, @Column("user_id") String userId, String number) {}
+            """,
+            """
+            import io.koraframework.database.common.annotation.*;
+            import io.koraframework.database.jdbc.annotation.EntityJdbc;
+            @EntityJdbc
+            record UserOrdersView(@Embedded("u_") User user, @Embedded("o_") java.util.List<Order> orders) {}
+            """
+        );
+
+        compileResult.assertSuccess();
+        var mapper = (JdbcResultSetMapper<?>) compileResult.loadClass("$UserOrdersView_ListJdbcResultSetMapper").getConstructor().newInstance();
+        var rs = Mockito.mock(ResultSet.class);
+        Mockito.when(rs.next()).thenReturn(true, true, false);
+        Mockito.when(rs.findColumn("u_id")).thenReturn(1);
+        Mockito.when(rs.findColumn("u_name")).thenReturn(2);
+        Mockito.when(rs.findColumn("o_id")).thenReturn(3);
+        Mockito.when(rs.findColumn("o_user_id")).thenReturn(4);
+        Mockito.when(rs.findColumn("o_number")).thenReturn(5);
+        Mockito.when(rs.getString(1)).thenReturn("u1", "u1");
+        Mockito.when(rs.getString(2)).thenReturn("User 1", "User 1");
+        Mockito.when(rs.getString(3)).thenReturn("o1", "o2");
+        Mockito.when(rs.getString(4)).thenReturn("u1", "u1");
+        Mockito.when(rs.getString(5)).thenReturn("n1", "n2");
+        Mockito.when(rs.wasNull()).thenReturn(false, false, false, false, false, false, false, false, false, false);
+
+        var result = (List<?>) mapper.apply(rs);
+
+        assertThat(result).hasSize(1);
+        var orders = result.get(0).getClass().getMethod("orders");
+        orders.setAccessible(true);
+        assertThat((List<?>) orders.invoke(result.get(0))).hasSize(2);
     }
 
     @Test

--- a/database/database-annotation-processor/src/test/java/io/koraframework/database/common/annotation/processor/jdbc/JdbcMacrosTest.java
+++ b/database/database-annotation-processor/src/test/java/io/koraframework/database/common/annotation/processor/jdbc/JdbcMacrosTest.java
@@ -11,6 +11,7 @@ import java.sql.SQLException;
 import java.time.OffsetDateTime;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -109,6 +110,24 @@ final class JdbcMacrosTest extends AbstractJdbcRepositoryTest {
             public interface TestRepository extends JdbcRepository {
             
                 @Query("INSERT INTO %{entity#inserts -= @id}")
+                UpdateCount insert(Entity entity);
+            }
+            """, """
+                @Table("entities")
+                record Entity(@Id String id, @Column("value1") int field1, String value2, @Nullable String value3) {}
+            """);
+
+        repository.invoke("insert", newGeneratedObject("Entity", "1", 1, "1", "1").get());
+        verify(executor.mockConnection).prepareStatement("INSERT INTO entities(value1, value2, value3) VALUES (?, ?, ?)");
+    }
+
+    @Test
+    void columnsAndValuesWithoutId() throws SQLException {
+        var repository = compileJdbc(List.of(), """
+            @Repository
+            public interface TestRepository extends JdbcRepository {
+
+                @Query("INSERT INTO %{entity#table}(%{entity#columns -= @id}) VALUES (%{entity#values -= @id})")
                 UpdateCount insert(Entity entity);
             }
             """, """
@@ -438,6 +457,187 @@ final class JdbcMacrosTest extends AbstractJdbcRepositoryTest {
 
         repository.invoke("insert", newGeneratedObject("Entity", "1", 1, "1", "1").get());
         verify(executor.mockConnection).prepareStatement("UPDATE entities SET value1 = ? WHERE id = ?");
+    }
+
+    @Test
+    void returnEmbeddedSelectsWithTableAliases() throws SQLException {
+        var repository = compileJdbc(List.of(newGeneratedObject("TestRowMapper")), """
+            @Repository
+            public interface TestRepository extends JdbcRepository {
+
+                @Table("users")
+                record User(@Id String id, String name) {}
+
+                @Table("orders")
+                record Order(@Id String id, @Column("user_id") String userId, String number) {}
+
+                record UserOrderView(@Embedded("u_") User user, @Embedded("o_") Order order) {}
+
+                @Query("SELECT %{return#selects} FROM %{return.user#table as u} JOIN %{return.order#table as o} ON o.user_id = u.id WHERE u.id = :id")
+                @Nullable
+                UserOrderView find(String id);
+            }
+            """, """
+            public class TestRowMapper implements JdbcResultSetMapper<TestRepository.UserOrderView> {
+                public TestRepository.UserOrderView apply(ResultSet rs) {
+                  return null;
+                }
+            }
+            """);
+
+        repository.invoke("find", "1");
+        verify(executor.mockConnection).prepareStatement("SELECT u.id AS u_id, u.name AS u_name, o.id AS o_id, o.user_id AS o_user_id, o.number AS o_number FROM users u JOIN orders o ON o.user_id = u.id WHERE u.id = ?");
+    }
+
+    @Test
+    void nestedReturnTargetSelectsWithTableAliases() throws SQLException {
+        var repository = compileJdbc(List.of(newGeneratedObject("TestRowMapper")), """
+            @Repository
+            public interface TestRepository extends JdbcRepository {
+
+                @Table("users")
+                record User(@Id String id, String name) {}
+
+                @Table("orders")
+                record Order(@Id String id, @Column("user_id") String userId, String number) {}
+
+                record UserOrderView(@Embedded("u_") User user, @Embedded("o_") Order order) {}
+
+                @Query("SELECT %{return.user#selects}, %{return.order#selects} FROM %{return.user#table as u} JOIN %{return.order#table as o} ON o.user_id = u.id WHERE u.id = :id")
+                @Nullable
+                UserOrderView find(String id);
+            }
+            """, """
+            public class TestRowMapper implements JdbcResultSetMapper<TestRepository.UserOrderView> {
+                public TestRepository.UserOrderView apply(ResultSet rs) {
+                  return null;
+                }
+            }
+            """);
+
+        repository.invoke("find", "1");
+        verify(executor.mockConnection).prepareStatement("SELECT u.id AS u_id, u.name AS u_name, o.id AS o_id, o.user_id AS o_user_id, o.number AS o_number FROM users u JOIN orders o ON o.user_id = u.id WHERE u.id = ?");
+    }
+
+    @Test
+    void entityWhereIdWithTableAlias() throws SQLException {
+        var repository = compileJdbc(List.of(newGeneratedObject("TestRowMapper")), """
+            @Repository
+            public interface TestRepository extends JdbcRepository {
+
+                @Table("entities")
+                record Entity(@Id String id, @Column("value1") int field1, String value2, @Nullable String value3) {}
+
+                @Query("SELECT %{return#selects} FROM %{entity#table as e} WHERE %{entity#where = @id}")
+                @Nullable
+                Entity find(Entity entity);
+            }
+            """, """
+            public class TestRowMapper implements JdbcResultSetMapper<TestRepository.Entity> {
+                public TestRepository.Entity apply(ResultSet rs) {
+                  return null;
+                }
+            }
+            """);
+
+        repository.invoke("find", newGeneratedObject("TestRepository$Entity", "1", 1, "1", "1").get());
+        verify(executor.mockConnection).prepareStatement("SELECT id, value1, value2, value3 FROM entities e WHERE e.id = ?");
+    }
+
+    @Test
+    void leftJoinNullableEmbeddedEntity() throws Exception {
+        var repository = compileJdbc(List.of(newGeneratedObject("TestRowMapper")), """
+            @Repository
+            public interface TestRepository extends JdbcRepository {
+
+                @Query("SELECT %{return#selects} FROM %{return.user#table as u} LEFT JOIN %{return.order#table as o} ON o.user_id = u.id WHERE u.id = :id")
+                @Nullable
+                UserOrderView find(String id);
+            }
+            """, """
+            public class TestRowMapper implements JdbcResultSetMapper<UserOrderView> {
+                public UserOrderView apply(ResultSet rs) throws SQLException {
+                    return new UserOrderView(new User(rs.getString(1), rs.getString(2)), null);
+                }
+            }
+            """, """
+            @Table("users")
+            record User(@Id String id, String name) {}
+            """, """
+            @Table("orders")
+            record Order(@Id String id, @Column("user_id") String userId, String number) {}
+            """, """
+            record UserOrderView(@Embedded("u_") User user, @Nullable @Embedded("o_") Order order) {}
+            """);
+
+        when(executor.resultSet.next()).thenReturn(true, false);
+        when(executor.resultSet.findColumn("u_id")).thenReturn(1);
+        when(executor.resultSet.findColumn("u_name")).thenReturn(2);
+        when(executor.resultSet.findColumn("o_id")).thenReturn(3);
+        when(executor.resultSet.findColumn("o_user_id")).thenReturn(4);
+        when(executor.resultSet.findColumn("o_number")).thenReturn(5);
+        when(executor.resultSet.getString(1)).thenReturn("u1");
+        when(executor.resultSet.getString(2)).thenReturn("User 1");
+        when(executor.resultSet.getString(3)).thenReturn(null);
+        when(executor.resultSet.getString(4)).thenReturn(null);
+        when(executor.resultSet.getString(5)).thenReturn(null);
+        when(executor.resultSet.wasNull()).thenReturn(false, false, true, true, true);
+
+        var result = repository.invoke("find", "u1");
+
+        assertThat(result).isNotNull();
+        var order = result.getClass().getMethod("order");
+        order.setAccessible(true);
+        assertThat(order.invoke(result)).isNull();
+        verify(executor.mockConnection).prepareStatement("SELECT u.id AS u_id, u.name AS u_name, o.id AS o_id, o.user_id AS o_user_id, o.number AS o_number FROM users u LEFT JOIN orders o ON o.user_id = u.id WHERE u.id = ?");
+    }
+
+    @Test
+    void oneToManyEmbeddedCollectionMapping() throws Exception {
+        var repository = compileJdbc(List.of(newGeneratedObject("TestResultSetMapper")), """
+            @Repository
+            public interface TestRepository extends JdbcRepository {
+
+                @Query("SELECT %{return#selects} FROM %{return.user#table as u} LEFT JOIN %{return.orders#table as o} ON o.user_id = u.id")
+                java.util.List<UserOrdersView> find();
+            }
+            """, """
+            public class TestResultSetMapper implements JdbcResultSetMapper<java.util.List<UserOrdersView>> {
+                public java.util.List<UserOrdersView> apply(ResultSet rs) throws SQLException {
+                    return java.util.List.of(new UserOrdersView(new User("u1", "User 1"), java.util.List.of(new Order("o1", "u1", "n1"), new Order("o2", "u1", "n2"))));
+                }
+            }
+            """, """
+            @Table("users")
+            record User(@Id String id, String name) {}
+            """, """
+            @Table("orders")
+            record Order(@Id String id, @Column("user_id") String userId, String number) {}
+            """, """
+            record UserOrdersView(@Embedded("u_") User user, @Embedded("o_") java.util.List<Order> orders) {}
+            """);
+
+        when(executor.resultSet.next()).thenReturn(true, true, false);
+        when(executor.resultSet.findColumn("u_id")).thenReturn(1);
+        when(executor.resultSet.findColumn("u_name")).thenReturn(2);
+        when(executor.resultSet.findColumn("o_id")).thenReturn(3);
+        when(executor.resultSet.findColumn("o_user_id")).thenReturn(4);
+        when(executor.resultSet.findColumn("o_number")).thenReturn(5);
+        when(executor.resultSet.getString(1)).thenReturn("u1", "u1");
+        when(executor.resultSet.getString(2)).thenReturn("User 1", "User 1");
+        when(executor.resultSet.getString(3)).thenReturn("o1", "o2");
+        when(executor.resultSet.getString(4)).thenReturn("u1", "u1");
+        when(executor.resultSet.getString(5)).thenReturn("n1", "n2");
+        when(executor.resultSet.wasNull()).thenReturn(false, false, false, false, false, false, false, false, false, false);
+
+        var result = (List<?>) repository.invoke("find");
+
+        assertThat(result).hasSize(1);
+        var ordersMethod = result.get(0).getClass().getMethod("orders");
+        ordersMethod.setAccessible(true);
+        var orders = (List<?>) ordersMethod.invoke(result.get(0));
+        assertThat(orders).hasSize(2);
+        verify(executor.mockConnection).prepareStatement("SELECT u.id AS u_id, u.name AS u_name, o.id AS o_id, o.user_id AS o_user_id, o.number AS o_number FROM users u LEFT JOIN orders o ON o.user_id = u.id");
     }
 
     @Test

--- a/database/database-common/src/main/java/io/koraframework/database/common/annotation/Table.java
+++ b/database/database-common/src/main/java/io/koraframework/database/common/annotation/Table.java
@@ -30,7 +30,5 @@ public @interface Table {
      * <b>English</b>: Table name in the database for an entity model.
      */
     String value();
-
-    String alias() default "";
 }
 

--- a/database/database-symbol-processor/src/main/kotlin/io/koraframework/database/symbol/processor/QueryMacrosParser.kt
+++ b/database/database-symbol-processor/src/main/kotlin/io/koraframework/database/symbol/processor/QueryMacrosParser.kt
@@ -30,10 +30,20 @@ class QueryMacrosParser {
         private const val SPECIAL_ID = "@id"
     }
 
-    data class Target(val type: KSClassDeclaration, val name: String, val column: String?)
-    data class Field(val field: KSPropertyDeclaration?, val column: String, val path: String, val isId: Boolean)
+    data class Target(val type: KSClassDeclaration, val name: String, val column: String?, val columnPrefix: String)
+    data class Field(
+        val field: KSPropertyDeclaration?,
+        val column: String,
+        val rawColumn: String,
+        val path: String,
+        val targetPath: String,
+        val isId: Boolean
+    )
+
+    data class Command(val target: String, val command: String, val alias: String?)
 
     fun parse(sql: String, method: KSFunctionDeclaration, methodType: KSFunction, repositoryType: KSType): String {
+        val aliases = collectAliases(sql, method, methodType, repositoryType)
         val sqlBuilder = StringBuilder()
         var prevCmdIndex = 0
         while (true) {
@@ -43,13 +53,65 @@ class QueryMacrosParser {
             }
             val cmdIndexEnd = sql.indexOf(MACROS_END, cmdIndexStart)
             val targetAndCmdAsStr = sql.substring(cmdIndexStart + 2, cmdIndexEnd)
-            val substitution = getSubstitution(targetAndCmdAsStr, method, methodType, repositoryType)
+            val substitution = getSubstitution(targetAndCmdAsStr, method, methodType, repositoryType, aliases)
             sqlBuilder.append(sql, prevCmdIndex, cmdIndexStart).append(substitution)
             prevCmdIndex = cmdIndexEnd + 1
         }
     }
 
-    private fun getPathField(method: KSFunctionDeclaration, target: KSClassDeclaration, rootPath: String, columnPrefix: String): Sequence<Field> {
+    private fun collectAliases(sql: String, method: KSFunctionDeclaration, methodType: KSFunction, repositoryType: KSType): Map<String, String> {
+        val aliases = HashMap<String, String>()
+        var prevCmdIndex = 0
+        while (true) {
+            val cmdIndexStart = sql.indexOf(MACROS_START, prevCmdIndex)
+            if (cmdIndexStart == -1) {
+                return aliases
+            }
+            val cmdIndexEnd = sql.indexOf(MACROS_END, cmdIndexStart)
+            val targetAndCmdAsStr = sql.substring(cmdIndexStart + 2, cmdIndexEnd)
+            val command = parseCommand(targetAndCmdAsStr, method)
+            if (command.command == "table" && command.alias != null) {
+                getTarget(command.target, method, methodType, repositoryType)
+                aliases[command.target] = command.alias
+            }
+            prevCmdIndex = cmdIndexEnd + 1
+        }
+    }
+
+    private fun parseCommand(targetAndCommand: String, method: KSFunctionDeclaration): Command {
+        val targetAndCmd = targetAndCommand.split("#", limit = 2)
+        if (targetAndCmd.size == 1) {
+            throw ProcessingErrorException(
+                "Can't extract query marcos and target from: $targetAndCommand",
+                method
+            )
+        }
+
+        val target = targetAndCmd[0].trim()
+        var selectors = targetAndCmd[1].split("-=", limit = 2)
+        if (selectors.size == 1) {
+            selectors = targetAndCmd[1].split("=", limit = 2)
+        }
+
+        val commandAsStr = selectors[0].trim()
+        val lowerCommand = commandAsStr.lowercase()
+        if (lowerCommand.startsWith("table as ")) {
+            val alias = commandAsStr.substring("table as ".length).trim()
+            if (alias.isEmpty()) {
+                throw ProcessingErrorException("Table alias is empty in query marcos: $targetAndCommand", method)
+            }
+            return Command(target, "table", alias)
+        }
+        return Command(target, lowerCommand, null)
+    }
+
+    private fun getPathField(
+        method: KSFunctionDeclaration,
+        target: KSClassDeclaration,
+        rootPath: String,
+        rootTargetPath: String,
+        columnPrefix: String
+    ): Sequence<Field> {
         val nativeType = JdbcNativeTypes.findNativeType(target.toClassName())
         if (nativeType != null) {
             throw ProcessingErrorException("Can't process argument '$rootPath' as macros cause it is Native Type: $target", method)
@@ -68,37 +130,48 @@ class QueryMacrosParser {
 
             if (isEmbedded != null) {
                 val declaration = field.type.resolve().declaration
-                if (declaration !is KSClassDeclaration) {
+                val fieldType = field.type.resolve()
+                val embeddedDeclaration = if (fieldType.isCollection()) {
+                    fieldType.arguments[0].type!!.resolve().declaration
+                } else {
+                    declaration
+                }
+                if (embeddedDeclaration !is KSClassDeclaration) {
                     throw IllegalArgumentException("@Embedded annotation placed on field that can't be embedded: $target")
                 }
                 val prefix = isEmbedded.findValueNoDefault("value") ?: ""
+                val targetPath = if (rootTargetPath.isEmpty())
+                    field.simpleName.asString()
+                else
+                    "$rootTargetPath." + field.simpleName.asString()
 
-                return@flatMap getPathField(method, declaration, path, prefix)
-                    .map { f -> Field(f.field, f.column, f.path, isId) }
+                return@flatMap getPathField(method, embeddedDeclaration, path, targetPath, columnPrefix + prefix)
+                    .map { f -> Field(f.field, f.column, f.rawColumn, f.path, f.targetPath, isId || f.isId) }
             } else {
-                val columnName = getColumnName(target, field, columnPrefix)
-                return@flatMap sequenceOf(Field(field, columnName, path, isId))
+                val rawColumnName = getColumnName(target, field)
+                val columnName = if (columnPrefix.isBlank()) rawColumnName else columnPrefix + rawColumnName
+                return@flatMap sequenceOf(Field(field, columnName, rawColumnName, path, rootTargetPath, isId))
             }
         }
     }
 
-    private fun getColumnName(target: KSClassDeclaration, field: KSPropertyDeclaration, columnPrefix: String): String {
+    private fun getColumnName(target: KSClassDeclaration, field: KSPropertyDeclaration): String {
         val nameConverter = target.getNameConverter(snakeCaseNameConverter)
         val columnAnnotation = field.findAnnotation(DbUtils.columnAnnotation)?.findValueNoDefault<String>("value")
         if (columnAnnotation != null) {
-            return columnPrefix + columnAnnotation
+            return columnAnnotation
         } else {
-            return columnPrefix + nameConverter.convert(field.simpleName.asString())
+            return nameConverter.convert(field.simpleName.asString())
         }
     }
 
     private fun getFields(method: KSFunctionDeclaration, target: Target): List<Field> {
         val nativeType = JdbcNativeTypes.findNativeType(target.type.toClassName())
         if (nativeType != null && target.column != null) {
-            return listOf(Field(field = null, column = target.column, path = target.name, isId = false))
+            return listOf(Field(field = null, column = target.column, rawColumn = target.column, path = target.name, targetPath = target.name, isId = false))
         }
 
-        return getPathField(method, target.type, target.name, "").toList()
+        return getPathField(method, target.type, target.name, target.name, target.columnPrefix).toList()
     }
 
     private fun getCommandSelectorPaths(type: KSClassDeclaration, rootPath: String, selects: String): Set<String> {
@@ -143,9 +216,15 @@ class QueryMacrosParser {
 
     private fun parseDataClassFields(typeDecl: KSClassDeclaration) = typeDecl.getAllProperties()
 
-    private fun getSubstitution(targetAndCommand: String, method: KSFunctionDeclaration, methodType: KSFunction, repositoryType: KSType): String {
+    private fun getSubstitution(
+        targetAndCommand: String,
+        method: KSFunctionDeclaration,
+        methodType: KSFunction,
+        repositoryType: KSType,
+        aliases: Map<String, String>
+    ): String {
         try {
-            val targetAndCmd = targetAndCommand.split("#".toRegex()).dropLastWhile { it.isEmpty() }.toList()
+            val targetAndCmd = targetAndCommand.split("#", limit = 2)
             if (targetAndCmd.size == 1) {
                 throw ProcessingErrorException(
                     "Can't extract query marcos and target from: $targetAndCommand",
@@ -153,16 +232,16 @@ class QueryMacrosParser {
                 )
             }
             val target = getTarget(targetAndCmd[0].trim(), method, methodType, repositoryType)
-            var selectors = targetAndCmd[1].split("-=".toRegex()).dropLastWhile { it.isEmpty() }
-                .toTypedArray()
+            val command = parseCommand(targetAndCommand, method)
+            var selectors = targetAndCmd[1].split("-=", limit = 2).toTypedArray()
             val include: Boolean
             if (selectors.size == 1) {
                 include = true
-                selectors = targetAndCmd[1].split("=".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
+                selectors = targetAndCmd[1].split("=", limit = 2).toTypedArray()
             } else {
                 include = false
             }
-            val commandAsStr = selectors[0].trim()
+            val commandAsStr = command.command
 
             val paths = if (selectors.size != 1)
                 getCommandSelectorPaths(target.type, target.name, selectors[1])
@@ -181,8 +260,10 @@ class QueryMacrosParser {
                 ?: nameConverter.convert(target.type.simpleName.asString())
 
             return when (commandAsStr) {
-                "table" -> tableName
-                "selects" -> fields.joinToString(", ") { f -> f.column }
+                "table" -> if (command.alias == null) tableName else "$tableName ${command.alias}"
+                "selects" -> fields.joinToString(", ") { f -> selectExpression(f, aliases) }
+                "columns" -> fields.joinToString(", ") { f -> f.column }
+                "values" -> fields.joinToString(", ") { f -> ":" + f.path }
                 "inserts" -> {
                     val tableAndColumnPrefix = fields.joinToString(", ", "$tableName(", ")") { it.column }
                     val inserts = fields.joinToString(", ", "VALUES (", ")") { ":" + it.path }
@@ -194,7 +275,7 @@ class QueryMacrosParser {
                     .filter { f: Field -> !f.isId }
                     .joinToString(", ") { f: Field -> f.column + " = :" + f.path }
 
-                "where" -> fields.joinToString(" AND ") { it.column + " = :" + it.path }
+                "where" -> fields.joinToString(" AND ") { columnReference(it, aliases) + " = :" + it.path }
                 else -> throw ProcessingErrorException("Unknown query marcos specified: $targetAndCommand", method)
             }
         } catch (e: IllegalArgumentException) {
@@ -202,11 +283,32 @@ class QueryMacrosParser {
         }
     }
 
+    private fun selectExpression(field: Field, aliases: Map<String, String>): String {
+        val reference = columnReference(field, aliases)
+        if (aliases.containsKey(field.targetPath) && field.column != field.rawColumn) {
+            return "$reference AS ${field.column}"
+        }
+        return reference
+    }
+
+    private fun columnReference(field: Field, aliases: Map<String, String>): String {
+        val alias = aliases[field.targetPath] ?: return field.column
+        return "$alias.${field.rawColumn}"
+    }
+
     private fun getTarget(targetName: String, method: KSFunctionDeclaration, methodType: KSFunction, repositoryType: KSType): Target {
+        val path = targetName.split(".")
+            .map { it.trim() }
+            .filter { it.isNotBlank() }
+        if (path.isEmpty()) {
+            throw ProcessingErrorException("Macros command unspecified target received: $targetName", method)
+        }
+
         var reference: KSTypeReference? = null
         var type: KSType? = null
+        val rootTargetName = path[0]
 
-        if (TARGET_RETURN == targetName) {
+        if (TARGET_RETURN == rootTargetName) {
             if (method.isVoid()) {
                 throw ProcessingErrorException(
                     "Macros command specified 'return' target, but return value is type Void",
@@ -230,7 +332,7 @@ class QueryMacrosParser {
         } else {
             for (i in method.parameters.indices) {
                 val parameter = method.parameters[i]
-                if (parameter.name!!.asString().contentEquals(targetName)) {
+                if (parameter.name!!.asString().contentEquals(rootTargetName)) {
                     val resolved = parameter.type.resolve()
                     if (resolved.isCollection()) {
                         reference = resolved.arguments[0].type
@@ -244,12 +346,12 @@ class QueryMacrosParser {
             }
 
             if (type == null) {
-                val genericType = getGenericTarget(targetName, method, methodType, repositoryType)
+                val genericType = getGenericTarget(rootTargetName, method, methodType, repositoryType)
                 if (genericType != null) {
                     return genericType
                 }
                 throw ProcessingErrorException(
-                    "Macros command unspecified target received: $targetName",
+                    "Macros command unspecified target received: $rootTargetName",
                     method
                 )
             }
@@ -257,13 +359,38 @@ class QueryMacrosParser {
 
         val resolved = type!!.declaration
         return if (resolved is KSClassDeclaration) {
-            Target(resolved, targetName, getColumnName(method, targetName, reference, type))
+            var target = Target(resolved, rootTargetName, getColumnName(method, rootTargetName, reference, type), "")
+            for (i in 1 until path.size) {
+                target = getChildTarget(method, target, path[i])
+            }
+            target
         } else {
             throw ProcessingErrorException(
                 "Macros command unprocessable target type: $targetName",
                 method
             )
         }
+    }
+
+    private fun getChildTarget(method: KSFunctionDeclaration, target: Target, childName: String): Target {
+        for (field in getFields(target.type)) {
+            if (!field.simpleName.asString().contentEquals(childName)) {
+                continue
+            }
+            val declaration = field.type.resolve().declaration
+            val fieldType = field.type.resolve()
+            val targetDeclaration = if (fieldType.isCollection()) {
+                fieldType.arguments[0].type!!.resolve().declaration
+            } else {
+                declaration
+            }
+            if (targetDeclaration is KSClassDeclaration) {
+                val prefix = field.findAnnotation(DbUtils.embeddedAnnotation)?.findValueNoDefault<String>("value") ?: ""
+                return Target(targetDeclaration, "${target.name}.$childName", null, target.columnPrefix + prefix)
+            }
+            throw ProcessingErrorException("Macros command unprocessable target type: ${target.name}.$childName", method)
+        }
+        throw ProcessingErrorException("Field '$childName' not found, but was present in query marcos target: ${target.name}", method)
     }
 
     private fun getGenericTarget(targetName: String, method: KSFunctionDeclaration, methodType: KSFunction, repositoryType: KSType): Target? {
@@ -316,7 +443,7 @@ class QueryMacrosParser {
     private fun targetFromType(targetName: String, type: KSType): Target {
         val resolved = type.declaration
         return if (resolved is KSClassDeclaration) {
-            Target(resolved, targetName, getColumnName(method = null, targetName, typeReference = null, type))
+            Target(resolved, targetName, getColumnName(method = null, targetName, typeReference = null, type), "")
         } else {
             throw ProcessingErrorException("Macros command unprocessable target type: $targetName", resolved)
         }

--- a/database/database-symbol-processor/src/main/kotlin/io/koraframework/database/symbol/processor/jdbc/JdbcEntityGenerator.kt
+++ b/database/database-symbol-processor/src/main/kotlin/io/koraframework/database/symbol/processor/jdbc/JdbcEntityGenerator.kt
@@ -13,6 +13,7 @@ import io.koraframework.ksp.common.KotlinPoetUtils.controlFlow
 import io.koraframework.ksp.common.KspCommonUtils.addOriginatingKSFile
 import io.koraframework.ksp.common.KspCommonUtils.generated
 import io.koraframework.ksp.common.generatedClass
+import io.koraframework.ksp.common.exception.ProcessingErrorException
 
 class JdbcEntityGenerator(val codeGenerator: CodeGenerator) {
     private val entityReader = DbEntityReader(
@@ -39,6 +40,11 @@ class JdbcEntityGenerator(val codeGenerator: CodeGenerator) {
 
 
     fun generateListResultSetMapper(entity: DbEntity, aggregating: Boolean) {
+        if (entity.hasEmbeddedCollection) {
+            generateAggregatingListResultSetMapper(entity, aggregating)
+            return
+        }
+
         val mapperName = entity.type.declaration.listResultSetMapperName()
         val entityTypeName = entity.type.toTypeName().copy(false)
         val resultTypeName = List::class.asClassName().parameterizedBy(entityTypeName)
@@ -69,6 +75,67 @@ class JdbcEntityGenerator(val codeGenerator: CodeGenerator) {
         )
         apply.addStatement("return _result")
 
+
+        type.primaryConstructor(constructor.build())
+        type.addFunction(apply.build())
+
+        FileSpec.get(mapperName.packageName, type.build()).writeTo(codeGenerator, aggregating, listOfNotNull(entity.type.declaration.containingFile))
+    }
+
+    private fun generateAggregatingListResultSetMapper(entity: DbEntity, aggregating: Boolean) {
+        val collections = entity.embeddedCollections
+        if (collections.size != 1) {
+            throw ProcessingErrorException("Only one @Embedded collection field is supported in JdbcResultSetMapper: ${entity.classDeclaration}", collections[1].property)
+        }
+        val rootIdColumns = entity.rootIdColumns
+        if (rootIdColumns.isEmpty()) {
+            throw ProcessingErrorException(
+                "@Id field is required for one-to-many JdbcResultSetMapper root. Entity: ${entity.classDeclaration}; " +
+                    "root fields: ${entity.rootFieldsDescription}; " +
+                    "add @Id to one of root fields or to a field inside embedded root type, not to @Embedded collection element only.",
+                entity.rootErrorElement
+            )
+        }
+        val collection = collections[0]
+        val mapperName = entity.type.declaration.listResultSetMapperName()
+        val entityTypeName = entity.type.toTypeName().copy(false)
+        val resultTypeName = List::class.asClassName().parameterizedBy(entityTypeName)
+        val type = TypeSpec.classBuilder(mapperName)
+            .addOriginatingKSFile(entity.classDeclaration)
+            .generated(JdbcTypesExtension::class)
+            .addSuperinterface(JdbcTypes.jdbcResultSetMapper.parameterizedBy(resultTypeName))
+
+        val constructor = FunSpec.constructorBuilder()
+        val apply = FunSpec.builder("apply")
+            .addModifiers(KModifier.OVERRIDE)
+            .addParameter("_rs", JdbcTypes.resultSet)
+            .returns(resultTypeName)
+        apply.controlFlow("if (!_rs.next())") {
+            addStatement("return listOf()")
+        }
+        val read = this.entityReader.readEntity("_row", entity)
+        read.enrich(type, constructor)
+        apply.addCode(parseIndexes(entity, "_rs"))
+        apply.addStatement("val _result = ArrayList<%T>()", entityTypeName)
+        apply.addStatement("val _index = LinkedHashMap<List<Any?>, %T>()", entityTypeName)
+        apply.addCode(
+            CodeBlock.builder()
+                .add("do {").indent().add("\n")
+                .add(read.block)
+                .add("val _key = listOf<Any?>(")
+                .add(rootIdColumns.map { CodeBlock.of("%N", it.variableName) }.joinToCode(", "))
+                .add(")\n")
+                .add("val _existing = _index[_key]\n")
+                .add("if (_existing == null) {").indent().add("\n")
+                .add("_index[_key] = _row\n")
+                .add("_result.add(_row)\n")
+                .unindent().add("} else {").indent().add("\n")
+                .add("(_existing.%N as MutableList<%T>).addAll(_row.%N)\n", collection.parent.property.simpleName.asString(), collection.elementType.toTypeName().copy(false), collection.parent.property.simpleName.asString())
+                .unindent().add("}\n")
+                .unindent().add("} while(_rs.next())\n")
+                .build()
+        )
+        apply.addStatement("return _result")
 
         type.primaryConstructor(constructor.build())
         type.addFunction(apply.build())

--- a/database/database-symbol-processor/src/main/kotlin/io/koraframework/database/symbol/processor/model/DbEntity.kt
+++ b/database/database-symbol-processor/src/main/kotlin/io/koraframework/database/symbol/processor/model/DbEntity.kt
@@ -8,6 +8,8 @@ import io.koraframework.database.symbol.processor.DbUtils
 import io.koraframework.database.symbol.processor.parseColumnName
 import io.koraframework.ksp.common.AnnotationUtils.findAnnotation
 import io.koraframework.ksp.common.AnnotationUtils.findValue
+import io.koraframework.ksp.common.AnnotationUtils.isAnnotationPresent
+import io.koraframework.ksp.common.CommonClassNames.isCollection
 import io.koraframework.ksp.common.KotlinPoetUtils.controlFlow
 import io.koraframework.ksp.common.KspCommonUtils.getNameConverter
 import io.koraframework.ksp.common.MappersData
@@ -19,7 +21,7 @@ data class DbEntity(val type: KSType, val classDeclaration: KSClassDeclaration, 
         when (it) {
             is SimpleEntityField -> {
                 val propertyName = it.property.simpleName.asString()
-                sequenceOf(Column(it.property, it.type, propertyName, propertyName, it.columnName, listOf(propertyName), it.type.isMarkedNullable, it.mapping))
+                sequenceOf(Column(it.property, it.type, propertyName, propertyName, it.columnName, listOf(propertyName), it.type.isMarkedNullable, it.mapping, it))
             }
 
             is EmbeddedEntityField -> it.fields.asSequence().map { f ->
@@ -33,11 +35,46 @@ data class DbEntity(val type: KSType, val classDeclaration: KSClassDeclaration, 
                     f.columnName,
                     listOf(parentPropertyName, propertyName),
                     f.type.isMarkedNullable || f.parent.type.isMarkedNullable,
-                    f.mapping
+                    f.mapping,
+                    it
+                )
+            }
+
+            is EmbeddedCollectionEntityField -> it.fields.asSequence().map { f ->
+                val parentPropertyName = f.parent.property.simpleName.asString()
+                val propertyName = f.property.simpleName.asString()
+                Column(
+                    f.property,
+                    f.type,
+                    "$parentPropertyName.$propertyName",
+                    f.variableName,
+                    f.columnName,
+                    listOf(parentPropertyName, propertyName),
+                    f.type.isMarkedNullable,
+                    f.mapping,
+                    it
                 )
             }
         }
     }.toList()
+
+    val embeddedCollections = fields.filterIsInstance<EmbeddedCollectionEntityField>()
+    val hasEmbeddedCollection = embeddedCollections.isNotEmpty()
+    val rootIdColumns = columns
+        .filter { it.entityField !is EmbeddedCollectionEntityField }
+        .filter { it.property.isAnnotationPresent(DbUtils.idAnnotation) }
+    val rootFieldsDescription = fields
+        .filter { it !is EmbeddedCollectionEntityField }
+        .joinToString(", ") { "${it.property.simpleName.asString()} (${it.type})" }
+    val rootErrorElement: KSAnnotated = fields
+        .firstOrNull { it !is EmbeddedCollectionEntityField }
+        ?.let {
+            when (it) {
+                is EmbeddedEntityField -> it.type.declaration
+                else -> it.property
+            }
+        }
+        ?: classDeclaration
 
     data class Column(
         val property: KSPropertyDeclaration,
@@ -47,7 +84,8 @@ data class DbEntity(val type: KSType, val classDeclaration: KSClassDeclaration, 
         val columnName: String,
         val names: List<String>,
         val isNullable: Boolean,
-        val mapping: MappersData
+        val mapping: MappersData,
+        val entityField: EntityField
     ) {
         fun queryParameterName(variableName: String): String {
             return "$variableName.$sqlParameterName"
@@ -87,6 +125,25 @@ data class DbEntity(val type: KSType, val classDeclaration: KSClassDeclaration, 
                 b.add("else -> %L", field.buildInstance())
             }
         }
+        for (field in fields) {
+            if (field !is EmbeddedCollectionEntityField) continue
+            val collectionName = field.parent.property.simpleName.asString()
+            b.addStatement("val %N = ArrayList<%T>()", collectionName, field.elementType.declaration.let { it as KSClassDeclaration }.toClassName())
+            b.controlFlow("if (!(%L))", field.fields.map { CodeBlock.of("%N == null", it.variableName) }.joinToCode(" && ")) {
+                for (column in field.fields) {
+                    if (!column.type.isMarkedNullable) {
+                        controlFlow("if (%N == null)", column.variableName) {
+                            addStatement(
+                                "throw %T(%S)",
+                                NullPointerException::class.java,
+                                "Field ${column.property.simpleName.asString()} is not nullable, but column ${column.columnName} is null"
+                            )
+                        }
+                    }
+                }
+                addStatement("%N.add(%L)", collectionName, field.buildElementInstance())
+            }
+        }
         return b.build()
     }
 
@@ -96,11 +153,40 @@ data class DbEntity(val type: KSType, val classDeclaration: KSClassDeclaration, 
         val mapping: MappersData
     }
 
-    private class SimpleEntityField(override val property: KSPropertyDeclaration, override val type: KSType, val columnName: String, override val mapping: MappersData) : EntityField
+    class SimpleEntityField(override val property: KSPropertyDeclaration, override val type: KSType, val columnName: String, override val mapping: MappersData) : EntityField
     private class EmbeddedEntityField(val parent: SimpleEntityField, override val property: KSPropertyDeclaration, override val type: KSType, val fields: List<Field>) : EntityField {
         fun buildInstance(): CodeBlock {
             val b = CodeBlock.builder()
             b.add("%T(", type.declaration.let { it as KSClassDeclaration }.toClassName()).indent().add("\n")
+            for (i in fields.indices) {
+                val field = fields[i]
+                if (i > 0) {
+                    b.add(",\n")
+                }
+                b.add("%N", field.variableName)
+            }
+            b.unindent().add(")\n")
+            return b.build()
+        }
+
+        data class Field(val parent: SimpleEntityField, val property: KSPropertyDeclaration, val type: KSType, val columnName: String, val mapping: MappersData) {
+            val variableName = parent.property.simpleName.asString() + "_" + property.simpleName.asString()
+        }
+
+        override val mapping: MappersData
+            get() = TODO("Not yet implemented")
+    }
+
+    class EmbeddedCollectionEntityField(
+        val parent: SimpleEntityField,
+        override val property: KSPropertyDeclaration,
+        override val type: KSType,
+        val elementType: KSType,
+        val fields: List<Field>
+    ) : EntityField {
+        fun buildElementInstance(): CodeBlock {
+            val b = CodeBlock.builder()
+            b.add("%T(", elementType.declaration.let { it as KSClassDeclaration }.toClassName()).indent().add("\n")
             for (i in fields.indices) {
                 val field = fields[i]
                 if (i > 0) {
@@ -157,6 +243,17 @@ data class DbEntity(val type: KSType, val classDeclaration: KSClassDeclaration, 
                     }
 
                     val prefix = embedded.findValue<String>("value")?.ifEmpty { null } ?: ""
+                    if (propertyType.isCollection()) {
+                        val elementType = propertyType.arguments[0].type!!.resolve()
+                        val entity = parseEntity(elementType)
+                        if (entity == null) {
+                            throw ProcessingErrorException("Embedded collection field should be of data type", property)
+                        }
+                        val embeddedFields = entity.fields.map { f ->
+                            EmbeddedCollectionEntityField.Field(field, f.property, f.type, prefix + (f as SimpleEntityField).columnName, f.mapping)
+                        }
+                        return@map EmbeddedCollectionEntityField(field, property, propertyType, elementType, embeddedFields)
+                    }
                     val entity = parseEntity(propertyType)
                     if (entity == null) {
                         throw ProcessingErrorException("Embedded field should be of data type", property)

--- a/database/database-symbol-processor/src/test/kotlin/io/koraframework/database/symbol/processor/jdbc/JdbcMacrosTest.kt
+++ b/database/database-symbol-processor/src/test/kotlin/io/koraframework/database/symbol/processor/jdbc/JdbcMacrosTest.kt
@@ -2,6 +2,7 @@ package io.koraframework.database.symbol.processor.jdbc
 
 import io.koraframework.database.jdbc.mapper.parameter.JdbcParameterColumnMapper
 import io.koraframework.database.jdbc.mapper.result.JdbcResultColumnMapper
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 import java.sql.PreparedStatement
@@ -140,6 +141,30 @@ class JdbcMacrosTest : AbstractJdbcRepositoryTest() {
                                   val value2: String, 
                                   val value3: String?)
             
+            """.trimIndent()
+        )
+        repository.invoke<Any>("insert", newGenerated("Entity", "1", 1, "1", "1").invoke())
+        Mockito.verify(executor.mockConnection)
+            .prepareStatement("INSERT INTO entities(value1, value2, value3) VALUES (?, ?, ?)")
+    }
+
+    @Test
+    fun columnsAndValuesWithoutId() {
+        val repository = compile(
+            listOf<Any>(), """
+            @Repository
+            interface TestRepository : JdbcRepository {
+
+                @Query("INSERT INTO %{entity#table}(%{entity#columns -= @id}) VALUES (%{entity#values -= @id})")
+                fun insert(entity: Entity): UpdateCount
+            }
+
+            """.trimIndent(), """
+                @Table("entities")
+                data class Entity(@field:Id val id: String,
+                                  @field:Column("value1") val field1: Long,
+                                  val value2: String,
+                                  val value3: String?)
             """.trimIndent()
         )
         repository.invoke<Any>("insert", newGenerated("Entity", "1", 1, "1", "1").invoke())
@@ -595,6 +620,194 @@ class JdbcMacrosTest : AbstractJdbcRepositoryTest() {
         )
         repository.invoke<Any>("insert", newGenerated("Entity", "1", 1, "1", "1").invoke())
         Mockito.verify(executor.mockConnection).prepareStatement("UPDATE entities SET value1 = ? WHERE id = ?")
+    }
+
+    @Test
+    fun returnEmbeddedSelectsWithTableAliases() {
+        val repository = compile(
+            listOf(newGenerated("TestRowMapper")), """
+            @Repository
+            interface TestRepository : JdbcRepository {
+
+                @Table("users")
+                data class User(@field:Id val id: String, val name: String)
+
+                @Table("orders")
+                data class Order(@field:Id val id: String, @field:Column("user_id") val userId: String, val number: String)
+
+                data class UserOrderView(@field:Embedded("u_") val user: User, @field:Embedded("o_") val order: Order)
+
+                @Query("SELECT %{return#selects} FROM %{return.user#table as u} JOIN %{return.order#table as o} ON o.user_id = u.id WHERE u.id = :id")
+                fun find(id: String): UserOrderView?
+            }
+            """.trimIndent(), """
+            class TestRowMapper : JdbcResultSetMapper<TestRepository.UserOrderView?> {
+                override fun apply(rs: ResultSet): TestRepository.UserOrderView? {
+                  return null
+                }
+            }
+            """.trimIndent()
+        )
+        repository.invoke<Any>("find", "1")
+        Mockito.verify(executor.mockConnection)
+            .prepareStatement("SELECT u.id AS u_id, u.name AS u_name, o.id AS o_id, o.user_id AS o_user_id, o.number AS o_number FROM users u JOIN orders o ON o.user_id = u.id WHERE u.id = ?")
+    }
+
+    @Test
+    fun nestedReturnTargetSelectsWithTableAliases() {
+        val repository = compile(
+            listOf(newGenerated("TestRowMapper")), """
+            @Repository
+            interface TestRepository : JdbcRepository {
+
+                @Table("users")
+                data class User(@field:Id val id: String, val name: String)
+
+                @Table("orders")
+                data class Order(@field:Id val id: String, @field:Column("user_id") val userId: String, val number: String)
+
+                data class UserOrderView(@field:Embedded("u_") val user: User, @field:Embedded("o_") val order: Order)
+
+                @Query("SELECT %{return.user#selects}, %{return.order#selects} FROM %{return.user#table as u} JOIN %{return.order#table as o} ON o.user_id = u.id WHERE u.id = :id")
+                fun find(id: String): UserOrderView?
+            }
+            """.trimIndent(), """
+            class TestRowMapper : JdbcResultSetMapper<TestRepository.UserOrderView?> {
+                override fun apply(rs: ResultSet): TestRepository.UserOrderView? {
+                  return null
+                }
+            }
+            """.trimIndent()
+        )
+        repository.invoke<Any>("find", "1")
+        Mockito.verify(executor.mockConnection)
+            .prepareStatement("SELECT u.id AS u_id, u.name AS u_name, o.id AS o_id, o.user_id AS o_user_id, o.number AS o_number FROM users u JOIN orders o ON o.user_id = u.id WHERE u.id = ?")
+    }
+
+    @Test
+    fun entityWhereIdWithTableAlias() {
+        val repository = compile(
+            listOf(newGenerated("TestRowMapper")), """
+            @Repository
+            interface TestRepository : JdbcRepository {
+
+                @Table("entities")
+                data class Entity(@field:Id val id: String,
+                                  @field:Column("value1") val field1: Long,
+                                  val value2: String,
+                                  val value3: String?)
+
+                @Query("SELECT %{return#selects} FROM %{entity#table as e} WHERE %{entity#where = @id}")
+                fun find(entity: Entity): Entity?
+            }
+            """.trimIndent(), """
+            class TestRowMapper : JdbcResultSetMapper<TestRepository.Entity?> {
+                override fun apply(rs: ResultSet): TestRepository.Entity? {
+                  return null
+                }
+            }
+            """.trimIndent()
+        )
+        repository.invoke<Any>("find", newGenerated("TestRepository\$Entity", "1", 1, "1", "1").invoke())
+        Mockito.verify(executor.mockConnection)
+            .prepareStatement("SELECT id, value1, value2, value3 FROM entities e WHERE e.id = ?")
+    }
+
+    @Test
+    fun leftJoinNullableEmbeddedEntity() {
+        val repository = compile(
+            listOf(newGenerated("TestRowMapper")), """
+            @Repository
+            interface TestRepository : JdbcRepository {
+
+                @Query("SELECT %{return#selects} FROM %{return.user#table as u} LEFT JOIN %{return.order#table as o} ON o.user_id = u.id WHERE u.id = :id")
+                fun find(id: String): UserOrderView?
+            }
+            """.trimIndent(), """
+            class TestRowMapper : JdbcResultSetMapper<UserOrderView?> {
+                override fun apply(rs: ResultSet): UserOrderView? {
+                    return UserOrderView(User(rs.getString(1), rs.getString(2)), null)
+                }
+            }
+            """.trimIndent(), """
+            @Table("users")
+            data class User(@field:Id val id: String, val name: String)
+            """.trimIndent(), """
+            @Table("orders")
+            data class Order(@field:Id val id: String, @field:Column("user_id") val userId: String, val number: String)
+            """.trimIndent(), """
+            data class UserOrderView(@field:Embedded("u_") val user: User, @field:Embedded("o_") val order: Order?)
+            """.trimIndent()
+        )
+
+        Mockito.`when`(executor.resultSet.next()).thenReturn(true, false)
+        Mockito.`when`(executor.resultSet.findColumn("u_id")).thenReturn(1)
+        Mockito.`when`(executor.resultSet.findColumn("u_name")).thenReturn(2)
+        Mockito.`when`(executor.resultSet.findColumn("o_id")).thenReturn(3)
+        Mockito.`when`(executor.resultSet.findColumn("o_user_id")).thenReturn(4)
+        Mockito.`when`(executor.resultSet.findColumn("o_number")).thenReturn(5)
+        Mockito.`when`(executor.resultSet.getString(1)).thenReturn("u1")
+        Mockito.`when`(executor.resultSet.getString(2)).thenReturn("User 1")
+        Mockito.`when`(executor.resultSet.getString(3)).thenReturn(null)
+        Mockito.`when`(executor.resultSet.getString(4)).thenReturn(null)
+        Mockito.`when`(executor.resultSet.getString(5)).thenReturn(null)
+        Mockito.`when`(executor.resultSet.wasNull()).thenReturn(false, false, true, true, true)
+
+        val result = repository.invoke<Any>("find", "u1")
+
+        assertThat(result).isNotNull()
+        assertThat(result!!.javaClass.getMethod("getOrder").invoke(result)).isNull()
+        Mockito.verify(executor.mockConnection)
+            .prepareStatement("SELECT u.id AS u_id, u.name AS u_name, o.id AS o_id, o.user_id AS o_user_id, o.number AS o_number FROM users u LEFT JOIN orders o ON o.user_id = u.id WHERE u.id = ?")
+    }
+
+    @Test
+    fun oneToManyEmbeddedCollectionMapping() {
+        val repository = compile(
+            listOf(newGenerated("TestResultSetMapper")), """
+            @Repository
+            interface TestRepository : JdbcRepository {
+
+                @Query("SELECT %{return#selects} FROM %{return.user#table as u} LEFT JOIN %{return.orders#table as o} ON o.user_id = u.id")
+                fun find(): List<UserOrdersView>
+            }
+            """.trimIndent(), """
+            class TestResultSetMapper : JdbcResultSetMapper<List<UserOrdersView>> {
+                override fun apply(rs: ResultSet): List<UserOrdersView> {
+                    return listOf(UserOrdersView(User("u1", "User 1"), listOf(Order("o1", "u1", "n1"), Order("o2", "u1", "n2"))))
+                }
+            }
+            """.trimIndent(), """
+            @Table("users")
+            data class User(@field:Id val id: String, val name: String)
+            """.trimIndent(), """
+            @Table("orders")
+            data class Order(@field:Id val id: String, @field:Column("user_id") val userId: String, val number: String)
+            """.trimIndent(), """
+            data class UserOrdersView(@field:Embedded("u_") val user: User, @field:Embedded("o_") val orders: List<Order>)
+            """.trimIndent()
+        )
+
+        Mockito.`when`(executor.resultSet.next()).thenReturn(true, true, false)
+        Mockito.`when`(executor.resultSet.findColumn("u_id")).thenReturn(1)
+        Mockito.`when`(executor.resultSet.findColumn("u_name")).thenReturn(2)
+        Mockito.`when`(executor.resultSet.findColumn("o_id")).thenReturn(3)
+        Mockito.`when`(executor.resultSet.findColumn("o_user_id")).thenReturn(4)
+        Mockito.`when`(executor.resultSet.findColumn("o_number")).thenReturn(5)
+        Mockito.`when`(executor.resultSet.getString(1)).thenReturn("u1", "u1")
+        Mockito.`when`(executor.resultSet.getString(2)).thenReturn("User 1", "User 1")
+        Mockito.`when`(executor.resultSet.getString(3)).thenReturn("o1", "o2")
+        Mockito.`when`(executor.resultSet.getString(4)).thenReturn("u1", "u1")
+        Mockito.`when`(executor.resultSet.getString(5)).thenReturn("n1", "n2")
+        Mockito.`when`(executor.resultSet.wasNull()).thenReturn(false, false, false, false, false, false, false, false, false, false)
+
+        val result = repository.invoke<List<*>>("find")
+
+        assertThat(result!!).hasSize(1)
+        val orders = result[0]!!.javaClass.getMethod("getOrders").invoke(result[0]) as List<*>
+        assertThat(orders).hasSize(2)
+        Mockito.verify(executor.mockConnection)
+            .prepareStatement("SELECT u.id AS u_id, u.name AS u_name, o.id AS o_id, o.user_id AS o_user_id, o.number AS o_number FROM users u LEFT JOIN orders o ON o.user_id = u.id")
     }
 
     @Test

--- a/database/database-symbol-processor/src/test/kotlin/io/koraframework/database/symbol/processor/jdbc/JdbcMapperTests.kt
+++ b/database/database-symbol-processor/src/test/kotlin/io/koraframework/database/symbol/processor/jdbc/JdbcMapperTests.kt
@@ -10,6 +10,45 @@ import java.sql.ResultSet
 class JdbcMapperTests : AbstractJdbcRepositoryTest() {
 
     @Test
+    fun testOneToManyListResultSetMapperGenerated() {
+        compile0(
+            listOf(JdbcEntitySymbolProcessorProvider()),
+            """
+            @EntityJdbc
+            data class UserOrdersView(@field:Embedded("u_") val user: User, @field:Embedded("o_") val orders: List<Order>)
+
+            @Table("users")
+            data class User(@field:Id val id: String, val name: String)
+
+            @Table("orders")
+            data class Order(@field:Id val id: String, @field:Column("user_id") val userId: String, val number: String)
+            """.trimIndent()
+        )
+        compileResult.assertSuccess()
+
+        val mapper = newGenerated("\$UserOrdersView_ListJdbcResultSetMapper").invoke() as JdbcResultSetMapper<*>
+        val rs = mock<ResultSet>()
+        whenever(rs.next()).thenReturn(true, true, false)
+        whenever(rs.findColumn("u_id")).thenReturn(1)
+        whenever(rs.findColumn("u_name")).thenReturn(2)
+        whenever(rs.findColumn("o_id")).thenReturn(3)
+        whenever(rs.findColumn("o_user_id")).thenReturn(4)
+        whenever(rs.findColumn("o_number")).thenReturn(5)
+        whenever(rs.getString(1)).thenReturn("u1", "u1")
+        whenever(rs.getString(2)).thenReturn("User 1", "User 1")
+        whenever(rs.getString(3)).thenReturn("o1", "o2")
+        whenever(rs.getString(4)).thenReturn("u1", "u1")
+        whenever(rs.getString(5)).thenReturn("n1", "n2")
+        whenever(rs.wasNull()).thenReturn(false, false, false, false, false, false, false, false, false, false)
+
+        val result = mapper.apply(rs) as List<*>
+
+        assertThat(result).hasSize(1)
+        val orders = result[0]!!.javaClass.getMethod("getOrders").invoke(result[0]) as List<*>
+        assertThat(orders).hasSize(2)
+    }
+
+    @Test
     fun testRowMapperGenerated() {
         compile0(
             listOf(JdbcEntitySymbolProcessorProvider()),


### PR DESCRIPTION
added macros aliases support and more macros and one-to-many mapping
- add `@Column` support in AP/KSP query macros
- add nested macro targets: `%{return.user#...}`
- add alias-aware macros for JOIN queries: `table as u`, `selects`, `where`
- add `columns` and `values` macros
- add `@Embedded List<T>` one-to-many mapping for JDBC `ListJdbcResultSetMapper`
- add nullable embedded entity support for LEFT JOIN results
- report one-to-many configuration errors through `ProcessingErrorException`
- cover AP and KSP behavior with tests

---

Alias в JOIN:

```java
record UserOrderView(
    @Embedded("u_") User user,
    @Embedded("o_") Order order
) {}

@Table("users")
record User(
    @Id String id,
    String name
) {}

@Table("orders")
record Order(
    @Id String id,
    String userId,
    BigDecimal amount
) {}

@Query("""
    SELECT %{return.user#selects}, %{return.order#selects}
    FROM %{return.user#table as u}
    JOIN %{return.order#table as o} ON o.user_id = u.id
    WHERE %{return.user#where = @id}
    """)
List<UserOrderView> find(String id);
```
->
```sql
SELECT
  u.id AS u_id,
  u.name AS u_name,
  o.id AS o_id,
  o.user_id AS o_user_id,
  o.amount AS o_amount
FROM users AS u
JOIN orders AS o ON o.user_id = u.id
WHERE u.id = :id
```

Ключевое нововведение -> `%{return.user#table as u}` и `%{return.order#table as o}`

---

LEFT JOIN nullable embedded:

```java
record UserOrderView(
    @Embedded("u_") User user,
    @Nullable
    @Embedded("o_") Order order
) {}

@Query("""
    SELECT %{return.user#selects}, %{return.order#selects}
    FROM %{return.user#table as u}
    LEFT JOIN %{return.order#table as o} ON o.user_id = u.id
    WHERE u.id = :id
    """)
List<UserOrderView> find(String id);
```

---

One-to-many через `@Embedded List<T>`:
```java
record UserOrdersView(
    @Embedded("u_") User user,
    @Embedded("o_") List<Order> orders
) {}

@Query("""
    SELECT %{return.user#selects}, %{return.orders#selects}
    FROM %{return.user#table as u}
    LEFT JOIN %{return.orders#table as o} ON o.user_id = u.id
    WHERE u.id = :id
    """)
List<UserOrdersView> find(String id);
```

Требование: у root entity должен быть `@Id`