### PR TITLE
Fixed AP log file locking on Windows

### DIFF
--- a/core/annotation-processor-common/src/main/java/io/koraframework/annotation/processor/common/AbstractKoraProcessor.java
+++ b/core/annotation-processor-common/src/main/java/io/koraframework/annotation/processor/common/AbstractKoraProcessor.java
@@ -20,6 +20,7 @@ public abstract class AbstractKoraProcessor extends AbstractProcessor {
     protected Types types;
     protected Elements elements;
     protected Messager messager;
+    private boolean buildEnvironmentClosed;
 
     @Override
     public SourceVersion getSupportedSourceVersion() {
@@ -48,30 +49,48 @@ public abstract class AbstractKoraProcessor extends AbstractProcessor {
 
     @Override
     public final boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
-        var start = System.currentTimeMillis();
-        var supportedAnnotationNames = getSupportedAnnotationClassNames();
-        var annotatedElements = new HashMap<ClassName, List<AnnotatedElement>>();
-        var annotatedElementsSize = 0;
-        for (var annotation : annotations) {
-            var annotationClassName = ClassName.get(annotation);
-            if (supportedAnnotationNames.contains(annotationClassName)) {
-                for (var element : roundEnv.getElementsAnnotatedWith(annotation)) {
-                    annotatedElements.computeIfAbsent(annotationClassName, n -> new ArrayList<>()).add(new AnnotatedElement(annotation, element));
-                    annotatedElementsSize++;
+        var closeAfterRound = roundEnv.processingOver() || roundEnv.errorRaised();
+        try {
+            var start = System.currentTimeMillis();
+            var supportedAnnotationNames = getSupportedAnnotationClassNames();
+            var annotatedElements = new HashMap<ClassName, List<AnnotatedElement>>();
+            var annotatedElementsSize = 0;
+            for (var annotation : annotations) {
+                var annotationClassName = ClassName.get(annotation);
+                if (supportedAnnotationNames.contains(annotationClassName)) {
+                    for (var element : roundEnv.getElementsAnnotatedWith(annotation)) {
+                        annotatedElements.computeIfAbsent(annotationClassName, n -> new ArrayList<>()).add(new AnnotatedElement(annotation, element));
+                        annotatedElementsSize++;
+                    }
                 }
             }
+            try {
+                this.process(annotations, roundEnv, annotatedElements);
+            } catch (ProcessingErrorException e) {
+                e.printError(this.processingEnv);
+            }
+            var end = System.currentTimeMillis();
+            var took = end - start;
+            if (took > 100) {
+                this.messager.printMessage(Diagnostic.Kind.NOTE, "%s processing took %sms for %d elements".formatted(this.getClass().getSimpleName(), took, annotatedElementsSize));
+            }
+            return false;
+        } catch (RuntimeException | Error e) {
+            closeBuildEnvironment();
+            throw e;
+        } finally {
+            if (closeAfterRound) {
+                closeBuildEnvironment();
+            }
         }
-        try {
-            this.process(annotations, roundEnv, annotatedElements);
-        } catch (ProcessingErrorException e) {
-            e.printError(this.processingEnv);
+    }
+
+    private void closeBuildEnvironment() {
+        if (this.buildEnvironmentClosed) {
+            return;
         }
-        var end = System.currentTimeMillis();
-        var took = end - start;
-        if (took > 100) {
-            this.messager.printMessage(Diagnostic.Kind.NOTE, "%s processing took %sms for %d elements".formatted(this.getClass().getSimpleName(), took, annotatedElementsSize));
-        }
-        return false;
+        this.buildEnvironmentClosed = true;
+        BuildEnvironment.close();
     }
 
     protected abstract void process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv, Map<ClassName, List<AnnotatedElement>> annotatedElements);

--- a/core/annotation-processor-common/src/main/java/io/koraframework/annotation/processor/common/BuildEnvironment.java
+++ b/core/annotation-processor-common/src/main/java/io/koraframework/annotation/processor/common/BuildEnvironment.java
@@ -4,8 +4,8 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
 import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.AppenderBase;
 import ch.qos.logback.core.ConsoleAppender;
-import ch.qos.logback.core.FileAppender;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -13,16 +13,19 @@ import javax.annotation.processing.ProcessingEnvironment;
 import javax.tools.StandardLocation;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class BuildEnvironment {
 
-    public static final Logger log = LoggerFactory.getLogger("io.koraframework");
+    private static final Logger logger = LoggerFactory.getLogger("io.koraframework");
     private static final AtomicBoolean INIT = new AtomicBoolean(false);
+    private static final AtomicBoolean SHUTDOWN_HOOK_REGISTERED = new AtomicBoolean(false);
     private static Path buildDir = Paths.get(".");
 
     private BuildEnvironment() {}
@@ -41,27 +44,32 @@ public class BuildEnvironment {
             } else if (dir.getFileName().toString().startsWith("generated-")) {
                 buildDir = dir.getParent();
             } else {
+                INIT.set(false);
                 return;
             }
         } catch (IOException e) {
+            INIT.set(false);
             return;
         }
         initLog(processingEnv);
 
-        var thread = getShutdownThread();
-        Runtime.getRuntime().addShutdownHook(thread);
+        if (SHUTDOWN_HOOK_REGISTERED.compareAndSet(false, true)) {
+            var thread = getShutdownThread();
+            Runtime.getRuntime().addShutdownHook(thread);
+        }
     }
 
     private static Thread getShutdownThread() {
         var thread = new Thread(() -> {
             try {
-                log.info("Annotation processing shutdown...");
+                logger.info("Annotation processing shutdown...");
                 close();
             } catch (Exception e) {
                 e.printStackTrace();
             }
         });
         thread.setName("kora-ap-shutdown");
+        thread.setDaemon(true);
         return thread;
     }
 
@@ -74,32 +82,79 @@ public class BuildEnvironment {
         kora.setAdditive(false);
         kora.detachAndStopAllAppenders();
         var consoleAppender = new ConsoleAppender<ILoggingEvent>();
-        var fileAppender = new FileAppender<ILoggingEvent>();
         var fileName = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'hh-mm-ss").format(LocalDateTime.now()) + ".log";
-        fileAppender.setFile(buildDir.resolve("kora").resolve("log").resolve(fileName).toString());
+        var file = buildDir.resolve("kora").resolve("log").resolve(fileName);
 
-        var patternLayoutEncoder = new PatternLayoutEncoder();
-        patternLayoutEncoder.setPattern("%d{HH:mm:ss.SSS} %-5level [%thread] %logger{36} - %msg%n");
-        patternLayoutEncoder.setCharset(StandardCharsets.UTF_8);
-        patternLayoutEncoder.setContext(ctx);
-        patternLayoutEncoder.start();
-        fileAppender.setEncoder(patternLayoutEncoder);
+        var fileAppender = new NonLockingFileAppender(file, createEncoder(ctx));
         fileAppender.setContext(ctx);
         fileAppender.start();
-        consoleAppender.setEncoder(patternLayoutEncoder);
+        var consoleEncoder = createEncoder(ctx);
+        consoleEncoder.start();
+        consoleAppender.setEncoder(consoleEncoder);
         consoleAppender.setContext(ctx);
         consoleAppender.start();
         kora.addAppender(fileAppender);
         kora.addAppender(consoleAppender);
 
-        if (log instanceof ch.qos.logback.classic.Logger logger) {
+        if (logger instanceof ch.qos.logback.classic.Logger logger) {
             logger.setLevel(Level.valueOf(processingEnv.getOptions().getOrDefault("koraLogLevel", "INFO")));
         }
     }
 
     public static synchronized void close() {
-        var ctx = (LoggerContext) LoggerFactory.getILoggerFactory();
+        if (!INIT.compareAndSet(true, false)) {
+            return;
+        }
+        if (!(LoggerFactory.getILoggerFactory() instanceof LoggerContext ctx)) {
+            return;
+        }
         var kora = ctx.getLogger("io.koraframework");
+        logger.info("Logger shutdown...");
         kora.detachAndStopAllAppenders();
+    }
+
+    private static PatternLayoutEncoder createEncoder(LoggerContext ctx) {
+        var encoder = new PatternLayoutEncoder();
+        encoder.setPattern("%d{HH:mm:ss.SSS} %-5level [%thread] %logger{36} - %msg%n");
+        encoder.setCharset(StandardCharsets.UTF_8);
+        encoder.setContext(ctx);
+        return encoder;
+    }
+
+    private static final class NonLockingFileAppender extends AppenderBase<ILoggingEvent> {
+        private final Path file;
+        private final PatternLayoutEncoder encoder;
+
+        private NonLockingFileAppender(Path file, PatternLayoutEncoder encoder) {
+            this.file = file;
+            this.encoder = encoder;
+        }
+
+        @Override
+        public void start() {
+            try {
+                Files.createDirectories(this.file.getParent());
+            } catch (IOException e) {
+                this.addError("Failed to create Kora annotation processor log directory", e);
+                return;
+            }
+            this.encoder.start();
+            super.start();
+        }
+
+        @Override
+        public void stop() {
+            super.stop();
+            this.encoder.stop();
+        }
+
+        @Override
+        protected synchronized void append(ILoggingEvent eventObject) {
+            try {
+                Files.write(this.file, this.encoder.encode(eventObject), StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+            } catch (IOException e) {
+                this.addError("Failed to write Kora annotation processor log", e);
+            }
+        }
     }
 }

--- a/core/application-graph/src/main/java/io/koraframework/application/graph/KoraApplication.java
+++ b/core/application-graph/src/main/java/io/koraframework/application/graph/KoraApplication.java
@@ -13,24 +13,24 @@ public final class KoraApplication {
     public static RefreshableGraph run(Supplier<ApplicationGraphDraw> supplier) {
         var start = System.currentTimeMillis();
         var graphDraw = supplier.get();
-        var log = LoggerFactory.getLogger(graphDraw.getRoot());
-        log.debug("Application initializing...");
+        var logger = LoggerFactory.getLogger(graphDraw.getRoot());
+        logger.debug("Application initializing...");
         try {
             var graph = graphDraw.init();
             var end = System.currentTimeMillis();
             try {
                 var uptime = ManagementFactory.getRuntimeMXBean().getUptime() / 1000.0;
-                log.info("Application initialized in {} ms (JVM running for {} s)", end - start, uptime);
+                logger.info("Application initialized in {} ms (JVM running for {} s)", end - start, uptime);
             } catch (Throwable ex) {
-                log.info("Application initialized in {}ms", end - start);
+                logger.info("Application initialized in {}ms", end - start);
             }
             var thread = new Thread(() -> {
                 try {
-                    log.info("Application shutdown");
+                    logger.info("Application shutdown");
                     graph.release();
-                    log.info("Application released");
+                    logger.info("Application released");
                 } catch (Exception e) {
-                    log.error("Application release error", e);
+                    logger.error("Application release error", e);
                     try {
                         Thread.sleep(100);// so async logger is able to write exception to log
                     } catch (InterruptedException ignore) {}
@@ -41,7 +41,7 @@ public final class KoraApplication {
             Runtime.getRuntime().addShutdownHook(thread);
             return graph;
         } catch (Exception e) {
-            log.error("Application initializing failed with error", e);
+            logger.error("Application initializing failed with error", e);
             e.printStackTrace();
             try {
                 Thread.sleep(100);// so async logger is able to write exception to log

--- a/core/application-graph/src/main/java/io/koraframework/application/graph/internal/GraphImpl.java
+++ b/core/application-graph/src/main/java/io/koraframework/application/graph/internal/GraphImpl.java
@@ -21,7 +21,7 @@ public final class GraphImpl implements InitializedGraph {
     private static final CompletableFuture<Void> EMPTY_FUTURE = CompletableFuture.completedFuture(null);
 
     private final ApplicationGraphDraw draw;
-    private final Logger log;
+    private final Logger logger;
     private final Set<Integer> refreshListenerNodes = new HashSet<>();
 
     private volatile AtomicReferenceArray<@Nullable Object> objects;
@@ -29,7 +29,7 @@ public final class GraphImpl implements InitializedGraph {
 
     public GraphImpl(ApplicationGraphDraw draw) {
         this.draw = draw;
-        this.log = LoggerFactory.getLogger(this.draw.getRoot());
+        this.logger = LoggerFactory.getLogger(this.draw.getRoot());
         this.objects = new AtomicReferenceArray<>(this.draw.size());
     }
 
@@ -113,15 +113,15 @@ public final class GraphImpl implements InitializedGraph {
         root.set(fromNode.index);
         this.initLock.lock();
 
-        log.debug("Dependency container refreshing from node {} of class {}...", fromNode.index, this.objects.get(fromNode.index).getClass());
-        final long started = log.isDebugEnabled() ? started() : 0;
+        logger.debug("Dependency container refreshing from node {} of class {}...", fromNode.index, this.objects.get(fromNode.index).getClass());
+        final long started = logger.isDebugEnabled() ? started() : 0;
         try {
             this.initializeSubgraph(fromNode.index);
-            if (log.isDebugEnabled()) {
-                log.debug("Dependency container refreshed in {}", tookForLogging(started));
+            if (logger.isDebugEnabled()) {
+                logger.debug("Dependency container refreshed in {}", tookForLogging(started));
             }
         } catch (Throwable e) {
-            log.debug("Dependency container refresh error", e);
+            logger.debug("Dependency container refresh error", e);
             throw e;
         } finally {
             this.initLock.unlock();
@@ -134,13 +134,13 @@ public final class GraphImpl implements InitializedGraph {
         root.set(0, this.objects.length());
         this.initLock.lock();
 
-        log.debug("Dependency container initializing...");
+        logger.debug("Dependency container initializing...");
         final long started = started();
         try {
             this.initializeSubgraph(0);
-            log.debug("Dependency container initialized in {}", tookForLogging(started));
+            logger.debug("Dependency container initialized in {}", tookForLogging(started));
         } catch (Exception e) {
-            log.debug("Dependency container initialization failed", e);
+            logger.debug("Dependency container initialization failed", e);
             throw e;
         } finally {
             this.initLock.unlock();
@@ -152,13 +152,13 @@ public final class GraphImpl implements InitializedGraph {
         var root = new BitSet(this.objects.length());
         root.set(0, this.objects.length());
         this.initLock.lock();
-        log.debug("Dependency container releasing...");
+        logger.debug("Dependency container releasing...");
         final long started = started();
         try {
             this.releaseNodes(this.objects, root);
-            log.debug("Dependency container released in {}", tookForLogging(started));
+            logger.debug("Dependency container released in {}", tookForLogging(started));
         } catch (Exception e) {
-            log.debug("Dependency container releasing failed", e);
+            logger.debug("Dependency container releasing failed", e);
             throw e;
         } finally {
             this.initLock.unlock();
@@ -166,7 +166,7 @@ public final class GraphImpl implements InitializedGraph {
     }
 
     private void initializeSubgraph(int startFrom) {
-        log.trace("Materializing graph objects {}", startFrom);
+        logger.trace("Materializing graph objects {}", startFrom);
         this.conditionResultsCache.clear();
         var tmpGraph = new TmpGraph(this);
         var errors = tmpGraph.init(startFrom);
@@ -174,7 +174,7 @@ public final class GraphImpl implements InitializedGraph {
             try {
                 this.releaseNodes(tmpGraph.tmpArray, tmpGraph.initialized);
             } catch (Throwable e) {
-                this.log.warn("Error on releasing temporary objects after init error", e);
+                this.logger.warn("Error on releasing temporary objects after init error", e);
             }
             if (errors.size() == 1) {
                 switch (errors.getFirst()) {
@@ -203,21 +203,21 @@ public final class GraphImpl implements InitializedGraph {
         try {
             this.releaseNodes(oldObjects, tmpGraph.initialized);
         } catch (Throwable e) {
-            this.log.warn("Error on releasing temporary objects after init error", e);
+            this.logger.warn("Error on releasing temporary objects after init error", e);
         }
-        log.trace("Dependency container refreshed, calling interceptors...");
+        logger.trace("Dependency container refreshed, calling interceptors...");
         for (var refreshListenerNode : this.refreshListenerNodes) {
             if (this.objects.get(refreshListenerNode) instanceof RefreshListener refreshListener) {
                 try {
                     refreshListener.graphRefreshed();
                 } catch (Exception e) {
-                    log.warn("Exception caught when calling listener.graphRefreshed(), object={}", refreshListener);
+                    logger.warn("Exception caught when calling listener.graphRefreshed(), object={}", refreshListener);
                 }
             }
         }
         this.conditionResultsCache.putAll(tmpGraph.conditionResultsCache);
         tmpGraph.delegate = this;
-        log.trace("Dependency container refreshed, ");
+        logger.trace("Dependency container refreshed, ");
     }
 
     private void releaseNodes(AtomicReferenceArray<Object> objects, BitSet root) {
@@ -284,13 +284,13 @@ public final class GraphImpl implements InitializedGraph {
             var interceptorNode = (NodeImpl<? extends GraphInterceptor<T>>) i.previous();
             @SuppressWarnings("unchecked")
             var interceptor = (GraphInterceptor<T>) objects.get(interceptorNode.index);
-            this.log.trace("Intercepting release node {} of class {} with node {} of class {}", node.index, object.getClass(), interceptorNode.index, interceptor.getClass());
+            this.logger.trace("Intercepting release node {} of class {} with node {} of class {}", node.index, object.getClass(), interceptorNode.index, interceptor.getClass());
             try {
                 var intercepted = interceptor.beforeRelease(object);
-                log.trace("Intercepting release node {} of class {} with node {} of class {} complete", node.index, object.getClass(), interceptorNode.index, interceptor.getClass());
+                logger.trace("Intercepting release node {} of class {} with node {} of class {} complete", node.index, object.getClass(), interceptorNode.index, interceptor.getClass());
                 object = intercepted;
             } catch (Throwable e) {
-                this.log.trace("Intercepting release node {} of class {} with node {} of class {} error", node.index, object.getClass(), interceptorNode.index, interceptor.getClass(), e);
+                this.logger.trace("Intercepting release node {} of class {} with node {} of class {} error", node.index, object.getClass(), interceptorNode.index, interceptor.getClass(), e);
                 if (error == null) {
                     error = e;
                 } else {
@@ -308,10 +308,10 @@ public final class GraphImpl implements InitializedGraph {
                     error.addSuppressed(e);
                 }
             }
-            log.trace("Node {} of class {} released", node.index, object.getClass());
+            logger.trace("Node {} of class {} released", node.index, object.getClass());
         }
         if (object instanceof AutoCloseable closeable) {
-            log.trace("Releasing node {} of class {}", node.index, object.getClass());
+            logger.trace("Releasing node {} of class {}", node.index, object.getClass());
             try {
                 closeable.close();
             } catch (Throwable e) {
@@ -321,7 +321,7 @@ public final class GraphImpl implements InitializedGraph {
                     error.addSuppressed(e);
                 }
             }
-            log.trace("Node {} of class {} released", node.index, object.getClass());
+            logger.trace("Node {} of class {} released", node.index, object.getClass());
         }
         if (error != null) {
             throw error;
@@ -347,7 +347,7 @@ public final class GraphImpl implements InitializedGraph {
             }
             this.inits = new AtomicReferenceArray<>(this.tmpArray.length());
             this.initialized = new BitSet(this.tmpArray.length());
-            this.debugEnabled = this.rootGraph.log.isDebugEnabled();
+            this.debugEnabled = this.rootGraph.logger.isDebugEnabled();
         }
 
         private final ConcurrentMap<GraphConditionKey, GraphCondition.ConditionResult> conditionResultsCache = new ConcurrentHashMap<>();
@@ -494,7 +494,7 @@ public final class GraphImpl implements InitializedGraph {
                 switch (node.condition().apply(this)) {
                     case GraphCondition.ConditionResult.Matched _ -> {}
                     case GraphCondition.ConditionResult.Failed failed -> {
-                        this.rootGraph.log.trace("Creating node {} canceled: {}", node.index, failed.reason());
+                        this.rootGraph.logger.trace("Creating node {} canceled: {}", node.index, failed.reason());
                         this.tmpArray.set(node.index, new ConditionFailedGraphValue(failed));
                         return;
                     }
@@ -502,9 +502,9 @@ public final class GraphImpl implements InitializedGraph {
             }
 
 
-            if (this.rootGraph.log.isTraceEnabled()) {
+            if (this.rootGraph.logger.isTraceEnabled()) {
                 var dependenciesStr = node.createDependencies.stream().map(Node::toString).collect(Collectors.joining(",", "[", "]"));
-                this.rootGraph.log.trace("Creating node {}, dependencies {}", node.index, dependenciesStr);
+                this.rootGraph.logger.trace("Creating node {}, dependencies {}", node.index, dependenciesStr);
             }
 
             var newObject = Objects.requireNonNull(node.factory.get(this));
@@ -525,7 +525,7 @@ public final class GraphImpl implements InitializedGraph {
                     this.rootGraph.refreshListenerNodes.add(node.index);
                 }
             }
-            this.rootGraph.log.trace("Created node {} {}", node.index, newObject.getClass());
+            this.rootGraph.logger.trace("Created node {} {}", node.index, newObject.getClass());
             if (newObject instanceof Lifecycle lifecycle) {
                 this.initializeNode(node, lifecycle);
             }
@@ -533,16 +533,16 @@ public final class GraphImpl implements InitializedGraph {
                 var interceptor = (NodeImpl<? extends GraphInterceptor<T>>) interceptorNode;
                 var interceptorObject = (GraphInterceptor<T>) this.get(interceptor);
                 // todo handle somehow errors on that stage?
-                this.rootGraph.log.trace("Intercepting init node {} of class {} with node {} of class {}", node.index, newObject.getClass(), interceptor.index, interceptorObject.getClass());
+                this.rootGraph.logger.trace("Intercepting init node {} of class {} with node {} of class {}", node.index, newObject.getClass(), interceptor.index, interceptorObject.getClass());
                 try {
                     var intercepted = interceptorObject.afterInit(newObject);
-                    this.rootGraph.log.trace("Intercepting init node {} of class {} with node {} of class {} complete", node.index, newObject.getClass(), interceptor.index, interceptorObject.getClass());
+                    this.rootGraph.logger.trace("Intercepting init node {} of class {} with node {} of class {} complete", node.index, newObject.getClass(), interceptor.index, interceptorObject.getClass());
                     newObject = intercepted;
                 } catch (RuntimeException | Error e) {
-                    this.rootGraph.log.trace("Intercepting init node {} of class {} with node {} of class {} error", node.index, newObject.getClass(), interceptor.index, interceptorObject.getClass(), e);
+                    this.rootGraph.logger.trace("Intercepting init node {} of class {} with node {} of class {} error", node.index, newObject.getClass(), interceptor.index, interceptorObject.getClass(), e);
                     throw e;
                 } catch (Throwable e) {
-                    this.rootGraph.log.trace("Intercepting init node {} of class {} with node {} of class {} error", node.index, newObject.getClass(), interceptor.index, interceptorObject.getClass(), e);
+                    this.rootGraph.logger.trace("Intercepting init node {} of class {} with node {} of class {} error", node.index, newObject.getClass(), interceptor.index, interceptorObject.getClass(), e);
                     throw new IllegalStateException(e);
                 }
             }
@@ -563,21 +563,21 @@ public final class GraphImpl implements InitializedGraph {
 
         private void initializeNode(NodeImpl<?> node, Lifecycle lifecycle) {
             var index = node.index;
-            this.rootGraph.log.trace("Initializing node {} of class {} cancelled", index, lifecycle.getClass());
+            this.rootGraph.logger.trace("Initializing node {} of class {} cancelled", index, lifecycle.getClass());
             try {
                 lifecycle.init();
-                this.rootGraph.log.trace("Node Initializing {} of class {} complete", index, lifecycle.getClass());
+                this.rootGraph.logger.trace("Node Initializing {} of class {} complete", index, lifecycle.getClass());
             } catch (CancellationException e) {
-                this.rootGraph.log.trace("Node Initializing {} of class {} cancelled", index, lifecycle.getClass());
+                this.rootGraph.logger.trace("Node Initializing {} of class {} cancelled", index, lifecycle.getClass());
                 throw e;
             } catch (CompletionException ce) {
-                this.rootGraph.log.trace("Node Initializing {} of class {} error", index, lifecycle.getClass(), ce.getCause());
+                this.rootGraph.logger.trace("Node Initializing {} of class {} error", index, lifecycle.getClass(), ce.getCause());
                 throw ce;
             } catch (RuntimeException | Error e) {
-                this.rootGraph.log.trace("Node Initializing {} of class {} error", index, lifecycle.getClass(), e);
+                this.rootGraph.logger.trace("Node Initializing {} of class {} error", index, lifecycle.getClass(), e);
                 throw e;
             } catch (Throwable e) {
-                this.rootGraph.log.trace("Initializing node {} of class {} error", index, lifecycle.getClass(), e);
+                this.rootGraph.logger.trace("Initializing node {} of class {} error", index, lifecycle.getClass(), e);
                 throw new IllegalStateException(e);
             }
         }
@@ -594,7 +594,7 @@ public final class GraphImpl implements InitializedGraph {
                         if (this.debugEnabled) {
                             var took = System.nanoTime() - startTime;
                             if (took > SLOW_NODE_INIT_THRESHOLD * 1_000_000) {
-                                this.rootGraph.log.debug("Initialized node {} at index {} in {}ms", node.type(), node.index, took / 1_000_000);
+                                this.rootGraph.logger.debug("Initialized node {} at index {} in {}ms", node.type(), node.index, took / 1_000_000);
                             }
                         }
                         future.complete(null);
@@ -602,7 +602,7 @@ public final class GraphImpl implements InitializedGraph {
                         if (this.debugEnabled) {
                             var took = System.nanoTime() - startTime;
                             if (took > SLOW_NODE_INIT_THRESHOLD * 1_000_000) {
-                                this.rootGraph.log.debug("Initialized node {} at index {} in {}ms", node.type(), node.index, took / 1_000_000);
+                                this.rootGraph.logger.debug("Initialized node {} at index {} in {}ms", node.type(), node.index, took / 1_000_000);
                             }
                         }
                         future.completeExceptionally(t);

--- a/core/kora-app-annotation-processor/src/main/java/io/koraframework/kora/app/annotation/processor/DependencyModuleHintProvider.java
+++ b/core/kora-app-annotation-processor/src/main/java/io/koraframework/kora/app/annotation/processor/DependencyModuleHintProvider.java
@@ -20,7 +20,7 @@ import java.util.regex.Pattern;
 
 public class DependencyModuleHintProvider {
 
-    private static final Logger log = LoggerFactory.getLogger(DependencyModuleHintProvider.class);
+    private static final Logger logger = LoggerFactory.getLogger(DependencyModuleHintProvider.class);
 
     private final List<KoraHint> hints;
 
@@ -76,12 +76,12 @@ public class DependencyModuleHintProvider {
 
     List<Hint> findHints(TypeMirror missingType, @Nullable String missingTag) {
         var typeName = TypeName.get(missingType);
-        log.trace("Checking hints for {}/{}", missingTag, typeName);
+        logger.trace("Checking hints for {}/{}", missingTag, typeName);
         var result = new ArrayList<Hint>();
         for (var hint : this.hints) {
             var matcher = hint.typeRegex().matcher(typeName.toString());
             if (matcher.matches()) {
-                log.trace("Hint {} matched!", hint);
+                logger.trace("Hint {} matched!", hint);
                 if (this.tagMatches(missingTag, hint.tag())) {
                     if (hint instanceof KoraHint.KoraModuleHint h) {
                         result.add(new Hint.ModuleHint(typeName, h.tag(), h.artifact(), h.module()));
@@ -92,7 +92,7 @@ public class DependencyModuleHintProvider {
                     }
                 }
             } else {
-                log.trace("Hint {} doesn't match because of regex", hint);
+                logger.trace("Hint {} doesn't match because of regex", hint);
             }
         }
         return result;

--- a/core/kora-app-annotation-processor/src/main/java/io/koraframework/kora/app/annotation/processor/KoraAppProcessor.java
+++ b/core/kora-app-annotation-processor/src/main/java/io/koraframework/kora/app/annotation/processor/KoraAppProcessor.java
@@ -17,6 +17,7 @@ import javax.lang.model.element.*;
 import javax.lang.model.type.TypeKind;
 import javax.tools.Diagnostic;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -28,7 +29,7 @@ public class KoraAppProcessor extends AbstractKoraProcessor {
 
     public static final int COMPONENTS_PER_HOLDER_CLASS = 500;
 
-    private static final Logger log = LoggerFactory.getLogger(KoraAppProcessor.class);
+    private static final Logger logger = LoggerFactory.getLogger(KoraAppProcessor.class);
 
     private final List<TypeElement> annotatedInterfaceModules = new ArrayList<>();
     private final List<TypeElement> annotatedClassModules = new ArrayList<>(); // @Disabled("Haven't decided whether to release it yet")
@@ -38,7 +39,7 @@ public class KoraAppProcessor extends AbstractKoraProcessor {
     @Override
     public synchronized void init(ProcessingEnvironment processingEnv) {
         super.init(processingEnv);
-        log.info("@KoraApp processor started");
+        logger.info("@KoraApp processor started");
     }
 
     @Override
@@ -57,7 +58,7 @@ public class KoraAppProcessor extends AbstractKoraProcessor {
                 return;
             }
             var ctx = new ProcessingContext(processingEnv);
-            LogUtils.logElementsFull(log, Level.DEBUG, "Processing elements", this.koraApps);
+            LogUtils.logElementsFull(logger, Level.DEBUG, "Processing elements", this.koraApps);
 
             for (var element : this.koraApps) {
                 try {
@@ -66,7 +67,7 @@ public class KoraAppProcessor extends AbstractKoraProcessor {
                 } catch (ProcessingErrorException e) {
                     e.printError(this.processingEnv);
                 } catch (IOException e) {
-                    throw new RuntimeException(e);
+                    throw new UncheckedIOException(e);
                 }
             }
         }
@@ -76,8 +77,8 @@ public class KoraAppProcessor extends AbstractKoraProcessor {
         for (var annotated : annotatedElements.getOrDefault(CommonClassNames.koraApp, List.of())) {
             var element = annotated.element();
             if (element.getKind() == ElementKind.INTERFACE) {
-                if (log.isInfoEnabled()) {
-                    log.info("@KoraApp element found:\n{}", element.toString().indent(4));
+                if (logger.isInfoEnabled()) {
+                    logger.info("@KoraApp element found:\n{}", element.toString().indent(4));
                 }
                 this.koraApps.add((TypeElement) element);
             } else {
@@ -135,14 +136,14 @@ public class KoraAppProcessor extends AbstractKoraProcessor {
         }
         var type = (TypeElement) classElement;
         var interfaces = KoraAppUtils.collectInterfaces(this.types, type);
-        if (log.isTraceEnabled()) {
-            log.trace("Effective modules found:\n{}", Stream.concat(Stream.of(type), this.annotatedInterfaceModules.stream()).flatMap(t -> KoraAppUtils.collectInterfaces(this.types, t).stream())
+        if (logger.isTraceEnabled()) {
+            logger.trace("Effective modules found:\n{}", Stream.concat(Stream.of(type), this.annotatedInterfaceModules.stream()).flatMap(t -> KoraAppUtils.collectInterfaces(this.types, t).stream())
                 .map(Object::toString).sorted()
                 .collect(Collectors.joining("\n")).indent(4));
         }
         var mixedInModuleComponents = KoraAppUtils.parseComponents(ctx, interfaces.stream().map(ModuleDeclaration.MixedInModule::new).toList());
-        if (log.isTraceEnabled()) {
-            log.trace("Effective methods of {}:\n{}", classElement, mixedInModuleComponents.stream().map(Object::toString).sorted().collect(Collectors.joining("\n")).indent(4));
+        if (logger.isTraceEnabled()) {
+            logger.trace("Effective methods of {}:\n{}", classElement, mixedInModuleComponents.stream().map(Object::toString).sorted().collect(Collectors.joining("\n")).indent(4));
         }
         var submodules = KoraAppUtils.findKoraSubmoduleModules(this.elements, interfaces, type, processingEnv);
         var discoveredModules = this.annotatedInterfaceModules.stream().flatMap(t -> KoraAppUtils.collectInterfaces(this.types, t).stream());

--- a/core/kora-app-annotation-processor/src/main/java/io/koraframework/kora/app/annotation/processor/extension/Extensions.java
+++ b/core/kora-app-annotation-processor/src/main/java/io/koraframework/kora/app/annotation/processor/extension/Extensions.java
@@ -13,7 +13,8 @@ import java.util.ServiceLoader;
 import java.util.stream.Collectors;
 
 public record Extensions(List<KoraExtension> extensions) {
-    private static final Logger log = LoggerFactory.getLogger(Extensions.class);
+
+    private static final Logger logger = LoggerFactory.getLogger(Extensions.class);
 
     public static Extensions load(ClassLoader classLoader, ProcessingEnvironment processingEnvironment) {
         var serviceLoader = ServiceLoader.load(ExtensionFactory.class, classLoader);
@@ -22,13 +23,13 @@ public record Extensions(List<KoraExtension> extensions) {
             .flatMap(f -> f.create(processingEnvironment).stream())
             .toList();
 
-        if (!extensions.isEmpty() && log.isInfoEnabled()) {
+        if (!extensions.isEmpty() && logger.isInfoEnabled()) {
             String out = extensions.stream()
                 .map(e -> e.getClass().getCanonicalName())
                 .collect(Collectors.joining("\n"))
                 .indent(4);
 
-            log.info("Extensions found:\n{}", out);
+            logger.info("Extensions found:\n{}", out);
         }
 
         return new Extensions(extensions);
@@ -40,7 +41,7 @@ public record Extensions(List<KoraExtension> extensions) {
         for (var extension : this.extensions) {
             var generator = extension.getDependencyGenerator(roundEnvironment, typeMirror, tag);
             if (generator != null) {
-                log.trace("Extension '{}' is suitable generating for type: {}", extension.getClass().getCanonicalName(), typeMirror);
+                logger.trace("Extension '{}' is suitable generating for type: {}", extension.getClass().getCanonicalName(), typeMirror);
                 extensions.add(generator);
             }
         }

--- a/core/kora-app-symbol-processor/src/main/kotlin/io/koraframework/kora/app/ksp/DependencyModuleHintProvider.kt
+++ b/core/kora-app-symbol-processor/src/main/kotlin/io/koraframework/kora/app/ksp/DependencyModuleHintProvider.kt
@@ -12,7 +12,8 @@ import java.io.IOException
 import java.util.regex.Pattern
 
 class DependencyModuleHintProvider {
-    private val log = LoggerFactory.getLogger(this::class.java)
+
+    private val logger = LoggerFactory.getLogger(this::class.java)
 
     private var hints: List<KoraHint> = mutableListOf()
 
@@ -71,23 +72,23 @@ class DependencyModuleHintProvider {
     }
 
     fun findHints(missingType: KSType, missingTag: String?): List<Hint> {
-        log.trace("Checking hints for {}/{}", missingTag, missingType)
+        logger.trace("Checking hints for {}/{}", missingTag, missingType)
         val result = mutableListOf<Hint>()
         for (hint in hints) {
             val matcher = hint.typeRegex.matcher(missingType.toTypeName().toString())
             if (matcher.matches()) {
                 if (tagMatches(missingTag, hint.tag)) {
-                    log.trace("Hint {} matched!", hint)
+                    logger.trace("Hint {} matched!", hint)
                     when (hint) {
                         is KoraHint.KoraModuleHint -> result.add(Hint.ModuleHint(missingType, hint.tag, hint.artifact, hint.moduleName))
                         is KoraHint.KoraTipHint -> result.add(Hint.TipHint(missingType, hint.tag, hint.tip))
                         else -> throw UnsupportedOperationException("Unknown hint type: $hint")
                     }
                 } else {
-                    log.trace("Hint {} doesn't match because of tag", hint)
+                    logger.trace("Hint {} doesn't match because of tag", hint)
                 }
             } else {
-                log.trace("Hint {} doesn't match because of regex", hint)
+                logger.trace("Hint {} doesn't match because of regex", hint)
             }
         }
         return result


### PR DESCRIPTION
- Annotation processor logging used Logback `FileAppender`, which can keep `build/kora/log/*.log` open inside long-lived Gradle daemon/compiler workers. On Windows this made repeated `clean classes` fail because Gradle could not delete module `build` directories.
- Replace the AP file appender with a non-locking appender that opens the log file only for each write, and keep explicit `BuildEnvironment` cleanup on final/error processing rounds and processor failures.