### PR TITLE
Added PostgreSQL JDBC database module

### DIFF
--- a/database/database-jdbc-postgres/build.gradle
+++ b/database/database-jdbc-postgres/build.gradle
@@ -1,0 +1,9 @@
+dependencies {
+    api project(":database:database-jdbc")
+    api project(":core:common")
+    api project(":json:json-common")
+    api libs.jdbc.postgresql
+
+    testImplementation project(":internal:test-postgres")
+    testImplementation libs.mockito.core
+}

--- a/database/database-jdbc-postgres/src/main/java/io/koraframework/database/jdbc/postgres/PgArrayJdbcMappersModule.java
+++ b/database/database-jdbc-postgres/src/main/java/io/koraframework/database/jdbc/postgres/PgArrayJdbcMappersModule.java
@@ -1,0 +1,129 @@
+package io.koraframework.database.jdbc.postgres;
+
+import io.koraframework.common.annotation.DefaultComponent;
+import io.koraframework.database.jdbc.mapper.parameter.JdbcParameterColumnMapper;
+import io.koraframework.database.jdbc.mapper.result.JdbcResultColumnMapper;
+import io.koraframework.database.jdbc.postgres.annotation.Pg;
+import io.koraframework.database.jdbc.postgres.mapper.parameter.PgArrayParameterColumnMapper;
+import io.koraframework.database.jdbc.postgres.mapper.result.PgArrayResultColumnMapper;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+/**
+ * <b>Русский</b>: Конвертеры массивов Java в массивы PostgreSQL. Поддержаны только боксированные типы
+ * элемента: примитивный массив не может представить элемент {@code NULL}, который PostgreSQL в массиве допускает.
+ * <hr>
+ * <b>English</b>: Converters of Java arrays into PostgreSQL arrays. Only boxed element types are supported: a primitive
+ * array can't represent a {@code NULL} element, which PostgreSQL permits in an array.
+ */
+public interface PgArrayJdbcMappersModule {
+
+    @Pg
+    @DefaultComponent
+    default JdbcParameterColumnMapper<Boolean[]> booleanArrayJdbcParameterColumnMapper() {
+        return new PgArrayParameterColumnMapper<>("bool");
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcResultColumnMapper<Boolean[]> booleanArrayJdbcResultColumnMapper() {
+        return new PgArrayResultColumnMapper<>(Boolean[]::new);
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcParameterColumnMapper<Short[]> shortArrayJdbcParameterColumnMapper() {
+        return new PgArrayParameterColumnMapper<>("int2");
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcResultColumnMapper<Short[]> shortArrayJdbcResultColumnMapper() {
+        return new PgArrayResultColumnMapper<>(Short[]::new);
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcParameterColumnMapper<Integer[]> integerArrayJdbcParameterColumnMapper() {
+        return new PgArrayParameterColumnMapper<>("int4");
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcResultColumnMapper<Integer[]> integerArrayJdbcResultColumnMapper() {
+        return new PgArrayResultColumnMapper<>(Integer[]::new);
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcParameterColumnMapper<Long[]> longArrayJdbcParameterColumnMapper() {
+        return new PgArrayParameterColumnMapper<>("int8");
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcResultColumnMapper<Long[]> longArrayJdbcResultColumnMapper() {
+        return new PgArrayResultColumnMapper<>(Long[]::new);
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcParameterColumnMapper<Float[]> floatArrayJdbcParameterColumnMapper() {
+        return new PgArrayParameterColumnMapper<>("float4");
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcResultColumnMapper<Float[]> floatArrayJdbcResultColumnMapper() {
+        return new PgArrayResultColumnMapper<>(Float[]::new);
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcParameterColumnMapper<Double[]> doubleArrayJdbcParameterColumnMapper() {
+        return new PgArrayParameterColumnMapper<>("float8");
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcResultColumnMapper<Double[]> doubleArrayJdbcResultColumnMapper() {
+        return new PgArrayResultColumnMapper<>(Double[]::new);
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcParameterColumnMapper<BigDecimal[]> bigDecimalArrayJdbcParameterColumnMapper() {
+        return new PgArrayParameterColumnMapper<>("numeric");
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcResultColumnMapper<BigDecimal[]> bigDecimalArrayJdbcResultColumnMapper() {
+        return new PgArrayResultColumnMapper<>(BigDecimal[]::new);
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcParameterColumnMapper<String[]> stringArrayJdbcParameterColumnMapper() {
+        return new PgArrayParameterColumnMapper<>("varchar");
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcResultColumnMapper<String[]> stringArrayJdbcResultColumnMapper() {
+        return new PgArrayResultColumnMapper<>(String[]::new);
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcParameterColumnMapper<UUID[]> uuidArrayJdbcParameterColumnMapper() {
+        return new PgArrayParameterColumnMapper<>("uuid");
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcResultColumnMapper<UUID[]> uuidArrayJdbcResultColumnMapper() {
+        return new PgArrayResultColumnMapper<>(UUID[]::new);
+    }
+}

--- a/database/database-jdbc-postgres/src/main/java/io/koraframework/database/jdbc/postgres/PgCollectionJdbcMappersModule.java
+++ b/database/database-jdbc-postgres/src/main/java/io/koraframework/database/jdbc/postgres/PgCollectionJdbcMappersModule.java
@@ -1,0 +1,242 @@
+package io.koraframework.database.jdbc.postgres;
+
+import io.koraframework.common.annotation.DefaultComponent;
+import io.koraframework.database.jdbc.mapper.parameter.JdbcParameterColumnMapper;
+import io.koraframework.database.jdbc.mapper.result.JdbcResultColumnMapper;
+import io.koraframework.database.jdbc.postgres.annotation.Pg;
+import io.koraframework.database.jdbc.postgres.mapper.parameter.PgCollectionParameterColumnMapper;
+import io.koraframework.database.jdbc.postgres.mapper.result.PgCollectionResultColumnMapper;
+
+import java.math.BigDecimal;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * <b>Русский</b>: Конвертеры коллекций в массивы PostgreSQL. Параметр принимается как {@link List}, {@link Set}
+ * или {@link Collection}, чтобы не заставлять пересобирать коллекцию ради вызова; результат всегда {@link List} —
+ * уникальность задаётся запросом через {@code DISTINCT}.
+ * <hr>
+ * <b>English</b>: Converters of collections into PostgreSQL arrays. A parameter is accepted as a {@link List},
+ * {@link Set} or {@link Collection} so that a collection need not be rebuilt just to make the call; a result is always
+ * a {@link List} — uniqueness is expressed by the query via {@code DISTINCT}.
+ */
+public interface PgCollectionJdbcMappersModule {
+
+    @Pg
+    @DefaultComponent
+    default JdbcParameterColumnMapper<List<Boolean>> booleanListJdbcParameterColumnMapper() {
+        return new PgCollectionParameterColumnMapper<>("bool");
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcParameterColumnMapper<Set<Boolean>> booleanSetJdbcParameterColumnMapper() {
+        return new PgCollectionParameterColumnMapper<>("bool");
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcParameterColumnMapper<Collection<Boolean>> booleanCollectionJdbcParameterColumnMapper() {
+        return new PgCollectionParameterColumnMapper<>("bool");
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcResultColumnMapper<List<Boolean>> booleanListJdbcResultColumnMapper() {
+        return new PgCollectionResultColumnMapper<>();
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcParameterColumnMapper<List<Short>> shortListJdbcParameterColumnMapper() {
+        return new PgCollectionParameterColumnMapper<>("int2");
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcParameterColumnMapper<Set<Short>> shortSetJdbcParameterColumnMapper() {
+        return new PgCollectionParameterColumnMapper<>("int2");
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcParameterColumnMapper<Collection<Short>> shortCollectionJdbcParameterColumnMapper() {
+        return new PgCollectionParameterColumnMapper<>("int2");
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcResultColumnMapper<List<Short>> shortListJdbcResultColumnMapper() {
+        return new PgCollectionResultColumnMapper<>();
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcParameterColumnMapper<List<Integer>> integerListJdbcParameterColumnMapper() {
+        return new PgCollectionParameterColumnMapper<>("int4");
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcParameterColumnMapper<Set<Integer>> integerSetJdbcParameterColumnMapper() {
+        return new PgCollectionParameterColumnMapper<>("int4");
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcParameterColumnMapper<Collection<Integer>> integerCollectionJdbcParameterColumnMapper() {
+        return new PgCollectionParameterColumnMapper<>("int4");
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcResultColumnMapper<List<Integer>> integerListJdbcResultColumnMapper() {
+        return new PgCollectionResultColumnMapper<>();
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcParameterColumnMapper<List<Long>> longListJdbcParameterColumnMapper() {
+        return new PgCollectionParameterColumnMapper<>("int8");
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcParameterColumnMapper<Set<Long>> longSetJdbcParameterColumnMapper() {
+        return new PgCollectionParameterColumnMapper<>("int8");
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcParameterColumnMapper<Collection<Long>> longCollectionJdbcParameterColumnMapper() {
+        return new PgCollectionParameterColumnMapper<>("int8");
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcResultColumnMapper<List<Long>> longListJdbcResultColumnMapper() {
+        return new PgCollectionResultColumnMapper<>();
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcParameterColumnMapper<List<Float>> floatListJdbcParameterColumnMapper() {
+        return new PgCollectionParameterColumnMapper<>("float4");
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcParameterColumnMapper<Set<Float>> floatSetJdbcParameterColumnMapper() {
+        return new PgCollectionParameterColumnMapper<>("float4");
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcParameterColumnMapper<Collection<Float>> floatCollectionJdbcParameterColumnMapper() {
+        return new PgCollectionParameterColumnMapper<>("float4");
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcResultColumnMapper<List<Float>> floatListJdbcResultColumnMapper() {
+        return new PgCollectionResultColumnMapper<>();
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcParameterColumnMapper<List<Double>> doubleListJdbcParameterColumnMapper() {
+        return new PgCollectionParameterColumnMapper<>("float8");
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcParameterColumnMapper<Set<Double>> doubleSetJdbcParameterColumnMapper() {
+        return new PgCollectionParameterColumnMapper<>("float8");
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcParameterColumnMapper<Collection<Double>> doubleCollectionJdbcParameterColumnMapper() {
+        return new PgCollectionParameterColumnMapper<>("float8");
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcResultColumnMapper<List<Double>> doubleListJdbcResultColumnMapper() {
+        return new PgCollectionResultColumnMapper<>();
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcParameterColumnMapper<List<BigDecimal>> bigDecimalListJdbcParameterColumnMapper() {
+        return new PgCollectionParameterColumnMapper<>("numeric");
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcParameterColumnMapper<Set<BigDecimal>> bigDecimalSetJdbcParameterColumnMapper() {
+        return new PgCollectionParameterColumnMapper<>("numeric");
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcParameterColumnMapper<Collection<BigDecimal>> bigDecimalCollectionJdbcParameterColumnMapper() {
+        return new PgCollectionParameterColumnMapper<>("numeric");
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcResultColumnMapper<List<BigDecimal>> bigDecimalListJdbcResultColumnMapper() {
+        return new PgCollectionResultColumnMapper<>();
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcParameterColumnMapper<List<String>> stringListJdbcParameterColumnMapper() {
+        return new PgCollectionParameterColumnMapper<>("varchar");
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcParameterColumnMapper<Set<String>> stringSetJdbcParameterColumnMapper() {
+        return new PgCollectionParameterColumnMapper<>("varchar");
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcParameterColumnMapper<Collection<String>> stringCollectionJdbcParameterColumnMapper() {
+        return new PgCollectionParameterColumnMapper<>("varchar");
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcResultColumnMapper<List<String>> stringListJdbcResultColumnMapper() {
+        return new PgCollectionResultColumnMapper<>();
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcParameterColumnMapper<List<UUID>> uuidListJdbcParameterColumnMapper() {
+        return new PgCollectionParameterColumnMapper<>("uuid");
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcParameterColumnMapper<Set<UUID>> uuidSetJdbcParameterColumnMapper() {
+        return new PgCollectionParameterColumnMapper<>("uuid");
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcParameterColumnMapper<Collection<UUID>> uuidCollectionJdbcParameterColumnMapper() {
+        return new PgCollectionParameterColumnMapper<>("uuid");
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcResultColumnMapper<List<UUID>> uuidListJdbcResultColumnMapper() {
+        return new PgCollectionResultColumnMapper<>();
+    }
+}

--- a/database/database-jdbc-postgres/src/main/java/io/koraframework/database/jdbc/postgres/PgIntervalJdbcMappersModule.java
+++ b/database/database-jdbc-postgres/src/main/java/io/koraframework/database/jdbc/postgres/PgIntervalJdbcMappersModule.java
@@ -1,0 +1,88 @@
+package io.koraframework.database.jdbc.postgres;
+
+import io.koraframework.common.annotation.DefaultComponent;
+import io.koraframework.database.jdbc.mapper.parameter.JdbcParameterColumnMapper;
+import io.koraframework.database.jdbc.mapper.result.JdbcResultColumnMapper;
+import io.koraframework.database.jdbc.postgres.annotation.Pg;
+import org.postgresql.util.PGInterval;
+
+import java.sql.SQLException;
+import java.sql.Types;
+import java.time.Duration;
+import java.time.Period;
+
+/**
+ * <b>Русский</b>: Конвертеры {@link Duration} и {@link Period} в колонку типа {@code interval}.
+ * <hr>
+ * <b>English</b>: Converters of {@link Duration} and {@link Period} into an {@code interval} column.
+ */
+public interface PgIntervalJdbcMappersModule {
+
+    @Pg
+    @DefaultComponent
+    default JdbcParameterColumnMapper<Duration> durationJdbcParameterColumnMapper() {
+        return (stmt, index, value) -> {
+            if (value == null) {
+                stmt.setNull(index, Types.OTHER);
+                return;
+            }
+
+            var seconds = value.toSecondsPart() + value.toNanosPart() / 1_000_000_000d;
+            stmt.setObject(index, new PGInterval(0, 0, Math.toIntExact(value.toDaysPart()),
+                value.toHoursPart(), value.toMinutesPart(), seconds));
+        };
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcResultColumnMapper<Duration> durationJdbcResultColumnMapper() {
+        return (row, index) -> {
+            var interval = row.getObject(index, PGInterval.class);
+            if (row.wasNull()) {
+                return null;
+            }
+            // месяцы и годы не имеют фиксированной длины, молча отбросить их значит потерять данные
+            if (interval.getYears() != 0 || interval.getMonths() != 0) {
+                throw new SQLException("PostgreSQL interval with years or months can't be converted to Duration, "
+                                       + "use Period instead: " + interval.getValue());
+            }
+
+            return Duration.ofDays(interval.getDays())
+                .plusHours(interval.getHours())
+                .plusMinutes(interval.getMinutes())
+                .plusSeconds(interval.getWholeSeconds())
+                .plusNanos(interval.getMicroSeconds() * 1_000L);
+        };
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcParameterColumnMapper<Period> periodJdbcParameterColumnMapper() {
+        return (stmt, index, value) -> {
+            if (value == null) {
+                stmt.setNull(index, Types.OTHER);
+                return;
+            }
+
+            stmt.setObject(index, new PGInterval(value.getYears(), value.getMonths(), value.getDays(), 0, 0, 0));
+        };
+    }
+
+    @Pg
+    @DefaultComponent
+    default JdbcResultColumnMapper<Period> periodJdbcResultColumnMapper() {
+        return (row, index) -> {
+            var interval = row.getObject(index, PGInterval.class);
+            if (row.wasNull()) {
+                return null;
+            }
+            if (interval.getHours() != 0 || interval.getMinutes() != 0
+                || interval.getWholeSeconds() != 0 || interval.getMicroSeconds() != 0) {
+                throw new SQLException("PostgreSQL interval with a time part can't be converted to Period, "
+                                       + "use Duration instead: " + interval.getValue());
+            }
+
+            return Period.of(interval.getYears(), interval.getMonths(), interval.getDays());
+        };
+    }
+}

--- a/database/database-jdbc-postgres/src/main/java/io/koraframework/database/jdbc/postgres/PgJsonJdbcMappersModule.java
+++ b/database/database-jdbc-postgres/src/main/java/io/koraframework/database/jdbc/postgres/PgJsonJdbcMappersModule.java
@@ -1,0 +1,46 @@
+package io.koraframework.database.jdbc.postgres;
+
+import io.koraframework.common.annotation.DefaultComponent;
+import io.koraframework.database.jdbc.mapper.parameter.JdbcParameterColumnMapper;
+import io.koraframework.database.jdbc.mapper.result.JdbcResultColumnMapper;
+import io.koraframework.database.jdbc.postgres.annotation.PgJson;
+import io.koraframework.database.jdbc.postgres.annotation.PgJsonb;
+import io.koraframework.database.jdbc.postgres.mapper.parameter.PgJsonParameterColumnMapper;
+import io.koraframework.database.jdbc.postgres.mapper.result.PgJsonResultColumnMapper;
+import io.koraframework.json.common.JsonReader;
+import io.koraframework.json.common.JsonWriter;
+
+/**
+ * <b>Русский</b>: Конвертеры значения в колонку типа {@code json} либо {@code jsonb} через JSON.
+ * <hr>
+ * <b>English</b>: Converters of a value into a {@code json} or {@code jsonb} column via JSON.
+ *
+ * @see PgJson
+ * @see PgJsonb
+ */
+public interface PgJsonJdbcMappersModule {
+
+    @PgJson
+    @DefaultComponent
+    default <T> JdbcParameterColumnMapper<T> jsonJdbcParameterColumnMapper(JsonWriter<T> jsonWriter) {
+        return new PgJsonParameterColumnMapper<>(jsonWriter, "json");
+    }
+
+    @PgJson
+    @DefaultComponent
+    default <T> JdbcResultColumnMapper<T> jsonJdbcResultColumnMapper(JsonReader<T> jsonReader) {
+        return new PgJsonResultColumnMapper<>(jsonReader);
+    }
+
+    @PgJsonb
+    @DefaultComponent
+    default <T> JdbcParameterColumnMapper<T> jsonbJdbcParameterColumnMapper(JsonWriter<T> jsonWriter) {
+        return new PgJsonParameterColumnMapper<>(jsonWriter, "jsonb");
+    }
+
+    @PgJsonb
+    @DefaultComponent
+    default <T> JdbcResultColumnMapper<T> jsonbJdbcResultColumnMapper(JsonReader<T> jsonReader) {
+        return new PgJsonResultColumnMapper<>(jsonReader);
+    }
+}

--- a/database/database-jdbc-postgres/src/main/java/io/koraframework/database/jdbc/postgres/PgRange.java
+++ b/database/database-jdbc-postgres/src/main/java/io/koraframework/database/jdbc/postgres/PgRange.java
@@ -1,0 +1,68 @@
+package io.koraframework.database.jdbc.postgres;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * <b>Русский</b>: Значение range-типа PostgreSQL: нижняя и верхняя границы с признаком включённости каждой из них.
+ * Граница {@code null} означает бесконечность с этой стороны.
+ * <hr>
+ * <b>English</b>: PostgreSQL range type value: lower and upper bounds with per-bound inclusivity.
+ * A {@code null} bound means unbounded (infinite) on that side.
+ * <br>
+ * <br>
+ * Обратите внимание / Note: PostgreSQL приводит дискретные range-типы ({@code int4range}, {@code int8range},
+ * {@code daterange}) к канонической форме {@code [)}, а вырожденные диапазоны — к {@link #empty()},
+ * поэтому прочитанное значение может отличаться от записанного. / PostgreSQL canonicalizes discrete range types
+ * to the {@code [)} form and degenerate ranges to {@link #empty()}, so a value read back may differ from the
+ * one written.
+ *
+ * @param lower          нижняя граница диапазона / range lower bound
+ * @param upper          верхняя граница диапазона / range upper bound
+ * @param lowerInclusive включена ли нижняя граница / whether the lower bound is included
+ * @param upperInclusive включена ли верхняя граница / whether the upper bound is included
+ * @param isEmpty        является ли диапазон пустым / whether the range is empty
+ */
+public record PgRange<T>(@Nullable T lower,
+                         @Nullable T upper,
+                         boolean lowerInclusive,
+                         boolean upperInclusive,
+                         boolean isEmpty) {
+
+    public PgRange {
+        if (isEmpty) {
+            lower = null;
+            upper = null;
+            lowerInclusive = false;
+            upperInclusive = false;
+        }
+    }
+
+    public PgRange(@Nullable T lower, @Nullable T upper, boolean lowerInclusive, boolean upperInclusive) {
+        this(lower, upper, lowerInclusive, upperInclusive, false);
+    }
+
+    /**
+     * <b>Русский</b>: Пустой диапазон, не содержащий ни одного значения ({@code empty} в PostgreSQL).
+     * <hr>
+     * <b>English</b>: Empty range that contains no values ({@code empty} in PostgreSQL).
+     */
+    public static <T> PgRange<T> empty() {
+        return new PgRange<>(null, null, false, false, true);
+    }
+
+    public static <T> PgRange<T> closed(@Nullable T lower, @Nullable T upper) {
+        return new PgRange<>(lower, upper, true, true);
+    }
+
+    public static <T> PgRange<T> closedOpen(@Nullable T lower, @Nullable T upper) {
+        return new PgRange<>(lower, upper, true, false);
+    }
+
+    public static <T> PgRange<T> openClosed(@Nullable T lower, @Nullable T upper) {
+        return new PgRange<>(lower, upper, false, true);
+    }
+
+    public static <T> PgRange<T> open(@Nullable T lower, @Nullable T upper) {
+        return new PgRange<>(lower, upper, false, false);
+    }
+}

--- a/database/database-jdbc-postgres/src/main/java/io/koraframework/database/jdbc/postgres/PgRangeFormats.java
+++ b/database/database-jdbc-postgres/src/main/java/io/koraframework/database/jdbc/postgres/PgRangeFormats.java
@@ -1,0 +1,26 @@
+package io.koraframework.database.jdbc.postgres;
+
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
+
+/**
+ * Текстовое представление границ временных range-типов: PostgreSQL отдаёт их не в ISO-8601, а через пробел
+ * ({@code 2021-01-01 10:00:00+03}), поэтому стандартные {@code DateTimeFormatter} не подходят.
+ */
+final class PgRangeFormats {
+
+    static final DateTimeFormatter TIMESTAMP = new DateTimeFormatterBuilder()
+        .appendPattern("yyyy-MM-dd HH:mm:ss")
+        .appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true)
+        .toFormatter();
+
+    // "+HH:mm" печатает и разбирает как "+03", так и "+05:30" — ровно то, что отдаёт PostgreSQL
+    static final DateTimeFormatter TIMESTAMP_WITH_TIMEZONE = new DateTimeFormatterBuilder()
+        .appendPattern("yyyy-MM-dd HH:mm:ss")
+        .appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true)
+        .appendOffset("+HH:mm", "+00")
+        .toFormatter();
+
+    private PgRangeFormats() { }
+}

--- a/database/database-jdbc-postgres/src/main/java/io/koraframework/database/jdbc/postgres/PgRangeJdbcMappersModule.java
+++ b/database/database-jdbc-postgres/src/main/java/io/koraframework/database/jdbc/postgres/PgRangeJdbcMappersModule.java
@@ -1,0 +1,82 @@
+package io.koraframework.database.jdbc.postgres;
+
+import io.koraframework.common.annotation.DefaultComponent;
+import io.koraframework.database.jdbc.mapper.parameter.JdbcParameterColumnMapper;
+import io.koraframework.database.jdbc.mapper.result.JdbcResultColumnMapper;
+import io.koraframework.database.jdbc.postgres.mapper.parameter.PgRangeParameterColumnMapper;
+import io.koraframework.database.jdbc.postgres.mapper.result.PgRangeResultColumnMapper;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+
+/**
+ * <b>Русский</b>: Конвертеры {@link PgRange} в range-типы PostgreSQL. Тега не требуют, потому что сам
+ * {@link PgRange} уже PostgreSQL специфичен и других претендентов на эти конвертеры нет.
+ * <hr>
+ * <b>English</b>: Converters of {@link PgRange} into PostgreSQL range types. They need no tag, because {@link PgRange}
+ * itself is already PostgreSQL specific and nothing else can claim those converters.
+ */
+public interface PgRangeJdbcMappersModule {
+
+    @DefaultComponent
+    default JdbcParameterColumnMapper<PgRange<Integer>> int4RangeJdbcParameterColumnMapper() {
+        return new PgRangeParameterColumnMapper<>("int4range", String::valueOf);
+    }
+
+    @DefaultComponent
+    default JdbcResultColumnMapper<PgRange<Integer>> int4RangeJdbcResultColumnMapper() {
+        return new PgRangeResultColumnMapper<>(Integer::valueOf);
+    }
+
+    @DefaultComponent
+    default JdbcParameterColumnMapper<PgRange<Long>> int8RangeJdbcParameterColumnMapper() {
+        return new PgRangeParameterColumnMapper<>("int8range", String::valueOf);
+    }
+
+    @DefaultComponent
+    default JdbcResultColumnMapper<PgRange<Long>> int8RangeJdbcResultColumnMapper() {
+        return new PgRangeResultColumnMapper<>(Long::valueOf);
+    }
+
+    @DefaultComponent
+    default JdbcParameterColumnMapper<PgRange<BigDecimal>> numRangeJdbcParameterColumnMapper() {
+        return new PgRangeParameterColumnMapper<>("numrange", BigDecimal::toPlainString);
+    }
+
+    @DefaultComponent
+    default JdbcResultColumnMapper<PgRange<BigDecimal>> numRangeJdbcResultColumnMapper() {
+        return new PgRangeResultColumnMapper<>(BigDecimal::new);
+    }
+
+    @DefaultComponent
+    default JdbcParameterColumnMapper<PgRange<LocalDate>> dateRangeJdbcParameterColumnMapper() {
+        return new PgRangeParameterColumnMapper<>("daterange", LocalDate::toString);
+    }
+
+    @DefaultComponent
+    default JdbcResultColumnMapper<PgRange<LocalDate>> dateRangeJdbcResultColumnMapper() {
+        return new PgRangeResultColumnMapper<>(LocalDate::parse);
+    }
+
+    @DefaultComponent
+    default JdbcParameterColumnMapper<PgRange<LocalDateTime>> tsRangeJdbcParameterColumnMapper() {
+        return new PgRangeParameterColumnMapper<>("tsrange", PgRangeFormats.TIMESTAMP::format);
+    }
+
+    @DefaultComponent
+    default JdbcResultColumnMapper<PgRange<LocalDateTime>> tsRangeJdbcResultColumnMapper() {
+        return new PgRangeResultColumnMapper<>(bound -> LocalDateTime.parse(bound, PgRangeFormats.TIMESTAMP));
+    }
+
+    @DefaultComponent
+    default JdbcParameterColumnMapper<PgRange<OffsetDateTime>> tstzRangeJdbcParameterColumnMapper() {
+        return new PgRangeParameterColumnMapper<>("tstzrange", PgRangeFormats.TIMESTAMP_WITH_TIMEZONE::format);
+    }
+
+    @DefaultComponent
+    default JdbcResultColumnMapper<PgRange<OffsetDateTime>> tstzRangeJdbcResultColumnMapper() {
+        return new PgRangeResultColumnMapper<>(bound -> OffsetDateTime.parse(bound, PgRangeFormats.TIMESTAMP_WITH_TIMEZONE));
+    }
+}

--- a/database/database-jdbc-postgres/src/main/java/io/koraframework/database/jdbc/postgres/PostgresJdbcDatabaseModule.java
+++ b/database/database-jdbc-postgres/src/main/java/io/koraframework/database/jdbc/postgres/PostgresJdbcDatabaseModule.java
@@ -1,0 +1,30 @@
+package io.koraframework.database.jdbc.postgres;
+
+import io.koraframework.database.jdbc.JdbcDatabaseModule;
+import io.koraframework.database.jdbc.postgres.annotation.Pg;
+import io.koraframework.database.jdbc.postgres.annotation.PgJson;
+import io.koraframework.database.jdbc.postgres.annotation.PgJsonb;
+
+/**
+ * <b>Русский</b>: Модуль JDBC с PostgreSQL специфичными конвертерами: интервалы, коллекции, массивы,
+ * range-типы и JSON. Конвертеры типов JDK поставляются с тегом {@link Pg}, а конвертеры JSON — с тегами
+ * {@link PgJson} и {@link PgJsonb}, и применяются только к тем полям сущностей и аргументам методов,
+ * где соответствующий тег указан явно.
+ * <br>
+ * Модули можно наследовать и по отдельности, если нужна только часть конвертеров.
+ * <hr>
+ * <b>English</b>: JDBC module with PostgreSQL specific converters: intervals, collections, arrays, range types and JSON.
+ * Converters of JDK types are supplied with the {@link Pg} tag, and JSON converters with the {@link PgJson} and
+ * {@link PgJsonb} tags, and are applied only to those entity fields and method arguments where the corresponding tag
+ * is specified explicitly.
+ * <br>
+ * The modules can also be inherited one by one when only a part of the converters is needed.
+ */
+public interface PostgresJdbcDatabaseModule extends
+        JdbcDatabaseModule,
+        PgIntervalJdbcMappersModule,
+        PgCollectionJdbcMappersModule,
+        PgArrayJdbcMappersModule,
+        PgRangeJdbcMappersModule,
+        PgJsonJdbcMappersModule {
+}

--- a/database/database-jdbc-postgres/src/main/java/io/koraframework/database/jdbc/postgres/annotation/Pg.java
+++ b/database/database-jdbc-postgres/src/main/java/io/koraframework/database/jdbc/postgres/annotation/Pg.java
@@ -1,0 +1,31 @@
+package io.koraframework.database.jdbc.postgres.annotation;
+
+import io.koraframework.common.annotation.Tag;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * <b>Русский</b>: Аннотация указывает что для значения требуется PostgreSQL специфичный конвертер.
+ * Указывается над полем сущности либо аргументом метода репозитория для типов, которые сами по себе не являются
+ * PostgreSQL специфичными, но имеют PostgreSQL специфичное представление в базе данных.
+ * <hr>
+ * <b>English</b>: Annotation specifies that a PostgreSQL specific converter is required for the value.
+ * Is specified over an entity field or a repository method argument for types that are not PostgreSQL specific
+ * themselves, but have a PostgreSQL specific representation in the database.
+ * <br>
+ * <br>
+ * Пример / Example:
+ * <pre>
+ * {@code
+ * @EntityJdbc
+ * public record User(long id, @Pg List<String> roles, @Pg Duration ttl) {}
+ * }
+ * </pre>
+ */
+@Tag(Pg.class)
+@Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD, ElementType.TYPE_USE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Pg { }

--- a/database/database-jdbc-postgres/src/main/java/io/koraframework/database/jdbc/postgres/annotation/PgJson.java
+++ b/database/database-jdbc-postgres/src/main/java/io/koraframework/database/jdbc/postgres/annotation/PgJson.java
@@ -1,0 +1,31 @@
+package io.koraframework.database.jdbc.postgres.annotation;
+
+import io.koraframework.common.annotation.Tag;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * <b>Русский</b>: Аннотация указывает что значение хранится в колонке типа {@code json}.
+ * Значение записывается и читается как JSON, для типа значения требуется читатель и писатель JSON.
+ * <hr>
+ * <b>English</b>: Annotation specifies that the value is stored in a {@code json} column.
+ * The value is written and read as JSON, a JSON reader and writer are required for the value type.
+ * <br>
+ * <br>
+ * Пример / Example:
+ * <pre>
+ * {@code
+ * @EntityJdbc
+ * public record User(long id, @PgJson Details details) {}
+ * }
+ * </pre>
+ *
+ * @see PgJsonb
+ */
+@Tag(PgJson.class)
+@Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD, ElementType.TYPE_USE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PgJson { }

--- a/database/database-jdbc-postgres/src/main/java/io/koraframework/database/jdbc/postgres/annotation/PgJsonb.java
+++ b/database/database-jdbc-postgres/src/main/java/io/koraframework/database/jdbc/postgres/annotation/PgJsonb.java
@@ -1,0 +1,33 @@
+package io.koraframework.database.jdbc.postgres.annotation;
+
+import io.koraframework.common.annotation.Tag;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * <b>Русский</b>: Аннотация указывает что значение хранится в колонке типа {@code jsonb}.
+ * Отличается от {@link PgJson} типом отправляемого параметра: операторы {@code jsonb} ({@code @>}, {@code ?},
+ * {@code jsonb_path_query}) требуют чтобы параметр имел именно тип {@code jsonb}.
+ * <hr>
+ * <b>English</b>: Annotation specifies that the value is stored in a {@code jsonb} column.
+ * Differs from {@link PgJson} in the type of the parameter being sent: {@code jsonb} operators ({@code @>},
+ * {@code ?}, {@code jsonb_path_query}) require the parameter to be of the {@code jsonb} type exactly.
+ * <br>
+ * <br>
+ * Пример / Example:
+ * <pre>
+ * {@code
+ * @EntityJdbc
+ * public record User(long id, @PgJsonb Details details) {}
+ * }
+ * </pre>
+ *
+ * @see PgJson
+ */
+@Tag(PgJsonb.class)
+@Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD, ElementType.TYPE_USE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PgJsonb { }

--- a/database/database-jdbc-postgres/src/main/java/io/koraframework/database/jdbc/postgres/mapper/parameter/PgArrayParameterColumnMapper.java
+++ b/database/database-jdbc-postgres/src/main/java/io/koraframework/database/jdbc/postgres/mapper/parameter/PgArrayParameterColumnMapper.java
@@ -1,0 +1,46 @@
+package io.koraframework.database.jdbc.postgres.mapper.parameter;
+
+import io.koraframework.database.jdbc.mapper.parameter.JdbcParameterColumnMapper;
+import org.jspecify.annotations.Nullable;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.function.Function;
+
+/**
+ * <b>Русский</b>: Конвертер массива Java в массив PostgreSQL указанного типа элемента.
+ * Элементы {@code null} передаются как есть — массив PostgreSQL их допускает.
+ * <hr>
+ * <b>English</b>: Converter of a Java array into a PostgreSQL array of the given element type.
+ * {@code null} elements are passed through as is — a PostgreSQL array permits them.
+ */
+public class PgArrayParameterColumnMapper<T> implements JdbcParameterColumnMapper<T[]> {
+
+    private final String elementTypeName;
+    private final Function<T, Object> elementWriter;
+
+    public PgArrayParameterColumnMapper(String elementTypeName) {
+        this(elementTypeName, element -> element);
+    }
+
+    public PgArrayParameterColumnMapper(String elementTypeName, Function<T, Object> elementWriter) {
+        this.elementTypeName = elementTypeName;
+        this.elementWriter = elementWriter;
+    }
+
+    @Override
+    public void set(PreparedStatement stmt, int index, T @Nullable [] value) throws SQLException {
+        if (value == null) {
+            stmt.setNull(index, Types.ARRAY);
+            return;
+        }
+
+        var elements = new Object[value.length];
+        for (int i = 0; i < value.length; i++) {
+            var element = value[i];
+            elements[i] = (element == null) ? null : elementWriter.apply(element);
+        }
+        stmt.setArray(index, stmt.getConnection().createArrayOf(elementTypeName, elements));
+    }
+}

--- a/database/database-jdbc-postgres/src/main/java/io/koraframework/database/jdbc/postgres/mapper/parameter/PgCollectionParameterColumnMapper.java
+++ b/database/database-jdbc-postgres/src/main/java/io/koraframework/database/jdbc/postgres/mapper/parameter/PgCollectionParameterColumnMapper.java
@@ -1,0 +1,47 @@
+package io.koraframework.database.jdbc.postgres.mapper.parameter;
+
+import io.koraframework.database.jdbc.mapper.parameter.JdbcParameterColumnMapper;
+import org.jspecify.annotations.Nullable;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.Collection;
+import java.util.function.Function;
+
+/**
+ * <b>Русский</b>: Конвертер {@link Collection} в массив PostgreSQL указанного типа элемента.
+ * Элементы {@code null} передаются как есть — массив PostgreSQL их допускает.
+ * <hr>
+ * <b>English</b>: Converter of a {@link Collection} into a PostgreSQL array of the given element type.
+ * {@code null} elements are passed through as is — a PostgreSQL array permits them.
+ */
+public class PgCollectionParameterColumnMapper<T, C extends Collection<T>> implements JdbcParameterColumnMapper<C> {
+
+    private final String elementTypeName;
+    private final Function<T, Object> elementWriter;
+
+    public PgCollectionParameterColumnMapper(String elementTypeName) {
+        this(elementTypeName, element -> element);
+    }
+
+    public PgCollectionParameterColumnMapper(String elementTypeName, Function<T, Object> elementWriter) {
+        this.elementTypeName = elementTypeName;
+        this.elementWriter = elementWriter;
+    }
+
+    @Override
+    public void set(PreparedStatement stmt, int index, @Nullable C value) throws SQLException {
+        if (value == null) {
+            stmt.setNull(index, Types.ARRAY);
+            return;
+        }
+
+        var elements = new Object[value.size()];
+        var i = 0;
+        for (var element : value) {
+            elements[i++] = (element == null) ? null : elementWriter.apply(element);
+        }
+        stmt.setArray(index, stmt.getConnection().createArrayOf(elementTypeName, elements));
+    }
+}

--- a/database/database-jdbc-postgres/src/main/java/io/koraframework/database/jdbc/postgres/mapper/parameter/PgJsonParameterColumnMapper.java
+++ b/database/database-jdbc-postgres/src/main/java/io/koraframework/database/jdbc/postgres/mapper/parameter/PgJsonParameterColumnMapper.java
@@ -1,0 +1,39 @@
+package io.koraframework.database.jdbc.postgres.mapper.parameter;
+
+import io.koraframework.database.jdbc.mapper.parameter.JdbcParameterColumnMapper;
+import io.koraframework.json.common.JsonWriter;
+import org.jspecify.annotations.Nullable;
+import org.postgresql.util.PGobject;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
+
+/**
+ * <b>Русский</b>: Конвертер значения в JSON для колонки типа {@code json} либо {@code jsonb}.
+ * <hr>
+ * <b>English</b>: Converter of a value into JSON for a {@code json} or {@code jsonb} column.
+ */
+public class PgJsonParameterColumnMapper<T> implements JdbcParameterColumnMapper<T> {
+
+    private final JsonWriter<T> jsonWriter;
+    private final String jsonTypeName;
+
+    public PgJsonParameterColumnMapper(JsonWriter<T> jsonWriter, String jsonTypeName) {
+        this.jsonWriter = jsonWriter;
+        this.jsonTypeName = jsonTypeName;
+    }
+
+    @Override
+    public void set(PreparedStatement stmt, int index, @Nullable T value) throws SQLException {
+        if (value == null) {
+            stmt.setNull(index, Types.OTHER);
+            return;
+        }
+
+        var pgObject = new PGobject();
+        pgObject.setType(jsonTypeName);
+        pgObject.setValue(jsonWriter.toString(value));
+        stmt.setObject(index, pgObject);
+    }
+}

--- a/database/database-jdbc-postgres/src/main/java/io/koraframework/database/jdbc/postgres/mapper/parameter/PgRangeParameterColumnMapper.java
+++ b/database/database-jdbc-postgres/src/main/java/io/koraframework/database/jdbc/postgres/mapper/parameter/PgRangeParameterColumnMapper.java
@@ -1,0 +1,73 @@
+package io.koraframework.database.jdbc.postgres.mapper.parameter;
+
+import io.koraframework.database.jdbc.mapper.parameter.JdbcParameterColumnMapper;
+import io.koraframework.database.jdbc.postgres.PgRange;
+import org.jspecify.annotations.Nullable;
+import org.postgresql.util.PGobject;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.function.Function;
+
+/**
+ * <b>Русский</b>: Конвертер {@link PgRange} в range-тип PostgreSQL с указанным именем типа.
+ * <hr>
+ * <b>English</b>: Converter of a {@link PgRange} into a PostgreSQL range type with the given type name.
+ */
+public class PgRangeParameterColumnMapper<T> implements JdbcParameterColumnMapper<PgRange<T>> {
+
+    private final String rangeTypeName;
+    private final Function<T, String> boundWriter;
+
+    public PgRangeParameterColumnMapper(String rangeTypeName, Function<T, String> boundWriter) {
+        this.rangeTypeName = rangeTypeName;
+        this.boundWriter = boundWriter;
+    }
+
+    @Override
+    public void set(PreparedStatement stmt, int index, @Nullable PgRange<T> value) throws SQLException {
+        if (value == null) {
+            stmt.setNull(index, Types.OTHER);
+            return;
+        }
+
+        var pgObject = new PGobject();
+        pgObject.setType(rangeTypeName);
+        pgObject.setValue(format(value));
+        stmt.setObject(index, pgObject);
+    }
+
+    private String format(PgRange<T> range) {
+        if (range.isEmpty()) {
+            return "empty";
+        }
+
+        var builder = new StringBuilder();
+        builder.append(range.lowerInclusive() ? '[' : '(');
+        var lower = range.lower();
+        if (lower != null) {
+            appendQuoted(builder, boundWriter.apply(lower));
+        }
+        builder.append(',');
+        var upper = range.upper();
+        if (upper != null) {
+            appendQuoted(builder, boundWriter.apply(upper));
+        }
+        builder.append(range.upperInclusive() ? ']' : ')');
+        return builder.toString();
+    }
+
+    // границы всегда в кавычках: иначе PostgreSQL трактует запятую и скобки внутри границы как разделители
+    private static void appendQuoted(StringBuilder builder, String bound) {
+        builder.append('"');
+        for (int i = 0; i < bound.length(); i++) {
+            var c = bound.charAt(i);
+            if (c == '"' || c == '\\') {
+                builder.append('\\');
+            }
+            builder.append(c);
+        }
+        builder.append('"');
+    }
+}

--- a/database/database-jdbc-postgres/src/main/java/io/koraframework/database/jdbc/postgres/mapper/result/PgArrayResultColumnMapper.java
+++ b/database/database-jdbc-postgres/src/main/java/io/koraframework/database/jdbc/postgres/mapper/result/PgArrayResultColumnMapper.java
@@ -1,0 +1,48 @@
+package io.koraframework.database.jdbc.postgres.mapper.result;
+
+import io.koraframework.database.jdbc.mapper.result.JdbcResultColumnMapper;
+import org.jspecify.annotations.Nullable;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.function.Function;
+import java.util.function.IntFunction;
+
+/**
+ * <b>Русский</b>: Конвертер массива PostgreSQL в массив Java.
+ * Элементы {@code null} передаются как есть, поэтому тип элемента должен быть боксированным.
+ * <hr>
+ * <b>English</b>: Converter of a PostgreSQL array into a Java array.
+ * {@code null} elements are passed through as is, hence the element type must be a boxed one.
+ */
+public class PgArrayResultColumnMapper<T> implements JdbcResultColumnMapper<T[]> {
+
+    private final IntFunction<T[]> arrayFactory;
+    private final Function<Object, T> elementReader;
+
+    @SuppressWarnings("unchecked")
+    public PgArrayResultColumnMapper(IntFunction<T[]> arrayFactory) {
+        this(arrayFactory, element -> (T) element);
+    }
+
+    public PgArrayResultColumnMapper(IntFunction<T[]> arrayFactory, Function<Object, T> elementReader) {
+        this.arrayFactory = arrayFactory;
+        this.elementReader = elementReader;
+    }
+
+    @Override
+    public T @Nullable [] apply(ResultSet row, int index) throws SQLException {
+        var array = row.getArray(index);
+        if (row.wasNull() || array == null) {
+            return null;
+        }
+
+        var elements = (Object[]) array.getArray();
+        var result = arrayFactory.apply(elements.length);
+        for (int i = 0; i < elements.length; i++) {
+            var element = elements[i];
+            result[i] = (element == null) ? null : elementReader.apply(element);
+        }
+        return result;
+    }
+}

--- a/database/database-jdbc-postgres/src/main/java/io/koraframework/database/jdbc/postgres/mapper/result/PgCollectionResultColumnMapper.java
+++ b/database/database-jdbc-postgres/src/main/java/io/koraframework/database/jdbc/postgres/mapper/result/PgCollectionResultColumnMapper.java
@@ -1,0 +1,46 @@
+package io.koraframework.database.jdbc.postgres.mapper.result;
+
+import io.koraframework.database.jdbc.mapper.result.JdbcResultColumnMapper;
+import org.jspecify.annotations.Nullable;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * <b>Русский</b>: Конвертер массива PostgreSQL в {@link List}.
+ * Элементы {@code null} передаются как есть.
+ * <hr>
+ * <b>English</b>: Converter of a PostgreSQL array into a {@link List}.
+ * {@code null} elements are passed through as is.
+ */
+public class PgCollectionResultColumnMapper<T> implements JdbcResultColumnMapper<List<T>> {
+
+    private final Function<Object, T> elementReader;
+
+    @SuppressWarnings("unchecked")
+    public PgCollectionResultColumnMapper() {
+        this(element -> (T) element);
+    }
+
+    public PgCollectionResultColumnMapper(Function<Object, T> elementReader) {
+        this.elementReader = elementReader;
+    }
+
+    @Override
+    public @Nullable List<T> apply(ResultSet row, int index) throws SQLException {
+        var array = row.getArray(index);
+        if (row.wasNull() || array == null) {
+            return null;
+        }
+
+        var elements = (Object[]) array.getArray();
+        var result = new ArrayList<T>(elements.length);
+        for (var element : elements) {
+            result.add((element == null) ? null : elementReader.apply(element));
+        }
+        return result;
+    }
+}

--- a/database/database-jdbc-postgres/src/main/java/io/koraframework/database/jdbc/postgres/mapper/result/PgJsonResultColumnMapper.java
+++ b/database/database-jdbc-postgres/src/main/java/io/koraframework/database/jdbc/postgres/mapper/result/PgJsonResultColumnMapper.java
@@ -1,0 +1,31 @@
+package io.koraframework.database.jdbc.postgres.mapper.result;
+
+import io.koraframework.database.jdbc.mapper.result.JdbcResultColumnMapper;
+import io.koraframework.json.common.JsonReader;
+import org.jspecify.annotations.Nullable;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * <b>Русский</b>: Конвертер значения колонки типа {@code json} либо {@code jsonb} из JSON.
+ * <hr>
+ * <b>English</b>: Converter of a {@code json} or {@code jsonb} column value from JSON.
+ */
+public class PgJsonResultColumnMapper<T> implements JdbcResultColumnMapper<T> {
+
+    private final JsonReader<T> jsonReader;
+
+    public PgJsonResultColumnMapper(JsonReader<T> jsonReader) {
+        this.jsonReader = jsonReader;
+    }
+
+    @Override
+    public @Nullable T apply(ResultSet row, int index) throws SQLException {
+        var value = row.getString(index);
+        if (row.wasNull() || value == null) {
+            return null;
+        }
+        return jsonReader.read(value);
+    }
+}

--- a/database/database-jdbc-postgres/src/main/java/io/koraframework/database/jdbc/postgres/mapper/result/PgRangeResultColumnMapper.java
+++ b/database/database-jdbc-postgres/src/main/java/io/koraframework/database/jdbc/postgres/mapper/result/PgRangeResultColumnMapper.java
@@ -1,0 +1,81 @@
+package io.koraframework.database.jdbc.postgres.mapper.result;
+
+import io.koraframework.database.jdbc.mapper.result.JdbcResultColumnMapper;
+import io.koraframework.database.jdbc.postgres.PgRange;
+import org.jspecify.annotations.Nullable;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.function.Function;
+
+/**
+ * <b>Русский</b>: Конвертер range-типа PostgreSQL в {@link PgRange}.
+ * <hr>
+ * <b>English</b>: Converter of a PostgreSQL range type into a {@link PgRange}.
+ */
+public class PgRangeResultColumnMapper<T> implements JdbcResultColumnMapper<PgRange<T>> {
+
+    private static final String EMPTY_RANGE = "empty";
+
+    private final Function<String, T> boundReader;
+
+    public PgRangeResultColumnMapper(Function<String, T> boundReader) {
+        this.boundReader = boundReader;
+    }
+
+    @Override
+    public @Nullable PgRange<T> apply(ResultSet row, int index) throws SQLException {
+        var value = row.getString(index);
+        if (row.wasNull() || value == null) {
+            return null;
+        }
+        if (value.equals(EMPTY_RANGE)) {
+            return PgRange.empty();
+        }
+        if (value.length() < 3) {
+            throw new SQLException("Illegal PostgreSQL range value: " + value);
+        }
+
+        var lowerInclusive = value.charAt(0) == '[';
+        var upperInclusive = value.charAt(value.length() - 1) == ']';
+
+        String lowerBound = null;
+        var bound = new StringBuilder();
+        var boundPresent = false;
+        var quoted = false;
+        var separatorFound = false;
+        for (int i = 1, end = value.length() - 1; i < end; i++) {
+            var c = value.charAt(i);
+            if (quoted) {
+                if (c == '\\' && i + 1 < end) {
+                    bound.append(value.charAt(++i));
+                } else if (c == '"') {
+                    quoted = false;
+                } else {
+                    bound.append(c);
+                }
+            } else if (c == '"') {
+                quoted = true;
+                boundPresent = true;
+            } else if (c == ',' && !separatorFound) {
+                lowerBound = boundPresent ? bound.toString() : null;
+                bound.setLength(0);
+                boundPresent = false;
+                separatorFound = true;
+            } else {
+                bound.append(c);
+                boundPresent = true;
+            }
+        }
+        if (!separatorFound) {
+            throw new SQLException("Illegal PostgreSQL range value: " + value);
+        }
+        var upperBound = boundPresent ? bound.toString() : null;
+
+        return new PgRange<T>(
+            (lowerBound == null) ? null : boundReader.apply(lowerBound),
+            (upperBound == null) ? null : boundReader.apply(upperBound),
+            lowerInclusive,
+            upperInclusive);
+    }
+}

--- a/database/database-jdbc-postgres/src/main/java/module-info.java
+++ b/database/database-jdbc-postgres/src/main/java/module-info.java
@@ -1,0 +1,15 @@
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+module kora.database.jdbc.postgres {
+    requires transitive java.sql;
+    requires transitive kora.common;
+    requires transitive kora.database.jdbc;
+    requires transitive kora.json.common;
+    requires transitive org.postgresql.jdbc;
+
+    exports io.koraframework.database.jdbc.postgres;
+    exports io.koraframework.database.jdbc.postgres.annotation;
+    exports io.koraframework.database.jdbc.postgres.mapper.parameter;
+    exports io.koraframework.database.jdbc.postgres.mapper.result;
+}

--- a/database/database-jdbc-postgres/src/test/java/io/koraframework/database/jdbc/postgres/PgArrayColumnMapperTest.java
+++ b/database/database-jdbc-postgres/src/test/java/io/koraframework/database/jdbc/postgres/PgArrayColumnMapperTest.java
@@ -1,0 +1,119 @@
+package io.koraframework.database.jdbc.postgres;
+
+import io.koraframework.database.jdbc.postgres.mapper.parameter.PgArrayParameterColumnMapper;
+import io.koraframework.database.jdbc.postgres.mapper.result.PgArrayResultColumnMapper;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.sql.Array;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class PgArrayColumnMapperTest {
+
+    private final Connection connection = Mockito.mock(Connection.class);
+    private final PreparedStatement stmt = Mockito.mock(PreparedStatement.class);
+
+    private void mockConnection() throws SQLException {
+        when(stmt.getConnection()).thenReturn(connection);
+        when(connection.createArrayOf(anyString(), any())).thenReturn(Mockito.mock(Array.class));
+    }
+
+    private Object[] writtenElements() throws SQLException {
+        var elements = ArgumentCaptor.forClass(Object[].class);
+        verify(connection).createArrayOf(anyString(), elements.capture());
+        return elements.getValue();
+    }
+
+    private static ResultSet resultSetWith(Object... elements) throws SQLException {
+        var row = Mockito.mock(ResultSet.class);
+        var array = Mockito.mock(Array.class);
+        when(row.getArray(1)).thenReturn(array);
+        when(row.wasNull()).thenReturn(false);
+        when(array.getArray()).thenReturn(elements);
+        return row;
+    }
+
+    @Test
+    void writesArrayOfDeclaredElementType() throws SQLException {
+        mockConnection();
+        var first = UUID.randomUUID();
+        var second = UUID.randomUUID();
+
+        new PgArrayParameterColumnMapper<UUID>("uuid").set(stmt, 1, new UUID[]{first, second});
+
+        var elements = ArgumentCaptor.forClass(Object[].class);
+        verify(connection).createArrayOf(eq("uuid"), elements.capture());
+        assertThat(elements.getValue()).containsExactly(first, second);
+    }
+
+    @Test
+    void writesNullElementsAsIs() throws SQLException {
+        mockConnection();
+
+        new PgArrayParameterColumnMapper<String>("varchar").set(stmt, 1, new String[]{"a", null, "b"});
+
+        assertThat(writtenElements()).containsExactly("a", null, "b");
+    }
+
+    @Test
+    void writesElementsThroughElementWriter() throws SQLException {
+        mockConnection();
+
+        new PgArrayParameterColumnMapper<Integer>("varchar", String::valueOf).set(stmt, 1, new Integer[]{1, 2});
+
+        assertThat(writtenElements()).containsExactly("1", "2");
+    }
+
+    @Test
+    void writesNullAsSqlNull() throws SQLException {
+        new PgArrayParameterColumnMapper<UUID>("uuid").set(stmt, 1, null);
+
+        verify(stmt).setNull(1, Types.ARRAY);
+    }
+
+    @Test
+    void readsArrayOfDeclaredComponentType() throws SQLException {
+        var row = resultSetWith(1, 2, 3);
+
+        var result = new PgArrayResultColumnMapper<>(Integer[]::new).apply(row, 1);
+
+        assertThat(result).isInstanceOf(Integer[].class).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    void readsNullElementsAsIs() throws SQLException {
+        var row = resultSetWith("a", null, "b");
+
+        assertThat(new PgArrayResultColumnMapper<>(String[]::new).apply(row, 1)).containsExactly("a", null, "b");
+    }
+
+    @Test
+    void readsElementsThroughElementReader() throws SQLException {
+        var row = resultSetWith("1", "2");
+        var mapper = new PgArrayResultColumnMapper<>(Integer[]::new, element -> Integer.valueOf((String) element));
+
+        assertThat(mapper.apply(row, 1)).containsExactly(1, 2);
+    }
+
+    @Test
+    void readsSqlNullAsNull() throws SQLException {
+        var row = Mockito.mock(ResultSet.class);
+        when(row.getArray(1)).thenReturn(null);
+        when(row.wasNull()).thenReturn(true);
+
+        assertThat(new PgArrayResultColumnMapper<>(UUID[]::new).apply(row, 1)).isNull();
+    }
+}

--- a/database/database-jdbc-postgres/src/test/java/io/koraframework/database/jdbc/postgres/PgArrayIntegrationTest.java
+++ b/database/database-jdbc-postgres/src/test/java/io/koraframework/database/jdbc/postgres/PgArrayIntegrationTest.java
@@ -1,0 +1,187 @@
+package io.koraframework.database.jdbc.postgres;
+
+import io.koraframework.test.postgres.PostgresParams;
+import io.koraframework.test.postgres.PostgresTestContainer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.math.BigDecimal;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(PostgresTestContainer.class)
+class PgArrayIntegrationTest {
+
+    private final PostgresJdbcDatabaseModule module = new PostgresJdbcDatabaseModule() {};
+
+    @Test
+    void arrayRoundTripForEveryElementType(PostgresParams params) throws SQLException {
+        try (var connection = params.createConnection()) {
+            connection.createStatement().execute("CREATE TABLE t (c_bool bool[], c_int2 int2[], c_int4 int4[],"
+                                                 + " c_int8 int8[], c_float4 float4[], c_float8 float8[],"
+                                                 + " c_numeric numeric[], c_varchar varchar[], c_uuid uuid[])");
+
+            var booleans = List.of(true, false);
+            var shorts = List.of((short) 1, (short) 2);
+            var integers = List.of(1, 2);
+            var longs = List.of(1L, 2L);
+            var floats = List.of(1.5f, 2.5f);
+            var doubles = List.of(1.5d, 2.5d);
+            var decimals = List.of(new BigDecimal("1.50"), new BigDecimal("2.50"));
+            var strings = List.of("a", "b");
+            var uuids = List.of(UUID.randomUUID(), UUID.randomUUID());
+
+            try (var stmt = connection.prepareStatement("INSERT INTO t VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)")) {
+                module.booleanListJdbcParameterColumnMapper().set(stmt, 1, booleans);
+                module.shortListJdbcParameterColumnMapper().set(stmt, 2, shorts);
+                module.integerListJdbcParameterColumnMapper().set(stmt, 3, integers);
+                module.longListJdbcParameterColumnMapper().set(stmt, 4, longs);
+                module.floatListJdbcParameterColumnMapper().set(stmt, 5, floats);
+                module.doubleListJdbcParameterColumnMapper().set(stmt, 6, doubles);
+                module.bigDecimalListJdbcParameterColumnMapper().set(stmt, 7, decimals);
+                module.stringListJdbcParameterColumnMapper().set(stmt, 8, strings);
+                module.uuidListJdbcParameterColumnMapper().set(stmt, 9, uuids);
+                stmt.executeUpdate();
+            }
+
+            try (var stmt = connection.prepareStatement("SELECT * FROM t");
+                 var rs = stmt.executeQuery()) {
+                assertThat(rs.next()).isTrue();
+                assertThat(module.booleanListJdbcResultColumnMapper().apply(rs, 1)).isEqualTo(booleans);
+                assertThat(module.shortListJdbcResultColumnMapper().apply(rs, 2)).isEqualTo(shorts);
+                assertThat(module.integerListJdbcResultColumnMapper().apply(rs, 3)).isEqualTo(integers);
+                assertThat(module.longListJdbcResultColumnMapper().apply(rs, 4)).isEqualTo(longs);
+                assertThat(module.floatListJdbcResultColumnMapper().apply(rs, 5)).isEqualTo(floats);
+                assertThat(module.doubleListJdbcResultColumnMapper().apply(rs, 6)).isEqualTo(doubles);
+                assertThat(module.bigDecimalListJdbcResultColumnMapper().apply(rs, 7)).isEqualTo(decimals);
+                assertThat(module.stringListJdbcResultColumnMapper().apply(rs, 8)).isEqualTo(strings);
+                assertThat(module.uuidListJdbcResultColumnMapper().apply(rs, 9)).isEqualTo(uuids);
+            }
+        }
+    }
+
+    @Test
+    void nullAndNullElementsRoundTrip(PostgresParams params) throws SQLException {
+        try (var connection = params.createConnection()) {
+            connection.createStatement().execute("CREATE TABLE t (id int, c_varchar varchar[])");
+            var withNulls = Arrays.asList("a", null, "b");
+
+            try (var stmt = connection.prepareStatement("INSERT INTO t VALUES (?, ?)")) {
+                stmt.setInt(1, 1);
+                module.stringListJdbcParameterColumnMapper().set(stmt, 2, null);
+                stmt.executeUpdate();
+
+                stmt.setInt(1, 2);
+                module.stringListJdbcParameterColumnMapper().set(stmt, 2, withNulls);
+                stmt.executeUpdate();
+            }
+
+            try (var stmt = connection.prepareStatement("SELECT c_varchar FROM t ORDER BY id");
+                 var rs = stmt.executeQuery()) {
+                assertThat(rs.next()).isTrue();
+                assertThat(module.stringListJdbcResultColumnMapper().apply(rs, 1)).isNull();
+                assertThat(rs.next()).isTrue();
+                assertThat(module.stringListJdbcResultColumnMapper().apply(rs, 1)).isEqualTo(withNulls);
+            }
+        }
+    }
+
+    @Test
+    void emptyArrayRoundTrip(PostgresParams params) throws SQLException {
+        try (var connection = params.createConnection()) {
+            connection.createStatement().execute("CREATE TABLE t (c_int4 int4[])");
+
+            try (var stmt = connection.prepareStatement("INSERT INTO t VALUES (?)")) {
+                module.integerListJdbcParameterColumnMapper().set(stmt, 1, List.of());
+                stmt.executeUpdate();
+            }
+
+            try (var stmt = connection.prepareStatement("SELECT c_int4 FROM t");
+                 var rs = stmt.executeQuery()) {
+                assertThat(rs.next()).isTrue();
+                assertThat(module.integerListJdbcResultColumnMapper().apply(rs, 1)).isEmpty();
+            }
+        }
+    }
+
+    @Test
+    void setAndCollectionParametersRoundTrip(PostgresParams params) throws SQLException {
+        try (var connection = params.createConnection()) {
+            connection.createStatement().execute("CREATE TABLE t (id int, c_varchar varchar[])");
+            Set<String> set = new LinkedHashSet<>(Arrays.asList("a", null, "b"));
+            Collection<String> collection = Arrays.asList("x", "y");
+
+            try (var stmt = connection.prepareStatement("INSERT INTO t VALUES (?, ?)")) {
+                stmt.setInt(1, 1);
+                module.stringSetJdbcParameterColumnMapper().set(stmt, 2, set);
+                stmt.executeUpdate();
+
+                stmt.setInt(1, 2);
+                module.stringCollectionJdbcParameterColumnMapper().set(stmt, 2, collection);
+                stmt.executeUpdate();
+            }
+
+            try (var stmt = connection.prepareStatement("SELECT c_varchar FROM t ORDER BY id");
+                 var rs = stmt.executeQuery()) {
+                assertThat(rs.next()).isTrue();
+                assertThat(module.stringListJdbcResultColumnMapper().apply(rs, 1)).containsExactly("a", null, "b");
+                assertThat(rs.next()).isTrue();
+                assertThat(module.stringListJdbcResultColumnMapper().apply(rs, 1)).containsExactly("x", "y");
+            }
+        }
+    }
+
+    @Test
+    void javaArrayRoundTrip(PostgresParams params) throws SQLException {
+        try (var connection = params.createConnection()) {
+            connection.createStatement().execute("CREATE TABLE t (id int, c_varchar varchar[], c_int4 int4[])");
+            var strings = new String[]{"a", null, "b"};
+            var integers = new Integer[]{1, 2, 3};
+
+            try (var stmt = connection.prepareStatement("INSERT INTO t VALUES (?, ?, ?)")) {
+                stmt.setInt(1, 1);
+                module.stringArrayJdbcParameterColumnMapper().set(stmt, 2, strings);
+                module.integerArrayJdbcParameterColumnMapper().set(stmt, 3, integers);
+                stmt.executeUpdate();
+
+                stmt.setInt(1, 2);
+                module.stringArrayJdbcParameterColumnMapper().set(stmt, 2, null);
+                module.integerArrayJdbcParameterColumnMapper().set(stmt, 3, null);
+                stmt.executeUpdate();
+            }
+
+            try (var stmt = connection.prepareStatement("SELECT c_varchar, c_int4 FROM t ORDER BY id");
+                 var rs = stmt.executeQuery()) {
+                assertThat(rs.next()).isTrue();
+                assertThat(module.stringArrayJdbcResultColumnMapper().apply(rs, 1)).containsExactly(strings);
+                assertThat(module.integerArrayJdbcResultColumnMapper().apply(rs, 2)).containsExactly(integers);
+                assertThat(rs.next()).isTrue();
+                assertThat(module.stringArrayJdbcResultColumnMapper().apply(rs, 1)).isNull();
+                assertThat(module.integerArrayJdbcResultColumnMapper().apply(rs, 2)).isNull();
+            }
+        }
+    }
+
+    @Test
+    void arrayAsInListFilter(PostgresParams params) throws SQLException {
+        try (var connection = params.createConnection()) {
+            connection.createStatement().execute("CREATE TABLE t (id bigint)");
+            connection.createStatement().execute("INSERT INTO t(id) VALUES (1), (2), (3), (4)");
+
+            try (var stmt = connection.prepareStatement("SELECT count(*) FROM t WHERE id = ANY(?)")) {
+                module.longSetJdbcParameterColumnMapper().set(stmt, 1, new LinkedHashSet<>(List.of(2L, 4L, 99L)));
+                try (var rs = stmt.executeQuery()) {
+                    assertThat(rs.next()).isTrue();
+                    assertThat(rs.getInt(1)).isEqualTo(2);
+                }
+            }
+        }
+    }
+}

--- a/database/database-jdbc-postgres/src/test/java/io/koraframework/database/jdbc/postgres/PgCollectionColumnMapperTest.java
+++ b/database/database-jdbc-postgres/src/test/java/io/koraframework/database/jdbc/postgres/PgCollectionColumnMapperTest.java
@@ -1,0 +1,157 @@
+package io.koraframework.database.jdbc.postgres;
+
+import io.koraframework.database.jdbc.postgres.mapper.parameter.PgCollectionParameterColumnMapper;
+import io.koraframework.database.jdbc.postgres.mapper.result.PgCollectionResultColumnMapper;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.sql.Array;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class PgCollectionColumnMapperTest {
+
+    private final Connection connection = Mockito.mock(Connection.class);
+    private final PreparedStatement stmt = Mockito.mock(PreparedStatement.class);
+
+    private Object[] writtenElements() throws SQLException {
+        var elements = ArgumentCaptor.forClass(Object[].class);
+        verify(connection).createArrayOf(anyString(), elements.capture());
+        return elements.getValue();
+    }
+
+    private void mockConnection() throws SQLException {
+        when(stmt.getConnection()).thenReturn(connection);
+        when(connection.createArrayOf(anyString(), any())).thenReturn(Mockito.mock(Array.class));
+    }
+
+    private static ResultSet resultSetWith(Object... elements) throws SQLException {
+        var row = Mockito.mock(ResultSet.class);
+        var array = Mockito.mock(Array.class);
+        when(row.getArray(1)).thenReturn(array);
+        when(row.wasNull()).thenReturn(false);
+        when(array.getArray()).thenReturn(elements);
+        return row;
+    }
+
+    @Test
+    void writesListAsArrayOfDeclaredElementType() throws SQLException {
+        mockConnection();
+        var array = Mockito.mock(Array.class);
+        when(connection.createArrayOf(anyString(), any())).thenReturn(array);
+        var first = UUID.randomUUID();
+        var second = UUID.randomUUID();
+
+        new PgCollectionParameterColumnMapper<UUID, List<UUID>>("uuid").set(stmt, 1, List.of(first, second));
+
+        var elements = ArgumentCaptor.forClass(Object[].class);
+        verify(connection).createArrayOf(eq("uuid"), elements.capture());
+        assertThat(elements.getValue()).containsExactly(first, second);
+        verify(stmt).setArray(1, array);
+    }
+
+    @Test
+    void writesSetPreservingIterationOrder() throws SQLException {
+        mockConnection();
+        Set<String> value = new LinkedHashSet<>(List.of("b", "a", "c"));
+
+        new PgCollectionParameterColumnMapper<String, Set<String>>("varchar").set(stmt, 1, value);
+
+        assertThat(writtenElements()).containsExactly("b", "a", "c");
+    }
+
+    @Test
+    void writesArbitraryCollection() throws SQLException {
+        mockConnection();
+        Collection<Integer> value = Arrays.asList(1, 2, 3);
+
+        new PgCollectionParameterColumnMapper<Integer, Collection<Integer>>("int4").set(stmt, 1, value);
+
+        assertThat(writtenElements()).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    void writesNullElementsAsIs() throws SQLException {
+        mockConnection();
+
+        new PgCollectionParameterColumnMapper<String, List<String>>("varchar")
+            .set(stmt, 1, Arrays.asList("a", null, "b"));
+
+        assertThat(writtenElements()).containsExactly("a", null, "b");
+    }
+
+    @Test
+    void writesNullElementsOfSetAsIs() throws SQLException {
+        mockConnection();
+        Set<String> value = new LinkedHashSet<>(Arrays.asList("a", null, "b"));
+
+        new PgCollectionParameterColumnMapper<String, Set<String>>("varchar").set(stmt, 1, value);
+
+        assertThat(writtenElements()).containsExactly("a", null, "b");
+    }
+
+    @Test
+    void writesElementsThroughElementWriter() throws SQLException {
+        mockConnection();
+
+        new PgCollectionParameterColumnMapper<Integer, List<Integer>>("varchar", String::valueOf)
+            .set(stmt, 1, List.of(1, 2));
+
+        assertThat(writtenElements()).containsExactly("1", "2");
+    }
+
+    @Test
+    void writesNullAsSqlNull() throws SQLException {
+        new PgCollectionParameterColumnMapper<UUID, List<UUID>>("uuid").set(stmt, 1, null);
+
+        verify(stmt).setNull(1, Types.ARRAY);
+    }
+
+    @Test
+    void readsArrayAsList() throws SQLException {
+        var row = resultSetWith(1, 2, 3);
+
+        assertThat(new PgCollectionResultColumnMapper<Integer>().apply(row, 1)).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    void readsNullElementsAsIs() throws SQLException {
+        var row = resultSetWith("a", null, "b");
+
+        assertThat(new PgCollectionResultColumnMapper<String>().apply(row, 1)).containsExactly("a", null, "b");
+    }
+
+    @Test
+    void readsElementsThroughElementReader() throws SQLException {
+        var row = resultSetWith("1", "2");
+        var mapper = new PgCollectionResultColumnMapper<Integer>(element -> Integer.valueOf((String) element));
+
+        assertThat(mapper.apply(row, 1)).containsExactly(1, 2);
+    }
+
+    @Test
+    void readsSqlNullAsNull() throws SQLException {
+        var row = Mockito.mock(ResultSet.class);
+        when(row.getArray(1)).thenReturn(null);
+        when(row.wasNull()).thenReturn(true);
+
+        assertThat(new PgCollectionResultColumnMapper<UUID>().apply(row, 1)).isNull();
+    }
+}

--- a/database/database-jdbc-postgres/src/test/java/io/koraframework/database/jdbc/postgres/PgIntervalIntegrationTest.java
+++ b/database/database-jdbc-postgres/src/test/java/io/koraframework/database/jdbc/postgres/PgIntervalIntegrationTest.java
@@ -1,0 +1,107 @@
+package io.koraframework.database.jdbc.postgres;
+
+import io.koraframework.test.postgres.PostgresParams;
+import io.koraframework.test.postgres.PostgresTestContainer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.sql.SQLException;
+import java.time.Duration;
+import java.time.Period;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@ExtendWith(PostgresTestContainer.class)
+class PgIntervalIntegrationTest {
+
+    private final PostgresJdbcDatabaseModule module = new PostgresJdbcDatabaseModule() {};
+
+    @Test
+    void durationRoundTrip(PostgresParams params) throws SQLException {
+        try (var connection = params.createConnection()) {
+            connection.createStatement().execute("CREATE TABLE t (id int, c_interval interval)");
+            var duration = Duration.ofDays(1).plusHours(2).plusMinutes(3).plusSeconds(4).plusNanos(500_000_000);
+
+            try (var stmt = connection.prepareStatement("INSERT INTO t VALUES (?, ?)")) {
+                stmt.setInt(1, 1);
+                module.durationJdbcParameterColumnMapper().set(stmt, 2, duration);
+                stmt.executeUpdate();
+
+                stmt.setInt(1, 2);
+                module.durationJdbcParameterColumnMapper().set(stmt, 2, null);
+                stmt.executeUpdate();
+            }
+
+            try (var stmt = connection.prepareStatement("SELECT c_interval FROM t ORDER BY id");
+                 var rs = stmt.executeQuery()) {
+                assertThat(rs.next()).isTrue();
+                assertThat(module.durationJdbcResultColumnMapper().apply(rs, 1)).isEqualTo(duration);
+                assertThat(rs.next()).isTrue();
+                assertThat(module.durationJdbcResultColumnMapper().apply(rs, 1)).isNull();
+            }
+        }
+    }
+
+    @Test
+    void negativeDurationRoundTrip(PostgresParams params) throws SQLException {
+        try (var connection = params.createConnection()) {
+            connection.createStatement().execute("CREATE TABLE t (c_interval interval)");
+            var duration = Duration.ofHours(-2).minusMinutes(3).minusNanos(500_000_000);
+
+            try (var stmt = connection.prepareStatement("INSERT INTO t VALUES (?)")) {
+                module.durationJdbcParameterColumnMapper().set(stmt, 1, duration);
+                stmt.executeUpdate();
+            }
+
+            try (var stmt = connection.prepareStatement("SELECT c_interval FROM t");
+                 var rs = stmt.executeQuery()) {
+                assertThat(rs.next()).isTrue();
+                assertThat(module.durationJdbcResultColumnMapper().apply(rs, 1)).isEqualTo(duration);
+            }
+        }
+    }
+
+    @Test
+    void periodRoundTrip(PostgresParams params) throws SQLException {
+        try (var connection = params.createConnection()) {
+            connection.createStatement().execute("CREATE TABLE t (id int, c_interval interval)");
+            var period = Period.of(1, 2, 3);
+
+            try (var stmt = connection.prepareStatement("INSERT INTO t VALUES (?, ?)")) {
+                stmt.setInt(1, 1);
+                module.periodJdbcParameterColumnMapper().set(stmt, 2, period);
+                stmt.executeUpdate();
+
+                stmt.setInt(1, 2);
+                module.periodJdbcParameterColumnMapper().set(stmt, 2, null);
+                stmt.executeUpdate();
+            }
+
+            try (var stmt = connection.prepareStatement("SELECT c_interval FROM t ORDER BY id");
+                 var rs = stmt.executeQuery()) {
+                assertThat(rs.next()).isTrue();
+                assertThat(module.periodJdbcResultColumnMapper().apply(rs, 1)).isEqualTo(period);
+                assertThat(rs.next()).isTrue();
+                assertThat(module.periodJdbcResultColumnMapper().apply(rs, 1)).isNull();
+            }
+        }
+    }
+
+    @Test
+    void failsInsteadOfLosingDataOnIncompatibleInterval(PostgresParams params) throws SQLException {
+        try (var connection = params.createConnection()) {
+            connection.createStatement().execute("CREATE TABLE t (c_interval interval)");
+            connection.createStatement().execute("INSERT INTO t VALUES ('1 mon 5 hours')");
+
+            try (var stmt = connection.prepareStatement("SELECT c_interval FROM t");
+                 var rs = stmt.executeQuery()) {
+                assertThat(rs.next()).isTrue();
+                assertThatThrownBy(() -> module.durationJdbcResultColumnMapper().apply(rs, 1))
+                    .isInstanceOf(SQLException.class);
+                assertThatThrownBy(() -> module.periodJdbcResultColumnMapper().apply(rs, 1))
+                    .isInstanceOf(SQLException.class);
+            }
+        }
+    }
+}

--- a/database/database-jdbc-postgres/src/test/java/io/koraframework/database/jdbc/postgres/PgJsonColumnMapperTest.java
+++ b/database/database-jdbc-postgres/src/test/java/io/koraframework/database/jdbc/postgres/PgJsonColumnMapperTest.java
@@ -1,0 +1,92 @@
+package io.koraframework.database.jdbc.postgres;
+
+import io.koraframework.database.jdbc.postgres.mapper.parameter.PgJsonParameterColumnMapper;
+import io.koraframework.database.jdbc.postgres.mapper.result.PgJsonResultColumnMapper;
+import io.koraframework.json.common.JsonReader;
+import io.koraframework.json.common.JsonWriter;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.postgresql.util.PGobject;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class PgJsonColumnMapperTest {
+
+    record Payload(String name) {}
+
+    private static final Payload PAYLOAD = new Payload("kora");
+    private static final String PAYLOAD_JSON = "{\"name\":\"kora\"}";
+
+    @SuppressWarnings("unchecked")
+    private static JsonWriter<Payload> writer() {
+        var writer = (JsonWriter<Payload>) Mockito.mock(JsonWriter.class);
+        when(writer.toString(PAYLOAD)).thenReturn(PAYLOAD_JSON);
+        return writer;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static JsonReader<Payload> reader() {
+        var reader = (JsonReader<Payload>) Mockito.mock(JsonReader.class);
+        when(reader.read(PAYLOAD_JSON)).thenReturn(PAYLOAD);
+        return reader;
+    }
+
+    @Test
+    void writesJsonTypedParameter() throws SQLException {
+        var stmt = Mockito.mock(PreparedStatement.class);
+
+        new PgJsonParameterColumnMapper<>(writer(), "json").set(stmt, 1, PAYLOAD);
+
+        var captor = ArgumentCaptor.forClass(PGobject.class);
+        verify(stmt).setObject(eq(1), captor.capture());
+        assertThat(captor.getValue().getType()).isEqualTo("json");
+        assertThat(captor.getValue().getValue()).isEqualTo(PAYLOAD_JSON);
+    }
+
+    @Test
+    void writesJsonbTypedParameter() throws SQLException {
+        var stmt = Mockito.mock(PreparedStatement.class);
+
+        new PgJsonParameterColumnMapper<>(writer(), "jsonb").set(stmt, 1, PAYLOAD);
+
+        var captor = ArgumentCaptor.forClass(PGobject.class);
+        verify(stmt).setObject(eq(1), captor.capture());
+        assertThat(captor.getValue().getType()).isEqualTo("jsonb");
+    }
+
+    @Test
+    void writesNullAsSqlNull() throws SQLException {
+        var stmt = Mockito.mock(PreparedStatement.class);
+
+        new PgJsonParameterColumnMapper<>(writer(), "jsonb").set(stmt, 1, null);
+
+        verify(stmt).setNull(1, Types.OTHER);
+    }
+
+    @Test
+    void readsJson() throws SQLException {
+        var row = Mockito.mock(ResultSet.class);
+        when(row.getString(1)).thenReturn(PAYLOAD_JSON);
+        when(row.wasNull()).thenReturn(false);
+
+        assertThat(new PgJsonResultColumnMapper<>(reader()).apply(row, 1)).isEqualTo(PAYLOAD);
+    }
+
+    @Test
+    void readsSqlNullAsNull() throws SQLException {
+        var row = Mockito.mock(ResultSet.class);
+        when(row.getString(1)).thenReturn(null);
+        when(row.wasNull()).thenReturn(true);
+
+        assertThat(new PgJsonResultColumnMapper<>(reader()).apply(row, 1)).isNull();
+    }
+}

--- a/database/database-jdbc-postgres/src/test/java/io/koraframework/database/jdbc/postgres/PgJsonIntegrationTest.java
+++ b/database/database-jdbc-postgres/src/test/java/io/koraframework/database/jdbc/postgres/PgJsonIntegrationTest.java
@@ -1,0 +1,85 @@
+package io.koraframework.database.jdbc.postgres;
+
+import io.koraframework.json.common.JsonReader;
+import io.koraframework.json.common.JsonWriter;
+import io.koraframework.test.postgres.PostgresParams;
+import io.koraframework.test.postgres.PostgresTestContainer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(PostgresTestContainer.class)
+class PgJsonIntegrationTest {
+
+    record Payload(String name) {}
+
+    private static final Payload PAYLOAD = new Payload("kora");
+    private static final String PAYLOAD_JSON = "{\"name\":\"kora\"}";
+
+    private final PostgresJdbcDatabaseModule module = new PostgresJdbcDatabaseModule() {};
+
+    @SuppressWarnings("unchecked")
+    private static JsonWriter<Payload> writer() {
+        var writer = (JsonWriter<Payload>) Mockito.mock(JsonWriter.class);
+        when(writer.toString(PAYLOAD)).thenReturn(PAYLOAD_JSON);
+        return writer;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static JsonReader<Payload> reader() {
+        var reader = (JsonReader<Payload>) Mockito.mock(JsonReader.class);
+        when(reader.read(anyString())).thenReturn(PAYLOAD);
+        return reader;
+    }
+
+    @Test
+    void jsonAndJsonbRoundTrip(PostgresParams params) throws SQLException {
+        try (var connection = params.createConnection()) {
+            connection.createStatement().execute("CREATE TABLE t (id int, c_json json, c_jsonb jsonb)");
+
+            try (var stmt = connection.prepareStatement("INSERT INTO t VALUES (?, ?, ?)")) {
+                stmt.setInt(1, 1);
+                module.jsonJdbcParameterColumnMapper(writer()).set(stmt, 2, PAYLOAD);
+                module.jsonbJdbcParameterColumnMapper(writer()).set(stmt, 3, PAYLOAD);
+                stmt.executeUpdate();
+
+                stmt.setInt(1, 2);
+                module.jsonJdbcParameterColumnMapper(writer()).set(stmt, 2, null);
+                module.jsonbJdbcParameterColumnMapper(writer()).set(stmt, 3, null);
+                stmt.executeUpdate();
+            }
+
+            try (var stmt = connection.prepareStatement("SELECT c_json, c_jsonb FROM t ORDER BY id");
+                 var rs = stmt.executeQuery()) {
+                assertThat(rs.next()).isTrue();
+                assertThat(module.jsonJdbcResultColumnMapper(reader()).apply(rs, 1)).isEqualTo(PAYLOAD);
+                assertThat(module.jsonbJdbcResultColumnMapper(reader()).apply(rs, 2)).isEqualTo(PAYLOAD);
+                assertThat(rs.next()).isTrue();
+                assertThat(module.jsonJdbcResultColumnMapper(reader()).apply(rs, 1)).isNull();
+                assertThat(module.jsonbJdbcResultColumnMapper(reader()).apply(rs, 2)).isNull();
+            }
+        }
+    }
+
+    @Test
+    void jsonbContainmentQuery(PostgresParams params) throws SQLException {
+        try (var connection = params.createConnection()) {
+            connection.createStatement().execute("CREATE TABLE t (c_jsonb jsonb)");
+            connection.createStatement().execute("INSERT INTO t VALUES ('{\"name\": \"kora\", \"version\": 2}')");
+
+            try (var stmt = connection.prepareStatement("SELECT count(*) FROM t WHERE c_jsonb @> ?")) {
+                module.jsonbJdbcParameterColumnMapper(writer()).set(stmt, 1, PAYLOAD);
+                try (var rs = stmt.executeQuery()) {
+                    assertThat(rs.next()).isTrue();
+                    assertThat(rs.getInt(1)).isEqualTo(1);
+                }
+            }
+        }
+    }
+}

--- a/database/database-jdbc-postgres/src/test/java/io/koraframework/database/jdbc/postgres/PgRangeColumnMapperTest.java
+++ b/database/database-jdbc-postgres/src/test/java/io/koraframework/database/jdbc/postgres/PgRangeColumnMapperTest.java
@@ -1,0 +1,141 @@
+package io.koraframework.database.jdbc.postgres;
+
+import io.koraframework.database.jdbc.postgres.mapper.parameter.PgRangeParameterColumnMapper;
+import io.koraframework.database.jdbc.postgres.mapper.result.PgRangeResultColumnMapper;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.postgresql.util.PGobject;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class PgRangeColumnMapperTest {
+
+    private static final PgRangeParameterColumnMapper<Integer> INT4_WRITER =
+        new PgRangeParameterColumnMapper<>("int4range", String::valueOf);
+    private static final PgRangeResultColumnMapper<Integer> INT4_READER =
+        new PgRangeResultColumnMapper<>(Integer::valueOf);
+
+    private static <T> PGobject write(PgRangeParameterColumnMapper<T> mapper, PgRange<T> range) throws SQLException {
+        var stmt = Mockito.mock(PreparedStatement.class);
+        mapper.set(stmt, 1, range);
+
+        var captor = ArgumentCaptor.forClass(PGobject.class);
+        verify(stmt).setObject(eq(1), captor.capture());
+        return captor.getValue();
+    }
+
+    private static <T> PgRange<T> read(PgRangeResultColumnMapper<T> mapper, String value) throws SQLException {
+        var row = Mockito.mock(ResultSet.class);
+        when(row.getString(1)).thenReturn(value);
+        when(row.wasNull()).thenReturn(false);
+        return mapper.apply(row, 1);
+    }
+
+    @Test
+    void writesClosedOpenRange() throws SQLException {
+        var pgObject = write(INT4_WRITER, PgRange.closedOpen(1, 10));
+
+        assertThat(pgObject.getType()).isEqualTo("int4range");
+        assertThat(pgObject.getValue()).isEqualTo("[\"1\",\"10\")");
+    }
+
+    @Test
+    void writesOpenClosedRange() throws SQLException {
+        assertThat(write(INT4_WRITER, PgRange.openClosed(1, 10)).getValue()).isEqualTo("(\"1\",\"10\"]");
+    }
+
+    @Test
+    void writesUnboundedBounds() throws SQLException {
+        assertThat(write(INT4_WRITER, PgRange.closedOpen(5, null)).getValue()).isEqualTo("[\"5\",)");
+        assertThat(write(INT4_WRITER, PgRange.openClosed(null, 5)).getValue()).isEqualTo("(,\"5\"]");
+        assertThat(write(INT4_WRITER, PgRange.open(null, null)).getValue()).isEqualTo("(,)");
+    }
+
+    @Test
+    void writesEmptyRange() throws SQLException {
+        assertThat(write(INT4_WRITER, PgRange.empty()).getValue()).isEqualTo("empty");
+    }
+
+    @Test
+    void writesEscapedBounds() throws SQLException {
+        var mapper = new PgRangeParameterColumnMapper<String>("textrange", Function.identity());
+
+        assertThat(write(mapper, PgRange.closedOpen("a\"b\\c", "z")).getValue()).isEqualTo("[\"a\\\"b\\\\c\",\"z\")");
+    }
+
+    @Test
+    void writesNullAsSqlNull() throws SQLException {
+        var stmt = Mockito.mock(PreparedStatement.class);
+
+        INT4_WRITER.set(stmt, 1, null);
+
+        verify(stmt).setNull(1, Types.OTHER);
+    }
+
+    @Test
+    void readsClosedOpenRange() throws SQLException {
+        assertThat(read(INT4_READER, "[1,10)")).isEqualTo(PgRange.closedOpen(1, 10));
+    }
+
+    @Test
+    void readsQuotedBounds() throws SQLException {
+        assertThat(read(INT4_READER, "[\"1\",\"10\")")).isEqualTo(PgRange.closedOpen(1, 10));
+    }
+
+    @Test
+    void readsUnboundedBounds() throws SQLException {
+        assertThat(read(INT4_READER, "(,10]")).isEqualTo(PgRange.openClosed(null, 10));
+        assertThat(read(INT4_READER, "[5,)")).isEqualTo(PgRange.closedOpen(5, null));
+        assertThat(read(INT4_READER, "(,)")).isEqualTo(PgRange.open(null, null));
+    }
+
+    @Test
+    void readsEmptyRangeDistinctFromUnbounded() throws SQLException {
+        assertThat(read(INT4_READER, "empty")).isEqualTo(PgRange.empty());
+        assertThat(read(INT4_READER, "empty")).isNotEqualTo(read(INT4_READER, "(,)"));
+    }
+
+    @Test
+    void readsEscapedBounds() throws SQLException {
+        var mapper = new PgRangeResultColumnMapper<String>(Function.identity());
+
+        assertThat(read(mapper, "[\"a\\\"b\\\\c\",\"z\")")).isEqualTo(PgRange.closedOpen("a\"b\\c", "z"));
+    }
+
+    @Test
+    void readsCommaInsideQuotedBound() throws SQLException {
+        var mapper = new PgRangeResultColumnMapper<String>(Function.identity());
+
+        assertThat(read(mapper, "[\"a,b\",\"z\")")).isEqualTo(PgRange.closedOpen("a,b", "z"));
+    }
+
+    @Test
+    void readsSqlNullAsNull() throws SQLException {
+        var row = Mockito.mock(ResultSet.class);
+        when(row.getString(1)).thenReturn(null);
+        when(row.wasNull()).thenReturn(true);
+
+        assertThat(INT4_READER.apply(row, 1)).isNull();
+    }
+
+    @Test
+    void failsOnIllegalRangeValue() {
+        assertThatThrownBy(() -> read(INT4_READER, "[1)")).isInstanceOf(SQLException.class);
+    }
+
+    @Test
+    void emptyRangeIgnoresBounds() {
+        assertThat(new PgRange<>(1, 10, true, true, true)).isEqualTo(PgRange.<Integer>empty());
+    }
+}

--- a/database/database-jdbc-postgres/src/test/java/io/koraframework/database/jdbc/postgres/PgRangeIntegrationTest.java
+++ b/database/database-jdbc-postgres/src/test/java/io/koraframework/database/jdbc/postgres/PgRangeIntegrationTest.java
@@ -1,0 +1,134 @@
+package io.koraframework.database.jdbc.postgres;
+
+import io.koraframework.test.postgres.PostgresParams;
+import io.koraframework.test.postgres.PostgresTestContainer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.math.BigDecimal;
+import java.sql.SQLException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(PostgresTestContainer.class)
+class PgRangeIntegrationTest {
+
+    private final PostgresJdbcDatabaseModule module = new PostgresJdbcDatabaseModule() {};
+
+    @Test
+    void rangeRoundTripForEveryRangeType(PostgresParams params) throws SQLException {
+        try (var connection = params.createConnection()) {
+            connection.createStatement().execute("CREATE TABLE t (c_int4 int4range, c_int8 int8range,"
+                                                 + " c_num numrange, c_date daterange, c_ts tsrange)");
+
+            var int4 = PgRange.closedOpen(1, 10);
+            var int8 = PgRange.closedOpen(1L, 10L);
+            var num = PgRange.closedOpen(new BigDecimal("1.50"), new BigDecimal("2.50"));
+            var date = PgRange.closedOpen(LocalDate.of(2021, 1, 1), LocalDate.of(2021, 12, 31));
+            var ts = PgRange.closedOpen(
+                LocalDateTime.of(2021, 1, 1, 10, 0, 0, 123_456_000),
+                LocalDateTime.of(2021, 12, 31, 23, 59, 59));
+
+            try (var stmt = connection.prepareStatement("INSERT INTO t VALUES (?, ?, ?, ?, ?)")) {
+                module.int4RangeJdbcParameterColumnMapper().set(stmt, 1, int4);
+                module.int8RangeJdbcParameterColumnMapper().set(stmt, 2, int8);
+                module.numRangeJdbcParameterColumnMapper().set(stmt, 3, num);
+                module.dateRangeJdbcParameterColumnMapper().set(stmt, 4, date);
+                module.tsRangeJdbcParameterColumnMapper().set(stmt, 5, ts);
+                stmt.executeUpdate();
+            }
+
+            try (var stmt = connection.prepareStatement("SELECT * FROM t");
+                 var rs = stmt.executeQuery()) {
+                assertThat(rs.next()).isTrue();
+                assertThat(module.int4RangeJdbcResultColumnMapper().apply(rs, 1)).isEqualTo(int4);
+                assertThat(module.int8RangeJdbcResultColumnMapper().apply(rs, 2)).isEqualTo(int8);
+                assertThat(module.numRangeJdbcResultColumnMapper().apply(rs, 3)).isEqualTo(num);
+                assertThat(module.dateRangeJdbcResultColumnMapper().apply(rs, 4)).isEqualTo(date);
+                assertThat(module.tsRangeJdbcResultColumnMapper().apply(rs, 5)).isEqualTo(ts);
+            }
+        }
+    }
+
+    @Test
+    void timestampWithTimezoneRangeRoundTripInNonUtcSession(PostgresParams params) throws SQLException {
+        try (var connection = params.createConnection()) {
+            // PostgreSQL отдаёт границы tstzrange в таймзоне сессии, offset вида "+03" без минут
+            connection.createStatement().execute("SET TIME ZONE 'Europe/Moscow'");
+            connection.createStatement().execute("CREATE TABLE t (c_tstz tstzrange)");
+            var tstz = PgRange.closedOpen(
+                OffsetDateTime.of(2021, 1, 1, 10, 0, 0, 0, ZoneOffset.UTC),
+                OffsetDateTime.of(2021, 12, 31, 23, 59, 59, 0, ZoneOffset.UTC));
+
+            try (var stmt = connection.prepareStatement("INSERT INTO t VALUES (?)")) {
+                module.tstzRangeJdbcParameterColumnMapper().set(stmt, 1, tstz);
+                stmt.executeUpdate();
+            }
+
+            try (var stmt = connection.prepareStatement("SELECT c_tstz FROM t");
+                 var rs = stmt.executeQuery()) {
+                assertThat(rs.next()).isTrue();
+                var read = Objects.requireNonNull(module.tstzRangeJdbcResultColumnMapper().apply(rs, 1));
+                var lower = Objects.requireNonNull(read.lower());
+                var upper = Objects.requireNonNull(read.upper());
+                assertThat(lower.toInstant()).isEqualTo(Objects.requireNonNull(tstz.lower()).toInstant());
+                assertThat(upper.toInstant()).isEqualTo(Objects.requireNonNull(tstz.upper()).toInstant());
+                assertThat(read.lowerInclusive()).isTrue();
+                assertThat(read.upperInclusive()).isFalse();
+            }
+        }
+    }
+
+    @Test
+    void emptyUnboundedAndNullRoundTrip(PostgresParams params) throws SQLException {
+        try (var connection = params.createConnection()) {
+            connection.createStatement().execute("CREATE TABLE t (id int, c_int4 int4range)");
+
+            try (var stmt = connection.prepareStatement("INSERT INTO t VALUES (?, ?)")) {
+                stmt.setInt(1, 1);
+                module.int4RangeJdbcParameterColumnMapper().set(stmt, 2, PgRange.empty());
+                stmt.executeUpdate();
+
+                stmt.setInt(1, 2);
+                module.int4RangeJdbcParameterColumnMapper().set(stmt, 2, PgRange.open(null, null));
+                stmt.executeUpdate();
+
+                stmt.setInt(1, 3);
+                module.int4RangeJdbcParameterColumnMapper().set(stmt, 2, null);
+                stmt.executeUpdate();
+            }
+
+            try (var stmt = connection.prepareStatement("SELECT c_int4 FROM t ORDER BY id");
+                 var rs = stmt.executeQuery()) {
+                assertThat(rs.next()).isTrue();
+                assertThat(module.int4RangeJdbcResultColumnMapper().apply(rs, 1)).isEqualTo(PgRange.<Integer>empty());
+                assertThat(rs.next()).isTrue();
+                assertThat(module.int4RangeJdbcResultColumnMapper().apply(rs, 1))
+                    .isEqualTo(PgRange.<Integer>open(null, null));
+                assertThat(rs.next()).isTrue();
+                assertThat(module.int4RangeJdbcResultColumnMapper().apply(rs, 1)).isNull();
+            }
+        }
+    }
+
+    @Test
+    void rangeContainmentQuery(PostgresParams params) throws SQLException {
+        try (var connection = params.createConnection()) {
+            connection.createStatement().execute("CREATE TABLE t (c_int4 int4range)");
+            connection.createStatement().execute("INSERT INTO t VALUES ('[1,100)')");
+
+            try (var stmt = connection.prepareStatement("SELECT count(*) FROM t WHERE c_int4 @> ?")) {
+                module.int4RangeJdbcParameterColumnMapper().set(stmt, 1, PgRange.closedOpen(10, 20));
+                try (var rs = stmt.executeQuery()) {
+                    assertThat(rs.next()).isTrue();
+                    assertThat(rs.getInt(1)).isEqualTo(1);
+                }
+            }
+        }
+    }
+}

--- a/gradle/ci-tests.gradle
+++ b/gradle/ci-tests.gradle
@@ -77,6 +77,7 @@ def tasksOther = createTasks("other")
 // Postgres
 addDependencies(tasksPostgres, "database:database-common")
 addDependencies(tasksPostgres, "database:database-jdbc")
+addDependencies(tasksPostgres, "database:database-jdbc-postgres")
 addDependencies(tasksPostgres, "database:database-flyway")
 addDependencies(tasksPostgres, "database:database-liquibase")
 addDependencies(tasksPostgres, "experimental:camunda-engine-bpmn")

--- a/settings.gradle
+++ b/settings.gradle
@@ -50,6 +50,7 @@ include(
     'database:database-flyway',
     'database:database-cassandra',
     'database:database-liquibase',
+    'database:database-jdbc-postgres',
     'jms',
     'kafka:kafka',
     'kafka:kafka-annotation-processor',


### PR DESCRIPTION
## Summary

New `database-jdbc-postgres` module with PostgreSQL specific JDBC column mappers, split into
focused modules that `PostgresJdbcDatabaseModule` inherits — so a service can also take just the
part it needs:

| Module | Converters |
|---|---|
| `PgIntervalJdbcMappersModule` | `Duration`, `Period` ↔ `interval` |
| `PgCollectionJdbcMappersModule` | `List` / `Set` / `Collection` ↔ SQL arrays |
| `PgArrayJdbcMappersModule` | `T[]` ↔ SQL arrays |
| `PgRangeJdbcMappersModule` | `PgRange<T>` ↔ range types |
| `PgJsonJdbcMappersModule` | any type ↔ `json` / `jsonb` |

### `@Pg`

- `Duration` / `Period` ↔ `interval` — sub-second precision and negative values; fails instead of
  silently dropping years/months for `Duration` and the time part for `Period`
- Collections ↔ SQL arrays of `bool`, `int2`, `int4`, `int8`, `float4`, `float8`, `numeric`,
  `varchar`, `uuid`. A **parameter** is accepted as `List`, `Set` or `Collection` so a collection
  need not be rebuilt just to make the call; a **result** is always a `List` — uniqueness is
  expressed by the query via `DISTINCT`. Also usable as `WHERE id = ANY(:ids)`
- Boxed Java arrays (`Integer[]`, `String[]`, `UUID[]`, …) for both parameter and result. Primitive
  arrays are deliberately not supported: `int[]` can't represent a `NULL` element, which PostgreSQL
  permits in an array
- `null` elements are passed through as is in both directions

### `@PgJson` / `@PgJsonb`

Value is written and read as JSON. The two tags differ in the type of the parameter being sent,
because `jsonb` operators (`@>`, `?`, `jsonb_path_query`) require the parameter to be exactly `jsonb`.

### No tag

`PgRange<T>` ↔ `int4range` / `int8range` / `numrange` / `daterange` / `tsrange` / `tstzrange`,
including `empty` and unbounded bounds. The type itself is already PostgreSQL specific, so nothing
else can claim those mappers and a tag would only add noise at the use site.

### Extension points

`PgCollection*ColumnMapper`, `PgArray*ColumnMapper` and `PgRange*ColumnMapper` take the SQL type name
and, optionally, element/bound conversion functions — so a custom element or range type is one more
factory method.

## Testing

`./gradlew :database:database-jdbc-postgres:test` — 55 tests green.

Unit tests for every mapper plus Testcontainers round-trips on a real PostgreSQL: arrays for every
element type, `Set` / `Collection` parameters, Java arrays, `NULL` arrays, `NULL` elements, empty
arrays and `= ANY(?)`; ranges (incl. `empty`, unbounded, `@>` and a non-UTC session for `tstzrange`);
intervals (incl. negative and sub-second); `json` / `jsonb`.

## Notes

- `database-jdbc` and `json-common` are untouched — the whole diff is the new module plus two lines
  in `settings.gradle` and `gradle/ci-tests.gradle`.
- Only column mappers are supplied, no `JdbcRowMapper`: `JdbcTypesExtension` does not synthesize a
  result set mapper for a tagged type, so a tagged row mapper would be unreachable. Same shape as
  `@Json` usage in kora-examples.
- Native enum support is dropped from this PR and will be proposed separately.
