### PR TITLE
Add class-module support via `@FactoryModule` and `Tag.Factory`

### DIFF
--- a/core/annotation-processor-common/src/main/java/io/koraframework/annotation/processor/common/CommonClassNames.java
+++ b/core/annotation-processor-common/src/main/java/io/koraframework/annotation/processor/common/CommonClassNames.java
@@ -33,10 +33,12 @@ public class CommonClassNames {
     public static final ClassName namingStrategy = ClassName.get("io.koraframework.common.annotation", "NamingStrategy");
     public static final ClassName tag = ClassName.get("io.koraframework.common.annotation", "Tag");
     public static final ClassName tagAny = ClassName.get("io.koraframework.common.annotation", "Tag", "Any");
+    public static final ClassName tagFactory = ClassName.get("io.koraframework.common.annotation", "Tag", "Factory");
     public static final ClassName nameConverter = ClassName.get("io.koraframework.common.naming", "NameConverter");
     public static final ClassName koraApp = ClassName.get("io.koraframework.common.annotation", "KoraApp");
     public static final ClassName koraSubmodule = ClassName.get("io.koraframework.common.annotation", "KoraSubmodule");
     public static final ClassName module = ClassName.get("io.koraframework.common.annotation", "Module");
+    public static final ClassName factoryModule = ClassName.get("io.koraframework.common.annotation", "FactoryModule");
     public static final ClassName component = ClassName.get("io.koraframework.common.annotation", "Component");
     public static final ClassName defaultComponent = ClassName.get("io.koraframework.common.annotation", "DefaultComponent");
     public static final ClassName conditional = ClassName.get("io.koraframework.common.annotation", "Conditional");

--- a/core/annotation-processor-common/src/testFixtures/java/io/koraframework/annotation/processor/common/AbstractAnnotationProcessorTest.java
+++ b/core/annotation-processor-common/src/testFixtures/java/io/koraframework/annotation/processor/common/AbstractAnnotationProcessorTest.java
@@ -65,6 +65,7 @@ public abstract class AbstractAnnotationProcessorTest {
     protected String commonImports() {
         return """
             import io.koraframework.common.annotation.*;
+            import io.koraframework.common.annotation.Module;
             import io.koraframework.common.*;
             import org.jspecify.annotations.Nullable;
             import java.util.Optional;

--- a/core/common/src/main/java/io/koraframework/common/annotation/FactoryModule.java
+++ b/core/common/src/main/java/io/koraframework/common/annotation/FactoryModule.java
@@ -1,0 +1,40 @@
+package io.koraframework.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * <b>Русский</b>: Указывает что метод модуля возвращает объект, который сам является модулем.
+ * Возвращаемый тип регистрируется в графе зависимостей контейнера как компонент,
+ * а его методы-фабрики также обрабатываются как поставщики компонентов.
+ * <hr>
+ * <b>English</b>: Indicates that a module method returns an object that is itself a module.
+ * The return type is registered in the container's dependency graph as a component,
+ * and its factory methods are also processed as component providers.
+ * <br>
+ * <br>
+ * Пример / Example:
+ * <pre>
+ *  {@code
+ *  public interface MyModule {
+ *
+ *      @FactoryModule
+ *      default InnerModule innerModule() {
+ *          return new InnerModule();
+ *      }
+ *
+ *      interface InnerModule {
+ *          default Supplier<String> strSupplier() {
+ *              return () -> "value";
+ *          }
+ *      }
+ *  }
+ *  }
+ * </pre>
+ */
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.CLASS)
+public @interface FactoryModule {
+}

--- a/core/common/src/main/java/io/koraframework/common/annotation/Module.java
+++ b/core/common/src/main/java/io/koraframework/common/annotation/Module.java
@@ -26,7 +26,7 @@ import java.lang.annotation.Target;
  *  }
  * </pre>
  */
-@Target(ElementType.TYPE)
+@Target({ElementType.TYPE})
 @Retention(RetentionPolicy.CLASS)
 public @interface Module {
 }

--- a/core/common/src/main/java/io/koraframework/common/annotation/Tag.java
+++ b/core/common/src/main/java/io/koraframework/common/annotation/Tag.java
@@ -40,7 +40,16 @@ public @interface Tag {
      * <hr>
      * <b>English</b>: A special tag type which means that the tag matches any dependency enforcement condition, i.e. it matches any tag
      */
-    final class Any {}
+    @Tag(Any.class)
+    @interface Any {}
+
+    /**
+     * <b>Русский</b>: Специальный тип тега для параметров методов модуля-класса — означает «использовать тот же тег, что и у самого модуля».
+     * <hr>
+     * <b>English</b>: A special tag type for class-module method parameters — means "use the same tag as the enclosing module".
+     */
+    @Tag(Factory.class)
+    @interface Factory {}
 
     Class<?> value();
 }

--- a/core/kora-app-annotation-processor/src/main/java/io/koraframework/kora/app/annotation/processor/GraphFileGenerator.java
+++ b/core/kora-app-annotation-processor/src/main/java/io/koraframework/kora/app/annotation/processor/GraphFileGenerator.java
@@ -205,7 +205,7 @@ public class GraphFileGenerator {
         statement.add("),\n");
 
         statement.add("g -> ");
-        var dependenciesCode = this.generateDependenciesCode(ctx, component, graphTypeName);
+        var dependenciesCode = this.generateDependenciesCode(ctx, component, graphTypeName, 0);
 
         switch (declaration) {
             case ComponentDeclaration.AnnotatedComponent annotatedComponent -> {
@@ -221,10 +221,16 @@ public class GraphFileGenerator {
                 statement.add("($L)", dependenciesCode);
             }
             case ComponentDeclaration.FromModuleComponent moduleComponent -> {
-                if (moduleComponent.module() instanceof ModuleDeclaration.AnnotatedModule(var element)) {
-                    statement.add("impl.module$L.", allModules.indexOf(element));
+                if (moduleComponent.module() instanceof ModuleDeclaration.ClassModule || moduleComponent.module() instanceof ModuleDeclaration.FactoryModule) {
+                    dependenciesCode = this.generateDependenciesCode(ctx, component, graphTypeName, 1);
+                    var moduleInstDep = component.dependencies().getFirst();
+                    statement.add("$L.", moduleInstDep.write(ctx, graphTypeName));
                 } else {
-                    statement.add("impl.");
+                    if (moduleComponent.module() instanceof ModuleDeclaration.AnnotatedModule(var element)) {
+                        statement.add("impl.module$L.", allModules.indexOf(element));
+                    } else {
+                        statement.add("impl.");
+                    }
                 }
                 if (!moduleComponent.typeVariables().isEmpty()) {
                     statement.add("<");
@@ -256,7 +262,7 @@ public class GraphFileGenerator {
     }
 
 
-    private CodeBlock generateDependenciesCode(ProcessingContext ctx, ResolvedComponent component, ClassName graphTypeName) {
+    private CodeBlock generateDependenciesCode(ProcessingContext ctx, ResolvedComponent component, ClassName graphTypeName, int startFrom) {
         var resolvedDependencies = component.dependencies();
         if (resolvedDependencies.isEmpty()) {
             return CodeBlock.of("");
@@ -264,8 +270,8 @@ public class GraphFileGenerator {
         var b = CodeBlock.builder();
         b.indent();
         b.add("\n");
-        for (int i = 0, dependenciesSize = resolvedDependencies.size(); i < dependenciesSize; i++) {
-            if (i > 0) b.add(",\n");
+        for (int i = startFrom, dependenciesSize = resolvedDependencies.size(); i < dependenciesSize; i++) {
+            if (i > startFrom) b.add(",\n");
             var resolvedDependency = resolvedDependencies.get(i);
             b.add(resolvedDependency.write(ctx, graphTypeName));
         }

--- a/core/kora-app-annotation-processor/src/main/java/io/koraframework/kora/app/annotation/processor/KoraAppProcessor.java
+++ b/core/kora-app-annotation-processor/src/main/java/io/koraframework/kora/app/annotation/processor/KoraAppProcessor.java
@@ -30,10 +30,10 @@ public class KoraAppProcessor extends AbstractKoraProcessor {
 
     private static final Logger log = LoggerFactory.getLogger(KoraAppProcessor.class);
 
-    private final List<TypeElement> koraAppElements = new ArrayList<>();
-    private final List<TypeElement> modules = new ArrayList<>();
-    private final List<TypeElement> classModules = new ArrayList<>();
+    private final List<TypeElement> annotatedInterfaceModules = new ArrayList<>();
+    private final List<TypeElement> annotatedClassModules = new ArrayList<>(); // @Disabled("Haven't decided whether to release it yet")
     private final List<TypeElement> components = new ArrayList<>();
+    private final List<TypeElement> koraApps = new ArrayList<>();
 
     @Override
     public synchronized void init(ProcessingEnvironment processingEnv) {
@@ -57,9 +57,9 @@ public class KoraAppProcessor extends AbstractKoraProcessor {
                 return;
             }
             var ctx = new ProcessingContext(processingEnv);
-            LogUtils.logElementsFull(log, Level.DEBUG, "Processing elements", this.koraAppElements);
+            LogUtils.logElementsFull(log, Level.DEBUG, "Processing elements", this.koraApps);
 
-            for (var element : this.koraAppElements) {
+            for (var element : this.koraApps) {
                 try {
                     var result = buildGraph(roundEnv, ctx, element);
                     this.write(element, ctx, result);
@@ -79,7 +79,7 @@ public class KoraAppProcessor extends AbstractKoraProcessor {
                 if (log.isInfoEnabled()) {
                     log.info("@KoraApp element found:\n{}", element.toString().indent(4));
                 }
-                this.koraAppElements.add((TypeElement) element);
+                this.koraApps.add((TypeElement) element);
             } else {
                 this.processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, "@KoraApp can be placed only on interfaces", element);
             }
@@ -106,12 +106,7 @@ public class KoraAppProcessor extends AbstractKoraProcessor {
     private void processModules(Map<ClassName, List<AnnotatedElement>> annotatedElements) {
         for (var annotated : annotatedElements.getOrDefault(CommonClassNames.module, List.of())) {
             var kind = annotated.element().getKind();
-            if (kind == ElementKind.CLASS) {
-                var te = (TypeElement) annotated.element();
-                if (!te.getModifiers().contains(Modifier.ABSTRACT)) {
-                    this.classModules.add(te);
-                }
-            } else if (kind == ElementKind.INTERFACE) {
+            if (kind == ElementKind.INTERFACE) {
                 var te = (TypeElement) annotated.element();
                 for (var member : elements.getAllMembers(te)) {
                     if (member.getKind() == ElementKind.METHOD && member.getModifiers().contains(Modifier.DEFAULT)) {
@@ -121,7 +116,13 @@ public class KoraAppProcessor extends AbstractKoraProcessor {
                         }
                     }
                 }
-                this.modules.add(te);
+                this.annotatedInterfaceModules.add(te);
+//            @Disabled("Haven't decided whether to release it yet")
+//            } else if (kind == ElementKind.CLASS) {
+//                var te = (TypeElement) annotated.element();
+//                if (!te.getModifiers().contains(Modifier.ABSTRACT)) {
+//                    this.annotatedClassModules.add(te);
+//                }
             } else {
                 messager.printMessage(Diagnostic.Kind.ERROR, "Only classes and interfaces are allowed as modules");
             }
@@ -135,7 +136,7 @@ public class KoraAppProcessor extends AbstractKoraProcessor {
         var type = (TypeElement) classElement;
         var interfaces = KoraAppUtils.collectInterfaces(this.types, type);
         if (log.isTraceEnabled()) {
-            log.trace("Effective modules found:\n{}", Stream.concat(Stream.of(type), this.modules.stream()).flatMap(t -> KoraAppUtils.collectInterfaces(this.types, t).stream())
+            log.trace("Effective modules found:\n{}", Stream.concat(Stream.of(type), this.annotatedInterfaceModules.stream()).flatMap(t -> KoraAppUtils.collectInterfaces(this.types, t).stream())
                 .map(Object::toString).sorted()
                 .collect(Collectors.joining("\n")).indent(4));
         }
@@ -144,7 +145,7 @@ public class KoraAppProcessor extends AbstractKoraProcessor {
             log.trace("Effective methods of {}:\n{}", classElement, mixedInModuleComponents.stream().map(Object::toString).sorted().collect(Collectors.joining("\n")).indent(4));
         }
         var submodules = KoraAppUtils.findKoraSubmoduleModules(this.elements, interfaces, type, processingEnv);
-        var discoveredModules = this.modules.stream().flatMap(t -> KoraAppUtils.collectInterfaces(this.types, t).stream());
+        var discoveredModules = this.annotatedInterfaceModules.stream().flatMap(t -> KoraAppUtils.collectInterfaces(this.types, t).stream());
         var allModules = Stream.concat(discoveredModules, submodules.stream()).sorted(Comparator.comparing(Objects::toString)).toList();
         var annotatedModulesComponents = KoraAppUtils.parseComponents(ctx, allModules.stream().map(ModuleDeclaration.AnnotatedModule::new).toList());
         var allComponents = new ArrayList<ComponentDeclaration>(this.components.size() + mixedInModuleComponents.size() + annotatedModulesComponents.size());
@@ -153,9 +154,9 @@ public class KoraAppProcessor extends AbstractKoraProcessor {
         }
         allComponents.addAll(mixedInModuleComponents);
         allComponents.addAll(annotatedModulesComponents);
-        for (var classModule : this.classModules) {
-            var classModuleDecl = new ModuleDeclaration.ClassModule(classModule);
-            allComponents.add(ComponentDeclaration.fromAnnotated(ctx, classModule));
+        for (var factoryModule : this.annotatedClassModules) {
+            var classModuleDecl = new ModuleDeclaration.ClassModule(factoryModule);
+            allComponents.add(ComponentDeclaration.fromAnnotated(ctx, factoryModule));
             allComponents.addAll(KoraAppUtils.parseClassModuleComponents(ctx, classModuleDecl));
         }
         allComponents.sort(Comparator.comparing(Objects::toString));

--- a/core/kora-app-annotation-processor/src/main/java/io/koraframework/kora/app/annotation/processor/KoraAppProcessor.java
+++ b/core/kora-app-annotation-processor/src/main/java/io/koraframework/kora/app/annotation/processor/KoraAppProcessor.java
@@ -32,6 +32,7 @@ public class KoraAppProcessor extends AbstractKoraProcessor {
 
     private final List<TypeElement> koraAppElements = new ArrayList<>();
     private final List<TypeElement> modules = new ArrayList<>();
+    private final List<TypeElement> classModules = new ArrayList<>();
     private final List<TypeElement> components = new ArrayList<>();
 
     @Override
@@ -104,19 +105,26 @@ public class KoraAppProcessor extends AbstractKoraProcessor {
 
     private void processModules(Map<ClassName, List<AnnotatedElement>> annotatedElements) {
         for (var annotated : annotatedElements.getOrDefault(CommonClassNames.module, List.of())) {
-            if (annotated.element().getKind() != ElementKind.INTERFACE) {
-                continue;
-            }
-            var te = (TypeElement) annotated.element();
-            for (var member : elements.getAllMembers(te)) {
-                if (member.getKind() == ElementKind.METHOD && member.getModifiers().contains(Modifier.DEFAULT)) {
-                    var method = (ExecutableElement) member;
-                    if (method.getReturnType().getKind() != TypeKind.DECLARED) {
-                        messager.printMessage(Diagnostic.Kind.ERROR, "Only reference types are allowed as graph components");
+            var kind = annotated.element().getKind();
+            if (kind == ElementKind.CLASS) {
+                var te = (TypeElement) annotated.element();
+                if (!te.getModifiers().contains(Modifier.ABSTRACT)) {
+                    this.classModules.add(te);
+                }
+            } else if (kind == ElementKind.INTERFACE) {
+                var te = (TypeElement) annotated.element();
+                for (var member : elements.getAllMembers(te)) {
+                    if (member.getKind() == ElementKind.METHOD && member.getModifiers().contains(Modifier.DEFAULT)) {
+                        var method = (ExecutableElement) member;
+                        if (method.getReturnType().getKind() != TypeKind.DECLARED) {
+                            messager.printMessage(Diagnostic.Kind.ERROR, "Only reference types are allowed as graph components");
+                        }
                     }
                 }
+                this.modules.add(te);
+            } else {
+                messager.printMessage(Diagnostic.Kind.ERROR, "Only classes and interfaces are allowed as modules");
             }
-            this.modules.add(te);
         }
     }
 
@@ -145,6 +153,11 @@ public class KoraAppProcessor extends AbstractKoraProcessor {
         }
         allComponents.addAll(mixedInModuleComponents);
         allComponents.addAll(annotatedModulesComponents);
+        for (var classModule : this.classModules) {
+            var classModuleDecl = new ModuleDeclaration.ClassModule(classModule);
+            allComponents.add(ComponentDeclaration.fromAnnotated(ctx, classModule));
+            allComponents.addAll(KoraAppUtils.parseClassModuleComponents(ctx, classModuleDecl));
+        }
         allComponents.sort(Comparator.comparing(Objects::toString));
 
         record Components(List<ComponentDeclaration> templates, List<ComponentDeclaration> nonTemplates) {}

--- a/core/kora-app-annotation-processor/src/main/java/io/koraframework/kora/app/annotation/processor/KoraAppProcessor.java
+++ b/core/kora-app-annotation-processor/src/main/java/io/koraframework/kora/app/annotation/processor/KoraAppProcessor.java
@@ -124,7 +124,7 @@ public class KoraAppProcessor extends AbstractKoraProcessor {
 //                    this.annotatedClassModules.add(te);
 //                }
             } else {
-                messager.printMessage(Diagnostic.Kind.ERROR, "Only classes and interfaces are allowed as modules");
+                messager.printMessage(Diagnostic.Kind.ERROR, "Only interfaces are allowed as modules");
             }
         }
     }

--- a/core/kora-app-annotation-processor/src/main/java/io/koraframework/kora/app/annotation/processor/KoraAppUtils.java
+++ b/core/kora-app-annotation-processor/src/main/java/io/koraframework/kora/app/annotation/processor/KoraAppUtils.java
@@ -3,6 +3,7 @@ package io.koraframework.kora.app.annotation.processor;
 import io.koraframework.annotation.processor.common.AnnotationUtils;
 import io.koraframework.annotation.processor.common.CommonClassNames;
 import io.koraframework.annotation.processor.common.ProcessingErrorException;
+import io.koraframework.annotation.processor.common.TagUtils;
 import io.koraframework.kora.app.annotation.processor.declaration.ComponentDeclaration;
 import io.koraframework.kora.app.annotation.processor.declaration.ModuleDeclaration;
 
@@ -35,7 +36,18 @@ public class KoraAppUtils {
                 if (executableElement.getModifiers().contains(Modifier.STATIC)) {
                     continue;
                 }
-                result.add(ComponentDeclaration.fromModule(ctx, module, executableElement));
+                if (AnnotationUtils.isAnnotationPresent(executableElement, CommonClassNames.factoryModule)) {
+                    if (executableElement.getReturnType().getKind() != TypeKind.DECLARED) {
+                        throw new ProcessingErrorException("@FactoryModule method must return a class type", executableElement);
+                    }
+                    result.add(ComponentDeclaration.fromModule(ctx, module, executableElement));
+                    var returnTypeElement = (TypeElement) ctx.types.asElement(executableElement.getReturnType());
+                    var methodTag = TagUtils.parseTagValue(executableElement);
+                    var methodModule = new ModuleDeclaration.FactoryModule(returnTypeElement, methodTag);
+                    parseModuleTypeComponents(ctx, methodModule, returnTypeElement, result);
+                } else {
+                    result.add(ComponentDeclaration.fromModule(ctx, module, executableElement));
+                }
             }
         }
         var finalResult = new ArrayList<>(result);
@@ -55,6 +67,42 @@ public class KoraAppUtils {
             }
         }
         return finalResult;
+    }
+
+    static List<ComponentDeclaration> parseClassModuleComponents(ProcessingContext ctx, ModuleDeclaration.ClassModule classModule) {
+        var result = new ArrayList<ComponentDeclaration>();
+        parseModuleTypeComponents(ctx, classModule, classModule.element(), result);
+        return result;
+    }
+
+    private static void parseModuleTypeComponents(ProcessingContext ctx, ModuleDeclaration moduleDecl, TypeElement typeElement, List<ComponentDeclaration> result) {
+        var seen = new LinkedHashMap<String, ExecutableElement>();
+        var current = typeElement;
+        while (current != null && !current.getQualifiedName().contentEquals("java.lang.Object")) {
+            for (var enclosed : current.getEnclosedElements()) {
+                if (enclosed.getKind() != ElementKind.METHOD) continue;
+                var method = (ExecutableElement) enclosed;
+                if (!method.getModifiers().contains(Modifier.PUBLIC)) continue;
+                if (method.getModifiers().contains(Modifier.STATIC)) continue;
+                if (method.getModifiers().contains(Modifier.ABSTRACT)) continue;
+                if (method.getReturnType().getKind() != TypeKind.DECLARED) continue;
+                seen.putIfAbsent(methodSignature(ctx, method), method);
+            }
+            var superclass = current.getSuperclass();
+            current = superclass.getKind() == TypeKind.DECLARED
+                ? (TypeElement) ctx.types.asElement(superclass)
+                : null;
+        }
+        for (var method : seen.values()) {
+            result.add(ComponentDeclaration.fromModule(ctx, moduleDecl, method));
+        }
+    }
+
+    private static String methodSignature(ProcessingContext ctx, ExecutableElement method) {
+        var params = method.getParameters().stream()
+            .map(p -> ctx.types.erasure(p.asType()).toString())
+            .collect(java.util.stream.Collectors.joining(","));
+        return method.getSimpleName() + "(" + params + ")";
     }
 
     private static ArrayList<ExecutableElement> findOverridee(Types types, Elements elements, ExecutableElement executableElement) {
@@ -125,7 +173,7 @@ public class KoraAppUtils {
                     result.add(module);
                 } else {
                     processingEnv.getMessager().printMessage(Diagnostic.Kind.MANDATORY_WARNING, "Expected @KoraApp as SubModule, but Submodule implementation not found for: " + typeElement
-                                                                                                + "\nCheck that @KoraApp was generated with compile annotation processor option: -Akora.app.submodule.enabled=true", typeElement);
+                        + "\nCheck that @KoraApp was generated with compile annotation processor option: -Akora.app.submodule.enabled=true", typeElement);
                 }
             }
         }

--- a/core/kora-app-annotation-processor/src/main/java/io/koraframework/kora/app/annotation/processor/component/ComponentDependencyHelper.java
+++ b/core/kora-app-annotation-processor/src/main/java/io/koraframework/kora/app/annotation/processor/component/ComponentDependencyHelper.java
@@ -6,6 +6,7 @@ import io.koraframework.annotation.processor.common.*;
 import io.koraframework.kora.app.annotation.processor.ProcessingContext;
 import io.koraframework.kora.app.annotation.processor.component.DependencyClaim.DependencyClaimType;
 import io.koraframework.kora.app.annotation.processor.declaration.ComponentDeclaration;
+import io.koraframework.kora.app.annotation.processor.declaration.ModuleDeclaration;
 import org.jspecify.annotations.Nullable;
 
 import javax.lang.model.element.Element;
@@ -25,12 +26,22 @@ public class ComponentDependencyHelper {
             case ComponentDeclaration.FromModuleComponent moduleComponent -> {
                 var element = moduleComponent.method();
                 var result = new ArrayList<DependencyClaim>(moduleComponent.methodParameterTypes().size() + 1);
+                if (moduleComponent.module() instanceof ModuleDeclaration.ClassModule(var moduleTypeElement)) {
+                    result.add(new DependencyClaim(element, moduleTypeElement.asType(), null, DependencyClaimType.ONE_REQUIRED));
+                } else if (moduleComponent.module() instanceof ModuleDeclaration.FactoryModule(var moduleTypeElement, var moduleTag)) {
+                    result.add(new DependencyClaim(element, moduleTypeElement.asType(), moduleTag, DependencyClaimType.ONE_REQUIRED));
+                }
                 for (int i = 0; i < moduleComponent.methodParameterTypes().size(); i++) {
                     var parameterType = moduleComponent.methodParameterTypes().get(i);
                     var parameterElement = element.getParameters().get(i);
-                    var tags = TagUtils.parseTagValue(parameterElement);
+                    var tag = TagUtils.parseTagValue(parameterElement);
+                    if (CommonClassNames.tagFactory.canonicalName().equals(tag)) {
+                        if (moduleComponent.module() instanceof ModuleDeclaration.FactoryModule(_, var moduleTag)) {
+                            tag = moduleTag;
+                        }
+                    }
                     var isNullable = CommonUtils.isNullable(parameterElement);
-                    result.add(parseClaim(element, parameterType, tags, isNullable));
+                    result.add(parseClaim(element, parameterType, tag, isNullable));
                 }
                 return result;
             }

--- a/core/kora-app-annotation-processor/src/main/java/io/koraframework/kora/app/annotation/processor/declaration/ComponentDeclaration.java
+++ b/core/kora-app-annotation-processor/src/main/java/io/koraframework/kora/app/annotation/processor/declaration/ComponentDeclaration.java
@@ -238,7 +238,14 @@ public sealed interface ComponentDeclaration {
         if (TypeParameterUtils.hasRawTypes(type)) {
             throw new ProcessingErrorException("Components with raw types can break dependency resolution in unpredictable way so they are forbidden", method);
         }
-        var tags = TagUtils.parseTagValue(method);
+        var tag = TagUtils.parseTagValue(method);
+        if (CommonClassNames.tagFactory.canonicalName().equals(tag)) {
+            if (module instanceof ModuleDeclaration.FactoryModule(var _, var moduleTag)) {
+                tag = moduleTag;
+            } else {
+                throw new ProcessingErrorException("Tag @Tag.Factory is only allowed for factory modules ", method);
+            }
+        }
         var conditionalAnnotation = AnnotationUtils.findAnnotation(method, CommonClassNames.conditional);
         var condition = conditionalAnnotation != null
             ? (ClassName) TypeName.get(Objects.requireNonNull(AnnotationUtils.<TypeMirror>parseAnnotationValueWithoutDefault(conditionalAnnotation, "tag")))
@@ -246,7 +253,7 @@ public sealed interface ComponentDeclaration {
         var parameterTypes = method.getParameters().stream().map(VariableElement::asType).toList();
         var typeParameters = method.getTypeParameters().stream().map(TypeParameterElement::asType).toList();
         var isInterceptor = ctx.serviceTypeHelper.isInterceptor(type);
-        return new FromModuleComponent(type, module, tags, condition, method, parameterTypes, typeParameters, isInterceptor);
+        return new FromModuleComponent(type, module, tag, condition, method, parameterTypes, typeParameters, isInterceptor);
     }
 
     static ComponentDeclaration fromAnnotated(ProcessingContext ctx, TypeElement typeElement) {

--- a/core/kora-app-annotation-processor/src/main/java/io/koraframework/kora/app/annotation/processor/declaration/ModuleDeclaration.java
+++ b/core/kora-app-annotation-processor/src/main/java/io/koraframework/kora/app/annotation/processor/declaration/ModuleDeclaration.java
@@ -1,11 +1,17 @@
 package io.koraframework.kora.app.annotation.processor.declaration;
 
+import org.jspecify.annotations.Nullable;
+
 import javax.lang.model.element.TypeElement;
 
-public interface ModuleDeclaration {
+public sealed interface ModuleDeclaration {
     TypeElement element();
 
     record MixedInModule(TypeElement element) implements ModuleDeclaration {}
 
     record AnnotatedModule(TypeElement element) implements ModuleDeclaration {}
+
+    record ClassModule(TypeElement element) implements ModuleDeclaration {}
+
+    record FactoryModule(TypeElement element, @Nullable String tag) implements ModuleDeclaration {}
 }

--- a/core/kora-app-annotation-processor/src/test/java/io/koraframework/kora/app/annotation/processor/ModuleTest.java
+++ b/core/kora-app-annotation-processor/src/test/java/io/koraframework/kora/app/annotation/processor/ModuleTest.java
@@ -1,5 +1,6 @@
 package io.koraframework.kora.app.annotation.processor;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -164,6 +165,7 @@ class ModuleTest extends AbstractKoraAppTest {
         draw.init();
     }
 
+    @Disabled("Haven't decided whether to release it yet")
     @Test
     public void testClassModuleProvidesDependency() {
         var draw = compile("""
@@ -185,6 +187,7 @@ class ModuleTest extends AbstractKoraAppTest {
         draw.init();
     }
 
+    @Disabled("Haven't decided whether to release it yet")
     @Test
     public void testClassModuleWithConstructorDependency() {
         var draw = compile("""
@@ -214,6 +217,7 @@ class ModuleTest extends AbstractKoraAppTest {
         draw.init();
     }
 
+    @Disabled("Haven't decided whether to release it yet")
     @Test
     public void testClassModuleExtendsBaseModule() {
         var draw = compile("""
@@ -241,6 +245,7 @@ class ModuleTest extends AbstractKoraAppTest {
         draw.init();
     }
 
+    @Disabled("Haven't decided whether to release it yet")
     @Test
     public void testClassModuleOverridesInheritedMethod() {
         var draw = compile("""

--- a/core/kora-app-annotation-processor/src/test/java/io/koraframework/kora/app/annotation/processor/ModuleTest.java
+++ b/core/kora-app-annotation-processor/src/test/java/io/koraframework/kora/app/annotation/processor/ModuleTest.java
@@ -1,0 +1,393 @@
+package io.koraframework.kora.app.annotation.processor;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ModuleTest extends AbstractKoraAppTest {
+
+    @Test
+    public void testAnnotatedModuleProvidesDependency() {
+        var draw = compile("""
+            @KoraApp
+            public interface ExampleApplication {
+                @Root
+                default Object root(TestClass cls) { return cls; }
+            }
+            """, """
+            public class TestClass {}
+            """, """
+            @Module
+            public interface TestModule {
+                default TestClass testClass() { return new TestClass(); }
+            }
+            """);
+        assertThat(draw.getNodes()).hasSize(2);
+        draw.init();
+    }
+
+    @Test
+    public void testMixedInModuleProvidesDependency() {
+        var draw = compile("""
+            @KoraApp
+            public interface ExampleApplication extends TestMixin {
+                @Root
+                default Object root(TestClass cls) { return cls; }
+            }
+            """, """
+            public class TestClass {}
+            """, """
+            public interface TestMixin {
+                default TestClass testClass() { return new TestClass(); }
+            }
+            """);
+        assertThat(draw.getNodes()).hasSize(2);
+        draw.init();
+    }
+
+    @Test
+    public void testMultipleAnnotatedModules() {
+        var draw = compile("""
+            @KoraApp
+            public interface ExampleApplication {
+                @Root
+                default Object root(TestClass1 c1, TestClass2 c2) { return c1; }
+            }
+            """, """
+            public class TestClass1 {}
+            """, """
+            public class TestClass2 {}
+            """, """
+            @Module
+            public interface Module1 {
+                default TestClass1 testClass1() { return new TestClass1(); }
+            }
+            """, """
+            @Module
+            public interface Module2 {
+                default TestClass2 testClass2() { return new TestClass2(); }
+            }
+            """);
+        assertThat(draw.getNodes()).hasSize(3);
+        draw.init();
+    }
+
+    @Test
+    public void testModuleInheritsFromBaseInterface() {
+        var draw = compile("""
+            @KoraApp
+            public interface ExampleApplication {
+                @Root
+                default Object root(TestClass1 c1, TestClass2 c2) { return c1; }
+            }
+            """, """
+            public class TestClass1 {}
+            """, """
+            public class TestClass2 {}
+            """, """
+            public interface BaseModule {
+                default TestClass1 testClass1() { return new TestClass1(); }
+            }
+            """, """
+            @Module
+            public interface ExtendedModule extends BaseModule {
+                default TestClass2 testClass2() { return new TestClass2(); }
+            }
+            """);
+        assertThat(draw.getNodes()).hasSize(3);
+        draw.init();
+    }
+
+    @Test
+    public void testModuleOverridesBaseInterfaceMethod() {
+        var draw = compile("""
+            @KoraApp
+            public interface ExampleApplication {
+                @Root
+                default Object root(TestClass cls) { return cls; }
+            }
+            """, """
+            public class TestClass {}
+            """, """
+            public interface BaseModule {
+                default TestClass testClass() { throw new IllegalStateException("base should not be called"); }
+            }
+            """, """
+            @Module
+            public interface OverrideModule extends BaseModule {
+                @Override
+                default TestClass testClass() { return new TestClass(); }
+            }
+            """);
+        assertThat(draw.getNodes()).hasSize(2);
+        draw.init();
+    }
+
+    @Test
+    public void testNestedModuleInsideApp() {
+        var draw = compile("""
+            @KoraApp
+            public interface ExampleApplication {
+                @Root
+                default Object root(TestClass cls) { return cls; }
+            
+                class TestClass {}
+            
+                @Module
+                interface TestModule {
+                    default TestClass testClass() { return new TestClass(); }
+                }
+            }
+            """);
+        assertThat(draw.getNodes()).hasSize(2);
+        draw.init();
+    }
+
+    @Test
+    public void testModuleWithTaggedComponent() {
+        var draw = compile("""
+            @KoraApp
+            public interface ExampleApplication {
+                @Root
+                default Object root(@Tag(TestModule.class) TestClass cls) { return cls; }
+            }
+            """, """
+            public class TestClass {}
+            """, """
+            @Module
+            public interface TestModule {
+                @Tag(TestModule.class)
+                default TestClass testClass() { return new TestClass(); }
+            }
+            """);
+        assertThat(draw.getNodes()).hasSize(2);
+        draw.init();
+    }
+
+    @Test
+    public void testClassModuleProvidesDependency() {
+        var draw = compile("""
+            @KoraApp
+            public interface ExampleApplication {
+                @Root
+                default Object root(TestClass cls) { return cls; }
+            }
+            """, """
+            public class TestClass {}
+            """, """
+            @Module
+            public class TestModule {
+                public TestClass testClass() { return new TestClass(); }
+            }
+            """);
+        // 3 nodes: root, TestClass (from module method), TestModule (module instance)
+        assertThat(draw.getNodes()).hasSize(3);
+        draw.init();
+    }
+
+    @Test
+    public void testClassModuleWithConstructorDependency() {
+        var draw = compile("""
+            @KoraApp
+            public interface ExampleApplication {
+                @Root
+                default Object root(TestClass cls) { return cls; }
+            }
+            """, """
+            public class TestClass {}
+            """, """
+            public class Dep {}
+            """, """
+            @Module
+            public class TestModule {
+                private final Dep dep;
+                public TestModule(Dep dep) { this.dep = dep; }
+                public TestClass testClass() { return new TestClass(); }
+            }
+            """, """
+            @Module
+            public interface DepProvider {
+                default Dep dep() { return new Dep(); }
+            }
+            """);
+        assertThat(draw.getNodes()).hasSize(4);
+        draw.init();
+    }
+
+    @Test
+    public void testClassModuleExtendsBaseModule() {
+        var draw = compile("""
+            @KoraApp
+            public interface ExampleApplication {
+                @Root
+                default Object root(A a, B b) { return a; }
+            }
+            """, """
+            public class A {}
+            """, """
+            public class B {}
+            """, """
+            public class BaseModule {
+                public B b() { return new B(); }
+            }
+            """, """
+            @Module
+            public class ConcreteModule extends BaseModule {
+                public A a() { return new A(); }
+            }
+            """);
+        // 4 nodes: root, A (from ConcreteModule.a()), B (inherited from BaseModule.b()), ConcreteModule instance
+        assertThat(draw.getNodes()).hasSize(4);
+        draw.init();
+    }
+
+    @Test
+    public void testClassModuleOverridesInheritedMethod() {
+        var draw = compile("""
+            @KoraApp
+            public interface ExampleApplication {
+                @Root
+                default Object root(TestClass cls) { return cls; }
+            }
+            """, """
+            public class TestClass {}
+            """, """
+            public class BaseModule {
+                public TestClass testClass() { throw new IllegalStateException("base must not be called"); }
+            }
+            """, """
+            @Module
+            public class ConcreteModule extends BaseModule {
+                @Override
+                public TestClass testClass() { return new TestClass(); }
+            }
+            """);
+        // 3 nodes: root, TestClass, ConcreteModule
+        assertThat(draw.getNodes()).hasSize(3);
+        draw.init();
+    }
+
+    @Test
+    public void testMethodModuleProvidesDependency() {
+        var draw = compile("""
+            @KoraApp
+            public interface ExampleApplication {
+                @Root
+                default Object root(TestClass cls) { return cls; }
+            }
+            """, """
+            public class TestClass {}
+            """, """
+            public class InnerModule {
+                public TestClass testClass() { return new TestClass(); }
+            }
+            """, """
+            @Module
+            public interface OuterModule {
+                @FactoryModule
+                default InnerModule inner() { return new InnerModule(); }
+            }
+            """);
+        // 3 nodes: root, TestClass (from inner), InnerModule (from outer.inner())
+        assertThat(draw.getNodes()).hasSize(3);
+        draw.init();
+    }
+
+    @Test
+    public void testMethodModuleWithDependency() {
+        var draw = compile("""
+            @KoraApp
+            public interface ExampleApplication {
+                @Root
+                default Object root(TestClass cls) { return cls; }
+            }
+            """, """
+            public class TestClass {}
+            """, """
+            public class Config {}
+            """, """
+            public class InnerModule {
+                private final Config config;
+                public InnerModule(Config config) { this.config = config; }
+                public TestClass testClass() { return new TestClass(); }
+            }
+            """, """
+            @Module
+            public interface OuterModule {
+                @FactoryModule
+                default InnerModule inner(Config config) { return new InnerModule(config); }
+                default Config config() { return new Config(); }
+            }
+            """);
+        // 4 nodes: root, TestClass, InnerModule, Config
+        assertThat(draw.getNodes()).hasSize(4);
+        draw.init();
+    }
+
+
+    @Test
+    public void testAppExtendsMultipleMixedInInterfaces() {
+        var draw = compile("""
+            @KoraApp
+            public interface ExampleApplication extends TestMixin1, TestMixin2 {
+                @Root
+                default Object root(TestClass1 c1, TestClass2 c2) { return c1; }
+            }
+            """, """
+            public class TestClass1 {}
+            """, """
+            public class TestClass2 {}
+            """, """
+            public interface TestMixin1 {
+                default TestClass1 testClass1() { return new TestClass1(); }
+            }
+            """, """
+            public interface TestMixin2 {
+                default TestClass2 testClass2() { return new TestClass2(); }
+            }
+            """);
+        assertThat(draw.getNodes()).hasSize(3);
+        draw.init();
+    }
+
+    @Test
+    public void testFactoryModuleTagPropagation() {
+        var draw = compile("""
+            import io.koraframework.common.annotation.Tag;@KoraApp
+            public interface ExampleApplication {
+                @Root
+                default Object root(@Tag(Tag1.class) TestClass t1, @Tag(Tag2.class) TestClass t2) { return ""; }
+            
+                @Tag(Tag1.class)
+                @FactoryModule
+                default TestModule testModule() { return new TestModule(); }
+            
+                @Tag(Tag2.class)
+                @FactoryModule
+                default TestModule testModule2() { return new TestModule(); }
+            
+                @Tag(Tag1.class)
+                default TestDependency testDependency1() { return new TestDependency(); }
+            
+                @Tag(Tag2.class)
+                default TestDependency testDependency2() { return new TestDependency(); }
+            }
+            """, """
+            public class Tag1 {}
+            """, """
+            public class Tag2 {}
+            """, """
+            public class TestClass {}
+            """, """
+            public class TestDependency {}
+            """, """
+            public class TestModule {
+                @Tag(Tag.Factory.class)
+                public TestClass testClass(@Tag(Tag.Factory.class) TestDependency dep) { return new TestClass(); }
+            }
+            """);
+        assertThat(draw.getNodes()).hasSize(7);
+        draw.init();
+    }
+
+}

--- a/core/kora-app-symbol-processor/src/main/kotlin/io/koraframework/kora/app/ksp/GraphFileGenerator.kt
+++ b/core/kora-app-symbol-processor/src/main/kotlin/io/koraframework/kora/app/ksp/GraphFileGenerator.kt
@@ -210,10 +210,27 @@ class GraphFileGenerator(
             }
 
             is ComponentDeclaration.FromModuleComponent -> {
-                if (declaration.module is ModuleDeclaration.AnnotatedModule) {
-                    statement.add("impl.module%L.", allModules.indexOf(declaration.module.element))
-                } else {
-                    statement.add("impl.")
+                val methodDependenciesCode: CodeBlock
+                when (val module = declaration.module) {
+                    is ModuleDeclaration.AnnotatedModule -> {
+                        methodDependenciesCode = dependenciesCode
+                        statement.add("impl.module%L.", allModules.indexOf(module.element))
+                    }
+
+                    is ModuleDeclaration.FactoryModule -> {
+                        methodDependenciesCode = getDependenciesCode(component, 1)
+                        statement.add("%L.", component.dependencies.first().write(ctx))
+                    }
+
+                    is ModuleDeclaration.ClassModule -> {
+                        methodDependenciesCode = getDependenciesCode(component, 1)
+                        statement.add("%L.", component.dependencies.first().write(ctx))
+                    }
+
+                    else -> {
+                        methodDependenciesCode = dependenciesCode
+                        statement.add("impl.")
+                    }
                 }
                 statement.add("%N", declaration.method.simpleName.asString())
                 if (declaration.typeVariables.isNotEmpty()) {
@@ -226,7 +243,7 @@ class GraphFileGenerator(
                     }
                     statement.add(">")
                 }
-                statement.add("(%L)", dependenciesCode)
+                statement.add("(%L)", methodDependenciesCode)
             }
 
             is ComponentDeclaration.FromExtensionComponent -> {
@@ -367,12 +384,13 @@ class GraphFileGenerator(
     }
 
 
-    private fun getDependenciesCode(component: ResolvedComponent): CodeBlock {
-        if (component.dependencies.isEmpty()) {
+    private fun getDependenciesCode(component: ResolvedComponent, startIndex: Int = 0): CodeBlock {
+        val deps = component.dependencies.drop(startIndex)
+        if (deps.isEmpty()) {
             return CodeBlock.of("")
         }
         val block = CodeBlock.builder().indent().add("\n")
-        for ((i, dependency) in component.dependencies.withIndex()) {
+        for ((i, dependency) in deps.withIndex()) {
             if (i > 0) {
                 block.add(",\n")
             }

--- a/core/kora-app-symbol-processor/src/main/kotlin/io/koraframework/kora/app/ksp/KoraAppProcessor.kt
+++ b/core/kora-app-symbol-processor/src/main/kotlin/io/koraframework/kora/app/ksp/KoraAppProcessor.kt
@@ -35,8 +35,8 @@ class KoraAppProcessor(
 
 
     private val codeGenerator = environment.codeGenerator
-    private val annotatedModules = mutableListOf<String>()
-    private val classModules = mutableListOf<String>()
+    private val annotatedInterfaceModules = mutableListOf<String>()
+    private val annotatedClassModules = mutableListOf<String>() // @Disabled("Haven't decided whether to release it yet")
     private val components = mutableListOf<String>()
     private val koraApps = mutableListOf<String>()
 
@@ -119,7 +119,7 @@ class KoraAppProcessor(
 
         val allInterfaces = declaration.getAllSuperTypes().toList()
         val submodules = findKoraSubmoduleModules(ctx.resolver, allInterfaces, declaration)
-        val allModules = (submodules + annotatedModules.map { resolver!!.getClassDeclarationByName(it)!! })
+        val allModules = (submodules + annotatedInterfaceModules.map { resolver!!.getClassDeclarationByName(it)!! })
             .flatMap { it.getAllSuperTypes().map { it.declaration as KSClassDeclaration } + it }
             .filter { it.qualifiedName?.asString() != "kotlin.Any" }
             .toSet()
@@ -172,12 +172,12 @@ class KoraAppProcessor(
             }
         }
         allComponents.addAll(annotatedModuleComponents)
-        for (classModule in this.classModules) {
-            val classModuleDecl = ModuleDeclaration.ClassModule(resolver!!.getClassDeclarationByName(classModule)!!)
-            allComponents.add(ComponentDeclaration.fromAnnotated(ctx, classModuleDecl.element))
-            classModuleDecl.element.getAllFunctions()
+        for (factoryModule in this.annotatedClassModules) {
+            val factoryModuleDecl = ModuleDeclaration.ClassModule(resolver!!.getClassDeclarationByName(factoryModule)!!)
+            allComponents.add(ComponentDeclaration.fromAnnotated(ctx, factoryModuleDecl.element))
+            factoryModuleDecl.element.getAllFunctions()
                 .filter(filterObjectMethods)
-                .forEach { innerFunc -> factoryModuleComponents.add(ComponentDeclaration.fromModule(ctx, classModuleDecl, innerFunc)) }
+                .forEach { innerFunc -> allComponents.add(ComponentDeclaration.fromModule(ctx, factoryModuleDecl, innerFunc)) }
         }
         allComponents.sortedBy { it.toString() }
         // todo modules from kora app part
@@ -231,18 +231,19 @@ class KoraAppProcessor(
             if (module is KSClassDeclaration) {
                 if (module.classKind == ClassKind.INTERFACE) {
                     if (module.validateAll()) {
-                        annotatedModules.add(module.qualifiedName!!.asString())
+                        annotatedInterfaceModules.add(module.qualifiedName!!.asString())
                     } else {
                         deferred.add(module)
                     }
                 }
-                if (module.classKind == ClassKind.CLASS) {
-                    if (module.validateAll()) {
-                        classModules.add(module.qualifiedName!!.asString())
-                    } else {
-                        deferred.add(module)
-                    }
-                }
+//                @Disabled("Haven't decided whether to release it yet")
+//                if (module.classKind == ClassKind.CLASS) {
+//                    if (module.validateAll()) {
+//                        annotatedClassModules.add(module.qualifiedName!!.asString())
+//                    } else {
+//                        deferred.add(module)
+//                    }
+//                }
             }
         }
         return deferred

--- a/core/kora-app-symbol-processor/src/main/kotlin/io/koraframework/kora/app/ksp/KoraAppProcessor.kt
+++ b/core/kora-app-symbol-processor/src/main/kotlin/io/koraframework/kora/app/ksp/KoraAppProcessor.kt
@@ -17,10 +17,13 @@ import io.koraframework.kora.app.ksp.declaration.ModuleDeclaration
 import io.koraframework.kora.app.ksp.exception.UnresolvedDependencyException
 import io.koraframework.kora.app.ksp.interceptor.ComponentInterceptors
 import io.koraframework.ksp.common.AnnotationUtils.findAnnotation
+import io.koraframework.ksp.common.AnnotationUtils.isAnnotationPresent
 import io.koraframework.ksp.common.BaseSymbolProcessor
 import io.koraframework.ksp.common.CommonAopUtils.hasAopAnnotations
 import io.koraframework.ksp.common.CommonClassNames
+import io.koraframework.ksp.common.CommonClassNames.isVoid
 import io.koraframework.ksp.common.KspCommonUtils.generated
+import io.koraframework.ksp.common.TagUtils
 import io.koraframework.ksp.common.exception.ProcessingErrorException
 
 class KoraAppProcessor(
@@ -33,6 +36,7 @@ class KoraAppProcessor(
 
     private val codeGenerator = environment.codeGenerator
     private val annotatedModules = mutableListOf<String>()
+    private val classModules = mutableListOf<String>()
     private val components = mutableListOf<String>()
     private val koraApps = mutableListOf<String>()
 
@@ -103,9 +107,11 @@ class KoraAppProcessor(
         val filterObjectMethods: (KSFunctionDeclaration) -> Boolean = {
             val name = it.simpleName.asString()
             !it.modifiers.contains(Modifier.PRIVATE)
+                && name != "<init>"
                 && name != "equals"
                 && name != "hashCode"
-                && name != "toString"// todo find out a better way to filter object methods
+                && name != "toString"
+                && it.returnType != null && !it.returnType!!.isVoid() // todo find out a better way to filter object methods
         }
         val mixedInComponents = declaration.getAllFunctions()
             .filter(filterObjectMethods)
@@ -122,8 +128,24 @@ class KoraAppProcessor(
         val annotatedModules = allModules
             .filter { !it.asStarProjectedType().isAssignableFrom(rootErasure) }
             .map { ModuleDeclaration.AnnotatedModule(it) }
-        val annotatedModuleComponentsTmp = annotatedModules
-            .flatMap { it.element.getDeclaredFunctions().filter(filterObjectMethods).map { f -> ComponentDeclaration.fromModule(ctx, it, f) } }
+        val annotatedModuleComponentsTmp = mutableListOf<ComponentDeclaration.FromModuleComponent>()
+        val factoryModuleComponents = mutableListOf<ComponentDeclaration.FromModuleComponent>()
+        for (module in annotatedModules) {
+            for (func in module.element.getDeclaredFunctions().filter(filterObjectMethods)) {
+                annotatedModuleComponentsTmp.add(ComponentDeclaration.fromModule(ctx, module, func))
+                if (func.isAnnotationPresent(CommonClassNames.factoryModule)) {
+                    val returnTypeDecl = func.returnType?.resolve()?.declaration
+                    if (returnTypeDecl !is KSClassDeclaration) {
+                        throw ProcessingErrorException("Factory module function must return a class", func)
+                    }
+                    val methodTag = TagUtils.parseTagValue(func)
+                    val methodModule = ModuleDeclaration.FactoryModule(returnTypeDecl, methodTag)
+                    returnTypeDecl.getAllFunctions()
+                        .filter(filterObjectMethods)
+                        .forEach { innerFunc -> factoryModuleComponents.add(ComponentDeclaration.fromModule(ctx, methodModule, innerFunc)) }
+                }
+            }
+        }
         val annotatedModuleComponents = ArrayList(annotatedModuleComponentsTmp)
         for (annotatedComponent in annotatedModuleComponentsTmp) {
             if (annotatedComponent.method.modifiers.contains(Modifier.OVERRIDE)) {
@@ -132,13 +154,31 @@ class KoraAppProcessor(
                 mixedInComponents.remove(overridee)
             }
         }
+        annotatedModuleComponents.addAll(factoryModuleComponents)
         val allComponents = ArrayList<ComponentDeclaration>(annotatedModuleComponents.size + mixedInComponents.size + 200)
         for (componentClass in components) {
             val decl = ctx.resolver.getClassDeclarationByName(componentClass)!!
             allComponents.add(ComponentDeclaration.fromAnnotated(ctx, decl))
         }
-        allComponents.addAll(mixedInComponents.asSequence().map { ComponentDeclaration.fromModule(ctx, rootModule, it) })
+        for (func in mixedInComponents) {
+            allComponents.add(ComponentDeclaration.fromModule(ctx, rootModule, func))
+            if (func.isAnnotationPresent(CommonClassNames.factoryModule)) {
+                val returnTypeDecl = func.returnType?.resolve()?.declaration as? KSClassDeclaration ?: continue
+                val methodTag = TagUtils.parseTagValue(func)
+                val methodModule = ModuleDeclaration.FactoryModule(returnTypeDecl, methodTag)
+                returnTypeDecl.getAllFunctions()
+                    .filter(filterObjectMethods)
+                    .forEach { innerFunc -> allComponents.add(ComponentDeclaration.fromModule(ctx, methodModule, innerFunc)) }
+            }
+        }
         allComponents.addAll(annotatedModuleComponents)
+        for (classModule in this.classModules) {
+            val classModuleDecl = ModuleDeclaration.ClassModule(resolver!!.getClassDeclarationByName(classModule)!!)
+            allComponents.add(ComponentDeclaration.fromAnnotated(ctx, classModuleDecl.element))
+            classModuleDecl.element.getAllFunctions()
+                .filter(filterObjectMethods)
+                .forEach { innerFunc -> factoryModuleComponents.add(ComponentDeclaration.fromModule(ctx, classModuleDecl, innerFunc)) }
+        }
         allComponents.sortedBy { it.toString() }
         // todo modules from kora app part
         val templateComponents = ArrayList<ComponentDeclaration>(allComponents.size)
@@ -188,11 +228,20 @@ class KoraAppProcessor(
         val deferred = mutableListOf<KSAnnotated>()
         val moduleOfSymbols = resolver.getSymbolsWithAnnotation(CommonClassNames.module.canonicalName)
         for (module in moduleOfSymbols) {
-            if (module is KSClassDeclaration && module.classKind == ClassKind.INTERFACE) {
-                if (module.validateAll()) {
-                    annotatedModules.add(module.qualifiedName!!.asString())
-                } else {
-                    deferred.add(module)
+            if (module is KSClassDeclaration) {
+                if (module.classKind == ClassKind.INTERFACE) {
+                    if (module.validateAll()) {
+                        annotatedModules.add(module.qualifiedName!!.asString())
+                    } else {
+                        deferred.add(module)
+                    }
+                }
+                if (module.classKind == ClassKind.CLASS) {
+                    if (module.validateAll()) {
+                        classModules.add(module.qualifiedName!!.asString())
+                    } else {
+                        deferred.add(module)
+                    }
                 }
             }
         }

--- a/core/kora-app-symbol-processor/src/main/kotlin/io/koraframework/kora/app/ksp/KoraAppProcessor.kt
+++ b/core/kora-app-symbol-processor/src/main/kotlin/io/koraframework/kora/app/ksp/KoraAppProcessor.kt
@@ -235,15 +235,17 @@ class KoraAppProcessor(
                     } else {
                         deferred.add(module)
                     }
-                }
 //                @Disabled("Haven't decided whether to release it yet")
-//                if (module.classKind == ClassKind.CLASS) {
+//                } else if (module.classKind == ClassKind.CLASS) {
 //                    if (module.validateAll()) {
 //                        annotatedClassModules.add(module.qualifiedName!!.asString())
 //                    } else {
 //                        deferred.add(module)
 //                    }
 //                }
+                } else {
+                    kspLogger.error("Only interfaces are allowed as modules", module)
+                }
             }
         }
         return deferred

--- a/core/kora-app-symbol-processor/src/main/kotlin/io/koraframework/kora/app/ksp/component/ComponentDependencyHelper.kt
+++ b/core/kora-app-symbol-processor/src/main/kotlin/io/koraframework/kora/app/ksp/component/ComponentDependencyHelper.kt
@@ -5,6 +5,7 @@ import com.google.devtools.ksp.symbol.KSType
 import com.squareup.kotlinpoet.ParameterizedTypeName
 import com.squareup.kotlinpoet.ksp.toTypeName
 import io.koraframework.kora.app.ksp.declaration.ComponentDeclaration
+import io.koraframework.kora.app.ksp.declaration.ModuleDeclaration
 import io.koraframework.ksp.common.AnnotationUtils.isAnnotationPresent
 import io.koraframework.ksp.common.CommonClassNames
 import io.koraframework.ksp.common.TagUtils
@@ -18,11 +19,36 @@ object ComponentDependencyHelper {
             is ComponentDeclaration.FromModuleComponent -> {
                 val element = declaration.method
                 val result = ArrayList<DependencyClaim>(declaration.methodParameterTypes.size + 1)
+                if (declaration.module is ModuleDeclaration.FactoryModule) {
+                    result.add(
+                        DependencyClaim(
+                            declaration.module.element.asType(listOf()),
+                            declaration.module.tag,
+                            DependencyClaim.DependencyClaimType.ONE_REQUIRED
+                        )
+                    )
+                }
+                if (declaration.module is ModuleDeclaration.ClassModule) {
+                    result.add(
+                        DependencyClaim(
+                            declaration.module.element.asType(listOf()),
+                            null,
+                            DependencyClaim.DependencyClaimType.ONE_REQUIRED
+                        )
+                    )
+                }
                 for (i in 0 until declaration.methodParameterTypes.size) {
                     val parameterType = declaration.methodParameterTypes[i]
                     val parameterElement = element.parameters[i]
-                    val tags = TagUtils.parseTagValue(parameterElement)
-                    result.add(parseClaim(parameterType, tags, declaration.method.parameters[i]))
+                    var tag = TagUtils.parseTagValue(parameterElement)
+                    if (CommonClassNames.tagFactory.canonicalName == tag) {
+                        if (declaration.module is ModuleDeclaration.FactoryModule) {
+                            tag = declaration.module.tag
+                        } else {
+                            throw ProcessingErrorException("Tag @Tag.Factory is only allowed for factory modules ", declaration.method)
+                        }
+                    }
+                    result.add(parseClaim(parameterType, tag, declaration.method.parameters[i]))
                 }
                 return result
             }

--- a/core/kora-app-symbol-processor/src/main/kotlin/io/koraframework/kora/app/ksp/declaration/ComponentDeclaration.kt
+++ b/core/kora-app-symbol-processor/src/main/kotlin/io/koraframework/kora/app/ksp/declaration/ComponentDeclaration.kt
@@ -156,7 +156,15 @@ sealed interface ComponentDeclaration {
                     method
                 )
             }
-            val tags = TagUtils.parseTagValue(method)
+            var tag = TagUtils.parseTagValue(method)
+            if (CommonClassNames.tagFactory.canonicalName == tag) {
+                if (module is ModuleDeclaration.FactoryModule) {
+                    tag = module.tag
+                } else {
+                    throw ProcessingErrorException("Tag @Tag.Factory is only allowed for factory modules ", method)
+                }
+            }
+
             val conditionalAnnotation = method.findAnnotation(CommonClassNames.conditional)
             val condition = conditionalAnnotation?.findValueNoDefault<KSType>("tag")
                 ?.toClassName()
@@ -170,7 +178,7 @@ sealed interface ComponentDeclaration {
                     it.variance
                 )
             }
-            return FromModuleComponent(type, module, tags, method, parameterTypes, typeParameters, ctx.serviceTypesHelper.isInterceptor(type), condition)
+            return FromModuleComponent(type, module, tag, method, parameterTypes, typeParameters, ctx.serviceTypesHelper.isInterceptor(type), condition)
         }
 
         fun fromAnnotated(ctx: ProcessingContext, classDeclaration: KSClassDeclaration): AnnotatedComponent {

--- a/core/kora-app-symbol-processor/src/main/kotlin/io/koraframework/kora/app/ksp/declaration/ModuleDeclaration.kt
+++ b/core/kora-app-symbol-processor/src/main/kotlin/io/koraframework/kora/app/ksp/declaration/ModuleDeclaration.kt
@@ -7,4 +7,6 @@ sealed interface ModuleDeclaration {
 
     data class MixedInModule(override val element: KSClassDeclaration) : ModuleDeclaration
     data class AnnotatedModule(override val element: KSClassDeclaration) : ModuleDeclaration
+    data class ClassModule(override val element: KSClassDeclaration) : ModuleDeclaration
+    data class FactoryModule(override val element: KSClassDeclaration, val tag: String?) : ModuleDeclaration
 }

--- a/core/kora-app-symbol-processor/src/test/kotlin/io/koraframework/kora/app/ksp/ComponentTemplatesTest.kt
+++ b/core/kora-app-symbol-processor/src/test/kotlin/io/koraframework/kora/app/ksp/ComponentTemplatesTest.kt
@@ -54,7 +54,7 @@ class ComponentTemplatesTest : AbstractKoraAppProcessorTest() {
                     class MyJsonWriterImpl<T> : MyJsonWriter<T>
 
                     @Root
-                    fun root(o: MyJsonWriter<List<String>>) {}
+                    fun root(o: MyJsonWriter<List<String>>): Any = o
                 }
                 """);
     }

--- a/core/kora-app-symbol-processor/src/test/kotlin/io/koraframework/kora/app/ksp/ModuleTest.kt
+++ b/core/kora-app-symbol-processor/src/test/kotlin/io/koraframework/kora/app/ksp/ModuleTest.kt
@@ -1,0 +1,596 @@
+package io.koraframework.kora.app.ksp
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ModuleTest : AbstractKoraAppProcessorTest() {
+
+    @Test
+    fun testAnnotatedModuleProvidesDependency() {
+        val draw = compile(
+            """
+            @KoraApp
+            interface ExampleApplication {
+                @Root
+                fun root(cls: TestClass): Any = cls
+            }
+            """.trimIndent(),
+            """
+            class TestClass
+            """.trimIndent(),
+            """
+            @Module
+            interface TestModule {
+                fun testClass(): TestClass = TestClass()
+            }
+            """.trimIndent()
+        )
+        assertThat(draw.nodes).hasSize(2)
+        draw.init()
+    }
+
+    @Test
+    fun testMixedInModuleProvidesDependency() {
+        val draw = compile(
+            """
+            @KoraApp
+            interface ExampleApplication : TestMixin {
+                @Root
+                fun root(cls: TestClass): Any = cls
+            }
+            """.trimIndent(),
+            """
+            class TestClass
+            """.trimIndent(),
+            """
+            interface TestMixin {
+                fun testClass(): TestClass = TestClass()
+            }
+            """.trimIndent()
+        )
+        assertThat(draw.nodes).hasSize(2)
+        draw.init()
+    }
+
+    @Test
+    fun testMultipleAnnotatedModules() {
+        val draw = compile(
+            """
+            @KoraApp
+            interface ExampleApplication {
+                @Root
+                fun root(c1: TestClass1, c2: TestClass2): Any = c1
+            }
+            """.trimIndent(),
+            """
+            class TestClass1
+            """.trimIndent(),
+            """
+            class TestClass2
+            """.trimIndent(),
+            """
+            @Module
+            interface Module1 {
+                fun testClass1(): TestClass1 = TestClass1()
+            }
+            """.trimIndent(),
+            """
+            @Module
+            interface Module2 {
+                fun testClass2(): TestClass2 = TestClass2()
+            }
+            """.trimIndent()
+        )
+        assertThat(draw.nodes).hasSize(3)
+        draw.init()
+    }
+
+    @Test
+    fun testModuleInheritsFromBaseInterface() {
+        val draw = compile(
+            """
+            @KoraApp
+            interface ExampleApplication {
+                @Root
+                fun root(c1: TestClass1, c2: TestClass2): Any = c1
+            }
+            """.trimIndent(),
+            """
+            class TestClass1
+            """.trimIndent(),
+            """
+            class TestClass2
+            """.trimIndent(),
+            """
+            interface BaseModule {
+                fun testClass1(): TestClass1 = TestClass1()
+            }
+            """.trimIndent(),
+            """
+            @Module
+            interface ExtendedModule : BaseModule {
+                fun testClass2(): TestClass2 = TestClass2()
+            }
+            """.trimIndent()
+        )
+        assertThat(draw.nodes).hasSize(3)
+        draw.init()
+    }
+
+    @Test
+    fun testModuleOverridesBaseInterfaceMethod() {
+        val draw = compile(
+            """
+            @KoraApp
+            interface ExampleApplication {
+                @Root
+                fun root(cls: TestClass): Any = cls
+            }
+            """.trimIndent(),
+            """
+            class TestClass
+            """.trimIndent(),
+            """
+            interface BaseModule {
+                fun testClass(): TestClass = throw IllegalStateException("base should not be called")
+            }
+            """.trimIndent(),
+            """
+            @Module
+            interface OverrideModule : BaseModule {
+                override fun testClass(): TestClass = TestClass()
+            }
+            """.trimIndent()
+        )
+        assertThat(draw.nodes).hasSize(2)
+        draw.init()
+    }
+
+    @Test
+    fun testNestedModuleInsideApp() {
+        val draw = compile(
+            """
+            @KoraApp
+            interface ExampleApplication {
+                @Root
+                fun root(cls: TestClass): Any = cls
+
+                class TestClass
+
+                @Module
+                interface TestModule {
+                    fun testClass(): TestClass = TestClass()
+                }
+            }
+            """.trimIndent()
+        )
+        assertThat(draw.nodes).hasSize(2)
+        draw.init()
+    }
+
+    @Test
+    fun testModuleWithTaggedComponent() {
+        val draw = compile(
+            """
+            @KoraApp
+            interface ExampleApplication {
+                @Root
+                fun root(@Tag(TestModule::class) cls: TestClass): Any = cls
+            }
+            """.trimIndent(),
+            """
+            class TestClass
+            """.trimIndent(),
+            """
+            @Module
+            interface TestModule {
+                @Tag(TestModule::class)
+                fun testClass(): TestClass = TestClass()
+            }
+            """.trimIndent()
+        )
+        assertThat(draw.nodes).hasSize(2)
+        draw.init()
+    }
+
+    @Test
+    fun testClassModuleProvidesDependency() {
+        val draw = compile(
+            """
+            @KoraApp
+            interface ExampleApplication {
+                @Root
+                fun root(cls: TestClass): Any = cls
+            }
+            """.trimIndent(),
+            """
+            class TestClass
+            """.trimIndent(),
+            """
+            @Module
+            class TestModule {
+                fun testClass(): TestClass = TestClass()
+            }
+            """.trimIndent()
+        )
+        // 3 nodes: root, TestClass (from module method), TestModule (module instance)
+        assertThat(draw.nodes).hasSize(3)
+        draw.init()
+    }
+
+    @Test
+    fun testClassModuleWithConstructorDependency() {
+        val draw = compile(
+            """
+            @KoraApp
+            interface ExampleApplication {
+                @Root
+                fun root(cls: TestClass): Any = cls
+            }
+            """.trimIndent(),
+            """
+            class TestClass
+            """.trimIndent(),
+            """
+            class Dep
+            """.trimIndent(),
+            """
+            @Module
+            class TestModule(private val dep: Dep) {
+                fun testClass(): TestClass = TestClass()
+            }
+            """.trimIndent(),
+            """
+            @Module
+            interface DepProvider {
+                fun dep(): Dep = Dep()
+            }
+            """.trimIndent()
+        )
+        assertThat(draw.nodes).hasSize(4)
+        draw.init()
+    }
+
+    @Test
+    fun testClassModuleExtendsBaseModule() {
+        val draw = compile(
+            """
+            @KoraApp
+            interface ExampleApplication {
+                @Root
+                fun root(a: A, b: B): Any = a
+            }
+            """.trimIndent(),
+            """
+            class A
+            """.trimIndent(),
+            """
+            class B
+            """.trimIndent(),
+            """
+            open class BaseModule {
+                fun b(): B = B()
+            }
+            """.trimIndent(),
+            """
+            @Module
+            class ConcreteModule : BaseModule() {
+                fun a(): A = A()
+            }
+            """.trimIndent()
+        )
+        // 4 nodes: root, A (from ConcreteModule.a()), B (inherited from BaseModule.b()), ConcreteModule instance
+        assertThat(draw.nodes).hasSize(4)
+        draw.init()
+    }
+
+    @Test
+    fun testClassModuleOverridesInheritedMethod() {
+        val draw = compile(
+            """
+            @KoraApp
+            interface ExampleApplication {
+                @Root
+                fun root(cls: TestClass): Any = cls
+            }
+            """.trimIndent(),
+            """
+            class TestClass
+            """.trimIndent(),
+            """
+            open class BaseModule {
+                open fun testClass(): TestClass = throw IllegalStateException("base must not be called")
+            }
+            """.trimIndent(),
+            """
+            @Module
+            class ConcreteModule : BaseModule() {
+                override fun testClass(): TestClass = TestClass()
+            }
+            """.trimIndent()
+        )
+        // 3 nodes: root, TestClass, ConcreteModule
+        assertThat(draw.nodes).hasSize(3)
+        draw.init()
+    }
+
+    @Test
+    fun testMethodModuleProvidesDependency() {
+        val draw = compile(
+            """
+            @KoraApp
+            interface ExampleApplication {
+                @Root
+                fun root(cls: TestClass): Any = cls
+            }
+            """.trimIndent(),
+            """
+            class TestClass
+            """.trimIndent(),
+            """
+            class InnerModule {
+                fun testClass(): TestClass = TestClass()
+            }
+            """.trimIndent(),
+            """
+            @Module
+            interface OuterModule {
+                @FactoryModule
+                fun inner(): InnerModule = InnerModule()
+            }
+            """.trimIndent()
+        )
+        // 3 nodes: root, TestClass (from inner), InnerModule (from outer.inner())
+        assertThat(draw.nodes).hasSize(3)
+        draw.init()
+    }
+
+    @Test
+    fun testMethodModuleWithDependency() {
+        val draw = compile(
+            """
+            @KoraApp
+            interface ExampleApplication {
+                @Root
+                fun root(cls: TestClass): Any = cls
+            }
+            """.trimIndent(),
+            """
+            class TestClass
+            """.trimIndent(),
+            """
+            class Config
+            """.trimIndent(),
+            """
+            class InnerModule(private val config: Config) {
+                fun testClass(): TestClass = TestClass()
+            }
+            """.trimIndent(),
+            """
+            @Module
+            interface OuterModule {
+                @FactoryModule
+                fun inner(config: Config): InnerModule = InnerModule(config)
+                fun config(): Config = Config()
+            }
+            """.trimIndent()
+        )
+        // 4 nodes: root, TestClass, InnerModule, Config
+        assertThat(draw.nodes).hasSize(4)
+        draw.init()
+    }
+
+    @Test
+    fun testMethodModuleWithTag() {
+        // @Tag on @FactoryModule applies to the InnerModule instance;
+        // the tag is used when inner-module components resolve their module dependency
+        val draw = compile(
+            """
+            @KoraApp
+            interface ExampleApplication {
+                @Root
+                fun root(cls: TestClass): Any = cls
+            }
+            """.trimIndent(),
+            """
+            class TestClass
+            """.trimIndent(),
+            """
+            class InnerModule {
+                fun testClass(): TestClass = TestClass()
+            }
+            """.trimIndent(),
+            """
+            @Module
+            interface OuterModule {
+                @FactoryModule
+                @Tag(OuterModule::class)
+                fun inner(): InnerModule = InnerModule()
+            }
+            """.trimIndent()
+        )
+        // 3 nodes: root, TestClass (untagged, produced by the tagged InnerModule), InnerModule(@Tag(OuterModule))
+        assertThat(draw.nodes).hasSize(3)
+        draw.init()
+    }
+
+    @Test
+    fun testMethodModuleInMixedIn() {
+        val draw = compile(
+            """
+            @KoraApp
+            interface ExampleApplication {
+                @FactoryModule
+                fun inner(): InnerModule = InnerModule()
+
+                @Root
+                fun root(cls: TestClass): Any = cls
+            }
+            """.trimIndent(),
+            """
+            class TestClass
+            """.trimIndent(),
+            """
+            class InnerModule {
+                fun testClass(): TestClass = TestClass()
+            }
+            """.trimIndent()
+        )
+        // 3 nodes: root, TestClass (from inner), InnerModule
+        assertThat(draw.nodes).hasSize(3)
+        draw.init()
+    }
+
+    @Test
+    fun testMethodModuleInnerInheritsMethods() {
+        val draw = compile(
+            """
+            @KoraApp
+            interface ExampleApplication {
+                @Root
+                fun root(cls: TestClass): Any = cls
+            }
+            """.trimIndent(),
+            """
+            class TestClass
+            """.trimIndent(),
+            """
+            open class BaseModule {
+                fun testClass(): TestClass = TestClass()
+            }
+            """.trimIndent(),
+            """
+            class InnerModule : BaseModule()
+            """.trimIndent(),
+            """
+            @Module
+            interface OuterModule {
+                @FactoryModule
+                fun inner(): InnerModule = InnerModule()
+            }
+            """.trimIndent()
+        )
+        // 3 nodes: root, TestClass (from BaseModule.testClass()), InnerModule
+        assertThat(draw.nodes).hasSize(3)
+        draw.init()
+    }
+
+    @Test
+    fun testMultipleMethodModules() {
+        val draw = compile(
+            """
+            @KoraApp
+            interface ExampleApplication {
+                @Root
+                fun root(a: TestClass1, b: TestClass2): Any = a
+            }
+            """.trimIndent(),
+            """
+            class TestClass1
+            """.trimIndent(),
+            """
+            class TestClass2
+            """.trimIndent(),
+            """
+            class InnerModule1 {
+                fun testClass1(): TestClass1 = TestClass1()
+            }
+            """.trimIndent(),
+            """
+            class InnerModule2 {
+                fun testClass2(): TestClass2 = TestClass2()
+            }
+            """.trimIndent(),
+            """
+            @Module
+            interface OuterModule {
+                @FactoryModule
+                fun inner1(): InnerModule1 = InnerModule1()
+                @FactoryModule
+                fun inner2(): InnerModule2 = InnerModule2()
+            }
+            """.trimIndent()
+        )
+        // 5 nodes: root, TestClass1, TestClass2, InnerModule1, InnerModule2
+        assertThat(draw.nodes).hasSize(5)
+        draw.init()
+    }
+
+    @Test
+    fun testAppExtendsMultipleMixedInInterfaces() {
+        val draw = compile(
+            """
+            @KoraApp
+            interface ExampleApplication : TestMixin1, TestMixin2 {
+                @Root
+                fun root(c1: TestClass1, c2: TestClass2): Any = c1
+            }
+            """.trimIndent(),
+            """
+            class TestClass1
+            """.trimIndent(),
+            """
+            class TestClass2
+            """.trimIndent(),
+            """
+            interface TestMixin1 {
+                fun testClass1(): TestClass1 = TestClass1()
+            }
+            """.trimIndent(),
+            """
+            interface TestMixin2 {
+                fun testClass2(): TestClass2 = TestClass2()
+            }
+            """.trimIndent()
+        )
+        assertThat(draw.nodes).hasSize(3)
+        draw.init()
+    }
+
+    @Test
+    fun testFactoryModuleTagPropagation() {
+        val draw = compile(
+            """
+            @KoraApp
+            interface ExampleApplication {
+                @Root
+                fun root(@Tag(Tag1::class) t1: TestClass, @Tag(Tag2::class) t2: TestClass): Any = ""
+
+                @Tag(Tag1::class)
+                @FactoryModule
+                fun testModule(): TestModule = TestModule()
+
+                @Tag(Tag2::class)
+                @FactoryModule
+                fun testModule2(): TestModule = TestModule()
+
+                @Tag(Tag1::class)
+                fun testDependency1(): TestDependency = TestDependency()
+
+                @Tag(Tag2::class)
+                fun testDependency2(): TestDependency = TestDependency()
+            }
+            """.trimIndent(),
+            """
+            class Tag1
+            """.trimIndent(),
+            """
+            class Tag2
+            """.trimIndent(),
+            """
+            class TestClass
+            """.trimIndent(),
+            """
+            class TestDependency
+            """.trimIndent(),
+            """
+            class TestModule {
+                @Tag(Tag.Factory::class)
+                fun testClass(@Tag(Tag.Factory::class) dep: TestDependency): TestClass = TestClass()
+            }
+            """.trimIndent()
+        )
+        assertThat(draw.nodes).hasSize(7)
+        draw.init()
+    }
+}

--- a/core/kora-app-symbol-processor/src/test/kotlin/io/koraframework/kora/app/ksp/ModuleTest.kt
+++ b/core/kora-app-symbol-processor/src/test/kotlin/io/koraframework/kora/app/ksp/ModuleTest.kt
@@ -1,6 +1,7 @@
 package io.koraframework.kora.app.ksp
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 
 class ModuleTest : AbstractKoraAppProcessorTest() {
@@ -193,6 +194,7 @@ class ModuleTest : AbstractKoraAppProcessorTest() {
         draw.init()
     }
 
+    @Disabled("Haven't decided whether to release it yet")
     @Test
     fun testClassModuleProvidesDependency() {
         val draw = compile(
@@ -218,6 +220,7 @@ class ModuleTest : AbstractKoraAppProcessorTest() {
         draw.init()
     }
 
+    @Disabled("Haven't decided whether to release it yet")
     @Test
     fun testClassModuleWithConstructorDependency() {
         val draw = compile(
@@ -251,6 +254,7 @@ class ModuleTest : AbstractKoraAppProcessorTest() {
         draw.init()
     }
 
+    @Disabled("Haven't decided whether to release it yet")
     @Test
     fun testClassModuleExtendsBaseModule() {
         val draw = compile(
@@ -284,6 +288,7 @@ class ModuleTest : AbstractKoraAppProcessorTest() {
         draw.init()
     }
 
+    @Disabled("Haven't decided whether to release it yet")
     @Test
     fun testClassModuleOverridesInheritedMethod() {
         val draw = compile(

--- a/core/symbol-processor-common/src/main/kotlin/io/koraframework/ksp/common/CommonClassNames.kt
+++ b/core/symbol-processor-common/src/main/kotlin/io/koraframework/ksp/common/CommonClassNames.kt
@@ -30,6 +30,7 @@ object CommonClassNames {
     val namingStrategy = ClassName("io.koraframework.common.annotation", "NamingStrategy")
     val tag = ClassName("io.koraframework.common.annotation", "Tag")
     val tagAny = ClassName("io.koraframework.common.annotation", "Tag", "Any")
+    val tagFactory = ClassName("io.koraframework.common.annotation", "Tag", "Factory")
     val conditional = ClassName("io.koraframework.common.annotation", "Conditional")
     val nameConverter = ClassName("io.koraframework.common.naming", "NameConverter")
     val koraApp = ClassName("io.koraframework.common.annotation", "KoraApp")
@@ -38,6 +39,7 @@ object CommonClassNames {
     val component = ClassName("io.koraframework.common.annotation", "Component")
     val defaultComponent = ClassName("io.koraframework.common.annotation", "DefaultComponent")
     val root = ClassName("io.koraframework.common.annotation", "Root")
+    val factoryModule = ClassName("io.koraframework.common.annotation", "FactoryModule")
 
     val node = ClassName("io.koraframework.application.graph", "Node")
     val lifecycle = ClassName("io.koraframework.application.graph", "Lifecycle")

--- a/http/http-server-common/src/main/java/io/koraframework/http/server/common/HttpServerFactoryModule.java
+++ b/http/http-server-common/src/main/java/io/koraframework/http/server/common/HttpServerFactoryModule.java
@@ -8,10 +8,11 @@ import io.koraframework.http.server.common.interceptor.HttpServerInterceptor;
 import io.koraframework.http.server.common.request.HttpServerRequestHandler;
 import io.koraframework.http.server.common.router.HttpServerHandler;
 
-public class HttpServerInstanceModule {
+public class HttpServerFactoryModule {
+
     private final String configPath;
 
-    public HttpServerInstanceModule(String configPath) {
+    public HttpServerFactoryModule(String configPath) {
         this.configPath = configPath;
     }
 

--- a/http/http-server-common/src/main/java/io/koraframework/http/server/common/HttpServerInstanceModule.java
+++ b/http/http-server-common/src/main/java/io/koraframework/http/server/common/HttpServerInstanceModule.java
@@ -1,0 +1,29 @@
+package io.koraframework.http.server.common;
+
+import io.koraframework.application.graph.All;
+import io.koraframework.common.annotation.Tag;
+import io.koraframework.config.common.Config;
+import io.koraframework.config.common.mapper.ConfigValueMapper;
+import io.koraframework.http.server.common.interceptor.HttpServerInterceptor;
+import io.koraframework.http.server.common.request.HttpServerRequestHandler;
+import io.koraframework.http.server.common.router.HttpServerHandler;
+
+public class HttpServerInstanceModule {
+    private final String configPath;
+
+    public HttpServerInstanceModule(String configPath) {
+        this.configPath = configPath;
+    }
+
+    @Tag(Tag.Factory.class)
+    public HttpServerConfig config(Config config, ConfigValueMapper<HttpServerConfig> mapper) {
+        return mapper.mapOrThrow(config.get(this.configPath));
+    }
+
+    @Tag(Tag.Factory.class)
+    public HttpServerHandler handler(@Tag(Tag.Factory.class) All<HttpServerRequestHandler> handlers,
+                                     @Tag(Tag.Factory.class) All<HttpServerInterceptor> interceptors,
+                                     @Tag(Tag.Factory.class) HttpServerConfig config) {
+        return new HttpServerHandler(handlers, interceptors, config);
+    }
+}

--- a/http/http-server-common/src/main/java/io/koraframework/http/server/common/HttpServerModule.java
+++ b/http/http-server-common/src/main/java/io/koraframework/http/server/common/HttpServerModule.java
@@ -4,17 +4,14 @@ import io.koraframework.application.graph.All;
 import io.koraframework.application.graph.PromiseOf;
 import io.koraframework.application.graph.ValueOf;
 import io.koraframework.common.annotation.DefaultComponent;
-import io.koraframework.common.annotation.Tag;
 import io.koraframework.common.liveness.LivenessProbe;
 import io.koraframework.common.readiness.ReadinessProbe;
 import io.koraframework.config.common.Config;
 import io.koraframework.config.common.mapper.ConfigValueMapper;
-import io.koraframework.http.server.common.interceptor.HttpServerInterceptor;
 import io.koraframework.http.server.common.request.HttpServerRequestHandler;
 import io.koraframework.http.server.common.request.mapper.HttpServerParameterReaderModule;
 import io.koraframework.http.server.common.request.mapper.HttpServerRequestMapperModule;
 import io.koraframework.http.server.common.response.mapper.HttpServerResponseMapperModule;
-import io.koraframework.http.server.common.router.HttpServerHandler;
 import io.koraframework.http.server.common.system.*;
 import io.koraframework.http.server.common.telemetry.HttpServerTelemetryFactory;
 import io.koraframework.http.server.common.telemetry.impl.DefaultHttpServerBodyConverter;
@@ -29,16 +26,6 @@ import org.jspecify.annotations.Nullable;
 import java.util.Optional;
 
 public interface HttpServerModule extends HttpServerParameterReaderModule, HttpServerRequestMapperModule, HttpServerResponseMapperModule {
-
-    default HttpServerConfig publicHttpServerConfig(Config config, ConfigValueMapper<HttpServerConfig> mapper) {
-        return mapper.mapOrThrow(config.get("httpServer"));
-    }
-
-    default HttpServerHandler publicHttpServerHandler(All<HttpServerRequestHandler> handlers,
-                                                      @Tag(HttpServerModule.class) All<HttpServerInterceptor> interceptors,
-                                                      HttpServerConfig config) {
-        return new HttpServerHandler(handlers, interceptors, config);
-    }
 
     @DefaultComponent
     default HttpServerTelemetryFactory defaultHttpServerTelemetryFactory(@Nullable MeterRegistry meterRegistry,
@@ -69,8 +56,5 @@ public interface HttpServerModule extends HttpServerParameterReaderModule, HttpS
         return new MetricsHandler(config, meterRegistry);
     }
 
-    @SystemApi
-    default HttpServerHandler systemHttpServerHandler(@SystemApi All<HttpServerRequestHandler> handlers, @SystemApi All<HttpServerInterceptor> interceptors, HttpServerConfig config) {
-        return new HttpServerHandler(handlers, interceptors, config);
-    }
+
 }

--- a/http/http-server-common/src/main/java/io/koraframework/http/server/common/system/HttpServerSystemConfig.java
+++ b/http/http-server-common/src/main/java/io/koraframework/http/server/common/system/HttpServerSystemConfig.java
@@ -1,10 +1,9 @@
 package io.koraframework.http.server.common.system;
 
 import io.koraframework.config.common.annotation.ConfigMapper;
-import io.koraframework.http.server.common.HttpServerConfig;
 
 @ConfigMapper
-public interface HttpServerSystemConfig extends HttpServerConfig {
+public interface HttpServerSystemConfig {
 
     default String metricsPath() {
         return "/metrics";
@@ -16,10 +15,5 @@ public interface HttpServerSystemConfig extends HttpServerConfig {
 
     default String livenessPath() {
         return "/system/liveness";
-    }
-
-    @Override
-    default int port() {
-        return 8085;
     }
 }

--- a/http/http-server-common/src/testFixtures/java/io/koraframework/http/server/common/HttpServerTestKit.java
+++ b/http/http-server-common/src/testFixtures/java/io/koraframework/http/server/common/HttpServerTestKit.java
@@ -25,8 +25,7 @@ import io.koraframework.http.server.common.system.$HttpServerSystemConfig_Config
 import io.koraframework.http.server.common.system.LivenessHandler;
 import io.koraframework.http.server.common.system.MetricsHandler;
 import io.koraframework.http.server.common.system.ReadinessHandler;
-import io.koraframework.http.server.common.telemetry.HttpServerObservation;
-import io.koraframework.http.server.common.telemetry.HttpServerTelemetry;
+import io.koraframework.http.server.common.telemetry.*;
 import io.koraframework.http.server.common.telemetry.impl.NoopHttpServerTelemetry;
 import io.koraframework.telemetry.common.MetricsScraper;
 import io.opentelemetry.api.trace.Span;

--- a/http/http-server-common/src/testFixtures/java/io/koraframework/http/server/common/HttpServerTestKit.java
+++ b/http/http-server-common/src/testFixtures/java/io/koraframework/http/server/common/HttpServerTestKit.java
@@ -25,7 +25,8 @@ import io.koraframework.http.server.common.system.$HttpServerSystemConfig_Config
 import io.koraframework.http.server.common.system.LivenessHandler;
 import io.koraframework.http.server.common.system.MetricsHandler;
 import io.koraframework.http.server.common.system.ReadinessHandler;
-import io.koraframework.http.server.common.telemetry.*;
+import io.koraframework.http.server.common.telemetry.HttpServerObservation;
+import io.koraframework.http.server.common.telemetry.HttpServerTelemetry;
 import io.koraframework.http.server.common.telemetry.impl.NoopHttpServerTelemetry;
 import io.koraframework.telemetry.common.MetricsScraper;
 import io.opentelemetry.api.trace.Span;
@@ -76,7 +77,7 @@ public abstract class HttpServerTestKit {
             new MetricsHandler(valueOf($HttpServerSystemConfig_ConfigValueMapper.DEFAULTS), valueOf(Optional.of(registry)))
         ),
         List.of(),
-        $HttpServerSystemConfig_ConfigValueMapper.DEFAULTS
+        $HttpServerConfig_ConfigValueMapper.DEFAULTS
     );
 
     private volatile HttpServer httpServer = null;
@@ -991,7 +992,7 @@ public abstract class HttpServerTestKit {
     }
 
     protected void startSystemHttpServer() {
-        this.privateHttpServer = this.httpServer(valueOf($HttpServerSystemConfig_ConfigValueMapper.DEFAULTS), privateApiHandler, NoopHttpServerTelemetry.INSTANCE);
+        this.privateHttpServer = this.httpServer(valueOf($HttpServerConfig_ConfigValueMapper.DEFAULTS), privateApiHandler, NoopHttpServerTelemetry.INSTANCE);
         try {
             this.privateHttpServer.init();
         } catch (Exception e) {

--- a/http/http-server-undertow/src/main/java/io/koraframework/http/server/undertow/UndertowHttpServerFactoryModule.java
+++ b/http/http-server-undertow/src/main/java/io/koraframework/http/server/undertow/UndertowHttpServerFactoryModule.java
@@ -6,7 +6,7 @@ import io.koraframework.common.annotation.DefaultComponent;
 import io.koraframework.common.annotation.Root;
 import io.koraframework.common.annotation.Tag;
 import io.koraframework.http.server.common.HttpServerConfig;
-import io.koraframework.http.server.common.HttpServerInstanceModule;
+import io.koraframework.http.server.common.HttpServerFactoryModule;
 import io.koraframework.http.server.common.router.HttpServerHandler;
 import io.koraframework.http.server.common.telemetry.HttpServerTelemetryFactory;
 import io.koraframework.http.server.undertow.handler.KoraRequestProcessingHttpHandler;
@@ -16,10 +16,11 @@ import io.undertow.server.HttpHandler;
 import org.jspecify.annotations.Nullable;
 import org.xnio.XnioWorker;
 
-public class UndertowHttpServerModule extends HttpServerInstanceModule {
+public class UndertowHttpServerFactoryModule extends HttpServerFactoryModule {
+
     private final String name;
 
-    public UndertowHttpServerModule(String name, String configPath) {
+    public UndertowHttpServerFactoryModule(String name, String configPath) {
         super(configPath);
         this.name = name;
     }

--- a/http/http-server-undertow/src/main/java/io/koraframework/http/server/undertow/UndertowHttpServerModule.java
+++ b/http/http-server-undertow/src/main/java/io/koraframework/http/server/undertow/UndertowHttpServerModule.java
@@ -1,0 +1,47 @@
+package io.koraframework.http.server.undertow;
+
+import io.koraframework.application.graph.ValueOf;
+import io.koraframework.common.Configurer;
+import io.koraframework.common.annotation.DefaultComponent;
+import io.koraframework.common.annotation.Root;
+import io.koraframework.common.annotation.Tag;
+import io.koraframework.http.server.common.HttpServerConfig;
+import io.koraframework.http.server.common.HttpServerInstanceModule;
+import io.koraframework.http.server.common.router.HttpServerHandler;
+import io.koraframework.http.server.common.telemetry.HttpServerTelemetryFactory;
+import io.koraframework.http.server.undertow.handler.KoraRequestProcessingHttpHandler;
+import io.koraframework.http.server.undertow.handler.KoraVirtualThreadDispatchHttpHandler;
+import io.undertow.Undertow;
+import io.undertow.server.HttpHandler;
+import org.jspecify.annotations.Nullable;
+import org.xnio.XnioWorker;
+
+public class UndertowHttpServerModule extends HttpServerInstanceModule {
+    private final String name;
+
+    public UndertowHttpServerModule(String name, String configPath) {
+        super(configPath);
+        this.name = name;
+    }
+
+    @Root
+    @Tag(Tag.Factory.class)
+    public UndertowHttpServer server(XnioWorker worker,
+                                     @Tag(Tag.Factory.class) ValueOf<HttpHandler> httpHandler,
+                                     @Tag(Tag.Factory.class) ValueOf<HttpServerConfig> config,
+                                     @Tag(Tag.Factory.class) @Nullable Configurer<Undertow.Builder> configurer,
+                                     @Tag(Tag.Factory.class) @Nullable Configurer<HttpHandler> handlerConfigurer) {
+        return new UndertowHttpServer(this.name, httpHandler, worker, config, configurer, handlerConfigurer);
+    }
+
+    @DefaultComponent
+    @Tag(Tag.Factory.class)
+    public HttpHandler handler(@Tag(Tag.Factory.class) HttpServerConfig config,
+                               @Tag(Tag.Factory.class) HttpServerHandler publicApiHandler,
+                               HttpServerTelemetryFactory telemetryFactory) {
+        var telemetry = telemetryFactory.get(config.telemetry());
+        var handler = (HttpHandler) new KoraRequestProcessingHttpHandler(telemetry, publicApiHandler);
+        handler = new KoraVirtualThreadDispatchHttpHandler(this.name, handler);
+        return handler;
+    }
+}

--- a/http/http-server-undertow/src/main/java/io/koraframework/http/server/undertow/UndertowPublicHttpServerModule.java
+++ b/http/http-server-undertow/src/main/java/io/koraframework/http/server/undertow/UndertowPublicHttpServerModule.java
@@ -3,8 +3,9 @@ package io.koraframework.http.server.undertow;
 import io.koraframework.common.annotation.FactoryModule;
 
 public interface UndertowPublicHttpServerModule extends UndertowSystemHttpServerModule {
+
     @FactoryModule
-    default UndertowHttpServerModule publicApi() {
-        return new UndertowHttpServerModule("kora-undertow", "httpServer");
+    default UndertowHttpServerFactoryModule undertowPublicApi() {
+        return new UndertowHttpServerFactoryModule("kora-undertow", "httpServer");
     }
 }

--- a/http/http-server-undertow/src/main/java/io/koraframework/http/server/undertow/UndertowPublicHttpServerModule.java
+++ b/http/http-server-undertow/src/main/java/io/koraframework/http/server/undertow/UndertowPublicHttpServerModule.java
@@ -1,37 +1,10 @@
 package io.koraframework.http.server.undertow;
 
-import io.koraframework.application.graph.ValueOf;
-import io.koraframework.common.annotation.DefaultComponent;
-import io.koraframework.common.annotation.Root;
-import io.koraframework.common.Configurer;
-import io.koraframework.http.server.common.HttpServerConfig;
-import io.koraframework.http.server.common.router.HttpServerHandler;
-import io.koraframework.http.server.common.telemetry.HttpServerTelemetryFactory;
-import io.koraframework.http.server.undertow.handler.KoraRequestProcessingHttpHandler;
-import io.koraframework.http.server.undertow.handler.KoraVirtualThreadDispatchHttpHandler;
-import io.undertow.Undertow;
-import io.undertow.server.HttpHandler;
-import org.jspecify.annotations.Nullable;
-import org.xnio.XnioWorker;
+import io.koraframework.common.annotation.FactoryModule;
 
 public interface UndertowPublicHttpServerModule extends UndertowSystemHttpServerModule {
-
-    @Root
-    default UndertowHttpServer undertowPublicHttpServer(ValueOf<HttpHandler> httpHandler,
-                                                        XnioWorker worker,
-                                                        ValueOf<HttpServerConfig> config,
-                                                        @Nullable Configurer<Undertow.Builder> configurer,
-                                                        @Nullable Configurer<HttpHandler> handlerConfigurer) {
-        return new UndertowHttpServer("kora-undertow", httpHandler, worker, config, configurer, handlerConfigurer);
-    }
-
-    @DefaultComponent
-    default HttpHandler undertowPublicHttpHandler(HttpServerConfig config,
-                                                  HttpServerHandler publicApiHandler,
-                                                  HttpServerTelemetryFactory telemetryFactory) {
-        var telemetry = telemetryFactory.get(config.telemetry());
-        var handler = (HttpHandler) new KoraRequestProcessingHttpHandler(telemetry, publicApiHandler);
-        handler = new KoraVirtualThreadDispatchHttpHandler("kora-undertow", handler);
-        return handler;
+    @FactoryModule
+    default UndertowHttpServerModule publicApi() {
+        return new UndertowHttpServerModule("kora-undertow", "httpServer");
     }
 }

--- a/http/http-server-undertow/src/main/java/io/koraframework/http/server/undertow/UndertowSystemHttpServerModule.java
+++ b/http/http-server-undertow/src/main/java/io/koraframework/http/server/undertow/UndertowSystemHttpServerModule.java
@@ -13,10 +13,11 @@ import org.jspecify.annotations.Nullable;
 import org.xnio.XnioWorker;
 
 public interface UndertowSystemHttpServerModule extends HttpServerModule {
+
     @FactoryModule
     @SystemApi
-    default UndertowHttpServerModule systemApi() {
-        return new UndertowHttpServerModule("kora-undertow-system", "httpServer.system");
+    default UndertowHttpServerFactoryModule undertowSystemApi() {
+        return new UndertowHttpServerFactoryModule("kora-undertow-system", "httpServer.system");
     }
 
     default UndertowConfig undertowHttpServerConfig(Config config, ConfigValueMapper<UndertowConfig> mapper) {

--- a/http/http-server-undertow/src/main/java/io/koraframework/http/server/undertow/UndertowSystemHttpServerModule.java
+++ b/http/http-server-undertow/src/main/java/io/koraframework/http/server/undertow/UndertowSystemHttpServerModule.java
@@ -2,41 +2,21 @@ package io.koraframework.http.server.undertow;
 
 import io.koraframework.application.graph.ValueOf;
 import io.koraframework.application.graph.Wrapped;
-import io.koraframework.common.annotation.DefaultComponent;
-import io.koraframework.common.annotation.Root;
 import io.koraframework.common.Configurer;
+import io.koraframework.common.annotation.DefaultComponent;
+import io.koraframework.common.annotation.FactoryModule;
 import io.koraframework.config.common.Config;
 import io.koraframework.config.common.mapper.ConfigValueMapper;
 import io.koraframework.http.server.common.HttpServerModule;
-import io.koraframework.http.server.common.router.HttpServerHandler;
-import io.koraframework.http.server.common.system.HttpServerSystemConfig;
 import io.koraframework.http.server.common.system.SystemApi;
-import io.koraframework.http.server.common.telemetry.impl.NoopHttpServerTelemetry;
-import io.koraframework.http.server.undertow.handler.KoraRequestProcessingHttpHandler;
-import io.koraframework.http.server.undertow.handler.KoraVirtualThreadDispatchHttpHandler;
-import io.undertow.Undertow;
-import io.undertow.server.HttpHandler;
 import org.jspecify.annotations.Nullable;
 import org.xnio.XnioWorker;
 
 public interface UndertowSystemHttpServerModule extends HttpServerModule {
-
+    @FactoryModule
     @SystemApi
-    @Root
-    default UndertowHttpServer undertowSystemHttpServer(@SystemApi ValueOf<HttpHandler> httpHandler,
-                                                        XnioWorker worker,
-                                                        @SystemApi ValueOf<HttpServerSystemConfig> config,
-                                                        @SystemApi @Nullable Configurer<Undertow.Builder> configurer,
-                                                        @SystemApi @Nullable Configurer<HttpHandler> handlerConfigurer) {
-        return new UndertowHttpServer("kora-undertow-system", httpHandler, worker, config, configurer, handlerConfigurer);
-    }
-
-    @SystemApi
-    @DefaultComponent
-    default HttpHandler undertowSystemHttpHandler(@SystemApi HttpServerHandler systemApiHandler) {
-        var handler = (HttpHandler) new KoraRequestProcessingHttpHandler(NoopHttpServerTelemetry.INSTANCE, systemApiHandler);
-        handler = new KoraVirtualThreadDispatchHttpHandler("kora-undertow-system", handler);
-        return handler;
+    default UndertowHttpServerModule systemApi() {
+        return new UndertowHttpServerModule("kora-undertow-system", "httpServer.system");
     }
 
     default UndertowConfig undertowHttpServerConfig(Config config, ConfigValueMapper<UndertowConfig> mapper) {

--- a/json/json-symbol-processor/src/test/kotlin/io/koraframework/json/ksp/extension/JsonKoraExtensionTest.kt
+++ b/json/json-symbol-processor/src/test/kotlin/io/koraframework/json/ksp/extension/JsonKoraExtensionTest.kt
@@ -18,7 +18,7 @@ class JsonKoraExtensionTest : AbstractSymbolProcessorTest() {
                 data class TestClass(val a: String)
 
                 @Root
-                fun test(r: io.koraframework.json.common.JsonReader<TestClass>) {}
+                fun test(r: io.koraframework.json.common.JsonReader<TestClass>): Any = r
             }
         """.trimIndent()
         )
@@ -38,7 +38,7 @@ class JsonKoraExtensionTest : AbstractSymbolProcessorTest() {
                 data class TestClass(val a: String)
 
                 @Root
-                fun test(r: io.koraframework.json.common.JsonWriter<TestClass>) {}
+                fun test(r: io.koraframework.json.common.JsonWriter<TestClass>): Any = r
             }
         """.trimIndent()
         )
@@ -58,7 +58,7 @@ class JsonKoraExtensionTest : AbstractSymbolProcessorTest() {
                 enum class TestEnum { INSTANCE }
 
                 @Root
-                fun test(r: io.koraframework.json.common.JsonReader<TestEnum>) {}
+                fun test(r: io.koraframework.json.common.JsonReader<TestEnum>): Any = r
             }
         """.trimIndent()
         )
@@ -78,7 +78,7 @@ class JsonKoraExtensionTest : AbstractSymbolProcessorTest() {
                 enum class TestEnum { INSTANCE }
 
                 @Root
-                fun test(r: io.koraframework.json.common.JsonWriter<TestEnum>) {}
+                fun test(r: io.koraframework.json.common.JsonWriter<TestEnum>): Any = r
             }
         """.trimIndent()
         )
@@ -105,7 +105,7 @@ class JsonKoraExtensionTest : AbstractSymbolProcessorTest() {
                 }
 
                 @Root
-                fun test(r: io.koraframework.json.common.JsonReader<TestInterface>) {}
+                fun test(r: io.koraframework.json.common.JsonReader<TestInterface>): Any = r
             }
         """.trimIndent()
         )
@@ -132,7 +132,7 @@ class JsonKoraExtensionTest : AbstractSymbolProcessorTest() {
                 }
 
                 @Root
-                fun test(r: io.koraframework.json.common.JsonWriter<TestInterface>) {}
+                fun test(r: io.koraframework.json.common.JsonWriter<TestInterface>): Any = r
             }
         """.trimIndent()
         )


### PR DESCRIPTION
Lets a `@Module` method return another module instance (a "class module"), whose own factory methods are then processed as component providers and registered in the dependency graph. Tag.Factory lets those inner factory methods reuse the tag of the enclosing module method instead of requiring an explicit tag.