### PR TITLE
Added factory modules for server, client, database, and Redis components

### DIFF
--- a/cache/cache-redis-lettuce/src/test/java/io/koraframework/cache/redis/CacheRunner.java
+++ b/cache/cache-redis-lettuce/src/test/java/io/koraframework/cache/redis/CacheRunner.java
@@ -51,7 +51,7 @@ public abstract class CacheRunner extends Assertions implements RedisCacheModule
     }
 
     private RedisCacheClient createLettuce(RedisParams redisParams) throws Exception {
-        var lettuceClientFactory = lettuceFactory(null, null, null, null, null, null);
+        var lettuceClientFactory = lettuceFactory().lettuceFactory(null, null, null, null, null, null);
         var lettuceConfig = new LettuceConfig() {
             @Override
             public String uri() {

--- a/core/application-graph/src/main/java/io/koraframework/application/graph/ValueOf.java
+++ b/core/application-graph/src/main/java/io/koraframework/application/graph/ValueOf.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 import java.util.function.Function;
 
 public interface ValueOf<T> {
+
     T get();
 
     default <Q> ValueOf<Q> map(Function<T, Q> mapper) {

--- a/database/database-cassandra/src/main/java/io/koraframework/database/cassandra/CassandraDatabaseFactoryModule.java
+++ b/database/database-cassandra/src/main/java/io/koraframework/database/cassandra/CassandraDatabaseFactoryModule.java
@@ -1,0 +1,32 @@
+package io.koraframework.database.cassandra;
+
+import com.datastax.oss.driver.api.core.CqlSessionBuilder;
+import com.datastax.oss.driver.api.core.config.ProgrammaticDriverConfigLoaderBuilder;
+import io.koraframework.common.Configurer;
+import io.koraframework.common.annotation.Tag;
+import io.koraframework.config.common.Config;
+import io.koraframework.config.common.mapper.ConfigValueMapper;
+import io.koraframework.database.common.telemetry.DatabaseTelemetryFactory;
+import org.jspecify.annotations.Nullable;
+
+public class CassandraDatabaseFactoryModule {
+
+    private final String configPath;
+
+    public CassandraDatabaseFactoryModule(String configPath) {
+        this.configPath = configPath;
+    }
+
+    @Tag(Tag.Factory.class)
+    public CassandraConfig cassandraConfig(Config config, ConfigValueMapper<CassandraConfig> mapper) {
+        return mapper.mapOrThrow(config.get(this.configPath));
+    }
+
+    @Tag(Tag.Factory.class)
+    public CassandraSession cassandraSession(@Tag(Tag.Factory.class) CassandraConfig config,
+                                             DatabaseTelemetryFactory telemetryFactory,
+                                             @Tag(Tag.Factory.class) @Nullable Configurer<ProgrammaticDriverConfigLoaderBuilder> loaderConfigurer,
+                                             @Tag(Tag.Factory.class) @Nullable Configurer<CqlSessionBuilder> sessionBuilderConfigurer) {
+        return new CassandraSession(config, telemetryFactory, loaderConfigurer, sessionBuilderConfigurer);
+    }
+}

--- a/database/database-cassandra/src/main/java/io/koraframework/database/cassandra/CassandraDatabaseModule.java
+++ b/database/database-cassandra/src/main/java/io/koraframework/database/cassandra/CassandraDatabaseModule.java
@@ -1,23 +1,11 @@
 package io.koraframework.database.cassandra;
 
-import com.datastax.oss.driver.api.core.CqlSessionBuilder;
-import com.datastax.oss.driver.api.core.config.ProgrammaticDriverConfigLoaderBuilder;
-import io.koraframework.common.Configurer;
-import io.koraframework.config.common.Config;
-import io.koraframework.config.common.mapper.ConfigValueMapper;
-import io.koraframework.database.common.telemetry.DatabaseTelemetryFactory;
-import org.jspecify.annotations.Nullable;
+import io.koraframework.common.annotation.FactoryModule;
 
 public interface CassandraDatabaseModule extends CassandraMapperModule {
 
-    default CassandraConfig cassandraConfig(Config config, ConfigValueMapper<CassandraConfig> mapper) {
-        return mapper.mapOrThrow(config.get("cassandra"));
-    }
-
-    default CassandraSession cassandraSession(CassandraConfig config,
-                                              DatabaseTelemetryFactory telemetryFactory,
-                                              @Nullable Configurer<ProgrammaticDriverConfigLoaderBuilder> loaderConfigurer,
-                                              @Nullable Configurer<CqlSessionBuilder> sessionBuilderConfigurer) {
-        return new CassandraSession(config, telemetryFactory, loaderConfigurer, sessionBuilderConfigurer);
+    @FactoryModule
+    default CassandraDatabaseFactoryModule cassandraDatabase() {
+        return new CassandraDatabaseFactoryModule("cassandra");
     }
 }

--- a/database/database-jdbc/src/main/java/io/koraframework/database/jdbc/JdbcDatabaseFactoryModule.java
+++ b/database/database-jdbc/src/main/java/io/koraframework/database/jdbc/JdbcDatabaseFactoryModule.java
@@ -1,0 +1,30 @@
+package io.koraframework.database.jdbc;
+
+import com.zaxxer.hikari.HikariConfig;
+import io.koraframework.common.Configurer;
+import io.koraframework.common.annotation.Tag;
+import io.koraframework.config.common.Config;
+import io.koraframework.config.common.mapper.ConfigValueMapper;
+import io.koraframework.database.common.telemetry.DatabaseTelemetryFactory;
+import org.jspecify.annotations.Nullable;
+
+public class JdbcDatabaseFactoryModule {
+
+    private final String configPath;
+
+    public JdbcDatabaseFactoryModule(String configPath) {
+        this.configPath = configPath;
+    }
+
+    @Tag(Tag.Factory.class)
+    public JdbcDatabaseConfig jdbcDatabaseConfig(Config config, ConfigValueMapper<JdbcDatabaseConfig> mapper) {
+        return mapper.mapOrThrow(config.get(this.configPath));
+    }
+
+    @Tag(Tag.Factory.class)
+    public JdbcDataSource jdbcDataSource(@Tag(Tag.Factory.class) JdbcDatabaseConfig config,
+                                         DatabaseTelemetryFactory telemetryFactory,
+                                         @Tag(Tag.Factory.class) @Nullable Configurer<HikariConfig> configurer) {
+        return new JdbcDataSource(config, telemetryFactory, configurer);
+    }
+}

--- a/database/database-jdbc/src/main/java/io/koraframework/database/jdbc/JdbcDatabaseModule.java
+++ b/database/database-jdbc/src/main/java/io/koraframework/database/jdbc/JdbcDatabaseModule.java
@@ -1,21 +1,11 @@
 package io.koraframework.database.jdbc;
 
-import com.zaxxer.hikari.HikariConfig;
-import io.koraframework.common.Configurer;
-import io.koraframework.config.common.Config;
-import io.koraframework.config.common.mapper.ConfigValueMapper;
-import io.koraframework.database.common.telemetry.DatabaseTelemetryFactory;
-import org.jspecify.annotations.Nullable;
+import io.koraframework.common.annotation.FactoryModule;
 
 public interface JdbcDatabaseModule extends JdbcMapperModule {
 
-    default JdbcDatabaseConfig jdbcDatabaseConfig(Config config, ConfigValueMapper<JdbcDatabaseConfig> mapper) {
-        return mapper.mapOrThrow(config.get("db.jdbc"));
-    }
-
-    default JdbcDataSource jdbcDataSource(JdbcDatabaseConfig config,
-                                          DatabaseTelemetryFactory telemetryFactory,
-                                          @Nullable Configurer<HikariConfig> configurer) {
-        return new JdbcDataSource(config, telemetryFactory, configurer);
+    @FactoryModule
+    default JdbcDatabaseFactoryModule jdbcDatabase() {
+        return new JdbcDatabaseFactoryModule("jdbc");
     }
 }

--- a/http/http-client-apache/src/main/java/io/koraframework/http/client/apache/ApacheHttpClientFactoryModule.java
+++ b/http/http-client-apache/src/main/java/io/koraframework/http/client/apache/ApacheHttpClientFactoryModule.java
@@ -1,0 +1,45 @@
+package io.koraframework.http.client.apache;
+
+import io.koraframework.common.Configurer;
+import io.koraframework.common.annotation.DefaultComponent;
+import io.koraframework.common.annotation.Tag;
+import io.koraframework.config.common.Config;
+import io.koraframework.config.common.mapper.ConfigValueMapper;
+import io.koraframework.http.client.common.HttpClientConfig;
+import io.koraframework.http.client.common.HttpClientFactoryModule;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.jspecify.annotations.Nullable;
+
+public class ApacheHttpClientFactoryModule extends HttpClientFactoryModule {
+
+    private final String configPath;
+
+    public ApacheHttpClientFactoryModule(String baseConfigPath) {
+        this(baseConfigPath, baseConfigPath + ".apache");
+    }
+
+    public ApacheHttpClientFactoryModule(String baseConfigPath, String configPath) {
+        super(baseConfigPath);
+        this.configPath = configPath;
+    }
+
+    @Tag(Tag.Factory.class)
+    public ApacheHttpClientConfig apacheHttpClientConfig(Config config, ConfigValueMapper<ApacheHttpClientConfig> mapper) {
+        return mapper.mapOrThrow(config.get(this.configPath));
+    }
+
+    @Tag(Tag.Factory.class)
+    public ApacheHttpClient apacheHttpClient(@Tag(Tag.Factory.class) org.apache.hc.client5.http.classic.HttpClient apacheHttpClient) {
+        return new ApacheHttpClient(apacheHttpClient);
+    }
+
+    @DefaultComponent
+    @Tag(Tag.Factory.class)
+    public ApacheHttpClientWrapper apacheHttpClientWrapper(@Tag(Tag.Factory.class) HttpClientConfig baseConfig,
+                                                           @Tag(Tag.Factory.class) ApacheHttpClientConfig apacheConfig,
+                                                           @Tag(Tag.Factory.class) @Nullable Configurer<RequestConfig.Builder> requestConfigurer,
+                                                           @Tag(Tag.Factory.class) @Nullable Configurer<HttpClientBuilder> clientConfigurer) {
+        return new ApacheHttpClientWrapper(baseConfig, apacheConfig, requestConfigurer, clientConfigurer);
+    }
+}

--- a/http/http-client-apache/src/main/java/io/koraframework/http/client/apache/ApacheHttpClientModule.java
+++ b/http/http-client-apache/src/main/java/io/koraframework/http/client/apache/ApacheHttpClientModule.java
@@ -1,31 +1,12 @@
 package io.koraframework.http.client.apache;
 
-import io.koraframework.common.annotation.DefaultComponent;
-import io.koraframework.common.Configurer;
-import io.koraframework.config.common.Config;
-import io.koraframework.config.common.mapper.ConfigValueMapper;
-import io.koraframework.http.client.common.HttpClientConfig;
+import io.koraframework.common.annotation.FactoryModule;
 import io.koraframework.http.client.common.HttpClientModule;
-import org.apache.hc.client5.http.classic.HttpClient;
-import org.apache.hc.client5.http.config.RequestConfig;
-import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
-import org.jspecify.annotations.Nullable;
 
 public interface ApacheHttpClientModule extends HttpClientModule {
 
-    default ApacheHttpClient apacheHttpClient(HttpClient apacheHttpClient) {
-        return new ApacheHttpClient(apacheHttpClient);
-    }
-
-    default ApacheHttpClientConfig apacheHttpClientConfig(Config config, ConfigValueMapper<ApacheHttpClientConfig> mapper) {
-        return mapper.mapOrThrow(config.get("httpClient.apache"));
-    }
-
-    @DefaultComponent
-    default ApacheHttpClientWrapper apacheHttpClientWrapper(HttpClientConfig baseConfig,
-                                                            ApacheHttpClientConfig apacheConfig,
-                                                            @Nullable Configurer<RequestConfig.Builder> requestConfigurer,
-                                                            @Nullable Configurer<HttpClientBuilder> clientConfigurer) {
-        return new ApacheHttpClientWrapper(baseConfig, apacheConfig, requestConfigurer, clientConfigurer);
+    @FactoryModule
+    default ApacheHttpClientFactoryModule apacheHttpClientFactory() {
+        return new ApacheHttpClientFactoryModule("httpClient");
     }
 }

--- a/http/http-client-common/src/main/java/io/koraframework/http/client/common/HttpClientFactoryModule.java
+++ b/http/http-client-common/src/main/java/io/koraframework/http/client/common/HttpClientFactoryModule.java
@@ -1,0 +1,19 @@
+package io.koraframework.http.client.common;
+
+import io.koraframework.common.annotation.Tag;
+import io.koraframework.config.common.Config;
+import io.koraframework.config.common.mapper.ConfigValueMapper;
+
+public class HttpClientFactoryModule {
+
+    private final String configPath;
+
+    public HttpClientFactoryModule(String configPath) {
+        this.configPath = configPath;
+    }
+
+    @Tag(Tag.Factory.class)
+    public HttpClientConfig httpClientConfig(Config config, ConfigValueMapper<HttpClientConfig> mapper) {
+        return mapper.mapOrThrow(config.get(this.configPath));
+    }
+}

--- a/http/http-client-common/src/main/java/io/koraframework/http/client/common/HttpClientModule.java
+++ b/http/http-client-common/src/main/java/io/koraframework/http/client/common/HttpClientModule.java
@@ -1,8 +1,6 @@
 package io.koraframework.http.client.common;
 
 import io.koraframework.common.annotation.DefaultComponent;
-import io.koraframework.config.common.Config;
-import io.koraframework.config.common.mapper.ConfigValueMapper;
 import io.koraframework.http.client.common.request.mapper.HttpClientParameterWriterModule;
 import io.koraframework.http.client.common.request.mapper.HttpClientRequestMapperModule;
 import io.koraframework.http.client.common.response.HttpClientResponseMapperModule;
@@ -16,11 +14,6 @@ import io.opentelemetry.api.trace.Tracer;
 import org.jspecify.annotations.Nullable;
 
 public interface HttpClientModule extends HttpClientRequestMapperModule, HttpClientResponseMapperModule, HttpClientParameterWriterModule {
-
-    default HttpClientConfig httpClientConfig(Config config, ConfigValueMapper<HttpClientConfig> mapper) {
-        var configValue = config.get("httpClient");
-        return mapper.map(configValue);
-    }
 
     @DefaultComponent
     default HttpClientTelemetryFactory defaultHttpClientTelemetryFactory(@Nullable Tracer tracer,

--- a/http/http-client-jdk/src/main/java/io/koraframework/http/client/jdk/JdkHttpClientFactoryModule.java
+++ b/http/http-client-jdk/src/main/java/io/koraframework/http/client/jdk/JdkHttpClientFactoryModule.java
@@ -1,0 +1,44 @@
+package io.koraframework.http.client.jdk;
+
+import io.koraframework.common.Configurer;
+import io.koraframework.common.annotation.DefaultComponent;
+import io.koraframework.common.annotation.Tag;
+import io.koraframework.config.common.Config;
+import io.koraframework.config.common.mapper.ConfigValueMapper;
+import io.koraframework.http.client.common.HttpClientConfig;
+import io.koraframework.http.client.common.HttpClientFactoryModule;
+import org.jspecify.annotations.Nullable;
+
+import java.net.http.HttpClient;
+
+public class JdkHttpClientFactoryModule extends HttpClientFactoryModule {
+
+    private final String configPath;
+
+    public JdkHttpClientFactoryModule(String baseConfigPath) {
+        this(baseConfigPath, baseConfigPath + ".jdk");
+    }
+
+    public JdkHttpClientFactoryModule(String baseConfigPath, String configPath) {
+        super(baseConfigPath);
+        this.configPath = configPath;
+    }
+
+    @Tag(Tag.Factory.class)
+    public JdkHttpClientConfig jdkHttpClientConfig(Config config, ConfigValueMapper<JdkHttpClientConfig> mapper) {
+        return mapper.mapOrThrow(config.get(this.configPath));
+    }
+
+    @Tag(Tag.Factory.class)
+    public JdkHttpClient jdkHttpClient(@Tag(Tag.Factory.class) HttpClient client) {
+        return new JdkHttpClient(client);
+    }
+
+    @DefaultComponent
+    @Tag(Tag.Factory.class)
+    public JdkHttpClientWrapper jdkHttpClientWrapper(@Tag(Tag.Factory.class) JdkHttpClientConfig config,
+                                                     @Tag(Tag.Factory.class) HttpClientConfig baseConfig,
+                                                     @Tag(Tag.Factory.class) @Nullable Configurer<HttpClient.Builder> clientConfigurer) {
+        return new JdkHttpClientWrapper(config, baseConfig, clientConfigurer);
+    }
+}

--- a/http/http-client-jdk/src/main/java/io/koraframework/http/client/jdk/JdkHttpClientModule.java
+++ b/http/http-client-jdk/src/main/java/io/koraframework/http/client/jdk/JdkHttpClientModule.java
@@ -1,22 +1,18 @@
 package io.koraframework.http.client.jdk;
 
 import io.koraframework.common.annotation.DefaultComponent;
-import io.koraframework.config.common.Config;
+import io.koraframework.common.annotation.FactoryModule;
 import io.koraframework.config.common.ConfigValue;
 import io.koraframework.config.common.mapper.ConfigValueMapper;
-import io.koraframework.http.client.common.HttpClientConfig;
 import io.koraframework.http.client.common.HttpClientModule;
 
 import java.net.http.HttpClient;
 
 public interface JdkHttpClientModule extends HttpClientModule {
 
-    default JdkHttpClient jdkHttpClient(HttpClient client) {
-        return new JdkHttpClient(client);
-    }
-
-    default JdkHttpClientConfig jdkHttpClientConfig(Config config, ConfigValueMapper<JdkHttpClientConfig> mapper) {
-        return mapper.mapOrThrow(config.get("httpClient.jdk"));
+    @FactoryModule
+    default JdkHttpClientFactoryModule jdkHttpClientFactory() {
+        return new JdkHttpClientFactoryModule("httpClient");
     }
 
     @DefaultComponent
@@ -30,8 +26,4 @@ public interface JdkHttpClientModule extends HttpClientModule {
         };
     }
 
-    @DefaultComponent
-    default JdkHttpClientWrapper jdkHttpClientWrapper(JdkHttpClientConfig config, HttpClientConfig baseConfig) {
-        return new JdkHttpClientWrapper(config, baseConfig);
-    }
 }

--- a/http/http-client-jdk/src/main/java/io/koraframework/http/client/jdk/JdkHttpClientWrapper.java
+++ b/http/http-client-jdk/src/main/java/io/koraframework/http/client/jdk/JdkHttpClientWrapper.java
@@ -2,8 +2,10 @@ package io.koraframework.http.client.jdk;
 
 import io.koraframework.application.graph.Lifecycle;
 import io.koraframework.application.graph.Wrapped;
+import io.koraframework.common.Configurer;
 import io.koraframework.common.util.TimeUtils;
 import io.koraframework.http.client.common.HttpClientConfig;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,12 +24,17 @@ public final class JdkHttpClientWrapper implements Lifecycle, Wrapped<HttpClient
 
     private final JdkHttpClientConfig config;
     private final HttpClientConfig baseConfig;
+    @Nullable
+    private final Configurer<HttpClient.Builder> clientConfigurer;
 
     private volatile HttpClient client;
 
-    public JdkHttpClientWrapper(JdkHttpClientConfig config, HttpClientConfig baseConfig) {
+    public JdkHttpClientWrapper(JdkHttpClientConfig config,
+                                HttpClientConfig baseConfig,
+                                @Nullable Configurer<HttpClient.Builder> clientConfigurer) {
         this.config = config;
         this.baseConfig = baseConfig;
+        this.clientConfigurer = clientConfigurer;
     }
 
     @Override
@@ -61,6 +68,10 @@ public final class JdkHttpClientWrapper implements Lifecycle, Wrapped<HttpClient
                     }
                 });
             }
+        }
+
+        if (this.clientConfigurer != null) {
+            builder = this.clientConfigurer.configure(builder);
         }
 
         this.client = builder.build();

--- a/http/http-client-ok/src/main/java/io/koraframework/http/client/ok/OkHttpClientFactoryModule.java
+++ b/http/http-client-ok/src/main/java/io/koraframework/http/client/ok/OkHttpClientFactoryModule.java
@@ -1,0 +1,42 @@
+package io.koraframework.http.client.ok;
+
+import io.koraframework.common.Configurer;
+import io.koraframework.common.annotation.DefaultComponent;
+import io.koraframework.common.annotation.Tag;
+import io.koraframework.config.common.Config;
+import io.koraframework.config.common.mapper.ConfigValueMapper;
+import io.koraframework.http.client.common.HttpClientConfig;
+import io.koraframework.http.client.common.HttpClientFactoryModule;
+import org.jspecify.annotations.Nullable;
+
+public class OkHttpClientFactoryModule extends HttpClientFactoryModule {
+
+    private final String configPath;
+
+    public OkHttpClientFactoryModule(String baseConfigPath) {
+        this(baseConfigPath, baseConfigPath + ".ok");
+    }
+
+    public OkHttpClientFactoryModule(String baseConfigPath, String configPath) {
+        super(baseConfigPath);
+        this.configPath = configPath;
+    }
+
+    @Tag(Tag.Factory.class)
+    public OkHttpClientConfig okHttpClientConfig(Config config, ConfigValueMapper<OkHttpClientConfig> mapper) {
+        return mapper.mapOrThrow(config.get(this.configPath));
+    }
+
+    @Tag(Tag.Factory.class)
+    public OkHttpClient okHttpClient(@Tag(Tag.Factory.class) okhttp3.OkHttpClient client) {
+        return new OkHttpClient(client);
+    }
+
+    @DefaultComponent
+    @Tag(Tag.Factory.class)
+    public OkHttpClientWrapper okHttpClientWrapper(@Tag(Tag.Factory.class) OkHttpClientConfig config,
+                                                   @Tag(Tag.Factory.class) HttpClientConfig baseConfig,
+                                                   @Tag(Tag.Factory.class) @Nullable Configurer<okhttp3.OkHttpClient.Builder> configurer) {
+        return new OkHttpClientWrapper(config, baseConfig, configurer);
+    }
+}

--- a/http/http-client-ok/src/main/java/io/koraframework/http/client/ok/OkHttpClientModule.java
+++ b/http/http-client-ok/src/main/java/io/koraframework/http/client/ok/OkHttpClientModule.java
@@ -1,25 +1,12 @@
 package io.koraframework.http.client.ok;
 
-import io.koraframework.application.graph.All;
-import io.koraframework.common.annotation.DefaultComponent;
-import io.koraframework.common.Configurer;
-import io.koraframework.config.common.Config;
-import io.koraframework.config.common.mapper.ConfigValueMapper;
-import io.koraframework.http.client.common.HttpClientConfig;
+import io.koraframework.common.annotation.FactoryModule;
 import io.koraframework.http.client.common.HttpClientModule;
 
 public interface OkHttpClientModule extends HttpClientModule {
 
-    default OkHttpClient okHttpClient(okhttp3.OkHttpClient client) {
-        return new OkHttpClient(client);
-    }
-
-    default OkHttpClientConfig okHttpClientConfig(Config config, ConfigValueMapper<OkHttpClientConfig> mapper) {
-        return mapper.mapOrThrow(config.get("httpClient.ok"));
-    }
-
-    @DefaultComponent
-    default OkHttpClientWrapper okHttpClientWrapper(OkHttpClientConfig config, HttpClientConfig baseConfig, All<Configurer<okhttp3.OkHttpClient.Builder>> configurers) {
-        return new OkHttpClientWrapper(config, baseConfig, configurers);
+    @FactoryModule
+    default OkHttpClientFactoryModule okHttpClientFactory() {
+        return new OkHttpClientFactoryModule("httpClient");
     }
 }

--- a/http/http-client-ok/src/main/java/io/koraframework/http/client/ok/OkHttpClientWrapper.java
+++ b/http/http-client-ok/src/main/java/io/koraframework/http/client/ok/OkHttpClientWrapper.java
@@ -4,12 +4,12 @@ import okhttp3.OkHttpClient;
 import okhttp3.Protocol;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import io.koraframework.application.graph.All;
 import io.koraframework.application.graph.Lifecycle;
 import io.koraframework.application.graph.Wrapped;
 import io.koraframework.common.Configurer;
 import io.koraframework.common.util.TimeUtils;
 import io.koraframework.http.client.common.HttpClientConfig;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 
@@ -19,13 +19,17 @@ public final class OkHttpClientWrapper implements Lifecycle, Wrapped<OkHttpClien
 
     private final OkHttpClientConfig config;
     private final HttpClientConfig baseConfig;
-    private final All<Configurer<OkHttpClient.Builder>> configurers;
+    @Nullable
+    private final Configurer<OkHttpClient.Builder> configurer;
+
     private volatile OkHttpClient client;
 
-    public OkHttpClientWrapper(OkHttpClientConfig config, HttpClientConfig baseConfig, All<Configurer<OkHttpClient.Builder>> configurers) {
+    public OkHttpClientWrapper(OkHttpClientConfig config,
+                               HttpClientConfig baseConfig,
+                               @Nullable Configurer<OkHttpClient.Builder> configurer) {
         this.config = config;
         this.baseConfig = baseConfig;
-        this.configurers = configurers;
+        this.configurer = configurer;
     }
 
     @Override
@@ -55,8 +59,8 @@ public final class OkHttpClientWrapper implements Lifecycle, Wrapped<OkHttpClien
                 builder.proxyAuthenticator(new ProxyAuthenticator(proxyUser, proxyPassword));
             }
         }
-        for (var configurer : this.configurers) {
-            builder = configurer.configure(builder);
+        if (this.configurer != null) {
+            builder = this.configurer.configure(builder);
         }
         this.client = builder.build();
 

--- a/http/http-server-common/src/main/java/io/koraframework/http/server/common/HttpServerModule.java
+++ b/http/http-server-common/src/main/java/io/koraframework/http/server/common/HttpServerModule.java
@@ -37,11 +37,6 @@ public interface HttpServerModule extends HttpServerParameterReaderModule, HttpS
     }
 
     @SystemApi
-    default HttpServerSystemConfig systemHttpServerConfig(Config config, ConfigValueMapper<HttpServerSystemConfig> mapper) {
-        return mapper.mapOrThrow(config.get("httpServer.system"));
-    }
-
-    @SystemApi
     default HttpServerRequestHandler systemLivenessHttpServerRequestHandler(@SystemApi ValueOf<HttpServerSystemConfig> config, All<PromiseOf<LivenessProbe>> probes) {
         return new LivenessHandler(config, probes);
     }
@@ -55,6 +50,4 @@ public interface HttpServerModule extends HttpServerParameterReaderModule, HttpS
     default HttpServerRequestHandler systemMetricsHttpServerRequestHandler(@SystemApi ValueOf<HttpServerSystemConfig> config, ValueOf<Optional<MetricsScraper>> meterRegistry) {
         return new MetricsHandler(config, meterRegistry);
     }
-
-
 }

--- a/http/http-server-common/src/main/java/io/koraframework/http/server/common/telemetry/HttpServerTelemetryFactory.java
+++ b/http/http-server-common/src/main/java/io/koraframework/http/server/common/telemetry/HttpServerTelemetryFactory.java
@@ -1,5 +1,6 @@
 package io.koraframework.http.server.common.telemetry;
 
 public interface HttpServerTelemetryFactory {
-    HttpServerTelemetry get(HttpServerTelemetryConfig telemetryConfig);
+
+    HttpServerTelemetry get(String name, int port, HttpServerTelemetryConfig telemetryConfig);
 }

--- a/http/http-server-common/src/main/java/io/koraframework/http/server/common/telemetry/impl/DefaultHttpServerLoggerFactory.java
+++ b/http/http-server-common/src/main/java/io/koraframework/http/server/common/telemetry/impl/DefaultHttpServerLoggerFactory.java
@@ -91,6 +91,8 @@ public class DefaultHttpServerLoggerFactory {
                 : null;
             var arg = (StructuredArgumentWriter) gen -> {
                 gen.writeStartObject();
+                gen.writeStringProperty("serverName", this.context.name());
+                gen.writeNumberProperty("serverPort", this.context.port());
                 gen.writeStringProperty("authority", request.host());
                 gen.writeStringProperty("operation", operation);
                 if (finalQuery != null && !finalQuery.isEmpty()) {
@@ -141,6 +143,8 @@ public class DefaultHttpServerLoggerFactory {
 
             var w = (StructuredArgumentWriter) gen -> {
                 gen.writeStartObject();
+                gen.writeStringProperty("serverName", this.context.name());
+                gen.writeNumberProperty("serverPort", this.context.port());
                 gen.writeStringProperty("authority", request.host());
                 gen.writeStringProperty("operation", operation);
                 gen.writeStringProperty("resultCode", resultCode.string());

--- a/http/http-server-common/src/main/java/io/koraframework/http/server/common/telemetry/impl/DefaultHttpServerMetricsFactory.java
+++ b/http/http-server-common/src/main/java/io/koraframework/http/server/common/telemetry/impl/DefaultHttpServerMetricsFactory.java
@@ -103,9 +103,11 @@ public class DefaultHttpServerMetricsFactory {
                     extraTags++;
                 }
             }
-            var staticTags = new ArrayList<Tag>(5 + this.context.config().metrics().tags().size() + extraTags);
+            var staticTags = new ArrayList<Tag>(7 + this.context.config().metrics().tags().size() + extraTags);
 
             var errorType = (throwable == null) ? "" : throwable.getClass().getCanonicalName();
+            staticTags.add(Tag.of("server.name", this.context.name()));
+            staticTags.add(Tag.of(ServerAttributes.SERVER_PORT.getKey(), String.valueOf(this.context.port())));
             staticTags.add(Tag.of(HttpAttributes.HTTP_REQUEST_METHOD.getKey(), request.method()));
             staticTags.add(Tag.of(HttpAttributes.HTTP_ROUTE.getKey(), metricKey.pathTemplate()));
             staticTags.add(Tag.of(UrlAttributes.URL_SCHEME.getKey(), request.scheme()));
@@ -148,8 +150,10 @@ public class DefaultHttpServerMetricsFactory {
                     extraTags++;
                 }
             }
-            var staticTags = new ArrayList<Tag>(4 + this.context.config().metrics().tags().size() + extraTags);
+            var staticTags = new ArrayList<Tag>(6 + this.context.config().metrics().tags().size() + extraTags);
 
+            staticTags.add(Tag.of("server.name", this.context.name()));
+            staticTags.add(Tag.of(ServerAttributes.SERVER_PORT.getKey(), String.valueOf(this.context.port())));
             staticTags.add(Tag.of(HttpAttributes.HTTP_REQUEST_METHOD.getKey(), request.method()));
             staticTags.add(Tag.of(HttpAttributes.HTTP_ROUTE.getKey(), metricKey.pathTemplate));
             staticTags.add(Tag.of(UrlAttributes.URL_SCHEME.getKey(), request.scheme()));

--- a/http/http-server-common/src/main/java/io/koraframework/http/server/common/telemetry/impl/DefaultHttpServerTelemetry.java
+++ b/http/http-server-common/src/main/java/io/koraframework/http/server/common/telemetry/impl/DefaultHttpServerTelemetry.java
@@ -16,7 +16,9 @@ import java.util.Objects;
 
 public class DefaultHttpServerTelemetry implements HttpServerTelemetry {
 
-    public record TelemetryContext(HttpServerTelemetryConfig config,
+    public record TelemetryContext(String name,
+                                   int port,
+                                   HttpServerTelemetryConfig config,
                                    boolean isTracingEnabled,
                                    boolean isMetricsEnabled,
                                    MeterRegistry meterRegistry,
@@ -24,6 +26,7 @@ public class DefaultHttpServerTelemetry implements HttpServerTelemetry {
                                    DefaultHttpServerBodyConverter bodyLogger) {
 
         public static final TelemetryContext EMPTY = new TelemetryContext(
+            "NONE", -1,
             new $HttpServerTelemetryConfig_ConfigValueMapper.HttpServerTelemetryConfig_Impl(
                 new $HttpServerTelemetryConfig_HttpServerLoggingConfig_ConfigValueMapper.HttpServerLoggingConfig_Defaults(),
                 new $HttpServerTelemetryConfig_HttpServerMetricsConfig_ConfigValueMapper.HttpServerMetricsConfig_Defaults(),
@@ -36,7 +39,9 @@ public class DefaultHttpServerTelemetry implements HttpServerTelemetry {
     protected final DefaultHttpServerLoggerFactory.DefaultHttpServerLogger logger;
     protected final DefaultHttpServerMetricsFactory.DefaultHttpServerMetrics metrics;
 
-    public DefaultHttpServerTelemetry(HttpServerTelemetryConfig config,
+    public DefaultHttpServerTelemetry(String name,
+                                      int port,
+                                      HttpServerTelemetryConfig config,
                                       Tracer tracer,
                                       MeterRegistry meterRegistry,
                                       DefaultHttpServerMetricsFactory metricsFactory,
@@ -45,7 +50,9 @@ public class DefaultHttpServerTelemetry implements HttpServerTelemetry {
         var isTracingEnabled = config.tracing().enabled() && tracer != DefaultHttpServerTelemetryFactory.NOOP_TRACER;
         var isMetricsEnabled = config.metrics().enabled() && meterRegistry != DefaultHttpServerTelemetryFactory.NOOP_METER_REGISTRY;
 
-        this.context = new TelemetryContext(config,
+        this.context = new TelemetryContext(name,
+            port,
+            config,
             isTracingEnabled,
             isMetricsEnabled,
             meterRegistry,
@@ -66,7 +73,6 @@ public class DefaultHttpServerTelemetry implements HttpServerTelemetry {
     }
 
     protected SpanBuilder startSpan(HttpServerRequest request) {
-        @SuppressWarnings("DataFlowIssue")
         var span = this.context.tracer()
             .spanBuilder(request.method() + " " + request.pathTemplate())
             .setSpanKind(SpanKind.SERVER)
@@ -74,6 +80,8 @@ public class DefaultHttpServerTelemetry implements HttpServerTelemetry {
             .setAttribute(UrlAttributes.URL_SCHEME, request.scheme())
             .setAttribute(HttpAttributes.HTTP_ROUTE, request.pathTemplate())
             .setAttribute(ServerAttributes.SERVER_ADDRESS, request.host())
+            .setAttribute(ServerAttributes.SERVER_PORT, this.context.port())
+            .setAttribute("server.name", this.context.name())
             .setAttribute(HttpAttributes.HTTP_REQUEST_METHOD, request.method()); // if unknown tracing is disabled
 
         if (request.body().contentType() != null) {

--- a/http/http-server-common/src/main/java/io/koraframework/http/server/common/telemetry/impl/DefaultHttpServerTelemetryFactory.java
+++ b/http/http-server-common/src/main/java/io/koraframework/http/server/common/telemetry/impl/DefaultHttpServerTelemetryFactory.java
@@ -38,7 +38,7 @@ public class DefaultHttpServerTelemetryFactory implements HttpServerTelemetryFac
     }
 
     @Override
-    public HttpServerTelemetry get(HttpServerTelemetryConfig config) {
+    public HttpServerTelemetry get(String name, int port, HttpServerTelemetryConfig config) {
         var traceEnabled = this.tracer != null && config.tracing().enabled();
         var metricEnabled = this.meterRegistry != null && config.metrics().enabled();
         if (!traceEnabled && !metricEnabled && !config.logging().enabled()) {
@@ -66,15 +66,17 @@ public class DefaultHttpServerTelemetryFactory implements HttpServerTelemetryFac
             enabledLoggerFactory = NoopHttpServerLoggerFactory.INSTANCE;
         }
 
-        return build(config, tracer, meterRegistry, enabledMetricsFactory, enabledLoggerFactory, bodyLogger != null ? bodyLogger : new DefaultHttpServerBodyConverter());
+        return build(name, port, config, tracer, meterRegistry, enabledMetricsFactory, enabledLoggerFactory, bodyLogger != null ? bodyLogger : new DefaultHttpServerBodyConverter());
     }
 
-    protected HttpServerTelemetry build(HttpServerTelemetryConfig config,
+    protected HttpServerTelemetry build(String name,
+                                        int port,
+                                        HttpServerTelemetryConfig config,
                                         Tracer tracer,
                                         MeterRegistry meterRegistry,
                                         DefaultHttpServerMetricsFactory metricsFactory,
                                         DefaultHttpServerLoggerFactory loggerFactory,
                                         DefaultHttpServerBodyConverter loggerBodyConverter) {
-        return new DefaultHttpServerTelemetry(config, tracer, meterRegistry, metricsFactory, loggerFactory, loggerBodyConverter);
+        return new DefaultHttpServerTelemetry(name, port, config, tracer, meterRegistry, metricsFactory, loggerFactory, loggerBodyConverter);
     }
 }

--- a/http/http-server-common/src/test/java/io/koraframework/http/server/common/router/HttpServerHandlerProcessTests.java
+++ b/http/http-server-common/src/test/java/io/koraframework/http/server/common/router/HttpServerHandlerProcessTests.java
@@ -25,6 +25,8 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.when;
 
 class HttpServerHandlerProcessTests {
@@ -67,7 +69,7 @@ class HttpServerHandlerProcessTests {
         var handlers = List.of(handler(method, route));
         var telemetry = NoopHttpServerTelemetry.INSTANCE;
         var telemetryFactory = Mockito.mock(HttpServerTelemetryFactory.class);
-        when(telemetryFactory.get(any())).thenReturn(telemetry);
+        when(telemetryFactory.get(anyString(), anyInt(), any())).thenReturn(telemetry);
         var config = config(false);
         var handler = new HttpServerHandler(handlers, All.of(), config);
 
@@ -115,7 +117,7 @@ class HttpServerHandlerProcessTests {
         var handlers = List.of(handler(method, route));
         var telemetry = NoopHttpServerTelemetry.INSTANCE;
         var telemetryFactory = Mockito.mock(HttpServerTelemetryFactory.class);
-        when(telemetryFactory.get(any())).thenReturn(telemetry);
+        when(telemetryFactory.get(anyString(), anyInt(), any())).thenReturn(telemetry);
         var config = config(true);
         var handler = new HttpServerHandler(handlers, All.of(), config);
 
@@ -136,7 +138,7 @@ class HttpServerHandlerProcessTests {
         );
         var config = config(false);
         var telemetryFactory = Mockito.mock(HttpServerTelemetryFactory.class);
-        when(telemetryFactory.get(any())).thenReturn(NoopHttpServerTelemetry.INSTANCE);
+        when(telemetryFactory.get(anyString(), anyInt(), any())).thenReturn(NoopHttpServerTelemetry.INSTANCE);
         var handler = new HttpServerHandler(handlers, All.of(), config);
 
         var request = new HttpRouterRequestImpl("POST", "/baz", "test", "http", HttpHeaders.of(), Map.of(), HttpBody.empty());

--- a/http/http-server-common/src/test/java/io/koraframework/http/server/common/telemetry/DefaultHttpServerLoggerTests.java
+++ b/http/http-server-common/src/test/java/io/koraframework/http/server/common/telemetry/DefaultHttpServerLoggerTests.java
@@ -225,6 +225,8 @@ public class DefaultHttpServerLoggerTests {
 
     private DefaultHttpServerTelemetry.TelemetryContext context(HttpServerTelemetryConfig.HttpServerLoggingConfig loggingConfig) {
         return new DefaultHttpServerTelemetry.TelemetryContext(
+            "test-http-server",
+            8080,
             new $HttpServerTelemetryConfig_ConfigValueMapper.HttpServerTelemetryConfig_Impl(
                 loggingConfig,
                 new $HttpServerTelemetryConfig_HttpServerMetricsConfig_ConfigValueMapper.HttpServerMetricsConfig_Defaults(),

--- a/http/http-server-undertow/src/main/java/io/koraframework/http/server/undertow/UndertowHttpServerFactoryModule.java
+++ b/http/http-server-undertow/src/main/java/io/koraframework/http/server/undertow/UndertowHttpServerFactoryModule.java
@@ -40,7 +40,7 @@ public class UndertowHttpServerFactoryModule extends HttpServerFactoryModule {
     public HttpHandler handler(@Tag(Tag.Factory.class) HttpServerConfig config,
                                @Tag(Tag.Factory.class) HttpServerHandler publicApiHandler,
                                HttpServerTelemetryFactory telemetryFactory) {
-        var telemetry = telemetryFactory.get(config.telemetry());
+        var telemetry = telemetryFactory.get(this.name, config.port(), config.telemetry());
         var handler = (HttpHandler) new KoraRequestProcessingHttpHandler(telemetry, publicApiHandler);
         handler = new KoraVirtualThreadDispatchHttpHandler(this.name, handler);
         return handler;

--- a/jms/src/main/java/io/koraframework/jms/JmsMessageListenerContainer.java
+++ b/jms/src/main/java/io/koraframework/jms/JmsMessageListenerContainer.java
@@ -1,5 +1,6 @@
 package io.koraframework.jms;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -24,12 +25,15 @@ public class JmsMessageListenerContainer implements Lifecycle {
     private static final Logger logger = LoggerFactory.getLogger(JmsMessageListenerContainer.class);
 
     private static final ConcurrentHashMap<String, AtomicInteger> threadCounters = new ConcurrentHashMap<>();
+
     private final ConnectionFactory connectionFactory;
     private final JmsListenerContainerConfig config;
     private final JmsMessageListener messageListener;
     private final Logger log;
     private final JmsConsumerTelemetry telemetry;
     private final AtomicBoolean isStarted = new AtomicBoolean(false);
+
+    @Nullable
     private volatile ExecutorService executorService;
 
     public JmsMessageListenerContainer(ConnectionFactory connectionFactory, JmsListenerContainerConfig config, JmsMessageListener messageListener, JmsConsumerTelemetryFactory telemetryFactory) {

--- a/jms/src/main/java/io/koraframework/jms/JmsMessageListenerContainerFactory.java
+++ b/jms/src/main/java/io/koraframework/jms/JmsMessageListenerContainerFactory.java
@@ -5,6 +5,7 @@ import io.koraframework.jms.telemetry.JmsConsumerTelemetryFactory;
 import javax.jms.ConnectionFactory;
 
 public class JmsMessageListenerContainerFactory {
+
     private final ConnectionFactory jmsConnectionFactory;
     private final JmsConsumerTelemetryFactory telemetry;
 

--- a/jms/src/main/java/io/koraframework/jms/telemetry/impl/DefaultJmsConsumerLoggerFactory.java
+++ b/jms/src/main/java/io/koraframework/jms/telemetry/impl/DefaultJmsConsumerLoggerFactory.java
@@ -1,6 +1,6 @@
 package io.koraframework.jms.telemetry.impl;
 
-import io.koraframework.jms.JmsUtils;
+import io.koraframework.jms.util.JmsUtils;
 import io.koraframework.logging.common.arg.StructuredArgumentWriter;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;

--- a/jms/src/main/java/io/koraframework/jms/util/JmsUtils.java
+++ b/jms/src/main/java/io/koraframework/jms/util/JmsUtils.java
@@ -1,4 +1,4 @@
-package io.koraframework.jms;
+package io.koraframework.jms.util;
 
 import javax.jms.*;
 import java.nio.charset.StandardCharsets;

--- a/redis/redis-lettuce/src/main/java/io/koraframework/redis/lettuce/LettuceFactoryModule.java
+++ b/redis/redis-lettuce/src/main/java/io/koraframework/redis/lettuce/LettuceFactoryModule.java
@@ -1,0 +1,48 @@
+package io.koraframework.redis.lettuce;
+
+import io.koraframework.common.Configurer;
+import io.koraframework.common.annotation.DefaultComponent;
+import io.koraframework.common.annotation.Tag;
+import io.koraframework.config.common.Config;
+import io.koraframework.config.common.mapper.ConfigValueMapper;
+import io.koraframework.netty.common.NettyModule;
+import io.lettuce.core.AbstractRedisClient;
+import io.lettuce.core.ClientOptions;
+import io.lettuce.core.cluster.ClusterClientOptions;
+import io.lettuce.core.metrics.CommandLatencyRecorder;
+import io.lettuce.core.resource.DefaultClientResources;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.netty.channel.EventLoopGroup;
+import org.jspecify.annotations.Nullable;
+
+public class LettuceFactoryModule {
+
+    private final String configPath;
+
+    public LettuceFactoryModule(String configPath) {
+        this.configPath = configPath;
+    }
+
+    @Tag(Tag.Factory.class)
+    public LettuceConfig lettuceConfig(Config config, ConfigValueMapper<LettuceConfig> mapper) {
+        return mapper.mapOrThrow(config.get(this.configPath));
+    }
+
+    @DefaultComponent
+    @Tag(Tag.Factory.class)
+    public LettuceFactory lettuceFactory(@Nullable MeterRegistry meterRegistry,
+                                         @Nullable CommandLatencyRecorder commandLatencyRecorder,
+                                         @Tag(NettyModule.EventLoopWorker.class) @Nullable EventLoopGroup eventLoopGroup,
+                                         @Tag(Tag.Factory.class) @Nullable Configurer<DefaultClientResources.Builder> resourcesConfigurer,
+                                         @Tag(Tag.Factory.class) @Nullable Configurer<ClientOptions.Builder> standaloneOptionsConfigurer,
+                                         @Tag(Tag.Factory.class) @Nullable Configurer<ClusterClientOptions.Builder> clusterOptionsConfigurer) {
+        return new LettuceFactory(meterRegistry, commandLatencyRecorder, eventLoopGroup, resourcesConfigurer, standaloneOptionsConfigurer, clusterOptionsConfigurer);
+    }
+
+    @DefaultComponent
+    @Tag(Tag.Factory.class)
+    public AbstractRedisClient lettuceRedisClient(@Tag(Tag.Factory.class) LettuceFactory factory,
+                                                  @Tag(Tag.Factory.class) LettuceConfig config) {
+        return factory.build(config);
+    }
+}

--- a/redis/redis-lettuce/src/main/java/io/koraframework/redis/lettuce/LettuceModule.java
+++ b/redis/redis-lettuce/src/main/java/io/koraframework/redis/lettuce/LettuceModule.java
@@ -6,7 +6,7 @@ import io.koraframework.netty.common.NettyModule;
 public interface LettuceModule extends NettyModule {
 
     @FactoryModule
-    default LettuceFactoryModule lettuce() {
+    default LettuceFactoryModule lettuceFactory() {
         return new LettuceFactoryModule("lettuce");
     }
 }

--- a/redis/redis-lettuce/src/main/java/io/koraframework/redis/lettuce/LettuceModule.java
+++ b/redis/redis-lettuce/src/main/java/io/koraframework/redis/lettuce/LettuceModule.java
@@ -1,39 +1,12 @@
 package io.koraframework.redis.lettuce;
 
-import io.koraframework.common.annotation.DefaultComponent;
-import io.koraframework.common.annotation.Tag;
-import io.koraframework.common.Configurer;
-import io.koraframework.config.common.Config;
-import io.koraframework.config.common.mapper.ConfigValueMapper;
+import io.koraframework.common.annotation.FactoryModule;
 import io.koraframework.netty.common.NettyModule;
-import io.lettuce.core.AbstractRedisClient;
-import io.lettuce.core.ClientOptions;
-import io.lettuce.core.cluster.ClusterClientOptions;
-import io.lettuce.core.metrics.CommandLatencyRecorder;
-import io.lettuce.core.resource.DefaultClientResources;
-import io.micrometer.core.instrument.MeterRegistry;
-import io.netty.channel.EventLoopGroup;
-import org.jspecify.annotations.Nullable;
 
 public interface LettuceModule extends NettyModule {
 
-    default LettuceConfig lettuceConfig(Config config, ConfigValueMapper<LettuceConfig> mapper) {
-        return mapper.mapOrThrow(config.get("lettuce"));
-    }
-
-    @DefaultComponent
-    default LettuceFactory lettuceFactory(@Nullable MeterRegistry meterRegistry,
-                                          @Nullable CommandLatencyRecorder commandLatencyRecorder,
-                                          @Tag(NettyModule.EventLoopWorker.class) @Nullable EventLoopGroup eventLoopGroup,
-                                          @Nullable Configurer<DefaultClientResources.Builder> resourcesConfigurer,
-                                          @Nullable Configurer<ClientOptions.Builder> standaloneOptionsConfigurer,
-                                          @Nullable Configurer<ClusterClientOptions.Builder> clusterOptionsConfigurer) {
-        return new LettuceFactory(meterRegistry, commandLatencyRecorder, eventLoopGroup, resourcesConfigurer, standaloneOptionsConfigurer, clusterOptionsConfigurer);
-    }
-
-    @DefaultComponent
-    default AbstractRedisClient lettuceRedisClient(LettuceFactory factory,
-                                                   LettuceConfig config) {
-        return factory.build(config);
+    @FactoryModule
+    default LettuceFactoryModule lettuce() {
+        return new LettuceFactoryModule("lettuce");
     }
 }


### PR DESCRIPTION
Added dedicated factory modules across HTTP server, HTTP client, JDBC, Cassandra, and Lettuce integrations to separate reusable factory wiring from public modules while preserving existing default behavior.

- Added HTTP server factory wiring with name and port propagation into server telemetry logs, spans, and metrics.
- Added HTTP client factory extraction with Apache, JDK, and OkHttp client modules inheriting shared factory behavior and configurer support.
- Added JDBC, Cassandra, and Lettuce factory modules so public modules can reuse the same factory-style construction pattern.
- Added repository guidance for generating PR descriptions and commit messages through the local `.agents` skills when requested.