### PR TITLE
Added tagged S3 client factory injection for generated modules

### DIFF
--- a/experimental/s3-client-annotation-processor/src/main/java/io/koraframework/s3/client/kora/annotation/processor/gen/ModuleGenerator.java
+++ b/experimental/s3-client-annotation-processor/src/main/java/io/koraframework/s3/client/kora/annotation/processor/gen/ModuleGenerator.java
@@ -2,11 +2,13 @@ package io.koraframework.s3.client.kora.annotation.processor.gen;
 
 import com.palantir.javapoet.ClassName;
 import com.palantir.javapoet.MethodSpec;
+import com.palantir.javapoet.ParameterSpec;
 import com.palantir.javapoet.ParameterizedTypeName;
 import com.palantir.javapoet.TypeSpec;
 import io.koraframework.annotation.processor.common.AnnotationUtils;
 import io.koraframework.annotation.processor.common.CommonClassNames;
 import io.koraframework.annotation.processor.common.NameUtils;
+import io.koraframework.annotation.processor.common.TagUtils;
 import io.koraframework.s3.client.kora.annotation.processor.S3ClassNames;
 import io.koraframework.s3.client.kora.annotation.processor.S3ClientAnnotationProcessor;
 import io.koraframework.s3.client.kora.annotation.processor.S3ClientUtils;
@@ -16,6 +18,7 @@ import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeMirror;
 
 public class ModuleGenerator {
     public static TypeSpec generate(ProcessingEnvironment processingEnv, TypeElement s3client) {
@@ -49,11 +52,12 @@ public class ModuleGenerator {
             ? S3ClassNames.CONFIG_WITH_CREDS
             : S3ClassNames.CONFIG;
 
-        var s3ClientAnnotation = AnnotationUtils.findAnnotation(s3client, S3ClassNames.CLIENT);
+        var s3ClientAnnotation = AnnotationUtils.findAnnotation(s3client, S3ClassNames.Annotation.CLIENT);
         var s3ClientConfigPath = AnnotationUtils.<String>parseAnnotationValueWithoutDefault(s3ClientAnnotation, "value");
         if (s3ClientConfigPath == null || s3ClientConfigPath.isEmpty()) {
             s3ClientConfigPath = s3client.getSimpleName().toString();
         }
+        var factoryTag = AnnotationUtils.<TypeMirror>parseAnnotationValueWithoutDefault(s3ClientAnnotation, "factoryTag");
         b.addMethod(MethodSpec.methodBuilder("clientConfig")
             .addModifiers(Modifier.PUBLIC, Modifier.DEFAULT)
             .returns(configType)
@@ -64,7 +68,7 @@ public class ModuleGenerator {
         var clientImpl = MethodSpec.methodBuilder("clientImpl")
             .addModifiers(Modifier.PUBLIC, Modifier.DEFAULT)
             .returns(clientType)
-            .addParameter(S3ClassNames.CLIENT_FACTORY, "clientFactory")
+            .addParameter(clientFactoryParameter(factoryTag))
             .addParameter(configType, "clientConfig");
         if (paths.isEmpty()) {
             clientImpl
@@ -76,5 +80,14 @@ public class ModuleGenerator {
         b.addMethod(clientImpl.build());
 
         return b.build();
+    }
+
+    private static ParameterSpec clientFactoryParameter(TypeMirror factoryTag) {
+        var parameter = ParameterSpec.builder(S3ClassNames.CLIENT_FACTORY, "clientFactory");
+        var tag = TagUtils.makeAnnotationSpec(factoryTag);
+        if (tag != null) {
+            parameter.addAnnotation(tag);
+        }
+        return parameter.build();
     }
 }

--- a/experimental/s3-client-annotation-processor/src/test/java/io/koraframework/s3/client/kora/annotation/processor/S3ClientAnnotationProcessorTest.java
+++ b/experimental/s3-client-annotation-processor/src/test/java/io/koraframework/s3/client/kora/annotation/processor/S3ClientAnnotationProcessorTest.java
@@ -1,5 +1,30 @@
 package io.koraframework.s3.client.kora.annotation.processor;
 
-class S3ClientAnnotationProcessorTest {
+import org.junit.jupiter.api.Test;
 
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class S3ClientAnnotationProcessorTest extends AbstractS3ClientTest {
+
+    @Test
+    void testFactoryTag() throws Exception {
+        this.compile("""
+            @S3.Client(factoryTag = Client.CustomS3FactoryTag.class)
+            public interface Client {
+                final class CustomS3FactoryTag {}
+
+                @S3.List
+                List<String> list(S3Credentials creds, @Bucket String bucket, String prefix);
+            }
+            """);
+
+        var generatedModule = Paths.get(".", "build", "in-test-generated", "sources")
+            .resolve(this.testPackage().replace('.', '/'))
+            .resolve("$Client_S3Module.java");
+        assertThat(Files.readString(generatedModule))
+            .contains("@Tag(Client.CustomS3FactoryTag.class) S3ClientFactory clientFactory");
+    }
 }

--- a/experimental/s3-client-kora/src/main/java/io/koraframework/s3/client/kora/KoraS3ClientModule.java
+++ b/experimental/s3-client-kora/src/main/java/io/koraframework/s3/client/kora/KoraS3ClientModule.java
@@ -1,12 +1,10 @@
 package io.koraframework.s3.client.kora;
 
 import io.koraframework.common.annotation.DefaultComponent;
-import io.koraframework.common.annotation.Tag;
+import io.koraframework.common.annotation.FactoryModule;
 import io.koraframework.config.common.ConfigValue;
 import io.koraframework.config.common.exception.ConfigValueException;
 import io.koraframework.config.common.mapper.ConfigValueMapper;
-import io.koraframework.http.client.common.HttpClient;
-import io.koraframework.s3.client.kora.impl.KoraS3Client;
 import io.koraframework.s3.client.kora.telemetry.S3ClientTelemetryFactory;
 import io.koraframework.s3.client.kora.telemetry.impl.DefaultS3ClientLoggerFactory;
 import io.koraframework.s3.client.kora.telemetry.impl.DefaultS3ClientMetricsFactory;
@@ -25,27 +23,9 @@ public interface KoraS3ClientModule {
         return new DefaultS3ClientTelemetryFactory(tracer, meterRegistry, loggerFactory, metricsFactory);
     }
 
-    @Tag(S3Client.class)
-    @DefaultComponent
-    default HttpClient defaultKoraS3httpClient(HttpClient client) {
-        return client;
-    }
-
-    @DefaultComponent
-    default S3ClientFactory defaultKoraS3ClientFactory(@Tag(S3Client.class) HttpClient client,
-                                                       S3ClientTelemetryFactory telemetryFactory) {
-        return new S3ClientFactory() {
-            @Override
-            public S3Client create(S3ClientConfig config) {
-                return create("s3", KoraS3Client.class, config);
-            }
-
-            @Override
-            public S3Client create(String configPath, Class<?> clientImpl, S3ClientConfig config) {
-                var telemetry = telemetryFactory.get(configPath, clientImpl, config.telemetry());
-                return new KoraS3Client(client, config, telemetry);
-            }
-        };
+    @FactoryModule
+    default S3FactoryModule defaultKoraS3Factory() {
+        return new S3FactoryModule("s3");
     }
 
     @DefaultComponent

--- a/experimental/s3-client-kora/src/main/java/io/koraframework/s3/client/kora/S3FactoryModule.java
+++ b/experimental/s3-client-kora/src/main/java/io/koraframework/s3/client/kora/S3FactoryModule.java
@@ -1,0 +1,41 @@
+package io.koraframework.s3.client.kora;
+
+import io.koraframework.common.annotation.DefaultComponent;
+import io.koraframework.common.annotation.Tag;
+import io.koraframework.http.client.common.HttpClient;
+import io.koraframework.s3.client.kora.impl.KoraS3Client;
+import io.koraframework.s3.client.kora.telemetry.S3ClientTelemetryFactory;
+
+public class S3FactoryModule {
+
+    private final String configPath;
+
+    public S3FactoryModule(String configPath) {
+        this.configPath = configPath;
+    }
+
+    @Tag(Tag.Factory.class)
+    @DefaultComponent
+    public S3HttpClientProvider defaultKoraS3httpClientProvider(HttpClient client) {
+        return () -> client;
+    }
+
+    @Tag(Tag.Factory.class)
+    @DefaultComponent
+    public S3ClientFactory defaultKoraS3ClientFactory(S3HttpClientProvider clientProvider,
+                                                      S3ClientTelemetryFactory telemetryFactory) {
+        var client = clientProvider.get();
+        return new S3ClientFactory() {
+            @Override
+            public S3Client create(S3ClientConfig config) {
+                return create(configPath, KoraS3Client.class, config);
+            }
+
+            @Override
+            public S3Client create(String configPath, Class<?> clientImpl, S3ClientConfig config) {
+                var telemetry = telemetryFactory.get(configPath, clientImpl, config.telemetry());
+                return new KoraS3Client(client, config, telemetry);
+            }
+        };
+    }
+}

--- a/experimental/s3-client-kora/src/main/java/io/koraframework/s3/client/kora/S3HttpClientProvider.java
+++ b/experimental/s3-client-kora/src/main/java/io/koraframework/s3/client/kora/S3HttpClientProvider.java
@@ -1,0 +1,9 @@
+package io.koraframework.s3.client.kora;
+
+import io.koraframework.http.client.common.HttpClient;
+
+@FunctionalInterface
+public interface S3HttpClientProvider {
+
+    HttpClient get();
+}

--- a/experimental/s3-client-kora/src/main/java/io/koraframework/s3/client/kora/annotation/S3.java
+++ b/experimental/s3-client-kora/src/main/java/io/koraframework/s3/client/kora/annotation/S3.java
@@ -1,5 +1,6 @@
 package io.koraframework.s3.client.kora.annotation;
 
+import io.koraframework.common.annotation.Tag;
 import io.koraframework.s3.client.kora.S3ClientConfig;
 import io.koraframework.s3.client.kora.S3Credentials;
 import io.koraframework.s3.client.kora.exception.S3ClientNoSuchKeyException;
@@ -36,6 +37,8 @@ public @interface S3 {
          * }</pre>
          */
         String value() default "";
+
+        Class<?> factoryTag() default Tag.class;
     }
 
     @Target({ElementType.TYPE, ElementType.METHOD, ElementType.PARAMETER})

--- a/experimental/s3-client-symbol-processor/src/main/kotlin/io/koraframework/s3/client/kora/symbol/processor/gen/ModuleGenerator.kt
+++ b/experimental/s3-client-symbol-processor/src/main/kotlin/io/koraframework/s3/client/kora/symbol/processor/gen/ModuleGenerator.kt
@@ -1,16 +1,20 @@
 package io.koraframework.s3.client.kora.symbol.processor.gen
 
 import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSType
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.TypeSpec.Companion.interfaceBuilder
+import com.squareup.kotlinpoet.ksp.toTypeName
 import io.koraframework.ksp.common.AnnotationUtils.findAnnotation
 import io.koraframework.ksp.common.AnnotationUtils.findValueNoDefault
 import io.koraframework.ksp.common.CommonClassNames
 import io.koraframework.ksp.common.KotlinPoetUtils.controlFlow
 import io.koraframework.ksp.common.KspCommonUtils.generated
+import io.koraframework.ksp.common.TagUtils.addTag
 import io.koraframework.ksp.common.generatedClassName
 import io.koraframework.s3.client.kora.symbol.processor.S3ClientUtils
 import io.koraframework.s3.client.kora.symbol.processor.S3ClassNames
@@ -44,12 +48,13 @@ object ModuleGenerator {
         else
             S3ClassNames.config
 
-        val s3ClientAnnotation = s3client.findAnnotation(S3ClassNames.client)
+        val s3ClientAnnotation = s3client.findAnnotation(S3ClassNames.Annotation.client)
         var s3ClientConfigPath = s3ClientAnnotation?.findValueNoDefault<String>("value")
 
         if (s3ClientConfigPath.isNullOrEmpty()) {
             s3ClientConfigPath = s3client.simpleName.asString()
         }
+        val factoryTag = s3ClientAnnotation?.findValueNoDefault<KSType>("factoryTag")
         b.addFunction(
             FunSpec.builder("clientConfig")
                 .returns(configType)
@@ -60,7 +65,7 @@ object ModuleGenerator {
         )
         val clientImpl = FunSpec.builder("clientImpl")
             .returns(clientType)
-            .addParameter("clientFactory", S3ClassNames.clientFactory)
+            .addParameter(clientFactoryParameter(factoryTag))
             .addParameter("clientConfig", configType)
         if (paths.isEmpty()) {
             clientImpl
@@ -74,4 +79,9 @@ object ModuleGenerator {
         return b.build()
     }
 
+    private fun clientFactoryParameter(factoryTag: KSType?): ParameterSpec {
+        return ParameterSpec.builder("clientFactory", S3ClassNames.clientFactory)
+            .addTag(factoryTag?.toTypeName())
+            .build()
+    }
 }


### PR DESCRIPTION
## EN

Added S3 client factory injection support that keeps the default generated module behavior unchanged and allows selecting a tagged `S3ClientFactory` when `@S3.Client#factoryTag` is set.

---

## RU

Добавлена поддержка внедрения фабрики S3 client в генерируемые модули: поведение по умолчанию остается прежним, а при указании `@S3.Client#factoryTag` используется `S3ClientFactory` с нужным тегом.

---

- Added `@S3.Client#factoryTag` handling in the annotation processor so generated Java modules inject an untagged `S3ClientFactory` by default or a tagged one when configured.
- Added the same `factoryTag` handling in the KSP processor for generated Kotlin modules.
- Added processor coverage for explicit tagged S3 factory injection.

---

## S3 factory design

Added `S3FactoryModule` as the reusable factory module for Kora S3 clients, while keeping generated client modules direct: generated modules still receive `S3ClientFactory` and create typed clients through it.

When `factoryTag` is not set, generated modules inject the default untagged `S3ClientFactory`. When `factoryTag` is set, the generated `S3ClientFactory` parameter is annotated with the configured `@Tag`, allowing applications to provide a custom tagged factory without changing generated module shape.