### PR TITLE
Added gRPC server factory telemetry with logger body conversion

### DIFF
--- a/grpc/grpc-server/src/main/java/io/koraframework/grpc/server/GrpcServer.java
+++ b/grpc/grpc-server/src/main/java/io/koraframework/grpc/server/GrpcServer.java
@@ -7,6 +7,7 @@ import io.koraframework.application.graph.ValueOf;
 import io.koraframework.common.readiness.ReadinessProbe;
 import io.koraframework.common.readiness.ReadinessProbeFailure;
 import io.koraframework.common.util.TimeUtils;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,6 +25,8 @@ public class GrpcServer implements Lifecycle, ReadinessProbe {
     private final ValueOf<GrpcServerConfig> config;
 
     private final AtomicReference<GrpcServerState> state = new AtomicReference<>(GrpcServerState.INIT);
+
+    @Nullable
     private Server server;
 
     public GrpcServer(ValueOf<ForwardingServerBuilder<?>> serverBuilder,
@@ -48,7 +51,7 @@ public class GrpcServer implements Lifecycle, ReadinessProbe {
                 throw new RuntimeException("gRPC Server failed to start, cause port '%s' is already in use"
                     .formatted(config.get().port()), be);
             } else {
-                throw new RuntimeException("gRPC Server failed to start on port '%s', due to: {}"
+                throw new RuntimeException("gRPC Server failed to start on port '%s', due to: %s"
                     .formatted(config.get().port(), e.getMessage()), e);
             }
         }
@@ -56,24 +59,27 @@ public class GrpcServer implements Lifecycle, ReadinessProbe {
 
     @Override
     public void release() {
-        logger.debug("gRPC Server stopping...");
         final long started = TimeUtils.started();
-
         state.set(GrpcServerState.SHUTDOWN);
-        server.shutdown();
-        final Duration shutdownAwait = config.get().shutdownWait();
-        try {
-            logger.debug("gRPC Server awaiting graceful shutdown...");
-            if (!server.awaitTermination(shutdownAwait.toMillis(), TimeUnit.MILLISECONDS)) {
-                logger.warn("gRPC Server failed completing graceful shutdown in {}", shutdownAwait);
+
+        if (server != null) {
+            logger.debug("gRPC Server stopping...");
+
+            server.shutdown();
+            final Duration shutdownAwait = config.get().shutdownWait();
+            try {
+                logger.debug("gRPC Server awaiting graceful shutdown...");
+                if (!server.awaitTermination(shutdownAwait.toMillis(), TimeUnit.MILLISECONDS)) {
+                    logger.warn("gRPC Server failed completing graceful shutdown in {}", shutdownAwait);
+                    server.shutdownNow();
+                }
+            } catch (InterruptedException e) {
+                logger.warn("gRPC Server failed completing graceful shutdown in {}", shutdownAwait, e);
                 server.shutdownNow();
             }
-        } catch (InterruptedException e) {
-            logger.warn("gRPC Server failed completing graceful shutdown in {}", shutdownAwait, e);
-            server.shutdownNow();
+            server = null;
+            logger.info("gRPC Server stopped in {}", TimeUtils.tookForLogging(started));
         }
-
-        logger.info("gRPC Server stopped in {}", TimeUtils.tookForLogging(started));
     }
 
     @Override

--- a/grpc/grpc-server/src/main/java/io/koraframework/grpc/server/GrpcServerFactoryModule.java
+++ b/grpc/grpc-server/src/main/java/io/koraframework/grpc/server/GrpcServerFactoryModule.java
@@ -1,0 +1,143 @@
+package io.koraframework.grpc.server;
+
+import io.grpc.*;
+import io.grpc.okhttp.OkHttpServerBuilder;
+import io.grpc.protobuf.services.ProtoReflectionServiceV1;
+import io.koraframework.application.graph.All;
+import io.koraframework.application.graph.ValueOf;
+import io.koraframework.application.graph.WrappedRefreshListener;
+import io.koraframework.common.Configurer;
+import io.koraframework.common.annotation.DefaultComponent;
+import io.koraframework.common.annotation.Root;
+import io.koraframework.common.annotation.Tag;
+import io.koraframework.config.common.Config;
+import io.koraframework.config.common.mapper.ConfigValueMapper;
+import io.koraframework.grpc.server.handler.DynamicBindableService;
+import io.koraframework.grpc.server.handler.VirtualThreadExecutorTransportFilter;
+import io.koraframework.grpc.server.interceptor.DynamicServerInterceptor;
+import io.koraframework.grpc.server.interceptor.TelemetryInterceptor;
+import io.koraframework.grpc.server.telemetry.GrpcServerTelemetryFactory;
+import org.jspecify.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+public class GrpcServerFactoryModule {
+
+    private final String name;
+    private final String configPath;
+
+    public GrpcServerFactoryModule(String name, String configPath) {
+        this.name = name;
+        this.configPath = configPath;
+    }
+
+    @Tag(Tag.Factory.class)
+    public GrpcServerConfig grpcServerConfig(Config config, ConfigValueMapper<GrpcServerConfig> mapper) {
+        return mapper.mapOrThrow(config.get(this.configPath));
+    }
+
+    @Root
+    @Tag(Tag.Factory.class)
+    public GrpcServer grpcServer(@Tag(Tag.Factory.class) ValueOf<ForwardingServerBuilder<?>> serverBuilder,
+                                 @Tag(Tag.Factory.class) ValueOf<GrpcServerConfig> config) {
+        return new GrpcServer(serverBuilder, config);
+    }
+
+    @DefaultComponent
+    @Tag(Tag.Factory.class)
+    public ForwardingServerBuilder<?> grpcServerBuilder(@Tag(Tag.Factory.class) ValueOf<GrpcServerConfig> config,
+                                                        @Tag(Tag.Factory.class) List<DynamicBindableService> services,
+                                                        @Tag(Tag.Factory.class) List<DynamicServerInterceptor> interceptors,
+                                                        @Tag(Tag.Factory.class) @Nullable ServerCredentials serverCredentials,
+                                                        @Tag(Tag.Factory.class) @Nullable Configurer<ForwardingServerBuilder<?>> configurer,
+                                                        @Tag(Tag.Factory.class) GrpcServerTelemetryFactory telemetryFactory) {
+        if (serverCredentials == null) {
+            serverCredentials = InsecureServerCredentials.create();
+        }
+        GrpcServerConfig grpcServerConfig = config.get();
+        var builder = OkHttpServerBuilder.forPort(grpcServerConfig.port(), serverCredentials)
+            .directExecutor()
+            .addTransportFilter(VirtualThreadExecutorTransportFilter.INSTANCE)
+            .callExecutor(VirtualThreadExecutorTransportFilter.INSTANCE)
+            .maxInboundMessageSize(((int) grpcServerConfig.maxMessageSize().toBytes()));
+
+        if (grpcServerConfig.maxConnectionAge() != null) {
+            builder.maxConnectionAge(grpcServerConfig.maxConnectionAge().toMillis(), TimeUnit.MILLISECONDS);
+        }
+        if (grpcServerConfig.maxConnectionAgeGrace() != null) {
+            builder.maxConnectionAgeGrace(grpcServerConfig.maxConnectionAgeGrace().toMillis(), TimeUnit.MILLISECONDS);
+        }
+        if (grpcServerConfig.keepAliveTime() != null) {
+            builder.keepAliveTime(grpcServerConfig.keepAliveTime().toMillis(), TimeUnit.MILLISECONDS);
+        }
+        if (grpcServerConfig.keepAliveTimeout() != null) {
+            builder.keepAliveTimeout(grpcServerConfig.keepAliveTimeout().toMillis(), TimeUnit.MILLISECONDS);
+        }
+        if (grpcServerConfig.reflectionEnabled() && isClassPresent("io.grpc.protobuf.services.ProtoReflectionServiceV1")) {
+            builder.addService(ProtoReflectionServiceV1.newInstance());
+        }
+
+        interceptors.forEach(builder::intercept);
+        builder.intercept(new TelemetryInterceptor(telemetryFactory.get(this.name, grpcServerConfig.port(), grpcServerConfig.telemetry())));
+
+        services.forEach(builder::addService);
+
+        if (configurer != null) {
+            return configurer.configure(builder);
+        }
+
+        return builder;
+    }
+
+    @Tag(Tag.Factory.class)
+    public WrappedRefreshListener<List<DynamicBindableService>> dynamicBindableServicesListener(@Tag(Tag.Factory.class) All<ValueOf<BindableService>> services) {
+        var dynamicServices = new ArrayList<DynamicBindableService>();
+        // caching All<ValueOf<T>> won't be safe after conditional components introduced, but let's just hope conditional grpc service instance is not a thing
+        for (var service : services) {
+            dynamicServices.add(new DynamicBindableService(service));
+        }
+
+        return new WrappedRefreshListener<>() {
+            @Override
+            public void graphRefreshed() {
+                dynamicServices.forEach(DynamicBindableService::graphRefreshed);
+            }
+
+            @Override
+            public List<DynamicBindableService> value() {
+                return dynamicServices;
+            }
+        };
+    }
+
+    @Tag(Tag.Factory.class)
+    public WrappedRefreshListener<List<DynamicServerInterceptor>> dynamicInterceptorsListener(@Tag(Tag.Factory.class) All<ValueOf<ServerInterceptor>> interceptors) {
+        var dynamicServerInterceptors = new ArrayList<DynamicServerInterceptor>();
+        // caching All<ValueOf<T>> won't be safe after conditional components introduced, but let's just hope conditional grpc service interceptor is not a thing
+        for (var interceptor : interceptors) {
+            dynamicServerInterceptors.add(new DynamicServerInterceptor(interceptor));
+        }
+
+        return new WrappedRefreshListener<>() {
+            @Override
+            public void graphRefreshed() {
+                dynamicServerInterceptors.forEach(DynamicServerInterceptor::graphRefreshed);
+            }
+
+            @Override
+            public List<DynamicServerInterceptor> value() {
+                return dynamicServerInterceptors;
+            }
+        };
+    }
+
+    private static boolean isClassPresent(String className) {
+        try {
+            return GrpcServerFactoryModule.class.getClassLoader().loadClass(className) != null;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+}

--- a/grpc/grpc-server/src/main/java/io/koraframework/grpc/server/GrpcServerModule.java
+++ b/grpc/grpc-server/src/main/java/io/koraframework/grpc/server/GrpcServerModule.java
@@ -1,21 +1,9 @@
 package io.koraframework.grpc.server;
 
-import io.grpc.*;
-import io.grpc.okhttp.OkHttpServerBuilder;
-import io.grpc.protobuf.services.ProtoReflectionServiceV1;
-import io.koraframework.application.graph.All;
-import io.koraframework.application.graph.ValueOf;
-import io.koraframework.application.graph.WrappedRefreshListener;
 import io.koraframework.common.annotation.DefaultComponent;
-import io.koraframework.common.annotation.Root;
-import io.koraframework.common.Configurer;
-import io.koraframework.config.common.Config;
-import io.koraframework.config.common.mapper.ConfigValueMapper;
-import io.koraframework.grpc.server.handler.DynamicBindableService;
-import io.koraframework.grpc.server.handler.VirtualThreadExecutorTransportFilter;
-import io.koraframework.grpc.server.interceptors.DynamicServerInterceptor;
-import io.koraframework.grpc.server.interceptors.TelemetryInterceptor;
-import io.koraframework.grpc.server.telemetry.GrpcServerTelemetry;
+import io.koraframework.common.annotation.FactoryModule;
+import io.koraframework.grpc.server.telemetry.GrpcServerTelemetryFactory;
+import io.koraframework.grpc.server.telemetry.impl.DefaultGrpcServerBodyConverter;
 import io.koraframework.grpc.server.telemetry.impl.DefaultGrpcServerLoggerFactory;
 import io.koraframework.grpc.server.telemetry.impl.DefaultGrpcServerMetricsFactory;
 import io.koraframework.grpc.server.telemetry.impl.DefaultGrpcServerTelemetryFactory;
@@ -23,121 +11,19 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.opentelemetry.api.trace.Tracer;
 import org.jspecify.annotations.Nullable;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-
 public interface GrpcServerModule {
 
-    default GrpcServerConfig grpcServerConfig(Config config, ConfigValueMapper<GrpcServerConfig> mapper) {
-        return mapper.map(config.get("grpcServer"));
-    }
-
-    @Root
-    default GrpcServer grpcServer(ValueOf<ForwardingServerBuilder<?>> serverBuilder,
-                                  ValueOf<GrpcServerConfig> config) {
-        return new GrpcServer(serverBuilder, config);
+    @FactoryModule
+    default GrpcServerFactoryModule grpcServer() {
+        return new GrpcServerFactoryModule("kora-grpc", "grpcServer");
     }
 
     @DefaultComponent
-    default GrpcServerTelemetry defaultGrpcServerTelemetry(GrpcServerConfig config,
-                                                           @Nullable Tracer tracer,
-                                                           @Nullable MeterRegistry meterRegistry,
-                                                           @Nullable DefaultGrpcServerLoggerFactory loggerFactory,
-                                                           @Nullable DefaultGrpcServerMetricsFactory metricsFactory) {
-        return new DefaultGrpcServerTelemetryFactory(tracer, meterRegistry, loggerFactory, metricsFactory).get(config.telemetry());
-    }
-
-    @DefaultComponent
-    default ForwardingServerBuilder<?> grpcServerBuilder(ValueOf<GrpcServerConfig> config,
-                                                         List<DynamicBindableService> services,
-                                                         List<DynamicServerInterceptor> interceptors,
-                                                         @Nullable ServerCredentials serverCredentials,
-                                                         @Nullable Configurer<ForwardingServerBuilder<?>> configurer,
-                                                         ValueOf<GrpcServerTelemetry> telemetry) {
-        if (serverCredentials == null) {
-            serverCredentials = InsecureServerCredentials.create();
-        }
-        GrpcServerConfig grpcServerConfig = config.get();
-        var builder = OkHttpServerBuilder.forPort(grpcServerConfig.port(), serverCredentials)
-            .directExecutor()
-            .addTransportFilter(VirtualThreadExecutorTransportFilter.INSTANCE)
-            .callExecutor(VirtualThreadExecutorTransportFilter.INSTANCE)
-            .maxInboundMessageSize(((int) grpcServerConfig.maxMessageSize().toBytes()));
-
-        if (grpcServerConfig.maxConnectionAge() != null) {
-            builder.maxConnectionAge(grpcServerConfig.maxConnectionAge().toMillis(), TimeUnit.MILLISECONDS);
-        }
-        if (grpcServerConfig.maxConnectionAgeGrace() != null) {
-            builder.maxConnectionAgeGrace(grpcServerConfig.maxConnectionAgeGrace().toMillis(), TimeUnit.MILLISECONDS);
-        }
-        if (grpcServerConfig.keepAliveTime() != null) {
-            builder.keepAliveTime(grpcServerConfig.keepAliveTime().toMillis(), TimeUnit.MILLISECONDS);
-        }
-        if (grpcServerConfig.keepAliveTimeout() != null) {
-            builder.keepAliveTimeout(grpcServerConfig.keepAliveTimeout().toMillis(), TimeUnit.MILLISECONDS);
-        }
-        if (grpcServerConfig.reflectionEnabled() && isClassPresent("io.grpc.protobuf.services.ProtoReflectionServiceV1")) {
-            builder.addService(ProtoReflectionServiceV1.newInstance());
-        }
-
-        interceptors.forEach(builder::intercept);
-        builder.intercept(new TelemetryInterceptor(telemetry));
-
-        services.forEach(builder::addService);
-
-        if (configurer != null) {
-            return configurer.configure(builder);
-        }
-
-        return builder;
-    }
-
-    default WrappedRefreshListener<List<DynamicBindableService>> dynamicBindableServicesListener(All<ValueOf<BindableService>> services) {
-        var dynamicServices = new ArrayList<DynamicBindableService>();
-        // caching All<ValueOf<T>> won't be safe after conditional components introduced, but let's just hope conditional grpc service instance is not a thing
-        for (var service : services) {
-            dynamicServices.add(new DynamicBindableService(service));
-        }
-
-        return new WrappedRefreshListener<>() {
-            @Override
-            public void graphRefreshed() {
-                dynamicServices.forEach(DynamicBindableService::graphRefreshed);
-            }
-
-            @Override
-            public List<DynamicBindableService> value() {
-                return dynamicServices;
-            }
-        };
-    }
-
-    default WrappedRefreshListener<List<DynamicServerInterceptor>> dynamicInterceptorsListener(All<ValueOf<ServerInterceptor>> interceptors) {
-        var dynamicServerInterceptors = new ArrayList<DynamicServerInterceptor>();
-        // caching All<ValueOf<T>> won't be safe after conditional components introduced, but let's just hope conditional grpc service interceptor is not a thing
-        for (var interceptor : interceptors) {
-            dynamicServerInterceptors.add(new DynamicServerInterceptor(interceptor));
-        }
-
-        return new WrappedRefreshListener<>() {
-            @Override
-            public void graphRefreshed() {
-                dynamicServerInterceptors.forEach(DynamicServerInterceptor::graphRefreshed);
-            }
-
-            @Override
-            public List<DynamicServerInterceptor> value() {
-                return dynamicServerInterceptors;
-            }
-        };
-    }
-
-    private static boolean isClassPresent(String className) {
-        try {
-            return GrpcServerModule.class.getClassLoader().loadClass(className) != null;
-        } catch (ClassNotFoundException e) {
-            return false;
-        }
+    default GrpcServerTelemetryFactory defaultGrpcServerTelemetryFactory(@Nullable Tracer tracer,
+                                                                         @Nullable MeterRegistry meterRegistry,
+                                                                         @Nullable DefaultGrpcServerLoggerFactory loggerFactory,
+                                                                         @Nullable DefaultGrpcServerMetricsFactory metricsFactory,
+                                                                         @Nullable DefaultGrpcServerBodyConverter bodyConverter) {
+        return new DefaultGrpcServerTelemetryFactory(tracer, meterRegistry, loggerFactory, metricsFactory, bodyConverter);
     }
 }

--- a/grpc/grpc-server/src/main/java/io/koraframework/grpc/server/interceptor/DynamicServerInterceptor.java
+++ b/grpc/grpc-server/src/main/java/io/koraframework/grpc/server/interceptor/DynamicServerInterceptor.java
@@ -1,4 +1,4 @@
-package io.koraframework.grpc.server.interceptors;
+package io.koraframework.grpc.server.interceptor;
 
 import io.grpc.Metadata;
 import io.grpc.ServerCall;
@@ -8,8 +8,10 @@ import io.koraframework.application.graph.RefreshListener;
 import io.koraframework.application.graph.ValueOf;
 
 public final class DynamicServerInterceptor implements ServerInterceptor, RefreshListener {
-    private volatile ServerInterceptor interceptor;
+
     private final ValueOf<ServerInterceptor> interceptorNode;
+
+    private volatile ServerInterceptor interceptor;
 
     public DynamicServerInterceptor(ValueOf<ServerInterceptor> interceptor) {
         this.interceptorNode = interceptor;

--- a/grpc/grpc-server/src/main/java/io/koraframework/grpc/server/interceptor/TelemetryInterceptor.java
+++ b/grpc/grpc-server/src/main/java/io/koraframework/grpc/server/interceptor/TelemetryInterceptor.java
@@ -1,4 +1,4 @@
-package io.koraframework.grpc.server.interceptors;
+package io.koraframework.grpc.server.interceptor;
 
 import io.grpc.*;
 import io.opentelemetry.context.Context;
@@ -10,15 +10,16 @@ import io.koraframework.grpc.server.telemetry.GrpcServerTelemetryCall;
 import io.koraframework.grpc.server.telemetry.GrpcServerTelemetryCallListener;
 
 public class TelemetryInterceptor implements ServerInterceptor {
-    private final ValueOf<GrpcServerTelemetry> telemetry;
 
-    public TelemetryInterceptor(ValueOf<GrpcServerTelemetry> telemetry) {
+    private final GrpcServerTelemetry telemetry;
+
+    public TelemetryInterceptor(GrpcServerTelemetry telemetry) {
         this.telemetry = telemetry;
     }
 
     @Override
     public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
-        var observation = this.telemetry.get().observe(call, headers);
+        var observation = this.telemetry.observe(call, headers);
         var context = Context.root()
             .with(observation.span());
         return ScopedValue.where(Observation.VALUE, observation)

--- a/grpc/grpc-server/src/main/java/io/koraframework/grpc/server/telemetry/GrpcServerObservation.java
+++ b/grpc/grpc-server/src/main/java/io/koraframework/grpc/server/telemetry/GrpcServerObservation.java
@@ -9,7 +9,7 @@ public interface GrpcServerObservation extends Observation {
 
     void observeRequest(int numMessages);
 
-    void observeSendMessage(Object rs);
+    void observeSendMessage(Object request);
 
     void observeClose(Status status, Metadata trailers);
 
@@ -19,7 +19,7 @@ public interface GrpcServerObservation extends Observation {
 
     void observeHalfClosed();
 
-    void observeReceiveMessage(Object rq);
+    void observeReceiveMessage(Object response);
 
     void observeReady();
 

--- a/grpc/grpc-server/src/main/java/io/koraframework/grpc/server/telemetry/GrpcServerTelemetryFactory.java
+++ b/grpc/grpc-server/src/main/java/io/koraframework/grpc/server/telemetry/GrpcServerTelemetryFactory.java
@@ -1,0 +1,6 @@
+package io.koraframework.grpc.server.telemetry;
+
+public interface GrpcServerTelemetryFactory {
+
+    GrpcServerTelemetry get(String name, int port, GrpcServerTelemetryConfig config);
+}

--- a/grpc/grpc-server/src/main/java/io/koraframework/grpc/server/telemetry/impl/DefaultGrpcServerBodyConverter.java
+++ b/grpc/grpc-server/src/main/java/io/koraframework/grpc/server/telemetry/impl/DefaultGrpcServerBodyConverter.java
@@ -1,0 +1,28 @@
+package io.koraframework.grpc.server.telemetry.impl;
+
+import com.google.protobuf.MessageOrBuilder;
+import org.jspecify.annotations.Nullable;
+
+public class DefaultGrpcServerBodyConverter {
+
+    @Nullable
+    public String convertRequestMessage(Object message) {
+        return convertMessage(message);
+    }
+
+    @Nullable
+    public String convertResponseMessage(Object message) {
+        return convertMessage(message);
+    }
+
+    @Nullable
+    protected String convertMessage(Object message) {
+        if (message instanceof MessageOrBuilder messageOrBuilder) {
+            return messageOrBuilder.toString();
+        }
+        if (message instanceof CharSequence charSequence) {
+            return charSequence.toString();
+        }
+        return null;
+    }
+}

--- a/grpc/grpc-server/src/main/java/io/koraframework/grpc/server/telemetry/impl/DefaultGrpcServerLoggerFactory.java
+++ b/grpc/grpc-server/src/main/java/io/koraframework/grpc/server/telemetry/impl/DefaultGrpcServerLoggerFactory.java
@@ -15,38 +15,61 @@ public class DefaultGrpcServerLoggerFactory {
     public DefaultGrpcServerLogger create(DefaultGrpcServerTelemetry.TelemetryContext context) {
         var requestLog = LoggerFactory.getLogger(GrpcServer.class.getCanonicalName() + ".request");
         var responseLog = LoggerFactory.getLogger(GrpcServer.class.getCanonicalName() + ".response");
-        return new DefaultGrpcServerLogger(requestLog, responseLog);
+        return new DefaultGrpcServerLogger(context, requestLog, responseLog);
     }
 
     public static class DefaultGrpcServerLogger {
 
+        protected final DefaultGrpcServerTelemetry.TelemetryContext context;
         protected final Logger requestLog;
         protected final Logger responseLog;
 
-        public DefaultGrpcServerLogger(Logger requestLog, Logger responseLog) {
+        public DefaultGrpcServerLogger(DefaultGrpcServerTelemetry.TelemetryContext context, Logger requestLog, Logger responseLog) {
+            this.context = context;
             this.requestLog = requestLog;
             this.responseLog = responseLog;
         }
 
-        public void logRequest(String service, String method, Metadata requestHeaders) {
+        public boolean logRequestBody() {
+            return this.requestLog.isTraceEnabled();
+        }
+
+        public boolean logResponseBody() {
+            return this.responseLog.isTraceEnabled();
+        }
+
+        public void logRequest(String service, String method, Metadata requestHeaders, @Nullable Object requestMessage) {
             if (!this.requestLog.isInfoEnabled()) {
                 return;
             }
             var headers = this.requestLog.isDebugEnabled() ? requestHeaders.toString() : null;
+            var body = this.requestLog.isTraceEnabled() && requestMessage != null
+                ? this.context.bodyConverter().convertRequestMessage(requestMessage)
+                : null;
             this.requestLog.atInfo()
                 .addKeyValue("grpcRequest", StructuredArgument.value(gen -> {
                     gen.writeStartObject();
+                    gen.writeStringProperty("serverName", this.context.name());
+                    gen.writeNumberProperty("serverPort", this.context.port());
                     gen.writeStringProperty("serviceName", service);
                     gen.writeStringProperty("operation", service + "/" + method);
                     if (headers != null) {
                         gen.writeStringProperty("headers", headers);
+                    }
+                    if (body != null) {
+                        gen.writeStringProperty("body", body);
                     }
                     gen.writeEndObject();
                 }))
                 .log("GrpcCall received");
         }
 
-        public void logResponse(String service, String method, @Nullable Status status, @Nullable Throwable error, long processingTimeNanos) {
+        public void logResponse(String service,
+                                String method,
+                                @Nullable Status status,
+                                @Nullable Throwable error,
+                                @Nullable Object responseMessage,
+                                long processingTimeNanos) {
             if (error == null && !this.responseLog.isInfoEnabled()) {
                 return;
             }
@@ -55,14 +78,22 @@ public class DefaultGrpcServerLoggerFactory {
             }
             var statusCode = status == null ? Status.Code.UNKNOWN : status.getCode();
             var exceptionType = error == null ? null : error.getClass().getCanonicalName();
+            var body = this.responseLog.isTraceEnabled() && responseMessage != null
+                ? this.context.bodyConverter().convertResponseMessage(responseMessage)
+                : null;
             var arg = StructuredArgument.value(gen -> {
                 gen.writeStartObject();
+                gen.writeStringProperty("serverName", this.context.name());
+                gen.writeNumberProperty("serverPort", this.context.port());
                 gen.writeStringProperty("serviceName", service);
                 gen.writeStringProperty("operation", service + "/" + method);
                 gen.writeNumberProperty("processingTime", processingTimeNanos / 1_000_000);
                 gen.writeStringProperty("status", statusCode.name());
                 if (exceptionType != null) {
                     gen.writeStringProperty("exceptionType", exceptionType);
+                }
+                if (body != null) {
+                    gen.writeStringProperty("body", body);
                 }
                 gen.writeEndObject();
             });

--- a/grpc/grpc-server/src/main/java/io/koraframework/grpc/server/telemetry/impl/DefaultGrpcServerMetricsFactory.java
+++ b/grpc/grpc-server/src/main/java/io/koraframework/grpc/server/telemetry/impl/DefaultGrpcServerMetricsFactory.java
@@ -4,6 +4,7 @@ import io.grpc.Status;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
+import io.opentelemetry.semconv.ServerAttributes;
 import io.opentelemetry.semconv.incubating.RpcIncubatingAttributes;
 import org.jspecify.annotations.Nullable;
 
@@ -59,7 +60,9 @@ public class DefaultGrpcServerMetricsFactory {
                     extraTags++;
                 }
             }
-            var tags = new ArrayList<Tag>(4 + this.context.config().metrics().tags().size() + extraTags);
+            var tags = new ArrayList<Tag>(6 + this.context.config().metrics().tags().size() + extraTags);
+            tags.add(Tag.of("server.name", this.context.name()));
+            tags.add(Tag.of(ServerAttributes.SERVER_PORT.getKey(), String.valueOf(this.context.port())));
             tags.add(Tag.of(RpcIncubatingAttributes.RPC_SYSTEM.getKey(), RpcIncubatingAttributes.RpcSystemIncubatingValues.GRPC));
             tags.add(Tag.of(RpcIncubatingAttributes.RPC_SERVICE.getKey(), metricKey.service()));
             tags.add(Tag.of(RpcIncubatingAttributes.RPC_METHOD.getKey(), metricKey.method()));

--- a/grpc/grpc-server/src/main/java/io/koraframework/grpc/server/telemetry/impl/DefaultGrpcServerObservation.java
+++ b/grpc/grpc-server/src/main/java/io/koraframework/grpc/server/telemetry/impl/DefaultGrpcServerObservation.java
@@ -21,6 +21,8 @@ public class DefaultGrpcServerObservation implements GrpcServerObservation {
     protected final DefaultGrpcServerLoggerFactory.DefaultGrpcServerLogger logger;
     protected final DefaultGrpcServerMetricsFactory.DefaultGrpcServerMetrics metrics;
 
+    protected volatile Object responseMessage;
+    protected volatile Object requestMessage;
     protected volatile Throwable error;
     protected volatile Status status;
 
@@ -53,10 +55,11 @@ public class DefaultGrpcServerObservation implements GrpcServerObservation {
     public void observeRequest(int numMessages) {}
 
     @Override
-    public void observeSendMessage(Object rs) {
+    public void observeSendMessage(Object request) {
         this.span.addEvent("rpc.message", Attributes.of(
             RpcIncubatingAttributes.RPC_MESSAGE_TYPE, RpcIncubatingAttributes.RpcMessageTypeIncubatingValues.SENT
         ));
+        this.requestMessage = request;
     }
 
     @Override
@@ -80,10 +83,11 @@ public class DefaultGrpcServerObservation implements GrpcServerObservation {
     public void observeHalfClosed() {}
 
     @Override
-    public void observeReceiveMessage(Object rq) {
+    public void observeReceiveMessage(Object response) {
         this.span.addEvent("rpc.message", Attributes.of(
             RpcIncubatingAttributes.RPC_MESSAGE_TYPE, RpcIncubatingAttributes.RpcMessageTypeIncubatingValues.RECEIVED
         ));
+        this.responseMessage = response;
     }
 
     @Override
@@ -91,7 +95,7 @@ public class DefaultGrpcServerObservation implements GrpcServerObservation {
 
     @Override
     public void observeStart() {
-        this.logger.logRequest(service, method, requestHeaders);
+        this.logger.logRequest(service, method, requestHeaders, requestMessage);
     }
 
     @Override
@@ -104,7 +108,7 @@ public class DefaultGrpcServerObservation implements GrpcServerObservation {
         var processingTimeNanos = System.nanoTime() - this.started;
         this.metrics.record(service, method, status, processingTimeNanos);
         this.closeSpan();
-        this.logger.logResponse(service, method, status, error, processingTimeNanos);
+        this.logger.logResponse(service, method, status, error, responseMessage, processingTimeNanos);
     }
 
     protected void closeSpan() {

--- a/grpc/grpc-server/src/main/java/io/koraframework/grpc/server/telemetry/impl/DefaultGrpcServerTelemetry.java
+++ b/grpc/grpc-server/src/main/java/io/koraframework/grpc/server/telemetry/impl/DefaultGrpcServerTelemetry.java
@@ -11,18 +11,24 @@ import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapGetter;
+import io.opentelemetry.semconv.ServerAttributes;
 import io.opentelemetry.semconv.NetworkAttributes;
 import io.opentelemetry.semconv.incubating.RpcIncubatingAttributes;
 
 public class DefaultGrpcServerTelemetry implements GrpcServerTelemetry {
 
-    public record TelemetryContext(GrpcServerTelemetryConfig config,
+    public record TelemetryContext(String name,
+                                   int port,
+                                   GrpcServerTelemetryConfig config,
                                    boolean isTracingEnabled,
                                    boolean isMetricsEnabled,
                                    MeterRegistry meterRegistry,
-                                   Tracer tracer) {
+                                   Tracer tracer,
+                                   DefaultGrpcServerBodyConverter bodyConverter) {
 
         public static final TelemetryContext EMPTY = new TelemetryContext(
+            "NONE",
+            -1,
             new $GrpcServerTelemetryConfig_ConfigValueMapper.GrpcServerTelemetryConfig_Impl(
                 new $GrpcServerTelemetryConfig_GrpcServerLoggingConfig_ConfigValueMapper.GrpcServerLoggingConfig_Defaults(),
                 new $GrpcServerTelemetryConfig_GrpcServerMetricsConfig_ConfigValueMapper.GrpcServerMetricsConfig_Defaults(),
@@ -31,7 +37,8 @@ public class DefaultGrpcServerTelemetry implements GrpcServerTelemetry {
             false,
             false,
             DefaultGrpcServerTelemetryFactory.NOOP_METER_REGISTRY,
-            DefaultGrpcServerTelemetryFactory.NOOP_TRACER
+            DefaultGrpcServerTelemetryFactory.NOOP_TRACER,
+            new DefaultGrpcServerBodyConverter()
         );
     }
 
@@ -39,14 +46,17 @@ public class DefaultGrpcServerTelemetry implements GrpcServerTelemetry {
     protected final DefaultGrpcServerLoggerFactory.DefaultGrpcServerLogger logger;
     protected final DefaultGrpcServerMetricsFactory.DefaultGrpcServerMetrics metrics;
 
-    public DefaultGrpcServerTelemetry(GrpcServerTelemetryConfig config,
+    public DefaultGrpcServerTelemetry(String name,
+                                      int port,
+                                      GrpcServerTelemetryConfig config,
                                       Tracer tracer,
                                       MeterRegistry meterRegistry,
                                       DefaultGrpcServerMetricsFactory metricsFactory,
-                                      DefaultGrpcServerLoggerFactory loggerFactory) {
+                                      DefaultGrpcServerLoggerFactory loggerFactory,
+                                      DefaultGrpcServerBodyConverter bodyConverter) {
         var isTracingEnabled = config.tracing().enabled() && tracer != DefaultGrpcServerTelemetryFactory.NOOP_TRACER;
         var isMetricsEnabled = config.metrics().enabled() && meterRegistry != DefaultGrpcServerTelemetryFactory.NOOP_METER_REGISTRY;
-        this.context = new TelemetryContext(config, isTracingEnabled, isMetricsEnabled, meterRegistry, tracer);
+        this.context = new TelemetryContext(name, port, config, isTracingEnabled, isMetricsEnabled, meterRegistry, tracer, bodyConverter);
         this.logger = loggerFactory.create(this.context);
         this.metrics = metricsFactory.create(this.context);
     }
@@ -80,6 +90,8 @@ public class DefaultGrpcServerTelemetry implements GrpcServerTelemetry {
             .spanBuilder(serviceName + "/" + methodName)
             .setSpanKind(SpanKind.SERVER)
             .setParent(parentCtx)
+            .setAttribute(ServerAttributes.SERVER_PORT, this.context.port())
+            .setAttribute("server.name", this.context.name())
             .setAttribute(RpcIncubatingAttributes.RPC_SYSTEM, "grpc")
             .setAttribute(RpcIncubatingAttributes.RPC_SERVICE, serviceName)
             .setAttribute(RpcIncubatingAttributes.RPC_METHOD, methodName)

--- a/grpc/grpc-server/src/main/java/io/koraframework/grpc/server/telemetry/impl/DefaultGrpcServerTelemetryFactory.java
+++ b/grpc/grpc-server/src/main/java/io/koraframework/grpc/server/telemetry/impl/DefaultGrpcServerTelemetryFactory.java
@@ -2,13 +2,14 @@ package io.koraframework.grpc.server.telemetry.impl;
 
 import io.koraframework.grpc.server.telemetry.GrpcServerTelemetry;
 import io.koraframework.grpc.server.telemetry.GrpcServerTelemetryConfig;
+import io.koraframework.grpc.server.telemetry.GrpcServerTelemetryFactory;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.TracerProvider;
 import org.jspecify.annotations.Nullable;
 
-public class DefaultGrpcServerTelemetryFactory {
+public class DefaultGrpcServerTelemetryFactory implements GrpcServerTelemetryFactory {
 
     public static final Tracer NOOP_TRACER = TracerProvider.noop().get("grpc-server");
     public static final MeterRegistry NOOP_METER_REGISTRY = new CompositeMeterRegistry();
@@ -21,18 +22,23 @@ public class DefaultGrpcServerTelemetryFactory {
     private final DefaultGrpcServerLoggerFactory loggerFactory;
     @Nullable
     private final DefaultGrpcServerMetricsFactory metricsFactory;
+    @Nullable
+    private final DefaultGrpcServerBodyConverter bodyConverter;
 
     public DefaultGrpcServerTelemetryFactory(@Nullable Tracer tracer,
                                              @Nullable MeterRegistry meterRegistry,
                                              @Nullable DefaultGrpcServerLoggerFactory loggerFactory,
-                                             @Nullable DefaultGrpcServerMetricsFactory metricsFactory) {
+                                             @Nullable DefaultGrpcServerMetricsFactory metricsFactory,
+                                             @Nullable DefaultGrpcServerBodyConverter bodyConverter) {
         this.tracer = tracer;
         this.meterRegistry = meterRegistry;
         this.loggerFactory = loggerFactory;
         this.metricsFactory = metricsFactory;
+        this.bodyConverter = bodyConverter;
     }
 
-    public GrpcServerTelemetry get(GrpcServerTelemetryConfig config) {
+    @Override
+    public GrpcServerTelemetry get(String name, int port, GrpcServerTelemetryConfig config) {
         var traceEnabled = this.tracer != null && config.tracing().enabled();
         var metricEnabled = this.meterRegistry != null && config.metrics().enabled();
         if (!traceEnabled && !metricEnabled && !config.logging().enabled()) {
@@ -60,14 +66,19 @@ public class DefaultGrpcServerTelemetryFactory {
             enabledLoggerFactory = NoopGrpcServerLoggerFactory.INSTANCE;
         }
 
-        return build(config, tracer, meterRegistry, enabledMetricsFactory, enabledLoggerFactory);
+        return build(name, port, config, tracer, meterRegistry, enabledMetricsFactory, enabledLoggerFactory);
     }
 
-    protected GrpcServerTelemetry build(GrpcServerTelemetryConfig config,
+    protected GrpcServerTelemetry build(String name,
+                                        int port,
+                                        GrpcServerTelemetryConfig config,
                                         Tracer tracer,
                                         MeterRegistry meterRegistry,
                                         DefaultGrpcServerMetricsFactory metricsFactory,
                                         DefaultGrpcServerLoggerFactory loggerFactory) {
-        return new DefaultGrpcServerTelemetry(config, tracer, meterRegistry, metricsFactory, loggerFactory);
+        var enabledBodyConverter = this.bodyConverter != null
+            ? this.bodyConverter
+            : new DefaultGrpcServerBodyConverter();
+        return new DefaultGrpcServerTelemetry(name, port, config, tracer, meterRegistry, metricsFactory, loggerFactory, enabledBodyConverter);
     }
 }

--- a/grpc/grpc-server/src/main/java/io/koraframework/grpc/server/telemetry/impl/NoopGrpcServerLoggerFactory.java
+++ b/grpc/grpc-server/src/main/java/io/koraframework/grpc/server/telemetry/impl/NoopGrpcServerLoggerFactory.java
@@ -21,16 +21,31 @@ public final class NoopGrpcServerLoggerFactory extends DefaultGrpcServerLoggerFa
         public static final NoopGrpcServerLogger INSTANCE = new NoopGrpcServerLogger();
 
         private NoopGrpcServerLogger() {
-            super(NOPLogger.NOP_LOGGER, NOPLogger.NOP_LOGGER);
+            super(DefaultGrpcServerTelemetry.TelemetryContext.EMPTY, NOPLogger.NOP_LOGGER, NOPLogger.NOP_LOGGER);
         }
 
         @Override
-        public void logRequest(String service, String method, Metadata requestHeaders) {
+        public boolean logRequestBody() {
+            return false;
+        }
+
+        @Override
+        public boolean logResponseBody() {
+            return false;
+        }
+
+        @Override
+        public void logRequest(String service, String method, Metadata requestHeaders, @Nullable Object requestMessage) {
 
         }
 
         @Override
-        public void logResponse(String service, String method, @Nullable Status status, @Nullable Throwable error, long processingTimeNanos) {
+        public void logResponse(String service,
+                                String method,
+                                @Nullable Status status,
+                                @Nullable Throwable error,
+                                @Nullable Object responseMessage,
+                                long processingTimeNanos) {
 
         }
     }

--- a/grpc/grpc-server/src/main/java/io/koraframework/grpc/server/telemetry/impl/NoopGrpcServerObservation.java
+++ b/grpc/grpc-server/src/main/java/io/koraframework/grpc/server/telemetry/impl/NoopGrpcServerObservation.java
@@ -22,7 +22,7 @@ public final class NoopGrpcServerObservation implements GrpcServerObservation {
     }
 
     @Override
-    public void observeSendMessage(Object rs) {
+    public void observeSendMessage(Object request) {
 
     }
 
@@ -47,7 +47,7 @@ public final class NoopGrpcServerObservation implements GrpcServerObservation {
     }
 
     @Override
-    public void observeReceiveMessage(Object rq) {
+    public void observeReceiveMessage(Object response) {
 
     }
 

--- a/grpc/grpc-server/src/main/java/module-info.java
+++ b/grpc/grpc-server/src/main/java/module-info.java
@@ -10,10 +10,11 @@ module kora.grpc.server {
     requires transitive io.grpc.stub;
     requires transitive io.grpc.okhttp;
     requires io.grpc.services;
+    requires com.google.protobuf;
 
     exports io.koraframework.grpc.server;
     exports io.koraframework.grpc.server.handler;
-    exports io.koraframework.grpc.server.interceptors;
+    exports io.koraframework.grpc.server.interceptor;
     exports io.koraframework.grpc.server.telemetry;
     exports io.koraframework.grpc.server.telemetry.impl;
 }


### PR DESCRIPTION
## EN

Added gRPC server factory wiring that propagates service name and port into telemetry logs, spans, and metrics while keeping request and response body conversion owned by logging.

---

## RU

Добавлена фабричная сборка telemetry для gRPC server: имя сервиса и порт теперь передаются в логи, спаны и метрики, а преобразование тел запросов и ответов выполняется только на стороне логирования.

---

- Added gRPC server factory module wiring for default telemetry creation with name and port context.
- Added `GrpcServerTelemetryFactory` support for name and port propagation, matching the HTTP server telemetry contract.
- Added request and response body conversion for gRPC logs without passing converted bodies into spans.

---

## gRPC body logging

Added logger-owned conversion for gRPC request and response bodies so logging can render body data without coupling converted payloads to span observation.