### PR TITLE
Added JSON discriminator defaults with missing-field fallback compatibility

### DIFF
--- a/json/json-annotation-processor/src/main/java/io/koraframework/json/annotation/processor/JsonUtils.java
+++ b/json/json-annotation-processor/src/main/java/io/koraframework/json/annotation/processor/JsonUtils.java
@@ -69,17 +69,31 @@ public final class JsonUtils {
 
     @Nullable
     public static String discriminatorField(Types types, TypeElement element) {
+        var discriminator = discriminator(types, element);
+        return discriminator == null
+            ? null
+            : discriminator.field();
+    }
+
+    @Nullable
+    public static Discriminator discriminator(Types types, TypeElement element) {
         if (element.getModifiers().contains(Modifier.SEALED)) {
             var annotation = AnnotationUtils.findAnnotation(element, JsonTypes.jsonDiscriminatorField);
             if (annotation != null) {
-                return AnnotationUtils.parseAnnotationValueWithoutDefault(annotation, "value");
+                return new Discriminator(
+                    AnnotationUtils.parseAnnotationValueWithoutDefault(annotation, "value"),
+                    AnnotationUtils.parseAnnotationValueWithoutDefault(annotation, "defaultValue")
+                );
             }
         }
         var superClass = types.asElement(element.getSuperclass());
         if (superClass instanceof TypeElement && superClass.getModifiers().contains(Modifier.SEALED)) {
             var annotation = AnnotationUtils.findAnnotation(superClass, JsonTypes.jsonDiscriminatorField);
             if (annotation != null) {
-                return AnnotationUtils.parseAnnotationValueWithoutDefault(annotation, "value");
+                return new Discriminator(
+                    AnnotationUtils.parseAnnotationValueWithoutDefault(annotation, "value"),
+                    AnnotationUtils.parseAnnotationValueWithoutDefault(annotation, "defaultValue")
+                );
             }
         }
         for (var directSupertype : types.directSupertypes(element.asType())) {
@@ -87,7 +101,7 @@ public final class JsonUtils {
                 continue;
             }
             var superelement = types.asElement(directSupertype);
-            var discriminator = discriminatorField(types, (TypeElement) superelement);
+            var discriminator = discriminator(types, (TypeElement) superelement);
             if (discriminator != null) {
                 return discriminator;
             }
@@ -108,4 +122,6 @@ public final class JsonUtils {
         }
         return List.of(element.getSimpleName().toString());
     }
+
+    public record Discriminator(String field, @Nullable String defaultValue) {}
 }

--- a/json/json-annotation-processor/src/main/java/io/koraframework/json/annotation/processor/reader/SealedInterfaceReaderGenerator.java
+++ b/json/json-annotation-processor/src/main/java/io/koraframework/json/annotation/processor/reader/SealedInterfaceReaderGenerator.java
@@ -41,10 +41,9 @@ public class SealedInterfaceReaderGenerator {
 
         this.addReaders(typeBuilder, permittedSubclasses);
 
-        var discriminatorField = JsonUtils.discriminatorField(this.types, jsonElement);
-        if (discriminatorField == null) {
-            discriminatorField = "@type";
-        }
+        var discriminator = JsonUtils.discriminator(this.types, jsonElement);
+        var discriminatorField = discriminator == null ? "@type" : discriminator.field();
+        var defaultDiscriminatorValue = discriminator == null ? null : discriminator.defaultValue();
         var method = MethodSpec.methodBuilder("read")
             .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
             .addParameter(JsonTypes.jsonParser, "__parser")
@@ -55,7 +54,11 @@ public class SealedInterfaceReaderGenerator {
             .endControlFlow();
         method.addCode("var bufferingParser = new $T(__parser);\n", JsonTypes.bufferingJsonParser);
         method.addCode("var discriminator = $T.readStringDiscriminator(bufferingParser, $S);\n", JsonTypes.discriminatorHelper, discriminatorField);
-        method.addCode("if (discriminator == null) throw new $T(__parser, $S);\n", JsonTypes.jsonParseException, "Discriminator required, but not provided");
+        if (defaultDiscriminatorValue == null || defaultDiscriminatorValue.isEmpty()) {
+            method.addCode("if (discriminator == null) throw new $T(__parser, $S);\n", JsonTypes.jsonParseException, "Discriminator required, but not provided");
+        } else {
+            method.addCode("if (discriminator == null) discriminator = $S;\n", defaultDiscriminatorValue);
+        }
         method.addCode("var bufferedParser = $T.createFlattened(false, bufferingParser.reset(), __parser);\n", JsonTypes.jsonParserSequence);
         method.addCode("bufferedParser.nextToken();\n");
         method.addCode("return switch(discriminator) {$>\n");

--- a/json/json-annotation-processor/src/test/java/io/koraframework/json/annotation/processor/SealedTest.java
+++ b/json/json-annotation-processor/src/test/java/io/koraframework/json/annotation/processor/SealedTest.java
@@ -159,6 +159,31 @@ public class SealedTest extends AbstractJsonAnnotationProcessorTest {
     }
 
     @Test
+    public void testSealedInterfaceWithDefaultDiscriminator() throws IOException {
+        compile("""
+            @Json
+            @JsonDiscriminatorField(value = "@type", defaultValue = "Impl1")
+            public sealed interface TestInterface {
+                @Json
+                record Impl1(String value) implements TestInterface{}
+                @Json
+                record Impl2(int value) implements TestInterface{}
+            }
+            """);
+        var o1 = newObject("TestInterface$Impl1", "test");
+        var json1 = "{\"value\":\"test\"}";
+        var o2 = newObject("TestInterface$Impl2", 42);
+        var json2 = "{\"@type\":\"Impl2\",\"value\":42}";
+
+        var m1 = mapper("TestInterface_Impl1");
+        var m2 = mapper("TestInterface_Impl2");
+        var m = mapper("TestInterface", List.of(m1, m2), List.of(m1, m2));
+
+        assertThat(m.read(json1.getBytes(StandardCharsets.UTF_8))).isEqualTo(o1);
+        assertThat(m.read(json2.getBytes(StandardCharsets.UTF_8))).isEqualTo(o2);
+    }
+
+    @Test
     public void testSealedAbstractClass() throws IOException {
         compile("""
             @Json

--- a/json/json-common/src/main/java/io/koraframework/json/common/annotation/JsonDiscriminatorField.java
+++ b/json/json-common/src/main/java/io/koraframework/json/common/annotation/JsonDiscriminatorField.java
@@ -45,4 +45,11 @@ public @interface JsonDiscriminatorField {
      * <b>English</b>: Name of the field that will determine the type of the deserializable value
      */
     String value();
+
+    /**
+     * @return <b>Русский</b>: Значение дискриминатора, которое будет использовано если поле {@link #value()} отсутствует
+     * <hr>
+     * <b>English</b>: Discriminator value that will be used when {@link #value()} field is missing
+     */
+    String defaultValue() default "";
 }

--- a/json/json-symbol-processor/src/main/kotlin/io/koraframework/json/ksp/JsonUtils.kt
+++ b/json/json-symbol-processor/src/main/kotlin/io/koraframework/json/ksp/JsonUtils.kt
@@ -106,24 +106,33 @@ fun findJsonField(param: KSAnnotated): KSAnnotation? {
 
 
 fun KSClassDeclaration.discriminatorField(): String? {
+    return discriminator()?.field
+}
+
+fun KSClassDeclaration.discriminator(): Discriminator? {
     if (this.packageName.asString() == "kotlin") {
         return null
     }
     if (this.modifiers.contains(Modifier.SEALED)) {
         val annotation = this.findAnnotation(JsonTypes.jsonDiscriminatorField)
         if (annotation != null) {
-            return annotation.findValue<String>("value")
+            return Discriminator(
+                annotation.findValue<String>("value")!!,
+                annotation.findValue<String>("defaultValue")
+            )
         }
     }
     for (type in this.superTypes) {
         val supertype = type.resolve().declaration as KSClassDeclaration
-        val discriminator = supertype.discriminatorField()
+        val discriminator = supertype.discriminator()
         if (discriminator != null) {
             return discriminator
         }
     }
     return null
 }
+
+data class Discriminator(val field: String, val defaultValue: String?)
 
 fun KSClassDeclaration.discriminatorValues(): List<String> {
     return findAnnotation(JsonTypes.jsonDiscriminatorValue)
@@ -169,4 +178,3 @@ fun detectSealedHierarchyTypeVariables(jsonClassDeclaration: KSClassDeclaration,
     }
     return map
 }
-

--- a/json/json-symbol-processor/src/main/kotlin/io/koraframework/json/ksp/reader/SealedInterfaceReaderGenerator.kt
+++ b/json/json-symbol-processor/src/main/kotlin/io/koraframework/json/ksp/reader/SealedInterfaceReaderGenerator.kt
@@ -38,8 +38,9 @@ class SealedInterfaceReaderGenerator {
 
         addReaders(typeBuilder, subclasses, typeArgMap)
 
-        val discriminatorField = jsonClassDeclaration.discriminatorField()
+        val discriminator = jsonClassDeclaration.discriminator()
             ?: throw ProcessingErrorException("Sealed interface should have @JsonDiscriminatorField annotation", jsonClassDeclaration)
+        val discriminatorField = discriminator.field
         val function = FunSpec.builder("read")
             .addModifiers(KModifier.PUBLIC, KModifier.OVERRIDE)
             .addParameter("__parser", JsonTypes.jsonParser)
@@ -48,8 +49,12 @@ class SealedInterfaceReaderGenerator {
             addStatement("return null")
         }
         function.addCode("val bufferingParser = %T(__parser)\n", JsonTypes.bufferingJsonParser)
-        function.addCode("val discriminator = %T.readStringDiscriminator(bufferingParser, %S)\n", JsonTypes.discriminatorHelper, discriminatorField);
-        function.addCode("if (discriminator == null) throw %T(__parser, %S)\n", JsonTypes.jsonParseException, "Discriminator required, but not provided");
+        if (discriminator.defaultValue.isNullOrEmpty()) {
+            function.addCode("val discriminator = %T.readStringDiscriminator(bufferingParser, %S)\n", JsonTypes.discriminatorHelper, discriminatorField);
+            function.addCode("if (discriminator == null) throw %T(__parser, %S)\n", JsonTypes.jsonParseException, "Discriminator required, but not provided");
+        } else {
+            function.addCode("val discriminator = %T.readStringDiscriminator(bufferingParser, %S) ?: %S\n", JsonTypes.discriminatorHelper, discriminatorField, discriminator.defaultValue);
+        }
         function.addCode("val bufferedParser = %T.createFlattened(false, bufferingParser.reset(), __parser)\n", JsonTypes.jsonParserSequence)
         function.addCode("bufferedParser.nextToken()\n")
         function.beginControlFlow("return when(discriminator) {")

--- a/json/json-symbol-processor/src/test/kotlin/io/koraframework/json/ksp/SealedTest.kt
+++ b/json/json-symbol-processor/src/test/kotlin/io/koraframework/json/ksp/SealedTest.kt
@@ -230,6 +230,33 @@ class SealedTest : AbstractJsonSymbolProcessorTest() {
     }
 
     @Test
+    fun testSealedInterfaceWithDefaultDiscriminator() {
+        compile(
+            """
+            @Json
+            @JsonDiscriminatorField(value = "@type", defaultValue = "Impl1")
+            sealed interface TestInterface {
+                @Json
+                data class Impl1(val value :String): TestInterface
+                @Json
+                data class Impl2(val value: Int): TestInterface
+            }
+            """
+        );
+
+        val m1 = mapper("TestInterface_Impl1")
+        val m2 = mapper("TestInterface_Impl2")
+        val m = mapper(
+            "TestInterface",
+            listOf(m1, m2),
+            listOf(m1, m2)
+        )
+
+        m.assertRead("{\"value\":\"test\"}", new("TestInterface\$Impl1", "test"))
+        m.assertRead("{\"value\":42, \"@type\":\"Impl2\"}", new("TestInterface\$Impl2", 42))
+    }
+
+    @Test
     fun testSealedSubinterface() {
         compile(
             """


### PR DESCRIPTION
Added JSON discriminator defaults with missing-field fallback compatibility

## EN

Added `JsonDiscriminatorField.defaultValue` support for sealed JSON readers, allowing payloads without a discriminator field to resolve to a configured subtype. Existing behavior remains compatible: missing discriminators still fail unless `defaultValue` is explicitly set, and explicit discriminator values continue to override the fallback.

---

## RU

Добавлена поддержка `JsonDiscriminatorField.defaultValue` для чтения запечатанных JSON-типов: если поле дискриминатора отсутствует, reader может использовать заданное значение по умолчанию. Совместимость сохранена: без явно заданного `defaultValue` отсутствие дискриминатора по-прежнему приводит к ошибке, а явно переданный дискриминатор имеет приоритет.

---

- Added `JsonDiscriminatorField.defaultValue` as an opt-in fallback for missing discriminator fields in Java annotation processor and KSP generated readers.

---

## Default discriminator value

Added a public annotation option for cases where incoming JSON commonly omits the discriminator but should map to a known subtype.

```java
@Json
@JsonDiscriminatorField(value = "@type", defaultValue = "Impl1")
public sealed interface TestInterface {
    @Json
    record Impl1(String value) implements TestInterface {}

    @Json
    record Impl2(int value) implements TestInterface {}
}
```