### PR TITLE
Added config validation for valid config mappers and sources

### DIFF
--- a/config/config-annotation-processor/build.gradle
+++ b/config/config-annotation-processor/build.gradle
@@ -4,8 +4,9 @@ dependencies {
     implementation project(":core:kora-app-annotation-processor")
 
     testImplementation project(':config:config-common')
+    testImplementation project(':validation:validation-annotation-processor')
+    testImplementation project(':validation:validation-common')
     testImplementation testFixtures(project(":core:annotation-processor-common"))
 }
 
 apply from: "${project.rootDir}/gradle/in-test-generated.gradle"
-

--- a/config/config-annotation-processor/src/main/java/io/koraframework/config/annotation/processor/ConfigClassNames.java
+++ b/config/config-annotation-processor/src/main/java/io/koraframework/config/annotation/processor/ConfigClassNames.java
@@ -9,6 +9,8 @@ public class ConfigClassNames {
     public static final ClassName config = CommonClassNames.config;
     public static final ClassName configSourceAnnotation = ClassName.get("io.koraframework.config.common.annotation", "ConfigSource");
     public static final ClassName configValueMapperAnnotation = ClassName.get("io.koraframework.config.common.annotation", "ConfigMapper");
+    public static final ClassName validAnnotation = ClassName.get("io.koraframework.validation.common.annotation", "Valid");
+    public static final ClassName validator = ClassName.get("io.koraframework.validation.common", "Validator");
     public static final ClassName configValue = ClassName.get("io.koraframework.config.common", "ConfigValue");
     public static final ClassName configValuePath = ClassName.get("io.koraframework.config.common", "ConfigValuePath");
     public static final ClassName pathElement = ClassName.get("io.koraframework.config.common", "PathElement");

--- a/config/config-annotation-processor/src/main/java/io/koraframework/config/annotation/processor/ConfigParserGenerator.java
+++ b/config/config-annotation-processor/src/main/java/io/koraframework/config/annotation/processor/ConfigParserGenerator.java
@@ -51,7 +51,7 @@ public class ConfigParserGenerator {
                 .initializer("new $T()", defaultImplClassName);
             typeBuilder.addField(field.build());
         }
-        var constructor = buildConstructor(typeBuilder, fields);
+        var constructor = buildConstructor(typeBuilder, targetType, fields);
         typeBuilder.addMethod(constructor);
         typeBuilder.addMethod(buildExtractMethod(element, TypeName.get(targetType), implClassName, fields));
 
@@ -117,13 +117,14 @@ public class ConfigParserGenerator {
                     rootParse.addStatement("_result.set$N($N)", CommonUtils.capitalize(field.name()), field.name());
                 }
             }
+            addValidation(rootParse, element);
             rootParse.addStatement("return _result");
         } else {
             var returnCodeBlock = CodeBlock.builder();
             if (element.getTypeParameters().isEmpty()) {
-                returnCodeBlock.add("return new $T(\n", implClassName);
+                returnCodeBlock.add("var _result = new $T(\n", implClassName);
             } else {
-                returnCodeBlock.add("return new $T<>(\n", implClassName);
+                returnCodeBlock.add("var _result = new $T<>(\n", implClassName);
             }
             for (int i = 0; i < fields.size(); i++) {
                 var field = fields.get(i);
@@ -133,8 +134,16 @@ public class ConfigParserGenerator {
                 returnCodeBlock.add("  $N", field.name());
             }
             rootParse.addCode(returnCodeBlock.add("\n);\n").build());
+            addValidation(rootParse, element);
+            rootParse.addStatement("return _result");
         }
         return rootParse.build();
+    }
+
+    private void addValidation(MethodSpec.Builder method, TypeElement element) {
+        if (AnnotationUtils.findAnnotation(element, ConfigClassNames.validAnnotation) != null) {
+            method.addStatement("this._validator.validateAndThrow(_result)");
+        }
     }
 
     public Either<Void, List<ProcessingError>> generateForRecord(DeclaredType targetType) {
@@ -151,7 +160,7 @@ public class ConfigParserGenerator {
             .addModifiers(Modifier.PUBLIC, Modifier.FINAL);
         var fields = Objects.requireNonNull(f.left());
         var implClassName = ClassName.get(element);
-        var constructor = buildConstructor(typeBuilder, fields);
+        var constructor = buildConstructor(typeBuilder, targetType, fields);
         typeBuilder.addMethod(constructor);
         typeBuilder.addMethod(buildExtractMethod(element, TypeName.get(targetType), implClassName, fields));
 
@@ -192,7 +201,7 @@ public class ConfigParserGenerator {
         }
 
 
-        var constructor = buildConstructor(typeBuilder, fields);
+        var constructor = buildConstructor(typeBuilder, targetType, fields);
         typeBuilder.addMethod(constructor);
         typeBuilder.addMethod(buildExtractMethod(element, TypeName.get(targetType), implClassName, fields));
 
@@ -304,7 +313,7 @@ public class ConfigParserGenerator {
         return parse.build();
     }
 
-    private MethodSpec buildConstructor(TypeSpec.Builder parser, List<ConfigUtils.ConfigField> fields) {
+    private MethodSpec buildConstructor(TypeSpec.Builder parser, DeclaredType targetType, List<ConfigUtils.ConfigField> fields) {
         var constructor = MethodSpec.constructorBuilder()
             .addModifiers(Modifier.PUBLIC);
         var fieldFactory = new FieldFactory(this.types, elements, null, constructor, "mapper");
@@ -320,6 +329,13 @@ public class ConfigParserGenerator {
             var fieldParserName = field.name() + "_parser";
             parser.addField(fieldParserType, fieldParserName, Modifier.PRIVATE, Modifier.FINAL);
             constructor.addStatement("this.$L = $L", fieldParserName, constructorParameterName);
+        }
+        var element = (TypeElement) targetType.asElement();
+        if (AnnotationUtils.findAnnotation(element, ConfigClassNames.validAnnotation) != null) {
+            var validatorType = ParameterizedTypeName.get(ConfigClassNames.validator, TypeName.get(targetType).withoutAnnotations());
+            parser.addField(validatorType, "_validator", Modifier.PRIVATE, Modifier.FINAL);
+            constructor.addParameter(validatorType, "_validator");
+            constructor.addStatement("this._validator = _validator");
         }
         return constructor.build();
     }

--- a/config/config-annotation-processor/src/test/java/io/koraframework/config/annotation/processor/AbstractConfigTest.java
+++ b/config/config-annotation-processor/src/test/java/io/koraframework/config/annotation/processor/AbstractConfigTest.java
@@ -4,6 +4,7 @@ import io.koraframework.annotation.processor.common.AbstractAnnotationProcessorT
 import io.koraframework.config.annotation.processor.processor.ConfigParserAnnotationProcessor;
 import io.koraframework.config.annotation.processor.processor.ConfigSourceAnnotationProcessor;
 import io.koraframework.config.common.mapper.ConfigValueMapper;
+import io.koraframework.validation.annotation.processor.ValidAnnotationProcessor;
 import org.intellij.lang.annotations.Language;
 
 import java.lang.reflect.InvocationTargetException;
@@ -19,7 +20,7 @@ public abstract class AbstractConfigTest extends AbstractAnnotationProcessorTest
     }
 
     protected ConfigValueMapper<Object> compileConfig(List<?> arguments, @Language("java") String... sources) {
-        super.compile(List.of(new ConfigParserAnnotationProcessor(), new ConfigSourceAnnotationProcessor()), sources);
+        super.compile(List.of(new ConfigParserAnnotationProcessor(), new ConfigSourceAnnotationProcessor(), new ValidAnnotationProcessor()), sources);
         this.compileResult.assertSuccess();
         var args = arguments
             .stream()

--- a/config/config-annotation-processor/src/test/java/io/koraframework/config/annotation/processor/AnnotationConfigTest.java
+++ b/config/config-annotation-processor/src/test/java/io/koraframework/config/annotation/processor/AnnotationConfigTest.java
@@ -4,6 +4,7 @@ import io.koraframework.config.common.ConfigValue;
 import io.koraframework.config.common.exception.ConfigValueException;
 import io.koraframework.config.common.mapper.ConfigValueMapper;
 import io.koraframework.config.common.util.ConfigMappingUtils;
+import io.koraframework.validation.common.Validator;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -99,6 +100,25 @@ public class AnnotationConfigTest extends AbstractConfigTest {
         assertThatThrownBy(() -> mapper.map(ConfigMappingUtils.fromMap(Map.of()).root()))
             .isInstanceOf(ConfigValueException.class)
             .hasMessageStartingWith("Config expected value, but got null at path: 'ROOT.value' for origin");
+    }
+
+    @Test
+    public void testValidInterfaceMapperValidatedAfterParse() {
+        var validator = Mockito.mock(Validator.class);
+        var mapper = this.compileConfig(List.of(validator), """
+            @ConfigMapper
+            @io.koraframework.validation.common.annotation.Valid
+            public interface TestConfig {
+              @io.koraframework.validation.common.annotation.NotBlank
+              String value();
+            }
+            """);
+
+        var result = mapper.map(ConfigMappingUtils.fromMap(Map.of("value", "test")).root());
+
+        assertThat(result)
+            .isEqualTo(newObject("$TestConfig_ConfigValueMapper$TestConfig_Impl", "test"));
+        verify(validator).validateAndThrow(result);
     }
 
     @Test

--- a/config/config-annotation-processor/src/test/java/io/koraframework/config/annotation/processor/ConfigSourceAnnotationTest.java
+++ b/config/config-annotation-processor/src/test/java/io/koraframework/config/annotation/processor/ConfigSourceAnnotationTest.java
@@ -1,14 +1,17 @@
 package io.koraframework.config.annotation.processor;
 
 import io.koraframework.config.common.mapper.ConfigValueMapper;
+import io.koraframework.validation.common.Validator;
 import org.junit.jupiter.api.Test;
 import io.koraframework.config.common.Config;
 import io.koraframework.config.common.util.ConfigMappingUtils;
+import org.mockito.Mockito;
 
 import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
 
 public class ConfigSourceAnnotationTest extends AbstractConfigTest {
 
@@ -23,6 +26,25 @@ public class ConfigSourceAnnotationTest extends AbstractConfigTest {
 
         assertThat(mapper.map(ConfigMappingUtils.fromMap(Map.of("value", 42)).root()))
             .isEqualTo(newObject("$TestConfig_ConfigValueMapper$TestConfig_Impl", 42));
+    }
+
+    @Test
+    public void testValidConfigSourceValidatedAfterParse() {
+        var validator = Mockito.mock(Validator.class);
+        var mapper = this.compileConfig(List.of(validator), """
+            @io.koraframework.config.common.annotation.ConfigSource("test.path")
+            @io.koraframework.validation.common.annotation.Valid
+            public interface TestConfig {
+              @io.koraframework.validation.common.annotation.NotBlank
+              String value();
+            }
+            """);
+
+        var result = mapper.map(ConfigMappingUtils.fromMap(Map.of("value", "test")).root());
+
+        assertThat(result)
+            .isEqualTo(newObject("$TestConfig_ConfigValueMapper$TestConfig_Impl", "test"));
+        verify(validator).validateAndThrow(result);
     }
 
     @Test

--- a/config/config-symbol-processor/build.gradle
+++ b/config/config-symbol-processor/build.gradle
@@ -8,9 +8,11 @@ dependencies {
     implementation libs.kotlinpoet
     implementation libs.kotlinpoet.ksp
 
+    testImplementation project(':config:config-common')
+    testImplementation project(':validation:validation-common')
+    testImplementation project(':validation:validation-symbol-processor')
     testImplementation testFixtures(project(":core:symbol-processor-common"))
     testImplementation testFixtures(project(":core:annotation-processor-common"))
-    testImplementation project(':config:config-common')
     testImplementation libs.mockito.kotlin
 }
 

--- a/config/config-symbol-processor/src/main/kotlin/io/koraframework/config/ksp/ConfigClassNames.kt
+++ b/config/config-symbol-processor/src/main/kotlin/io/koraframework/config/ksp/ConfigClassNames.kt
@@ -7,6 +7,8 @@ object ConfigClassNames {
     val config = CommonClassNames.config
     val configSourceAnnotation = ClassName("io.koraframework.config.common.annotation", "ConfigSource")
     val configValueMapperAnnotation = ClassName("io.koraframework.config.common.annotation", "ConfigMapper")
+    val validAnnotation = ClassName("io.koraframework.validation.common.annotation", "Valid")
+    val validator = ClassName("io.koraframework.validation.common", "Validator")
     val configValue = ClassName("io.koraframework.config.common", "ConfigValue")
     val pathElement = ClassName("io.koraframework.config.common", "PathElement")
     val pathElementKey = pathElement.nestedClass("Key")

--- a/config/config-symbol-processor/src/main/kotlin/io/koraframework/config/ksp/ConfigParserGenerator.kt
+++ b/config/config-symbol-processor/src/main/kotlin/io/koraframework/config/ksp/ConfigParserGenerator.kt
@@ -66,7 +66,7 @@ class ConfigParserGenerator(private val resolver: Resolver) {
                 typeBuilder.addProperty(defaultValue.build())
             }
         }
-        val constructor = buildConstructor(typeBuilder, fields)
+        val constructor = buildConstructor(typeBuilder, targetType, fields)
         typeBuilder.primaryConstructor(constructor)
         typeBuilder.addFunction(buildExtractMethod(element, targetType.toTypeName(), implClassName, fields))
         val companion = TypeSpec.companionObjectBuilder()
@@ -109,7 +109,7 @@ class ConfigParserGenerator(private val resolver: Resolver) {
             .addOriginatingKSFile(element)
         val fields = f.value
         val implClassName = element.toClassName()
-        val constructor = buildConstructor(typeBuilder, fields)
+        val constructor = buildConstructor(typeBuilder, targetType, fields)
         typeBuilder.primaryConstructor(constructor)
         typeBuilder.addFunction(buildExtractMethod(element, targetType.toTypeName(), implClassName, fields))
         val companion = TypeSpec.companionObjectBuilder()
@@ -163,7 +163,7 @@ class ConfigParserGenerator(private val resolver: Resolver) {
             }
             initializer.unindent().add("\n)")
         }
-        val constructor = buildConstructor(typeBuilder, fields)
+        val constructor = buildConstructor(typeBuilder, targetType, fields)
         typeBuilder.primaryConstructor(constructor)
         typeBuilder.addFunction(buildExtractMethod(decl, targetType.toTypeName(), implClassName, fields))
         val companion = TypeSpec.companionObjectBuilder()
@@ -209,7 +209,7 @@ class ConfigParserGenerator(private val resolver: Resolver) {
         val defaults = PropertySpec.builder("DEFAULTS", implClassName, KModifier.PRIVATE, KModifier.FINAL)
             .initializer(CodeBlock.of("%T()", implClassName))
         typeBuilder.addProperty(defaults.build())
-        val constructor = buildConstructor(typeBuilder, fields)
+        val constructor = buildConstructor(typeBuilder, targetType, fields)
         typeBuilder.primaryConstructor(constructor)
         typeBuilder.addFunction(buildExtractMethod(decl, targetType.toTypeName(), implClassName, fields))
         val companion = TypeSpec.companionObjectBuilder()
@@ -261,7 +261,7 @@ class ConfigParserGenerator(private val resolver: Resolver) {
         return null
     }
 
-    private fun buildConstructor(parser: TypeSpec.Builder, fields: List<ConfigField>): FunSpec {
+    private fun buildConstructor(parser: TypeSpec.Builder, targetType: KSType, fields: List<ConfigField>): FunSpec {
         val constructor = FunSpec.constructorBuilder();
         val fieldFactory = FieldFactory(parser, constructor, "parser")
         for (field in fields) {
@@ -277,6 +277,13 @@ class ConfigParserGenerator(private val resolver: Resolver) {
                     .build()
             )
             constructor.addStatement("this.%N = %N", fieldParserName, constructorParameterName)
+        }
+        val typeDecl = targetType.declaration as KSClassDeclaration
+        if (typeDecl.findAnnotation(ConfigClassNames.validAnnotation) != null) {
+            val validatorType = ConfigClassNames.validator.parameterizedBy(targetType.toTypeName().copy(false))
+            parser.addProperty(PropertySpec.builder("_validator", validatorType, KModifier.PRIVATE).build())
+            constructor.addParameter("_validator", validatorType)
+            constructor.addStatement("this.%N = %N", "_validator", "_validator")
         }
         return constructor.build()
     }
@@ -338,13 +345,15 @@ class ConfigParserGenerator(private val resolver: Resolver) {
             for (field in fields) {
                 rootParse.addStatement("_result.%N = %N", field.name, field.name)
             }
+            addValidation(rootParse, typeDecl)
             rootParse.addStatement("return _result")
         } else {
+            rootParse.addCode("val _result = ")
             if (fields.isEmpty()) {
-                rootParse.addStatement("return %T", implClassName)
+                rootParse.addStatement("%T", implClassName)
             } else {
                 val returnCodeBlock = CodeBlock.builder()
-                returnCodeBlock.add("return %T(\n", implClassName)
+                returnCodeBlock.add("%T(\n", implClassName)
                 for (i in fields.indices) {
                     val field = fields[i]
                     if (i > 0) {
@@ -354,8 +363,16 @@ class ConfigParserGenerator(private val resolver: Resolver) {
                 }
                 rootParse.addCode(returnCodeBlock.add("\n);\n").build())
             }
+            addValidation(rootParse, typeDecl)
+            rootParse.addStatement("return _result")
         }
         return rootParse.build()
+    }
+
+    private fun addValidation(builder: FunSpec.Builder, typeDecl: KSClassDeclaration) {
+        if (typeDecl.findAnnotation(ConfigClassNames.validAnnotation) != null) {
+            builder.addStatement("this.%N.validateAndThrow(_result)", "_validator")
+        }
     }
 
     private fun buildParseField(typeDecl: KSClassDeclaration, field: ConfigField): FunSpec {

--- a/config/config-symbol-processor/src/test/kotlin/io/koraframework/config/symbol/processor/AbstractConfigTest.kt
+++ b/config/config-symbol-processor/src/test/kotlin/io/koraframework/config/symbol/processor/AbstractConfigTest.kt
@@ -4,6 +4,7 @@ import io.koraframework.config.common.mapper.ConfigValueMapper
 import io.koraframework.config.ksp.processor.ConfigParserSymbolProcessorProvider
 import io.koraframework.config.ksp.processor.ConfigSourceSymbolProcessorProvider
 import io.koraframework.ksp.common.AbstractSymbolProcessorTest
+import io.koraframework.validation.symbol.processor.ValidSymbolProcessorProvider
 import org.intellij.lang.annotations.Language
 
 abstract class AbstractConfigTest : AbstractSymbolProcessorTest() {
@@ -14,7 +15,7 @@ abstract class AbstractConfigTest : AbstractSymbolProcessorTest() {
     }
 
     protected open fun compileConfig(arguments: List<*>, @Language("kotlin") vararg sources: String): ConfigValueMapper<Any?> {
-        super.compile0(listOf(ConfigSourceSymbolProcessorProvider(), ConfigParserSymbolProcessorProvider()), *sources)
+        super.compile0(listOf(ConfigSourceSymbolProcessorProvider(), ConfigParserSymbolProcessorProvider(), ValidSymbolProcessorProvider()), *sources)
         compileResult.assertSuccess()
         return loadClass("\$TestConfig_ConfigValueMapper")
             .constructors[0]

--- a/config/config-symbol-processor/src/test/kotlin/io/koraframework/config/symbol/processor/AnnotationConfigTest.kt
+++ b/config/config-symbol-processor/src/test/kotlin/io/koraframework/config/symbol/processor/AnnotationConfigTest.kt
@@ -5,6 +5,7 @@ import io.koraframework.config.common.ConfigValue.StringValue
 import io.koraframework.config.common.exception.ConfigValueException
 import io.koraframework.config.common.mapper.ConfigValueMapper
 import io.koraframework.config.common.util.ConfigMappingUtils
+import io.koraframework.validation.common.Validator
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
@@ -79,6 +80,27 @@ class AnnotationConfigTest : AbstractConfigTest() {
         assertThatThrownBy { mapper.map(ConfigMappingUtils.fromMap(mapOf<String, Any?>()).root()) }
             .isInstanceOf(ConfigValueException::class.java)
             .hasMessageStartingWith("Config expected value, but got null at path: 'ROOT.value' for origin");
+    }
+
+    @Test
+    fun testValidInterfaceMapperValidatedAfterParse() {
+        val validator = Mockito.mock(Validator::class.java) as Validator<Any?>
+        val mapper = compileConfig(
+            listOf(validator), """
+            @ConfigMapper
+            @io.koraframework.validation.common.annotation.Valid
+            interface TestConfig {
+              @io.koraframework.validation.common.annotation.NotBlank
+              fun value(): String
+            }
+            """.trimIndent()
+        )
+
+        val result = mapper.map(ConfigMappingUtils.fromMap(mapOf("value" to "test")).root())
+
+        assertThat(result)
+            .isEqualTo(new("\$TestConfig_ConfigValueMapper\$TestConfig_Impl", "test"))
+        verify(validator).validateAndThrow(result)
     }
 
     @Test

--- a/config/config-symbol-processor/src/test/kotlin/io/koraframework/config/symbol/processor/ConfigSourceAnnotationTest.kt
+++ b/config/config-symbol-processor/src/test/kotlin/io/koraframework/config/symbol/processor/ConfigSourceAnnotationTest.kt
@@ -5,6 +5,9 @@ import org.junit.jupiter.api.Test
 import io.koraframework.config.common.Config
 import io.koraframework.config.common.mapper.ConfigValueMapper
 import io.koraframework.config.common.util.ConfigMappingUtils
+import io.koraframework.validation.common.Validator
+import org.mockito.Mockito
+import org.mockito.Mockito.verify
 
 class ConfigSourceAnnotationTest : AbstractConfigTest() {
     @Test
@@ -20,6 +23,27 @@ class ConfigSourceAnnotationTest : AbstractConfigTest() {
         )
         assertThat(mapper.map(ConfigMappingUtils.fromMap(mapOf("value" to 42)).root()))
             .isEqualTo(new($$"$TestConfig_ConfigValueMapper$TestConfig_Impl", 42))
+    }
+
+    @Test
+    fun testValidConfigSourceValidatedAfterParse() {
+        val validator = Mockito.mock(Validator::class.java) as Validator<Any?>
+        val mapper = compileConfig(
+            listOf(validator), """
+            @ConfigSource("test.path")
+            @io.koraframework.validation.common.annotation.Valid
+            interface TestConfig {
+              @io.koraframework.validation.common.annotation.NotBlank
+              fun value(): String
+            }
+            """.trimIndent()
+        )
+
+        val result = mapper.map(ConfigMappingUtils.fromMap(mapOf("value" to "test")).root())
+
+        assertThat(result)
+            .isEqualTo(new($$"$TestConfig_ConfigValueMapper$TestConfig_Impl", "test"))
+        verify(validator).validateAndThrow(result)
     }
 
     @Test

--- a/validation/validation-annotation-processor/src/main/java/io/koraframework/validation/annotation/processor/ValidAnnotationProcessor.java
+++ b/validation/validation-annotation-processor/src/main/java/io/koraframework/validation/annotation/processor/ValidAnnotationProcessor.java
@@ -44,7 +44,7 @@ public final class ValidAnnotationProcessor extends AbstractKoraProcessor {
                 this.messager.printMessage(Diagnostic.Kind.ERROR, "Validation can't be generated for enum", element);
                 continue;
             }
-            if (element.getKind() == ElementKind.INTERFACE && !element.getModifiers().contains(Modifier.SEALED)) {
+            if (element.getKind() == ElementKind.INTERFACE && !element.getModifiers().contains(Modifier.SEALED) && !isConfigInterface(element)) {
                 this.messager.printMessage(Diagnostic.Kind.ERROR, "Validation can't be generated for non sealed interface", element);
                 continue;
             }
@@ -56,5 +56,12 @@ public final class ValidAnnotationProcessor extends AbstractKoraProcessor {
                 }
             }
         }
+    }
+
+    private static boolean isConfigInterface(javax.lang.model.element.Element element) {
+        return element.getAnnotationMirrors().stream()
+            .map(a -> a.getAnnotationType().toString())
+            .anyMatch(a -> a.equals("io.koraframework.config.common.annotation.ConfigMapper")
+                || a.equals("io.koraframework.config.common.annotation.ConfigSource"));
     }
 }

--- a/validation/validation-annotation-processor/src/main/java/io/koraframework/validation/annotation/processor/ValidMeta.java
+++ b/validation/validation-annotation-processor/src/main/java/io/koraframework/validation/annotation/processor/ValidMeta.java
@@ -38,12 +38,12 @@ public record ValidMeta(Type source, TypeElement sourceElement, List<Field> fiel
         }
     }
 
-    public record Field(Type type, String name, boolean isRecord, boolean isNullable, boolean isNotNull,
+    public record Field(Type type, String name, boolean isRecordOrInterface, boolean isNullable, boolean isNotNull,
                         boolean isJsonNullable, boolean isPrimitive, List<Constraint> constraint,
                         List<Validated> validates) {
 
         public String accessor() {
-            return (isRecord)
+            return (isRecordOrInterface)
                 ? name + "()"
                 : "get" + name.substring(0, 1).toUpperCase() + name.substring(1) + "()";
         }

--- a/validation/validation-annotation-processor/src/main/java/io/koraframework/validation/annotation/processor/ValidatorGenerator.java
+++ b/validation/validation-annotation-processor/src/main/java/io/koraframework/validation/annotation/processor/ValidatorGenerator.java
@@ -35,7 +35,7 @@ public class ValidatorGenerator {
     }
 
     public void generateFor(TypeElement validatedElement) {
-        if (validatedElement.getKind().isInterface()) {
+        if (validatedElement.getKind().isInterface() && validatedElement.getModifiers().contains(Modifier.SEALED)) {
             this.generateForSealed(validatedElement);
             return;
         }
@@ -274,6 +274,9 @@ public class ValidatorGenerator {
     }
 
     private ValidMeta getValidatorMetas(TypeElement element) {
+        if (element.getKind().isInterface()) {
+            return getInterfaceValidatorMetas(element);
+        }
         final List<VariableElement> elementFields = getFields(element);
         final List<ValidMeta.Field> fields = new ArrayList<>();
         for (VariableElement fieldElement : elementFields) {
@@ -331,9 +334,73 @@ public class ValidatorGenerator {
             .toList();
     }
 
+    private ValidMeta getInterfaceValidatorMetas(TypeElement element) {
+        final Map<String, ExecutableElement> accessors = new LinkedHashMap<>();
+        collectInterfaceAccessors(element, accessors, new HashSet<>());
+        final List<ValidMeta.Field> fields = new ArrayList<>();
+        for (var method : accessors.values()) {
+            final TypeMirror methodType = ((javax.lang.model.type.ExecutableType) types.asMemberOf((DeclaredType) element.asType(), method)).getReturnType();
+            final List<ValidMeta.Constraint> constraints = ValidUtils.getValidatedByConstraints(processingEnv, methodType, method.getAnnotationMirrors());
+            final List<ValidMeta.Validated> validateds = getValidated(method, methodType);
+            final boolean isNotNull = isNotNull(method);
+            final boolean isJsonNullable;
+            final TypeMirror targetType;
+            if (methodType instanceof DeclaredType dt && jsonNullable.canonicalName().equals(dt.asElement().toString())) {
+                targetType = dt.getTypeArguments().get(0);
+                isJsonNullable = true;
+            } else {
+                targetType = methodType;
+                isJsonNullable = false;
+            }
+
+            if (!constraints.isEmpty() || !validateds.isEmpty() || (isJsonNullable && isNotNull)) {
+                final boolean isNullable = CommonUtils.isNullable(element) || CommonUtils.isNullable(method);
+                final boolean isPrimitive = methodType.getKind().isPrimitive();
+                final TypeMirror fieldType = ValidUtils.getBoxType(targetType, processingEnv);
+                fields.add(new ValidMeta.Field(
+                    ValidMeta.Type.ofElement(processingEnv.getTypeUtils().asElement(fieldType), fieldType),
+                    method.getSimpleName().toString(),
+                    true,
+                    isNullable,
+                    isNotNull,
+                    isJsonNullable,
+                    isPrimitive,
+                    constraints,
+                    validateds));
+            }
+        }
+        return new ValidMeta(element, fields);
+    }
+
+    private void collectInterfaceAccessors(TypeElement element, Map<String, ExecutableElement> accessors, Set<TypeElement> seen) {
+        if (!seen.add(element)) {
+            return;
+        }
+        for (var enclosed : element.getEnclosedElements()) {
+            if (enclosed.getKind() != ElementKind.METHOD || enclosed.getModifiers().contains(Modifier.STATIC) || enclosed.getModifiers().contains(Modifier.PRIVATE)) {
+                continue;
+            }
+            var method = (ExecutableElement) enclosed;
+            if (method.getParameters().isEmpty() && method.getReturnType().getKind() != TypeKind.VOID && method.getTypeParameters().isEmpty()) {
+                accessors.putIfAbsent(method.getSimpleName().toString(), method);
+            }
+        }
+        for (var superinterface : element.getInterfaces()) {
+            collectInterfaceAccessors((TypeElement) types.asElement(superinterface), accessors, seen);
+        }
+    }
+
     private static List<ValidMeta.Validated> getValidated(VariableElement field) {
         if (field.getAnnotationMirrors().stream().anyMatch(a -> a.getAnnotationType().toString().equals(VALID_TYPE.canonicalName()))) {
             return List.of(new ValidMeta.Validated(ValidMeta.Type.ofElement(field, field.asType())));
+        }
+
+        return Collections.emptyList();
+    }
+
+    private static List<ValidMeta.Validated> getValidated(ExecutableElement method, TypeMirror methodType) {
+        if (method.getAnnotationMirrors().stream().anyMatch(a -> a.getAnnotationType().toString().equals(VALID_TYPE.canonicalName()))) {
+            return List.of(new ValidMeta.Validated(ValidMeta.Type.ofElement(method, methodType)));
         }
 
         return Collections.emptyList();

--- a/validation/validation-common/src/main/java/io/koraframework/validation/common/ViolationException.java
+++ b/validation/validation-common/src/main/java/io/koraframework/validation/common/ViolationException.java
@@ -14,7 +14,7 @@ public final class ViolationException extends RuntimeException {
 
     public ViolationException(List<Violation> violations) {
         super();
-        this.violations = violations;
+        this.violations = List.copyOf(violations);
     }
 
     public List<Violation> getViolations() {
@@ -31,15 +31,20 @@ public final class ViolationException extends RuntimeException {
     }
 
     private static String buildViolationMessage(List<Violation> violations) {
-        final StringBuilder builder = new StringBuilder("Validation failed with violations:\n");
+        if (violations.isEmpty()) {
+            return "Validation failed with no violations";
+        }
+
+        final StringBuilder builder = new StringBuilder("Validation failed with ")
+            .append(violations.size())
+            .append(violations.size() == 1 ? " violation:\n" : " violations:\n");
         for (int i = 1; i <= violations.size(); i++) {
             final Violation violation = violations.get(i - 1);
             builder.append(i)
                 .append(") Path '")
                 .append(violation.path().full())
                 .append("' violation: ")
-                .append(violation.message())
-                .append(';');
+                .append(violation.message());
 
             if (i != violations.size()) {
                 builder.append("\n");

--- a/validation/validation-symbol-processor/src/main/kotlin/io/koraframework/validation/symbol/processor/ValidMeta.kt
+++ b/validation/validation-symbol-processor/src/main/kotlin/io/koraframework/validation/symbol/processor/ValidMeta.kt
@@ -25,6 +25,7 @@ data class ValidatorType(val contract: TypeName)
 data class Field(
     val type: Type,
     val name: String,
+    val accessor: String,
     val isDataClass: Boolean,
     val isNullable: Boolean,
     val isNotNull: Boolean,
@@ -33,9 +34,9 @@ data class Field(
     val validates: List<Validated>
 ) {
 
-    fun accessor(): String = name
+    fun accessor(): String = accessor
 
-    fun accessorValue(): String = if(isJsonNullable) "$name.value()" else name
+    fun accessorValue(): String = if(isJsonNullable) "$accessor.value()" else accessor
 }
 
 data class Constraint(val annotation: Type, val factory: Factory) {

--- a/validation/validation-symbol-processor/src/main/kotlin/io/koraframework/validation/symbol/processor/ValidatorGenerator.kt
+++ b/validation/validation-symbol-processor/src/main/kotlin/io/koraframework/validation/symbol/processor/ValidatorGenerator.kt
@@ -221,7 +221,7 @@ class ValidatorGenerator(val codeGenerator: CodeGenerator) {
     }
 
     private fun getValidatorMeta(declaration: KSClassDeclaration): ValidatorMeta {
-        if (declaration.classKind == ClassKind.INTERFACE || declaration.classKind == ClassKind.ENUM_CLASS) {
+        if ((declaration.classKind == ClassKind.INTERFACE && !declaration.isConfigInterface()) || declaration.classKind == ClassKind.ENUM_CLASS) {
             throw ProcessingErrorException("Validation can't be generated for: ${declaration.classKind}", declaration)
         }
 
@@ -231,6 +231,7 @@ class ValidatorGenerator(val codeGenerator: CodeGenerator) {
             .toList()
 
         val fields = ArrayList<Field>()
+        val seen = HashSet<String>()
         for (fieldProperty in elementFields) {
             val constraints = fieldProperty.getConstraints()
             val validateds = getValid(fieldProperty)
@@ -242,10 +243,12 @@ class ValidatorGenerator(val codeGenerator: CodeGenerator) {
             val isJsonNullable = resolvedType.declaration.let { if (it is KSClassDeclaration) it.toClassName() else null } == ValidTypes.jsonNullable
 
             if (constraints.isNotEmpty() || validateds.isNotEmpty() || (isJsonNullable && isNotNull)) {
+                seen.add(fieldProperty.simpleName.asString())
                 val realType = if (isJsonNullable) resolvedType.arguments[0].type else fieldProperty.type
                 fields.add(
                     Field(
                         realType!!.asType(),
+                        fieldProperty.simpleName.asString(),
                         fieldProperty.simpleName.asString(),
                         declaration.modifiers.any { m -> m == Modifier.DATA },
                         isNullable,
@@ -255,6 +258,44 @@ class ValidatorGenerator(val codeGenerator: CodeGenerator) {
                         validateds
                     )
                 )
+            }
+        }
+        if (declaration.classKind == ClassKind.INTERFACE) {
+            for (function in declaration.getAllFunctions()) {
+                if (function.simpleName.asString() in setOf("equals", "hashCode", "toString")) {
+                    continue
+                }
+                if (function.parameters.isNotEmpty() || function.returnType == null || function.typeParameters.isNotEmpty()) {
+                    continue
+                }
+                val constraints = function.getConstraints()
+                val validateds = getValid(function)
+                val resolvedType = function.returnType!!.resolve()
+                val isNullable = resolvedType.isMarkedNullable
+                val isNotNull = (function.annotations + function.returnType!!.annotations)
+                    .map { it.annotationType.resolveToUnderlying().declaration.let { it as KSClassDeclaration }.toClassName().simpleName }
+                    .any { it.contentEquals("NonNull", true) || it.contentEquals("NotNull", true) }
+                val isJsonNullable = resolvedType.declaration.let { if (it is KSClassDeclaration) it.toClassName() else null } == ValidTypes.jsonNullable
+
+                if (constraints.isNotEmpty() || validateds.isNotEmpty() || (isJsonNullable && isNotNull)) {
+                    if (!seen.add(function.simpleName.asString())) {
+                        continue
+                    }
+                    val realType = if (isJsonNullable) resolvedType.arguments[0].type else function.returnType
+                    fields.add(
+                        Field(
+                            realType!!.asType(),
+                            function.simpleName.asString(),
+                            function.simpleName.asString() + "()",
+                            false,
+                            isNullable,
+                            isNotNull,
+                            isJsonNullable,
+                            constraints,
+                            validateds
+                        )
+                    )
+                }
             }
         }
 
@@ -278,6 +319,14 @@ class ValidatorGenerator(val codeGenerator: CodeGenerator) {
             ?.firstOrNull { it.isAnnotationPresent(VALID_TYPE) }
             ?.let { return listOf(Validated(field.type.asType())) }
             ?: emptyList()
+    }
+
+    private fun getValid(function: KSFunctionDeclaration): List<Validated> {
+        if (function.isAnnotationPresent(VALID_TYPE)) {
+            return listOf(Validated(function.returnType!!.asType()))
+        }
+
+        return emptyList()
     }
 
     fun generate(symbol: KSAnnotated) {
@@ -338,5 +387,13 @@ class ValidatorGenerator(val codeGenerator: CodeGenerator) {
             .build()
 
         fileSpec.writeTo(codeGenerator = codeGenerator, aggregating = false)
+    }
+
+    private fun KSClassDeclaration.isConfigInterface(): Boolean {
+        return this.annotations.any {
+            val className = it.annotationType.resolve().declaration.qualifiedName?.asString()
+            className == "io.koraframework.config.common.annotation.ConfigMapper"
+                || className == "io.koraframework.config.common.annotation.ConfigSource"
+        }
     }
 }


### PR DESCRIPTION
Added config validation for valid config mappers and sources

## EN

Added validation support for `@Valid` config interfaces annotated with `@ConfigMapper` or `@ConfigSource`. Validation processors now generate validators for these config interfaces, and generated config mappers validate parsed results before returning them.

---

## RU

Добавлена поддержка валидации конфигурационных интерфейсов, помеченных `@Valid` вместе с `@ConfigMapper` или `@ConfigSource`. Процессоры валидации теперь генерируют валидаторы для таких интерфейсов, а сгенерированные мапперы конфигурации проверяют результат после разбора и до возврата значения.

---

- Added validator generation for non-sealed `@Valid` interfaces when they are also annotated with `@ConfigMapper` or `@ConfigSource`.
- Added `Validator<T>` injection into generated config mappers for `@Valid` config types, with `validateAndThrow(...)` called after parsing.
- Improved `ViolationException` default messages with violation counts and immutable violation storage.

---

## Generated Validation

Generated config mappers now require a validator only when the config type itself is annotated with `@Valid`.

```java
@ConfigMapper
@Valid
public interface TestConfig {
    @NotBlank
    String value();
}
```

The generated mapper validates the parsed `TestConfig` instance before returning it, so invalid config values fail with `ViolationException`.