### PR TITLE
Fixed AOP proxy generation for noop method aspects

### DIFF
--- a/aop/aop-symbol-processor/src/main/kotlin/io/koraframework/aop/symbol/processor/AopProcessor.kt
+++ b/aop/aop-symbol-processor/src/main/kotlin/io/koraframework/aop/symbol/processor/AopProcessor.kt
@@ -185,6 +185,7 @@ class AopProcessor(private val aspects: List<KoraAspect>, private val resolver: 
 
             aspectsToApply.reverse()
             val generatedMethodNames = mutableSetOf<String>()
+            var isMethodAspectApplied = false
             for (aspect in aspectsToApply) {
                 val result: KoraAspect.ApplyResult = aspect.apply(function, superCall, aopContext)
                 if (result is KoraAspect.ApplyResult.Noop) {
@@ -227,9 +228,10 @@ class AopProcessor(private val aspects: List<KoraAspect>, private val resolver: 
                 f.returns(returnType.toTypeName())
                 typeBuilder.addFunction(f.build())
                 methodAspectsApplied.add(aspect)
+                isMethodAspectApplied = true
             }
 
-            if (methodAspectsApplied.isNotEmpty()) {
+            if (isMethodAspectApplied) {
                 val b = CodeBlock.builder()
                 if (function.returnType!!.resolve() != resolver.builtIns.unitType) {
                     b.add("return ")

--- a/aop/aop-symbol-processor/src/test/kotlin/io/koraframework/aop/ksp/AopAnnotationProcessorTest.kt
+++ b/aop/aop-symbol-processor/src/test/kotlin/io/koraframework/aop/ksp/AopAnnotationProcessorTest.kt
@@ -61,6 +61,27 @@ class AopAnnotationProcessorTest : AbstractSymbolProcessorTest() {
     }
 
     @Test
+    fun testNoopAspectAfterAppliedAspectDoesNotCreateOverride() {
+        compile0(listOf(AopSymbolProcessorProvider()), """
+            open class AopTarget {
+                @io.koraframework.aop.ksp.TestAnnotation1("test")
+                open fun test1(id: Long): Long = id
+
+                @io.koraframework.aop.ksp.TestNoopAnnotation
+                open fun test2(id: Long): Long = id
+            }
+            
+            """.trimIndent())
+        compileResult.assertSuccess()
+        val aopProxy = loadClass("\$AopTarget__AopProxy")
+
+        val methods = aopProxy.declaredMethods.filter { m: Method -> Modifier.isPublic(m.modifiers) }
+
+        assertThat(methods).hasSize(1)
+        assertThat(methods[0].name).isEqualTo("test1")
+    }
+
+    @Test
     fun testClassLevelAspectsApplied() {
         compile0(listOf(AopSymbolProcessorProvider()), """
             @io.koraframework.aop.ksp.TestAnnotation1("testClassLevelAspectsApplied")

--- a/aop/aop-symbol-processor/src/test/kotlin/io/koraframework/aop/ksp/TestNoopAnnotation.kt
+++ b/aop/aop-symbol-processor/src/test/kotlin/io/koraframework/aop/ksp/TestNoopAnnotation.kt
@@ -1,0 +1,25 @@
+package io.koraframework.aop.ksp
+
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.squareup.kotlinpoet.asClassName
+import io.koraframework.aop.symbol.processor.KoraAspect
+import io.koraframework.aop.symbol.processor.KoraAspectFactory
+import io.koraframework.common.annotation.AopAnnotation
+
+@AopAnnotation
+annotation class TestNoopAnnotation {
+    class TestNoopAspect : KoraAspect {
+        override fun getSupportedAnnotationTypes(): Set<String> = setOf(TestNoopAnnotation::class.asClassName().canonicalName)
+
+        override fun apply(
+            ksFunction: KSFunctionDeclaration,
+            superCall: String,
+            aspectContext: KoraAspect.AspectContext
+        ): KoraAspect.ApplyResult = KoraAspect.ApplyResult.Noop.INSTANCE
+    }
+
+    class TestNoopAspectFactory : KoraAspectFactory {
+        override fun create(resolver: Resolver) = TestNoopAspect()
+    }
+}

--- a/aop/aop-symbol-processor/src/test/resources/META-INF/services/io.koraframework.aop.symbol.processor.KoraAspectFactory
+++ b/aop/aop-symbol-processor/src/test/resources/META-INF/services/io.koraframework.aop.symbol.processor.KoraAspectFactory
@@ -5,3 +5,4 @@ io.koraframework.aop.ksp.aoptarget.AopTarget2$Aspect22Factory
 io.koraframework.aop.ksp.aoptarget.AopTarget3$Aspect3Factory
 io.koraframework.aop.ksp.TestAnnotation1$TestAnnotationAspectFactory
 io.koraframework.aop.ksp.TestAnnotation2$TestAnnotationAspectFactory
+io.koraframework.aop.ksp.TestNoopAnnotation$TestNoopAspectFactory


### PR DESCRIPTION
Fixed proxy override emission so AOP-generated methods are created only when an aspect actually applies to the current method. This prevents later noop aspects from producing invalid overrides with missing parameters after an earlier method generated a proxy.