### PR TITLE
docs(config): Javadoc for configuration classes from documentation

### DIFF
--- a/cache/cache-caffeine/src/main/java/ru/tinkoff/kora/cache/caffeine/CaffeineCacheConfig.java
+++ b/cache/cache-caffeine/src/main/java/ru/tinkoff/kora/cache/caffeine/CaffeineCacheConfig.java
@@ -9,16 +9,28 @@ import java.time.Duration;
 @ConfigValueExtractor
 public interface CaffeineCacheConfig {
 
+    /**
+     * @return Time after which a value is removed from the cache, counted from the moment the value was written.
+     */
     @Nullable
     Duration expireAfterWrite();
 
+    /**
+     * @return Time after which a value is removed from the cache, counted from the moment the value was read.
+     */
     @Nullable
     Duration expireAfterAccess();
 
+    /**
+     * @return Maximum cache size, upon reaching it or slightly earlier the least relevant values are evicted.
+     */
     default Long maximumSize() {
         return 100_000L;
     }
 
+    /**
+     * @return Initial cache size, helps to avoid resizing when the number of values grows quickly.
+     */
     @Nullable
     Integer initialSize();
 }

--- a/cache/cache-redis/src/main/java/ru/tinkoff/kora/cache/redis/RedisCacheConfig.java
+++ b/cache/cache-redis/src/main/java/ru/tinkoff/kora/cache/redis/RedisCacheConfig.java
@@ -16,9 +16,15 @@ public interface RedisCacheConfig {
      */
     String keyPrefix();
 
+    /**
+     * @return Value expiration time applied on write.
+     */
     @Nullable
     Duration expireAfterWrite();
 
+    /**
+     * @return Value expiration time applied on read.
+     */
     @Nullable
     Duration expireAfterAccess();
 }

--- a/cache/cache-redis/src/main/java/ru/tinkoff/kora/cache/redis/lettuce/LettuceClientConfig.java
+++ b/cache/cache-redis/src/main/java/ru/tinkoff/kora/cache/redis/lettuce/LettuceClientConfig.java
@@ -12,33 +12,60 @@ import java.util.List;
 @ConfigValueExtractor
 public interface LettuceClientConfig {
 
+    /**
+     * @return URI for connecting to Redis, single or multiple servers, optionally with SSL or TLS scheme.
+     */
     String uri();
 
+    /**
+     * @return Whether to create a cluster client even when a single connection URI is specified.
+     */
     default boolean forceClusterClient() {
         return false;
     }
 
+    /**
+     * @return Database number for the connection.
+     */
     @Nullable
     Integer database();
 
+    /**
+     * @return Username for the connection.
+     */
     @Nullable
     String user();
 
+    /**
+     * @return User password for the connection.
+     */
     @Nullable
     String password();
 
+    /**
+     * @return Protocol used to communicate with Redis.
+     */
     default Protocol protocol() {
         return Protocol.RESP3;
     }
 
+    /**
+     * @return Socket connection timeout.
+     */
     default Duration socketTimeout() {
         return Duration.ofSeconds(SocketOptions.DEFAULT_CONNECT_TIMEOUT);
     }
 
+    /**
+     * @return Command execution timeout.
+     */
     default Duration commandTimeout() {
         return Duration.ofSeconds(RedisURI.DEFAULT_TIMEOUT);
     }
 
+    /**
+     * @return Telemetry configuration of logging, metrics and tracing for the module.
+     */
     TelemetryConfig telemetry();
 
     enum Protocol {
@@ -49,15 +76,24 @@ public interface LettuceClientConfig {
         RESP3
     }
 
+    /**
+     * @return Configuration of the secure connection between client and server.
+     */
     SslConfig ssl();
 
     @ConfigValueExtractor
     interface SslConfig {
 
+        /**
+         * @return Cipher algorithms for a secure connection between client and server.
+         */
         default List<String> ciphers() {
             return List.of();
         }
 
+        /**
+         * @return Timeout for establishing a secure connection with the server.
+         */
         default Duration handshakeTimeout() {
             return Duration.ofSeconds(10);
         }

--- a/database/database-cassandra/src/main/java/ru/tinkoff/kora/database/cassandra/CassandraConfig.java
+++ b/database/database-cassandra/src/main/java/ru/tinkoff/kora/database/cassandra/CassandraConfig.java
@@ -25,19 +25,37 @@ public interface CassandraConfig {
     @Nullable
     Map<String, Profile> profiles();
 
+    /**
+     * @return Basic driver settings such as node addresses, datacenter, keyspace and request parameters.
+     */
     Basic basic();
 
+    /**
+     * @return Advanced driver settings such as connections, SSL, protocol, metadata, metrics and throttling.
+     */
     Advanced advanced();
 
+    /**
+     * @return Credentials used for authentication in Cassandra.
+     */
     @Nullable
     CassandraCredentials auth();
 
+    /**
+     * @return Kora telemetry settings for executed queries.
+     */
     TelemetryConfig telemetry();
 
     @ConfigValueExtractor
     interface CassandraCredentials {
+        /**
+         * @return Username for authentication in Cassandra.
+         */
         String login();
 
+        /**
+         * @return Password for authentication in Cassandra.
+         */
         String password();
     }
 
@@ -45,6 +63,9 @@ public interface CassandraConfig {
     interface Profile {
         @ConfigValueExtractor
         interface ProfileBasic extends Basic {
+            /**
+             * @return Cassandra node addresses, which can not be overridden per profile and are always taken from the root configuration.
+             */
             @Override
             @Nullable
             default List<String> contactPoints() {
@@ -52,60 +73,108 @@ public interface CassandraConfig {
             }
         }
 
+        /**
+         * @return Basic driver settings overridden by this profile.
+         */
         ProfileBasic basic();
 
+        /**
+         * @return Advanced driver settings overridden by this profile.
+         */
         @Nullable
         Advanced advanced();
     }
 
     @ConfigValueExtractor
     interface Basic {
+        /**
+         * @return Regular request execution settings such as timeout, consistency level and page size.
+         */
         @Nullable
         BasicRequestConfig request();
 
+        /**
+         * @return Driver session name used in logs, metrics and diagnostics.
+         */
         @Nullable
         String sessionName();
 
+        /**
+         * @return Cassandra node addresses in host:port format.
+         */
         List<String> contactPoints();
 
+        /**
+         * @return Local datacenter for the load balancing policy.
+         */
         @Nullable
         String dc();
 
+        /**
+         * @return Keyspace that is set for the session after connection.
+         */
         @Nullable
         String sessionKeyspace();
 
+        /**
+         * @return Basic load balancing policy settings.
+         */
         @Nullable
         LoadBalancingPolicyConfig loadBalancingPolicy();
 
+        /**
+         * @return Settings for connecting to DataStax Astra or cloud Cassandra.
+         */
         @Nullable
         CloudConfig cloud();
 
         @ConfigValueExtractor
         interface BasicRequestConfig {
+            /**
+             * @return Regular request execution timeout.
+             */
             @Nullable
             Duration timeout();
 
+            /**
+             * @return Regular request consistency level, for example ONE, LOCAL_ONE, LOCAL_QUORUM, QUORUM or ALL.
+             */
             @Nullable
             String consistency();
 
+            /**
+             * @return Result page size, meaning the maximum number of rows requested in one network round trip.
+             */
             @Nullable
             Integer pageSize();
 
+            /**
+             * @return Serial consistency level for lightweight transactions (LWT), either SERIAL or LOCAL_SERIAL.
+             */
             @Nullable
             String serialConsistency();
 
+            /**
+             * @return Default request idempotence that defines whether retries and speculative execution can be applied safely.
+             */
             @Nullable
             Boolean defaultIdempotence();
         }
 
         @ConfigValueExtractor
         interface LoadBalancingPolicyConfig {
+            /**
+             * @return Enables slow replica avoidance in the default load balancing policy.
+             */
             @Nullable
             Boolean slowReplicaAvoidance();
         }
 
         @ConfigValueExtractor
         interface CloudConfig {
+            /**
+             * @return Path or URL to the Secure Connect Bundle for connecting to DataStax Astra or cloud Cassandra.
+             */
             @Nullable
             String secureConnectBundle();
         }
@@ -113,78 +182,147 @@ public interface CassandraConfig {
 
     @ConfigValueExtractor
     interface Advanced {
+        /**
+         * @return Driver session leak detection settings.
+         */
         @Nullable
         SessionLeakConfig sessionLeak();
 
+        /**
+         * @return Node connection and connection pool settings.
+         */
         @Nullable
         ConnectionConfig connection();
 
+        /**
+         * @return Allows initialization retry when none of the contact points answer during startup.
+         */
         @Nullable
         Boolean reconnectOnInit();
 
+        /**
+         * @return Reconnection policy delay settings.
+         */
         @Nullable
         ReconnectionPolicyConfig reconnectionPolicy();
 
+        /**
+         * @return Advanced load balancing policy settings such as remote datacenter failover.
+         */
         @Nullable
         AdvancedLoadBalancingPolicyConfig loadBalancingPolicy();
 
+        /**
+         * @return SSL/TLS settings for connections to Cassandra.
+         */
         @Nullable
         SslEngineFactoryConfig sslEngineFactory();
 
+        /**
+         * @return Query timestamp generator settings.
+         */
         @Nullable
         TimestampGeneratorConfig timestampGenerator();
 
+        /**
+         * @return Cassandra binary protocol settings.
+         */
         @Nullable
         ProtocolConfig protocol();
 
+        /**
+         * @return Advanced request execution settings such as query tracing and warning logging.
+         */
         @Nullable
         AdvancedRequestConfig request();
 
+        /**
+         * @return Driver metrics settings.
+         */
         MetricsConfig metrics();
 
+        /**
+         * @return TCP socket settings for connections to Cassandra.
+         */
         @Nullable
         SocketConfig socket();
 
+        /**
+         * @return Heartbeat settings for idle connections.
+         */
         @Nullable
         HeartBeatConfig heartbeat();
 
+        /**
+         * @return Schema and cluster topology metadata settings.
+         */
         @Nullable
         MetadataConfig metadata();
 
+        /**
+         * @return Service control connection settings.
+         */
         @Nullable
         ControlConnectionConfig controlConnection();
 
+        /**
+         * @return Prepared statement preparation and caching settings.
+         */
         @Nullable
         PreparedStatementsConfig preparedStatements();
 
+        /**
+         * @return Netty thread group and timer settings of the driver.
+         */
         @Nullable
         NettyConfig netty();
 
+        /**
+         * @return Message coalescing settings applied before sending.
+         */
         @Nullable
         CoalescerConfig coalescer();
 
+        /**
+         * @return Allows the driver to resolve contact points through DNS during startup.
+         */
         @Nullable
         Boolean resolveContactPoints();
 
+        /**
+         * @return Driver request throttler settings.
+         */
         @Nullable
         ThrottlerConfig throttler();
 
         @ConfigValueExtractor
         interface SessionLeakConfig {
+            /**
+             * @return Driver session leak warning threshold.
+             */
             @Nullable
             Integer threshold();
         }
 
         @ConfigValueExtractor
         interface AdvancedLoadBalancingPolicyConfig {
+            /**
+             * @return Failover settings for remote datacenter nodes.
+             */
             @Nullable
             DcFailover dcFailover();
 
             @ConfigValueExtractor
             interface DcFailover {
+                /**
+                 * @return Maximum number of remote datacenter nodes that can be used for failover.
+                 */
                 @Nullable
                 Integer maxNodesPerRemoveDc();
 
+                /**
+                 * @return Allows failover to a remote datacenter for local consistency levels.
+                 */
                 @Nullable
                 Boolean allowForLocalConsistencyLevels();
             }
@@ -192,32 +330,59 @@ public interface CassandraConfig {
 
         @ConfigValueExtractor
         interface ConnectionConfig {
+            /**
+             * @return Timeout for opening a network connection to a node.
+             */
             @Nullable
             Duration connectTimeout();
 
+            /**
+             * @return Timeout for requests that the driver executes while initializing a connection.
+             */
             @Nullable
             Duration initQueryTimeout();
 
+            /**
+             * @return Timeout for setting the keyspace on a connection.
+             */
             @Nullable
             Duration setKeyspaceTimeout();
 
+            /**
+             * @return Maximum number of simultaneous requests per connection.
+             */
             @Nullable
             Integer maxRequestsPerConnection();
 
+            /**
+             * @return Maximum number of requests whose response is no longer awaited but may still complete inside the driver.
+             */
             @Nullable
             Integer maxOrphanRequests();
 
+            /**
+             * @return Logs a warning when connection initialization fails for an individual node.
+             */
             @Nullable
             Boolean warnOnInitError();
 
+            /**
+             * @return Connection pool size settings.
+             */
             @Nullable
             PoolConfig pool();
 
             @ConfigValueExtractor
             interface PoolConfig {
+                /**
+                 * @return Connection pool size for local datacenter nodes.
+                 */
                 @Nullable
                 Integer localSize();
 
+                /**
+                 * @return Connection pool size for remote nodes.
+                 */
                 @Nullable
                 Integer remoteSize();
             }
@@ -225,47 +390,83 @@ public interface CassandraConfig {
 
         @ConfigValueExtractor
         interface ReconnectionPolicyConfig {
+            /**
+             * @return Initial delay of the reconnection policy.
+             */
             @Nullable
             Duration baseDelay();
 
+            /**
+             * @return Maximum delay of the reconnection policy.
+             */
             @Nullable
             Duration maxDelay();
         }
 
         @ConfigValueExtractor
         interface SslEngineFactoryConfig {
+            /**
+             * @return Allowed cipher suites for SSL/TLS.
+             */
             @Nullable
             List<String> cipherSuites();
 
+            /**
+             * @return Checks that the node hostname matches the SSL/TLS certificate.
+             */
             @Nullable
             Boolean hostnameValidation();
 
+            /**
+             * @return Path to the client keystore.
+             */
             @Nullable
             String keystorePath();
 
+            /**
+             * @return Client keystore password.
+             */
             @Nullable
             String keystorePassword();
 
+            /**
+             * @return Path to the truststore.
+             */
             @Nullable
             String truststorePath();
 
+            /**
+             * @return Truststore password.
+             */
             @Nullable
             String truststorePassword();
         }
 
         @ConfigValueExtractor
         interface TimestampGeneratorConfig {
+            /**
+             * @return Forces Java system clock usage for query timestamp generation.
+             */
             @Nullable
             Boolean forceJavaClock();
 
+            /**
+             * @return Timestamp drift warning settings.
+             */
             @Nullable
             DriftWarningConfig driftWarning();
 
             @ConfigValueExtractor
             interface DriftWarningConfig {
+                /**
+                 * @return Warning threshold for timestamp drift into the future.
+                 */
                 @Nullable
                 Duration threshold();
 
+                /**
+                 * @return Minimum interval between timestamp drift warnings.
+                 */
                 @Nullable
                 Duration interval();
             }
@@ -273,35 +474,62 @@ public interface CassandraConfig {
 
         @ConfigValueExtractor
         interface ProtocolConfig {
+            /**
+             * @return Cassandra binary protocol version, for example V4.
+             */
             @Nullable
             String version();
 
+            /**
+             * @return Protocol compression algorithm, for example lz4 or snappy.
+             */
             @Nullable
             String compression();
 
+            /**
+             * @return Maximum protocol frame size in bytes.
+             */
             @Nullable
             Long maxFrameLength();
         }
 
         @ConfigValueExtractor
         interface AdvancedRequestConfig {
+            /**
+             * @return Logs a warning when a query explicitly changes the keyspace.
+             */
             @Nullable
             Boolean warnIfSetKeyspace();
 
+            /**
+             * @return Settings for fetching query tracing information.
+             */
             @Nullable
             TraceConfig trace();
 
+            /**
+             * @return Logs warnings returned by Cassandra along with a query response.
+             */
             @Nullable
             Boolean logWarnings();
 
             @ConfigValueExtractor
             interface TraceConfig {
+                /**
+                 * @return Number of attempts to fetch query tracing information from Cassandra.
+                 */
                 @Nullable
                 Integer attempts();
 
+                /**
+                 * @return Interval between attempts to fetch query tracing information.
+                 */
                 @Nullable
                 Duration interval();
 
+                /**
+                 * @return Consistency level for queries to tracing tables.
+                 */
                 @Nullable
                 String consistency();
             }
@@ -310,14 +538,26 @@ public interface CassandraConfig {
         @ConfigValueExtractor
         interface MetricsConfig {
 
+            /**
+             * @return Driver metric identifier generator settings.
+             */
             IdGenerator idGenerator();
 
+            /**
+             * @return Node level driver metrics settings.
+             */
             @Nullable
             NodeConfig node();
 
+            /**
+             * @return Session level driver metrics settings.
+             */
             @Nullable
             SessionConfig session();
 
+            /**
+             * @return Publishes percentile histograms for driver metrics.
+             */
             default boolean publishPercentileHistogram() {
                 return false;
             }
@@ -325,10 +565,16 @@ public interface CassandraConfig {
             @ConfigValueExtractor
             interface IdGenerator {
 
+                /**
+                 * @return Driver metric identifier generator name.
+                 */
                 default String name() {
                     return "TaggingMetricIdGenerator";
                 }
 
+                /**
+                 * @return Driver metric name prefix.
+                 */
                 @Nullable
                 String prefix();
             }
@@ -351,6 +597,9 @@ public interface CassandraConfig {
                     );
                 }
 
+                /**
+                 * @return Histogram settings of the node level cqlMessages metric.
+                 */
                 Config cqlMessages();
             }
 
@@ -371,28 +620,49 @@ public interface CassandraConfig {
                     );
                 }
 
+                /**
+                 * @return Histogram settings of the session level cqlRequests metric.
+                 */
                 Config cqlRequests();
 
+                /**
+                 * @return Histogram settings of the session level throttlingDelay metric.
+                 */
                 Config throttlingDelay();
             }
 
             @ConfigValueExtractor
             interface Config {
 
+                /**
+                 * @return Lowest expected latency of the metric histogram.
+                 */
                 default Duration lowestLatency() {
                     return Duration.ofMillis(1);
                 }
 
+                /**
+                 * @return Highest expected latency of the metric histogram.
+                 */
                 default Duration highestLatency() {
                     return Duration.ofSeconds(90);
                 }
 
+                /**
+                 * @return Number of significant digits of the metric histogram.
+                 */
                 @Nullable
                 Integer significantDigits();
 
+                /**
+                 * @return Snapshot refresh interval of the metric histogram.
+                 */
                 @Nullable
                 Duration refreshInterval();
 
+                /**
+                 * @return SLO boundaries of the metric.
+                 */
                 default double[] slo() {
                     return TelemetryConfig.MetricsConfig.DEFAULT_SLO;
                 }
@@ -401,67 +671,121 @@ public interface CassandraConfig {
 
         @ConfigValueExtractor
         interface SocketConfig {
+            /**
+             * @return Enables TCP_NODELAY, which disables the Nagle algorithm.
+             */
             @Nullable
             Boolean tcpNoDelay();
 
+            /**
+             * @return Enables SO_KEEPALIVE for TCP sockets.
+             */
             @Nullable
             Boolean keepAlive();
 
+            /**
+             * @return Enables SO_REUSEADDR for TCP sockets.
+             */
             @Nullable
             Boolean reuseAddress();
 
+            /**
+             * @return SO_LINGER value for TCP sockets.
+             */
             @Nullable
             Integer lingerInterval();
 
+            /**
+             * @return TCP socket receive buffer size in bytes.
+             */
             @Nullable
             Integer receiveBufferSize();
 
+            /**
+             * @return TCP socket send buffer size in bytes.
+             */
             @Nullable
             Integer sendBufferSize();
         }
 
         @ConfigValueExtractor
         interface HeartBeatConfig {
+            /**
+             * @return Interval for sending a heartbeat over an idle connection.
+             */
             @Nullable
             Duration interval();
 
+            /**
+             * @return Timeout for waiting for a heartbeat response.
+             */
             @Nullable
             Duration timeout();
         }
 
         @ConfigValueExtractor
         interface MetadataConfig {
+            /**
+             * @return Schema metadata loading and refresh settings.
+             */
             @Nullable
             SchemaConfig schema();
 
+            /**
+             * @return Coalescing settings for cluster topology change events.
+             */
             @Nullable
             TopologyConfig topologyEventDebouncer();
 
+            /**
+             * @return Enables the token map used for routing requests by data owners.
+             */
             @Nullable
             Boolean tokenMapEnabled();
 
             @ConfigValueExtractor
             interface SchemaConfig {
+                /**
+                 * @return Enables schema metadata loading and refresh.
+                 */
                 @Nullable
                 Boolean enabled();
 
+                /**
+                 * @return Timeout for schema metadata queries.
+                 */
                 @Nullable
                 Duration requestTimeout();
 
+                /**
+                 * @return Page size for schema metadata queries.
+                 */
                 @Nullable
                 Integer requestPageSize();
 
+                /**
+                 * @return Keyspace names whose schema metadata is refreshed by the driver.
+                 */
                 @Nullable
                 List<String> refreshedKeyspaces();
 
+                /**
+                 * @return Coalescing settings for schema refresh events.
+                 */
                 @Nullable
                 DebouncerConfig debouncer();
 
                 @ConfigValueExtractor
                 interface DebouncerConfig {
+                    /**
+                     * @return Window for coalescing schema refresh events before processing.
+                     */
                     @Nullable
                     Duration window();
 
+                    /**
+                     * @return Maximum number of schema refresh events that can be accumulated in the window.
+                     */
                     @Nullable
                     Integer maxEvents();
                 }
@@ -469,9 +793,15 @@ public interface CassandraConfig {
 
             @ConfigValueExtractor
             interface TopologyConfig {
+                /**
+                 * @return Window for coalescing cluster topology change events before processing.
+                 */
                 @Nullable
                 Duration window();
 
+                /**
+                 * @return Maximum number of topology change events that can be accumulated in the window.
+                 */
                 @Nullable
                 Integer maxEvents();
             }
@@ -479,20 +809,35 @@ public interface CassandraConfig {
 
         @ConfigValueExtractor
         interface ControlConnectionConfig {
+            /**
+             * @return Service control connection timeout.
+             */
             @Nullable
             Duration timeout();
 
+            /**
+             * @return Schema agreement check settings between nodes.
+             */
             @Nullable
             SchemaAgreementConfig schemaAgreement();
 
             @ConfigValueExtractor
             interface SchemaAgreementConfig {
+                /**
+                 * @return Interval for checking schema agreement between nodes.
+                 */
                 @Nullable
                 Duration interval();
 
+                /**
+                 * @return Maximum time to wait for schema agreement.
+                 */
                 @Nullable
                 Duration timeout();
 
+                /**
+                 * @return Logs a warning if schema agreement is not reached in time.
+                 */
                 @Nullable
                 Boolean warnOnFailure();
             }
@@ -500,35 +845,62 @@ public interface CassandraConfig {
 
         @ConfigValueExtractor
         interface PreparedStatementsConfig {
+            /**
+             * @return Prepares a statement on all nodes after it has been prepared successfully on one node.
+             */
             @Nullable
             Boolean prepareOnAllNodes();
 
+            /**
+             * @return Statement re-preparation settings for a node that became available again.
+             */
             @Nullable
             ReprepareConfig reprepareOnUp();
 
+            /**
+             * @return Prepared statement cache settings.
+             */
             @Nullable
             PreparedCacheConfig preparedCache();
 
             @ConfigValueExtractor
             interface ReprepareConfig {
+                /**
+                 * @return Re-prepares statements on a node that became available again.
+                 */
                 @Nullable
                 Boolean enabled();
 
+                /**
+                 * @return Checks the system.prepared_statements system table before re-preparing a statement.
+                 */
                 @Nullable
                 Boolean checkSystemTable();
 
+                /**
+                 * @return Maximum number of statements to re-prepare, where 0 means no driver side limit.
+                 */
                 @Nullable
                 Integer maxStatements();
 
+                /**
+                 * @return Maximum number of parallel re-prepare requests.
+                 */
                 @Nullable
                 Integer maxParallelism();
 
+                /**
+                 * @return Timeout for re-preparing statements on one node.
+                 */
                 @Nullable
                 Duration timeout();
             }
 
             @ConfigValueExtractor
             interface PreparedCacheConfig {
+                /**
+                 * @return Stores prepared statement cache values through weak references.
+                 */
                 @Nullable
                 Boolean weakValues();
             }
@@ -536,53 +908,92 @@ public interface CassandraConfig {
 
         @ConfigValueExtractor
         interface NettyConfig {
+            /**
+             * @return Netty thread group settings for network I/O.
+             */
             @Nullable
             IoGroupConfig ioGroup();
 
+            /**
+             * @return Netty thread group settings for driver administrative tasks.
+             */
             @Nullable
             AdminGroupConfig adminGroup();
 
+            /**
+             * @return Netty timer settings for delayed driver tasks.
+             */
             @Nullable
             TimerConfig timer();
 
+            /**
+             * @return Makes Netty threads daemon threads.
+             */
             @Nullable
             Boolean daemon();
 
             @ConfigValueExtractor
             interface IoGroupConfig {
+                /**
+                 * @return Number of Netty threads for network I/O, where 0 lets the driver choose automatically.
+                 */
                 @Nullable
                 Integer size();
 
+                /**
+                 * @return Graceful shutdown settings of the network I/O thread group.
+                 */
                 @Nullable
                 ShutdownConfig shutdown();
             }
 
             @ConfigValueExtractor
             interface AdminGroupConfig {
+                /**
+                 * @return Number of Netty threads for driver administrative tasks.
+                 */
                 @Nullable
                 Integer size();
 
+                /**
+                 * @return Graceful shutdown settings of the administrative thread group.
+                 */
                 @Nullable
                 ShutdownConfig shutdown();
             }
 
             @ConfigValueExtractor
             interface ShutdownConfig {
+                /**
+                 * @return Quiet period for graceful thread group shutdown.
+                 */
                 @Nullable
                 Integer quietPeriod();
 
+                /**
+                 * @return Maximum wait time for thread group shutdown.
+                 */
                 @Nullable
                 Integer timeout();
 
+                /**
+                 * @return Time unit of the thread group shutdown parameters.
+                 */
                 @Nullable
                 String unit();
             }
 
             @ConfigValueExtractor
             interface TimerConfig {
+                /**
+                 * @return Duration of one Netty timer tick for delayed driver tasks.
+                 */
                 @Nullable
                 Duration tickDuration();
 
+                /**
+                 * @return Number of ticks in the Netty timer wheel.
+                 */
                 @Nullable
                 Integer ticksPerWheel();
             }
@@ -590,24 +1001,42 @@ public interface CassandraConfig {
 
         @ConfigValueExtractor
         interface CoalescerConfig {
+            /**
+             * @return Rescheduling interval for message coalescing before sending.
+             */
             @Nullable
             Duration rescheduleInterval();
         }
 
         @ConfigValueExtractor
         interface ThrottlerConfig {
+            /**
+             * @return Driver request throttler class.
+             */
             @Nullable
             String throttlerClass();
 
+            /**
+             * @return Maximum number of concurrent requests for the throttler.
+             */
             @Nullable
             Integer maxConcurrentRequests();
 
+            /**
+             * @return Maximum number of requests per second for the throttler.
+             */
             @Nullable
             Integer maxRequestsPerSecond();
 
+            /**
+             * @return Maximum throttler request queue size.
+             */
             @Nullable
             Integer maxQueueSize();
 
+            /**
+             * @return Interval at which the throttler releases requests from the queue.
+             */
             @Nullable
             Duration drainInterval();
         }

--- a/database/database-flyway/src/main/java/ru/tinkoff/kora/database/flyway/FlywayConfig.java
+++ b/database/database-flyway/src/main/java/ru/tinkoff/kora/database/flyway/FlywayConfig.java
@@ -8,26 +8,44 @@ import java.util.Map;
 @ConfigValueExtractor
 public interface FlywayConfig {
 
+    /**
+     * @return Whether to execute migrations during JdbcDatabase initialization.
+     */
     default boolean enabled() {
         return true;
     }
 
+    /**
+     * @return Paths to directories with migration scripts.
+     */
     default List<String> locations() {
         return List.of("db/migration");
     }
 
+    /**
+     * @return Whether to execute migrations inside a transaction when supported by the database and the SQL operations themselves.
+     */
     default boolean executeInTransaction() {
         return true;
     }
 
+    /**
+     * @return Whether to validate checksums of already applied migrations before executing new ones.
+     */
     default boolean validateOnMigrate() {
         return true;
     }
 
+    /**
+     * @return Whether to allow mixing transactional and non-transactional SQL operations in one migration, executing the whole migration without a transaction.
+     */
     default boolean mixed() {
         return false;
     }
 
+    /**
+     * @return Additional Flyway key-value properties for settings that have no separate Kora configuration option.
+     */
     default Map<String, String> configurationProperties() {
         return Map.of();
     }

--- a/database/database-jdbc/src/main/java/ru/tinkoff/kora/database/jdbc/JdbcDatabaseConfig.java
+++ b/database/database-jdbc/src/main/java/ru/tinkoff/kora/database/jdbc/JdbcDatabaseConfig.java
@@ -16,56 +16,104 @@ import java.util.Properties;
  */
 @ConfigValueExtractor
 public interface JdbcDatabaseConfig {
+    /**
+     * @return Username for the database connection.
+     */
     String username();
 
+    /**
+     * @return User password for the database connection.
+     */
     String password();
 
+    /**
+     * @return JDBC URL for connecting to the database.
+     */
     String jdbcUrl();
 
+    /**
+     * @return Hikari connection pool name.
+     */
     String poolName();
 
+    /**
+     * @return Database schema for the connection.
+     */
     @Nullable
     String schema();
 
+    /**
+     * @return Maximum time to wait for a connection from the Hikari pool.
+     */
     default Duration connectionTimeout() {
         return Duration.ofSeconds(10);
     }
 
+    /**
+     * @return Maximum time for Hikari connection validation.
+     */
     default Duration validationTimeout() {
         return Duration.ofSeconds(5);
     }
 
+    /**
+     * @return Maximum idle time for a Hikari connection.
+     */
     default Duration idleTimeout() {
         return Duration.ofMinutes(10);
     }
 
+    /**
+     * @return Maximum lifetime of a Hikari connection.
+     */
     default Duration maxLifetime() {
         return Duration.ofMinutes(15);
     }
 
+    /**
+     * @return Time after which a busy connection is considered a possible leak.
+     */
     default Duration leakDetectionThreshold() {
         return Duration.ofSeconds(0);
     }
 
+    /**
+     * @return Maximum Hikari connection pool size.
+     */
     default int maxPoolSize() {
         return 10;
     }
 
+    /**
+     * @return Minimum number of idle ready connections in the Hikari pool.
+     */
     default int minIdle() {
         return 0;
     }
 
+    /**
+     * @return Maximum time to wait for connection initialization at service startup.
+     */
     @Nullable
     Duration initializationFailTimeout();
 
+    /**
+     * @return Whether to enable the readiness probe for the database connection.
+     */
     default boolean readinessProbe() {
         return false;
     }
 
+    /**
+     * @return Additional JDBC connection properties passed to Hikari dataSourceProperties.
+     */
     default Properties dsProperties() {
         return new Properties();
     }
 
+    /**
+     * @return Telemetry configuration for logging, metrics and tracing of database queries.
+     */
     TelemetryConfig telemetry();
 
     static HikariConfig toHikariConfig(JdbcDatabaseConfig config) {

--- a/database/database-liquibase/src/main/java/ru/tinkoff/kora/database/liquibase/LiquibaseConfig.java
+++ b/database/database-liquibase/src/main/java/ru/tinkoff/kora/database/liquibase/LiquibaseConfig.java
@@ -6,6 +6,9 @@ import ru.tinkoff.kora.config.common.annotation.ConfigValueExtractor;
 @ConfigValueExtractor
 public interface LiquibaseConfig {
 
+    /**
+     * @return Path to the main changelog file with migration definitions.
+     */
     default String changelog() {
         return "db/changelog/db.changelog-master.xml";
     }

--- a/database/database-r2dbc/src/main/java/ru/tinkoff/kora/database/r2dbc/R2dbcDatabaseConfig.java
+++ b/database/database-r2dbc/src/main/java/ru/tinkoff/kora/database/r2dbc/R2dbcDatabaseConfig.java
@@ -16,52 +16,97 @@ import java.util.Map;
  */
 @ConfigValueExtractor
 public interface R2dbcDatabaseConfig {
+    /**
+     * @return R2DBC URL for connecting to the database.
+     */
     String r2dbcUrl();
 
+    /**
+     * @return Username for the connection.
+     */
     String username();
 
+    /**
+     * @return User password for the connection.
+     */
     String password();
 
+    /**
+     * @return Connection pool name.
+     */
     String poolName();
 
+    /**
+     * @return Maximum time to acquire a connection from the pool.
+     */
     default Duration connectionTimeout() {
         return Duration.ofSeconds(10);
     }
 
+    /**
+     * @return Maximum time to create a new physical connection.
+     */
     default Duration connectionCreateTimeout() {
         return Duration.ofSeconds(30);
     }
 
+    /**
+     * @return Maximum time to execute a query on the database.
+     */
     @Nullable
     Duration statementTimeout();
 
+    /**
+     * @return Maximum idle time for a connection.
+     */
     default Duration idleTimeout() {
         return Duration.ofMinutes(10);
     }
 
+    /**
+     * @return Maximum lifetime of a connection, zero means no limit.
+     */
     default Duration maxLifetime() {
         return ConnectionPoolConfiguration.NO_TIMEOUT;
     }
 
+    /**
+     * @return Maximum number of attempts to acquire a connection.
+     */
     default int acquireRetry() {
         return 3;
     }
 
+    /**
+     * @return Maximum connection pool size.
+     */
     default int maxPoolSize() {
         return 10;
     }
 
+    /**
+     * @return Minimum number of idle ready connections in the pool.
+     */
     default int minIdle() {
         return 0;
     }
 
+    /**
+     * @return Whether to enable the readiness probe for the database connection.
+     */
     default boolean readinessProbe() {
         return false;
     }
 
+    /**
+     * @return Additional R2DBC connection options passed to the driver.
+     */
     default Map<String, String> options() {
         return Map.of();
     }
 
+    /**
+     * @return Telemetry configuration of logging, metrics and tracing for database queries.
+     */
     TelemetryConfig telemetry();
 }

--- a/database/database-vertx/src/main/java/ru/tinkoff/kora/database/vertx/VertxDatabaseConfig.java
+++ b/database/database-vertx/src/main/java/ru/tinkoff/kora/database/vertx/VertxDatabaseConfig.java
@@ -18,37 +18,70 @@ import java.util.Objects;
 @ConfigValueExtractor
 public interface VertxDatabaseConfig {
 
+    /**
+     * @return Connection URI for the database.
+     */
     String connectionUri();
 
+    /**
+     * @return Username for the connection.
+     */
     String username();
 
+    /**
+     * @return User password for the connection.
+     */
     String password();
 
+    /**
+     * @return Connection pool name.
+     */
     String poolName();
 
+    /**
+     * @return Maximum time to establish a physical connection.
+     */
     default Duration connectionTimeout() {
         return Duration.ofSeconds(10);
     }
 
+    /**
+     * @return Maximum idle time for a connection.
+     */
     default Duration idleTimeout() {
         return Duration.ofMinutes(10);
     }
 
+    /**
+     * @return Maximum time to acquire a connection from the pool, connection timeout is used when not specified.
+     */
     @Nullable
     Duration acquireTimeout();
 
+    /**
+     * @return Maximum connection pool size.
+     */
     default int maxPoolSize() {
         return 10;
     }
 
+    /**
+     * @return Whether to cache prepared statements.
+     */
     default boolean cachePreparedStatements() {
         return true;
     }
 
+    /**
+     * @return Whether to enable the readiness probe for the database connection.
+     */
     default boolean readinessProbe() {
         return false;
     }
 
+    /**
+     * @return Maximum time to wait for a connection check at service startup, no check is performed when not specified.
+     */
     @Nullable
     Duration initializationFailTimeout();
 
@@ -73,5 +106,8 @@ public interface VertxDatabaseConfig {
                 .setMaxSize(config.maxPoolSize());
     }
 
+    /**
+     * @return Telemetry configuration of logging, metrics and tracing for database queries.
+     */
     TelemetryConfig telemetry();
 }

--- a/experimental/camunda-engine-bpmn/src/main/java/ru/tinkoff/kora/camunda/engine/bpmn/CamundaEngineBpmnConfig.java
+++ b/experimental/camunda-engine-bpmn/src/main/java/ru/tinkoff/kora/camunda/engine/bpmn/CamundaEngineBpmnConfig.java
@@ -10,25 +10,46 @@ import java.util.List;
 @ConfigValueExtractor
 public interface CamundaEngineBpmnConfig {
 
+    /**
+     * @return Parallel engine initialization configuration.
+     */
     ParallelInitConfig parallelInitialization();
 
+    /**
+     * @return JobExecutor configuration.
+     */
     JobExecutorConfig jobExecutor();
 
+    /**
+     * @return Automatic BPMN / FORM / DMN resource deployment configuration.
+     */
     @Nullable
     DeploymentConfig deployment();
 
+    /**
+     * @return Camunda administrator user configuration.
+     */
     @Nullable
     AdminConfig admin();
 
+    /**
+     * @return Telemetry configuration of the module.
+     */
     CamundaTelemetryConfig telemetry();
 
     @ConfigValueExtractor
     interface ParallelInitConfig {
 
+        /**
+         * @return Whether parallel engine initialization is enabled.
+         */
         default boolean enabled() {
             return true;
         }
 
+        /**
+         * @return Whether incomplete engine statements are validated during parallel initialization.
+         */
         default boolean validateIncompleteStatements() {
             return true;
         }
@@ -37,16 +58,31 @@ public interface CamundaEngineBpmnConfig {
     @ConfigValueExtractor
     interface AdminConfig {
 
+        /**
+         * @return Camunda administrator identifier.
+         */
         String id();
 
+        /**
+         * @return Camunda administrator password.
+         */
         String password();
 
+        /**
+         * @return Camunda administrator first name, uppercase identifier is used when not specified.
+         */
         @Nullable
         String firstname();
 
+        /**
+         * @return Camunda administrator last name, uppercase identifier is used when not specified.
+         */
         @Nullable
         String lastname();
 
+        /**
+         * @return Camunda administrator email address.
+         */
         @Nullable
         String email();
     }
@@ -54,25 +90,43 @@ public interface CamundaEngineBpmnConfig {
     @ConfigValueExtractor
     interface FilterConfig {
 
+        /**
+         * @return Name of the Camunda filter to create.
+         */
         String create();
     }
 
     @ConfigValueExtractor
     interface DeploymentConfig {
 
+        /**
+         * @return Tenant identifier the deployment is bound to.
+         */
         @Nullable
         String tenantId();
 
+        /**
+         * @return Resource deployment name.
+         */
         default String name() {
             return "KoraEngineAutoDeployment";
         }
 
+        /**
+         * @return Whether only changed resources are deployed through Camunda duplicate filtering.
+         */
         default boolean deployChangedOnly() {
             return true;
         }
 
+        /**
+         * @return Paths where BPMN / FORM / DMN resources are searched for, only the classpath: prefix is supported.
+         */
         List<String> resources();
 
+        /**
+         * @return Delay before deploying resources to the engine.
+         */
         @Nullable
         Duration delay();
     }
@@ -80,22 +134,37 @@ public interface CamundaEngineBpmnConfig {
     @ConfigValueExtractor
     interface JobExecutorConfig {
 
+        /**
+         * @return Minimum number of permanently alive threads in the JobExecutor.
+         */
         default Integer corePoolSize() {
             return 5;
         }
 
+        /**
+         * @return Maximum number of threads in the JobExecutor.
+         */
         default Integer maxPoolSize() {
             return 25;
         }
 
+        /**
+         * @return JobExecutor task queue size before new tasks are rejected.
+         */
         default Integer queueSize() {
             return 25;
         }
 
+        /**
+         * @return Maximum number of jobs acquired by the JobExecutor in one request.
+         */
         default Integer maxJobsPerAcquisition() {
             return Runtime.getRuntime().availableProcessors() * 2;
         }
 
+        /**
+         * @return Whether virtual threads are used as the JobExecutor base, making pool and queue size settings unused.
+         */
         default boolean virtualThreadsEnabled() {
             return false;
         }
@@ -104,12 +173,21 @@ public interface CamundaEngineBpmnConfig {
     @ConfigValueExtractor
     interface CamundaTelemetryConfig extends TelemetryConfig {
 
+        /**
+         * @return Logging telemetry configuration.
+         */
         @Override
         CamundaEngineLogConfig logging();
 
+        /**
+         * @return Tracing telemetry configuration.
+         */
         @Override
         TracingConfig tracing();
 
+        /**
+         * @return Whether the built-in Camunda engine telemetry collection is enabled.
+         */
         default boolean engineTelemetryEnabled() {
             return false;
         }
@@ -118,6 +196,9 @@ public interface CamundaEngineBpmnConfig {
     @ConfigValueExtractor
     interface CamundaEngineLogConfig extends TelemetryConfig.LogConfig {
 
+        /**
+         * @return Whether error stack traces are logged.
+         */
         default boolean stacktrace() {
             return true;
         }
@@ -126,6 +207,9 @@ public interface CamundaEngineBpmnConfig {
     @ConfigValueExtractor
     interface CamundaEngineTelemetryConfig extends TelemetryConfig.LogConfig {
 
+        /**
+         * @return Whether error stack traces are logged.
+         */
         default boolean stacktrace() {
             return true;
         }

--- a/experimental/camunda-rest-undertow/src/main/java/ru/tinkoff/kora/camunda/rest/CamundaRestConfig.java
+++ b/experimental/camunda-rest-undertow/src/main/java/ru/tinkoff/kora/camunda/rest/CamundaRestConfig.java
@@ -12,31 +12,55 @@ import java.util.Set;
 @ConfigValueExtractor
 public interface CamundaRestConfig {
 
+    /**
+     * @return Whether the Camunda 7 REST API is enabled.
+     */
     default boolean enabled() {
         return false;
     }
 
+    /**
+     * @return Path prefix of the Camunda 7 REST API.
+     */
     default String path() {
         return "/engine-rest";
     }
 
+    /**
+     * @return Port of the separate Undertow HTTP server serving the REST API.
+     */
     default Integer port() {
         return 8081;
     }
 
+    /**
+     * @return Maximum time to wait for the HTTP server graceful shutdown.
+     */
     default Duration shutdownWait() {
         return Duration.ofSeconds(30);
     }
 
+    /**
+     * @return OpenAPI, Swagger UI and RapiDoc serving configuration.
+     */
     CamundaOpenApiConfig openapi();
 
+    /**
+     * @return CORS filter configuration.
+     */
     CamundaCorsConfig cors();
 
+    /**
+     * @return Telemetry configuration of the module.
+     */
     CamundaRestTelemetryConfig telemetry();
 
     @ConfigValueExtractor
     interface CamundaRestTelemetryConfig extends TelemetryConfig {
 
+        /**
+         * @return Logging telemetry configuration.
+         */
         @Override
         CamundaRestLoggerConfig logging();
     }
@@ -44,22 +68,37 @@ public interface CamundaRestConfig {
     @ConfigValueExtractor
     interface CamundaRestLoggerConfig extends TelemetryConfig.LogConfig {
 
+        /**
+         * @return Whether stack traces are logged when an exception occurs.
+         */
         default boolean stacktrace() {
             return true;
         }
 
+        /**
+         * @return Request query parameters hidden in logs.
+         */
         default Set<String> maskQueries() {
             return Collections.emptySet();
         }
 
+        /**
+         * @return Request and response headers hidden in logs.
+         */
         default Set<String> maskHeaders() {
             return Set.of("authorization");
         }
 
+        /**
+         * @return Mask used to hide the specified headers and query parameters.
+         */
         default String mask() {
             return "***";
         }
 
+        /**
+         * @return Whether the path template is logged instead of the full path, when not specified the full path is used only at TRACE level.
+         */
         @Nullable
         Boolean pathTemplate();
     }
@@ -67,29 +106,50 @@ public interface CamundaRestConfig {
     @ConfigValueExtractor
     interface CamundaOpenApiConfig {
 
+        /**
+         * @return Paths to the OpenAPI files in resources.
+         */
         default List<String> file() {
             return List.of("openapi.json");
         }
 
+        /**
+         * @return Whether the controller serving the OpenAPI file is enabled.
+         */
         default boolean enabled() {
             return false;
         }
 
+        /**
+         * @return Path where the OpenAPI file is available.
+         */
         default String endpoint() {
             return "/openapi";
         }
 
+        /**
+         * @return Swagger UI serving configuration.
+         */
         SwaggerUIConfig swaggerui();
 
+        /**
+         * @return RapiDoc serving configuration.
+         */
         RapidocConfig rapidoc();
 
         @ConfigValueExtractor
         interface SwaggerUIConfig {
 
+            /**
+             * @return Whether the controller serving Swagger UI is enabled.
+             */
             default boolean enabled() {
                 return false;
             }
 
+            /**
+             * @return Path where Swagger UI is available.
+             */
             default String endpoint() {
                 return "/swagger-ui";
             }
@@ -98,10 +158,16 @@ public interface CamundaRestConfig {
         @ConfigValueExtractor
         interface RapidocConfig {
 
+            /**
+             * @return Whether the controller serving RapiDoc is enabled.
+             */
             default boolean enabled() {
                 return false;
             }
 
+            /**
+             * @return Path where RapiDoc is available.
+             */
             default String endpoint() {
                 return "/rapidoc";
             }
@@ -111,29 +177,50 @@ public interface CamundaRestConfig {
     @ConfigValueExtractor
     interface CamundaCorsConfig {
 
+        /**
+         * @return Whether the CORS filter is enabled.
+         */
         default boolean enabled() {
             return false;
         }
 
+        /**
+         * @return Allowed origin for CORS requests, when not specified the request Origin header is reflected back.
+         */
         @Nullable
         String allowOrigin();
 
+        /**
+         * @return Allowed headers for CORS requests.
+         */
         default List<String> allowHeaders() {
             return List.of("*");
         }
 
+        /**
+         * @return Allowed HTTP methods for CORS requests.
+         */
         default List<String> allowMethods() {
             return List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD");
         }
 
+        /**
+         * @return Whether credentials are allowed in CORS requests.
+         */
         default Boolean allowCredentials() {
             return true;
         }
 
+        /**
+         * @return Headers exposed to the client in a CORS response.
+         */
         default List<String> exposeHeaders() {
             return List.of("*");
         }
 
+        /**
+         * @return Maximum caching time for CORS preflight requests.
+         */
         default Duration maxAge() {
             return Duration.ofHours(1);
         }

--- a/experimental/camunda-zeebe-worker/src/main/java/ru/tinkoff/kora/camunda/zeebe/worker/ZeebeClientConfig.java
+++ b/experimental/camunda-zeebe-worker/src/main/java/ru/tinkoff/kora/camunda/zeebe/worker/ZeebeClientConfig.java
@@ -12,74 +12,131 @@ import java.util.List;
 @ConfigValueExtractor
 public interface ZeebeClientConfig {
 
+    /**
+     * @return Maximum number of threads for job workers.
+     */
     default int executionThreads() {
         return Math.max(Runtime.getRuntime().availableProcessors(), 2);
     }
 
+    /**
+     * @return Whether TLS is used for the connection.
+     */
     default boolean tls() {
         return true;
     }
 
+    /**
+     * @return Time without read activity before sending a KeepAlive check.
+     */
     default Duration keepAlive() {
         return Duration.ofSeconds(45);
     }
 
+    /**
+     * @return File path to the connection certificate, when not specified the system certificate is used.
+     */
     @Nullable
     String certificatePath();
 
+    /**
+     * @return Maximum time to wait for the topology availability check on client startup.
+     */
     @Nullable
     Duration initializationFailTimeout();
 
+    /**
+     * @return gRPC connection configuration.
+     */
     GrpcConfig grpc();
 
+    /**
+     * @return REST connection configuration, when specified the client prefers REST over gRPC for supported operations.
+     */
     @Nullable
     RestConfig rest();
 
+    /**
+     * @return Resource deployment configuration.
+     */
     DeploymentConfig deployment();
 
+    /**
+     * @return Telemetry configuration of the module.
+     */
     TelemetryConfig telemetry();
 
     @ConfigValueExtractor
     interface RestConfig {
 
+        /**
+         * @return URL for connecting to the Zeebe REST address.
+         */
         String url();
     }
 
     @ConfigValueExtractor
     interface GrpcConfig {
 
+        /**
+         * @return URL for connecting to Zeebe through gRPC.
+         */
         String url();
 
+        /**
+         * @return How long a message sent through gRPC is kept on the broker.
+         */
         default Duration ttl() {
             return Duration.ofHours(1);
         }
 
+        /**
+         * @return Maximum inbound message size for gRPC.
+         */
         default Size maxMessageSize() {
             return Size.of(4, Size.Type.MiB);
         }
 
+        /**
+         * @return Retry policy configuration of the gRPC connection.
+         */
         GrpcRetryConfig retryPolicy();
     }
 
     @ConfigValueExtractor
     interface GrpcRetryConfig {
 
+        /**
+         * @return Whether the retry policy for the gRPC connection is enabled.
+         */
         default boolean enabled() {
             return true;
         }
 
+        /**
+         * @return Number of retry attempts.
+         */
         default int attempts() {
             return 5;
         }
 
+        /**
+         * @return Initial delay between attempts.
+         */
         default Duration delay() {
             return Duration.ofMillis(100);
         }
 
+        /**
+         * @return Maximum delay between attempts.
+         */
         default Duration delayMax() {
             return Duration.ofSeconds(5);
         }
 
+        /**
+         * @return Delay multiplier between attempts.
+         */
         default Double step() {
             return 3.0;
         }
@@ -88,10 +145,16 @@ public interface ZeebeClientConfig {
     @ConfigValueExtractor
     interface DeploymentConfig {
 
+        /**
+         * @return Maximum time to wait for resource upload.
+         */
         default Duration timeout() {
             return Duration.ofSeconds(45);
         }
 
+        /**
+         * @return Paths where resources uploaded to the orchestrator after startup are searched for, only the classpath: prefix is supported.
+         */
         default List<String> resources() {
             return Collections.emptyList();
         }

--- a/experimental/camunda-zeebe-worker/src/main/java/ru/tinkoff/kora/camunda/zeebe/worker/ZeebeWorkerConfig.java
+++ b/experimental/camunda-zeebe-worker/src/main/java/ru/tinkoff/kora/camunda/zeebe/worker/ZeebeWorkerConfig.java
@@ -13,6 +13,9 @@ public interface ZeebeWorkerConfig {
 
     String DEFAULT = "default";
 
+    /**
+     * @return Job worker settings by worker type, where the default section is applied to all workers.
+     */
     default Map<String, JobConfig> job() {
         return Map.of();
     }
@@ -20,34 +23,64 @@ public interface ZeebeWorkerConfig {
     @ConfigValueExtractor
     interface JobConfig {
 
+        /**
+         * @return Name the worker is registered under on the broker.
+         */
         default String name() {
             return "default";
         }
 
+        /**
+         * @return Retry backoff configuration of the worker.
+         */
         @Nullable
         BackoffConfig backoff();
 
+        /**
+         * @return Tenant identifiers for which the worker can receive jobs.
+         */
         @Nullable
         List<String> tenantIds();
 
+        /**
+         * @return Maximum time for one job execution by the worker.
+         */
         @Nullable
         Duration timeout();
 
+        /**
+         * @return Maximum number of jobs activated simultaneously for this worker, used to align job fetching speed with processing speed.
+         */
         @Nullable
         Integer maxJobsActive();
 
+        /**
+         * @return Request timeout used for polling a new job by the worker.
+         */
         @Nullable
         Duration requestTimeout();
 
+        /**
+         * @return Maximum interval between polling new jobs.
+         */
         @Nullable
         Duration pollInterval();
 
+        /**
+         * @return Whether the worker is enabled.
+         */
         @Nullable
         Boolean enabled();
 
+        /**
+         * @return Whether streaming is used together with polling for job activation.
+         */
         @Nullable
         Boolean streamEnabled();
 
+        /**
+         * @return Maximum stream lifetime when streaming is enabled.
+         */
         @Nullable
         Duration streamTimeout();
     }
@@ -55,15 +88,27 @@ public interface ZeebeWorkerConfig {
     @ConfigValueExtractor
     interface BackoffConfig {
 
+        /**
+         * @return Maximum retry delay, which can be exceeded due to jitter.
+         */
         @Nullable
         Duration maxDelay();
 
+        /**
+         * @return Minimum retry delay, which the actual delay can fall below due to jitter.
+         */
         @Nullable
         Duration minDelay();
 
+        /**
+         * @return Factor the previous delay is multiplied by.
+         */
         @Nullable
         Double factor();
 
+        /**
+         * @return Jitter factor randomly changing the next delay within its +/- range.
+         */
         @Nullable
         Double jitter();
     }

--- a/experimental/s3-client-aws/src/main/java/ru/tinkoff/kora/s3/client/aws/AwsS3ClientConfig.java
+++ b/experimental/s3-client-aws/src/main/java/ru/tinkoff/kora/s3/client/aws/AwsS3ClientConfig.java
@@ -15,31 +15,52 @@ public interface AwsS3ClientConfig {
         VIRTUAL_HOSTED
     }
 
+    /**
+     * @return Object access style, either PATH or VIRTUAL_HOSTED.
+     */
     default AddressStyle addressStyle() {
         return AddressStyle.PATH;
     }
 
+    /**
+     * @return Maximum operation execution time.
+     */
     default Duration requestTimeout() {
         return Duration.ofSeconds(45);
     }
 
+    /**
+     * @return Whether to check the MD5 checksum before upload and on retrieval from AWS.
+     */
     default boolean checksumValidationEnabled() {
         return false;
     }
 
+    /**
+     * @return Whether to use chunked encoding when signing file data during upload to AWS.
+     */
     default boolean chunkedEncodingEnabled() {
         return true;
     }
 
+    /**
+     * @return File upload configuration.
+     */
     UploadConfig upload();
 
     @ConfigValueExtractor
     interface UploadConfig {
 
+        /**
+         * @return Maximum buffer size for file uploads.
+         */
         default Size bufferSize() {
             return Size.of(32, Size.Type.MiB);
         }
 
+        /**
+         * @return Maximum file part size for a single file upload.
+         */
         default Size partSize() {
             return Size.of(8, Size.Type.MiB);
         }

--- a/experimental/s3-client-common/src/main/java/ru/tinkoff/kora/s3/client/S3ClientConfig.java
+++ b/experimental/s3-client-common/src/main/java/ru/tinkoff/kora/s3/client/S3ClientConfig.java
@@ -7,6 +7,9 @@ import ru.tinkoff.kora.config.common.annotation.ConfigValueExtractor;
 @ConfigValueExtractor
 public interface S3ClientConfig {
 
+    /**
+     * @return Bucket where files will be stored.
+     */
     String bucket();
 }
 

--- a/experimental/s3-client-common/src/main/java/ru/tinkoff/kora/s3/client/S3Config.java
+++ b/experimental/s3-client-common/src/main/java/ru/tinkoff/kora/s3/client/S3Config.java
@@ -8,16 +8,31 @@ import ru.tinkoff.kora.telemetry.common.TelemetryConfig;
 @ConfigValueExtractor
 public interface S3Config {
 
+    /**
+     * @return URL of the S3 storage where requests will be sent.
+     */
     String url();
 
+    /**
+     * @return S3 storage access key.
+     */
     String accessKey();
 
+    /**
+     * @return S3 storage secret key.
+     */
     String secretKey();
 
+    /**
+     * @return S3 storage region.
+     */
     default String region() {
         return "aws-global";
     }
 
+    /**
+     * @return Telemetry configuration of the S3 client: logging, metrics and tracing.
+     */
     TelemetryConfig telemetry();
 }
 

--- a/experimental/s3-client-minio/src/main/java/ru/tinkoff/kora/s3/client/minio/MinioS3ClientConfig.java
+++ b/experimental/s3-client-minio/src/main/java/ru/tinkoff/kora/s3/client/minio/MinioS3ClientConfig.java
@@ -15,19 +15,31 @@ public interface MinioS3ClientConfig {
         VIRTUAL_HOSTED
     }
 
+    /**
+     * @return Object access style, either PATH or VIRTUAL_HOSTED.
+     */
     default AddressStyle addressStyle() {
         return AddressStyle.PATH;
     }
 
+    /**
+     * @return Maximum operation execution time.
+     */
     default Duration requestTimeout() {
         return Duration.ofSeconds(45);
     }
 
+    /**
+     * @return File upload configuration.
+     */
     UploadConfig upload();
 
     @ConfigValueExtractor
     interface UploadConfig {
 
+        /**
+         * @return Maximum file part size for a single file upload.
+         */
         default Size partSize() {
             return Size.of(8, Size.Type.MiB);
         }

--- a/grpc/grpc-client/src/main/java/ru/tinkoff/grpc/client/config/GrpcClientConfig.java
+++ b/grpc/grpc-client/src/main/java/ru/tinkoff/grpc/client/config/GrpcClientConfig.java
@@ -10,22 +10,43 @@ import java.util.Objects;
 
 @ConfigValueExtractor
 public interface GrpcClientConfig {
+    /**
+     * @return Server URL where requests will be sent.
+     */
     String url();
 
+    /**
+     * @return Maximum request execution time, applied as a call deadline if the call does not already have its own.
+     */
     @Nullable
     Duration timeout();
 
+    /**
+     * @return Telemetry configuration for logging, metrics and tracing of client calls.
+     */
     TelemetryConfig telemetry();
 
+    /**
+     * @return Standard gRPC service configuration passed to ManagedChannelBuilder.defaultServiceConfig.
+     */
     @Nullable
     DefaultServiceConfig defaultServiceConfig();
 
+    /**
+     * @return Interval between gRPC PING frames.
+     */
     @Nullable
     Duration keepAliveTime();
 
+    /**
+     * @return Timeout for acknowledging a PING frame, after which the connection is closed.
+     */
     @Nullable
     Duration keepAliveTimeout();
 
+    /**
+     * @return Load balancing policy for ManagedChannelBuilder.
+     */
     @Nullable
     String loadBalancingPolicy();
 

--- a/grpc/grpc-server/src/main/java/ru/tinkoff/kora/grpc/server/config/GrpcServerConfig.java
+++ b/grpc/grpc-server/src/main/java/ru/tinkoff/kora/grpc/server/config/GrpcServerConfig.java
@@ -10,33 +10,60 @@ import java.time.Duration;
 @ConfigValueExtractor
 public interface GrpcServerConfig {
 
+    /**
+     * @return gRPC server port.
+     */
     default int port() {
         return 8090;
     }
 
+    /**
+     * @return Enables the gRPC Server Reflection service.
+     */
     default boolean reflectionEnabled() {
         return false;
     }
 
+    /**
+     * @return Maximum size of an incoming message.
+     */
     default Size maxMessageSize() {
         return Size.of(4, Size.Type.MiB);
     }
 
+    /**
+     * @return Time to wait for in-flight calls to complete before shutting down the server during graceful shutdown.
+     */
     default Duration shutdownWait() {
         return Duration.ofSeconds(30);
     }
 
+    /**
+     * @return Telemetry configuration for logging, metrics and tracing of server calls.
+     */
     TelemetryConfig telemetry();
 
+    /**
+     * @return Maximum connection age after which the connection is gracefully terminated, with a random jitter of +/-10%.
+     */
     @Nullable
     Duration maxConnectionAge();
 
+    /**
+     * @return Additional time for graceful connection termination after the maximum connection age is reached.
+     */
     @Nullable
     Duration maxConnectionAgeGrace();
 
+    /**
+     * @return Interval between PING frames.
+     */
     @Nullable
     Duration keepAliveTime();
 
+    /**
+     * @return Timeout for acknowledging a PING frame, after which the connection is closed.
+     */
     @Nullable
     Duration keepAliveTimeout();
 }

--- a/http/http-client-async/src/main/java/ru/tinkoff/kora/http/client/async/AsyncHttpClientConfig.java
+++ b/http/http-client-async/src/main/java/ru/tinkoff/kora/http/client/async/AsyncHttpClientConfig.java
@@ -5,6 +5,9 @@ import ru.tinkoff.kora.config.common.annotation.ConfigValueExtractor;
 @ConfigValueExtractor
 public interface AsyncHttpClientConfig {
 
+    /**
+     * @return Whether to follow HTTP redirects.
+     */
     default boolean followRedirects() {
         return true;
     }

--- a/http/http-client-common/src/main/java/ru/tinkoff/kora/http/client/common/HttpClientConfig.java
+++ b/http/http-client-common/src/main/java/ru/tinkoff/kora/http/client/common/HttpClientConfig.java
@@ -10,17 +10,29 @@ import java.util.List;
 @ConfigValueExtractor
 public interface HttpClientConfig {
 
+    /**
+     * @return Maximum time to establish a connection.
+     */
     default Duration connectTimeout() {
         return Duration.ofSeconds(5);
     }
 
+    /**
+     * @return Maximum time to read a response.
+     */
     default Duration readTimeout() {
         return Duration.ofMinutes(2);
     }
 
+    /**
+     * @return Proxy settings used for outgoing requests.
+     */
     @Nullable
     HttpClientProxyConfig proxy();
 
+    /**
+     * @return Whether to use https_proxy / HTTPS_PROXY / http_proxy / HTTP_PROXY and no_proxy / NO_PROXY environment variables for proxy configuration.
+     */
     default boolean useEnvProxy() {
         return false;
     }
@@ -28,16 +40,31 @@ public interface HttpClientConfig {
     @ConfigValueExtractor
     interface HttpClientProxyConfig {
 
+        /**
+         * @return Proxy host.
+         */
         String host();
 
+        /**
+         * @return Proxy port.
+         */
         int port();
 
+        /**
+         * @return Hosts to exclude from proxying.
+         */
         @Nullable
         List<String> nonProxyHosts();
 
+        /**
+         * @return Proxy user.
+         */
         @Nullable
         String user();
 
+        /**
+         * @return Proxy password.
+         */
         @Nullable
         String password();
 

--- a/http/http-client-common/src/main/java/ru/tinkoff/kora/http/client/common/declarative/DeclarativeHttpClientConfig.java
+++ b/http/http-client-common/src/main/java/ru/tinkoff/kora/http/client/common/declarative/DeclarativeHttpClientConfig.java
@@ -10,10 +10,19 @@ import java.time.Duration;
 
 public interface DeclarativeHttpClientConfig {
 
+    /**
+     * @return Base service URL where requests will be sent.
+     */
     String url();
 
+    /**
+     * @return Telemetry configuration for logging, metrics and tracing of client requests.
+     */
     TelemetryConfig telemetry();
 
+    /**
+     * @return Maximum request time that may include DNS resolution, connection, request body write, server processing and response body read.
+     */
     @Nullable
     Duration requestTimeout();
 

--- a/http/http-client-common/src/main/java/ru/tinkoff/kora/http/client/common/declarative/HttpClientOperationConfig.java
+++ b/http/http-client-common/src/main/java/ru/tinkoff/kora/http/client/common/declarative/HttpClientOperationConfig.java
@@ -9,8 +9,14 @@ import java.time.Duration;
 
 @ConfigValueExtractor
 public interface HttpClientOperationConfig {
+    /**
+     * @return Maximum request time that may include DNS resolution, connection, request body write, server processing and response body read.
+     */
     @Nullable
     Duration requestTimeout();
 
+    /**
+     * @return Telemetry settings that override the client telemetry settings for this operation.
+     */
     TelemetryConfig telemetry();
 }

--- a/http/http-client-common/src/main/java/ru/tinkoff/kora/http/client/common/telemetry/HttpClientLoggerConfig.java
+++ b/http/http-client-common/src/main/java/ru/tinkoff/kora/http/client/common/telemetry/HttpClientLoggerConfig.java
@@ -10,18 +10,30 @@ import java.util.Set;
 @ConfigValueExtractor
 public interface HttpClientLoggerConfig extends TelemetryConfig.LogConfig {
 
+    /**
+     * @return Request query parameters to hide.
+     */
     default Set<String> maskQueries() {
         return Collections.emptySet();
     }
 
+    /**
+     * @return Request or response headers to hide.
+     */
     default Set<String> maskHeaders() {
         return Set.of("authorization", "set-cookie", "cookie");
     }
 
+    /**
+     * @return Mask used to hide specified headers and request or response parameters.
+     */
     default String mask() {
         return "***";
     }
 
+    /**
+     * @return Whether to use the request path template in logging, when not specified the template is used except at TRACE level where the full path is used.
+     */
     @Nullable
     Boolean pathTemplate();
 }

--- a/http/http-client-common/src/main/java/ru/tinkoff/kora/http/client/common/telemetry/HttpClientTelemetryConfig.java
+++ b/http/http-client-common/src/main/java/ru/tinkoff/kora/http/client/common/telemetry/HttpClientTelemetryConfig.java
@@ -5,6 +5,9 @@ import ru.tinkoff.kora.telemetry.common.TelemetryConfig;
 
 @ConfigValueExtractor
 public interface HttpClientTelemetryConfig extends TelemetryConfig {
+    /**
+     * @return HTTP client logging telemetry settings.
+     */
     @Override
     HttpClientLoggerConfig logging();
 }

--- a/http/http-client-jdk/src/main/java/ru/tinkoff/kora/http/client/jdk/JdkHttpClientConfig.java
+++ b/http/http-client-jdk/src/main/java/ru/tinkoff/kora/http/client/jdk/JdkHttpClientConfig.java
@@ -7,14 +7,23 @@ import java.net.http.HttpClient;
 @ConfigValueExtractor
 public interface JdkHttpClientConfig {
 
+    /**
+     * @return Whether to follow HTTP redirects.
+     */
     default boolean followRedirects() {
         return true;
     }
 
+    /**
+     * @return Number of threads for the HTTP client.
+     */
     default int threads() {
         return Runtime.getRuntime().availableProcessors() * 2;
     }
 
+    /**
+     * @return Which HTTP protocol version to use.
+     */
     default HttpClient.Version httpVersion() {
         return HttpClient.Version.HTTP_1_1;
     }

--- a/http/http-client-ok/src/main/java/ru/tinkoff/kora/http/client/ok/OkHttpClientConfig.java
+++ b/http/http-client-ok/src/main/java/ru/tinkoff/kora/http/client/ok/OkHttpClientConfig.java
@@ -5,14 +5,23 @@ import ru.tinkoff.kora.config.common.annotation.ConfigValueExtractor;
 @ConfigValueExtractor
 public interface OkHttpClientConfig {
 
+    /**
+     * @return Whether to follow HTTP redirects.
+     */
     default boolean followRedirects() {
         return true;
     }
 
+    /**
+     * @return Whether to retry a request after a connection failure, this can affect the maximum connection establishment time.
+     */
     default boolean retryOnConnectionFailure() {
         return true;
     }
 
+    /**
+     * @return Maximum HTTP protocol version to use.
+     */
     default HttpVersion httpVersion() {
         return HttpVersion.HTTP_1_1;
     }

--- a/http/http-server-common/src/main/java/ru/tinkoff/kora/http/server/common/HttpServerConfig.java
+++ b/http/http-server-common/src/main/java/ru/tinkoff/kora/http/server/common/HttpServerConfig.java
@@ -9,60 +9,105 @@ import java.time.Duration;
 @ConfigValueExtractor
 public interface HttpServerConfig {
 
+    /**
+     * @return Public HTTP server port.
+     */
     default int publicApiHttpPort() {
         return 8080;
     }
 
+    /**
+     * @return Private HTTP server port.
+     */
     default int privateApiHttpPort() {
         return 8085;
     }
 
+    /**
+     * @return Path to get metrics on the private server.
+     */
     default String privateApiHttpMetricsPath() {
         return "/metrics";
     }
 
+    /**
+     * @return Path to get readiness probe status on the private server.
+     */
     default String privateApiHttpReadinessPath() {
         return "/system/readiness";
     }
 
+    /**
+     * @return Path to get liveness probe status on the private server.
+     */
     default String privateApiHttpLivenessPath() {
         return "/system/liveness";
     }
 
+    /**
+     * @return Whether to ignore a trailing slash in the path, so that /my/path and /my/path/ are treated as the same route.
+     */
     default boolean ignoreTrailingSlash() {
         return false;
     }
 
+    /**
+     * @return Number of network I/O threads.
+     */
     default int ioThreads() {
         return Math.max(Runtime.getRuntime().availableProcessors(), 2);
     }
 
+    /**
+     * @return Number of threads for blocking request processing.
+     */
     default int blockingThreads() {
         return Math.min(Math.max(Runtime.getRuntime().availableProcessors(), 2) * 8, 200);
     }
 
+    /**
+     * @return Maximum idle lifetime of a request handler thread.
+     */
     default Duration threadKeepAliveTimeout() {
         return Duration.ofSeconds(60);
     }
 
+    /**
+     * @return Maximum time to wait for reading data from a socket or connection, zero disables the timeout.
+     */
     default Duration socketReadTimeout() {
         return Duration.ZERO;
     }
 
+    /**
+     * @return Maximum time to wait for writing data to a socket or connection, zero disables the timeout.
+     */
     default Duration socketWriteTimeout() {
         return Duration.ZERO;
     }
 
+    /**
+     * @return Whether to enable TCP keep-alive for a socket or connection.
+     */
     default boolean socketKeepAliveEnabled() {
         return false;
     }
 
+    /**
+     * @return Time to wait for request processing before server shutdown during graceful shutdown.
+     */
     default Duration shutdownWait() {
         return Duration.ofSeconds(30);
     }
 
+    /**
+     * @return Telemetry configuration for logging, metrics and tracing of incoming requests.
+     */
     HttpServerTelemetryConfig telemetry();
 
+    /**
+     * @return Maximum allowed size of an incoming request body.
+     */
     default Size maxRequestBodySize() {
         return Size.of(256, Size.Type.MiB);
     }

--- a/http/http-server-common/src/main/java/ru/tinkoff/kora/http/server/common/telemetry/HttpServerLoggerConfig.java
+++ b/http/http-server-common/src/main/java/ru/tinkoff/kora/http/server/common/telemetry/HttpServerLoggerConfig.java
@@ -10,22 +10,37 @@ import java.util.Set;
 @ConfigValueExtractor
 public interface HttpServerLoggerConfig extends TelemetryConfig.LogConfig {
 
+    /**
+     * @return Enables call stack logging on exception.
+     */
     default boolean stacktrace() {
         return true;
     }
 
+    /**
+     * @return Request query parameters to hide.
+     */
     default Set<String> maskQueries() {
         return Collections.emptySet();
     }
 
+    /**
+     * @return Request or response headers to hide.
+     */
     default Set<String> maskHeaders() {
         return Set.of("authorization", "set-cookie", "cookie");
     }
 
+    /**
+     * @return Mask used to hide specified headers and request or response parameters.
+     */
     default String mask() {
         return "***";
     }
 
+    /**
+     * @return Whether to use the request path template in logs, when not specified the template is used everywhere except TRACE level where the full path is used.
+     */
     @Nullable
     Boolean pathTemplate();
 }

--- a/http/http-server-common/src/main/java/ru/tinkoff/kora/http/server/common/telemetry/HttpServerTelemetryConfig.java
+++ b/http/http-server-common/src/main/java/ru/tinkoff/kora/http/server/common/telemetry/HttpServerTelemetryConfig.java
@@ -5,6 +5,9 @@ import ru.tinkoff.kora.telemetry.common.TelemetryConfig;
 
 @ConfigValueExtractor
 public interface HttpServerTelemetryConfig extends TelemetryConfig {
+    /**
+     * @return Logging telemetry configuration of incoming requests.
+     */
     @Override
     HttpServerLoggerConfig logging();
 }

--- a/http/http-server-undertow/src/main/java/ru/tinkoff/kora/http/server/undertow/UndertowHttpServerConfig.java
+++ b/http/http-server-undertow/src/main/java/ru/tinkoff/kora/http/server/undertow/UndertowHttpServerConfig.java
@@ -5,6 +5,9 @@ import ru.tinkoff.kora.config.common.annotation.ConfigValueExtractor;
 @ConfigValueExtractor
 public interface UndertowHttpServerConfig {
 
+    /**
+     * @return Enables virtual threads for blocking request processing instead of the blockingThreads pool, requires Java 21+.
+     */
     default boolean virtualThreadsEnabled() {
         return false;
     }

--- a/http/soap-client/src/main/java/ru/tinkoff/kora/soap/client/common/SoapServiceConfig.java
+++ b/http/soap-client/src/main/java/ru/tinkoff/kora/soap/client/common/SoapServiceConfig.java
@@ -8,11 +8,20 @@ import java.time.Duration;
 @ConfigValueExtractor
 public interface SoapServiceConfig {
 
+    /**
+     * @return Service URL where requests will be sent.
+     */
     String url();
 
+    /**
+     * @return Maximum request execution time.
+     */
     default Duration timeout() {
         return Duration.ofSeconds(60);
     }
 
+    /**
+     * @return Telemetry configuration of the SOAP client such as logging, metrics and tracing.
+     */
     TelemetryConfig telemetry();
 }

--- a/jms/src/main/java/ru/tinkoff/kora/jms/JmsListenerContainerConfig.java
+++ b/jms/src/main/java/ru/tinkoff/kora/jms/JmsListenerContainerConfig.java
@@ -5,9 +5,18 @@ import ru.tinkoff.kora.telemetry.common.TelemetryConfig;
 
 @ConfigValueExtractor
 public interface JmsListenerContainerConfig {
+    /**
+     * @return Name of the JMS queue the listener consumes messages from.
+     */
     String queueName();
 
+    /**
+     * @return Number of consumer threads listening to the queue, zero disables the listener.
+     */
     int threads();
 
+    /**
+     * @return Telemetry configuration for logging, metrics and tracing of consumed messages.
+     */
     TelemetryConfig telemetry();
 }

--- a/kafka/kafka/src/main/java/ru/tinkoff/kora/kafka/common/consumer/KafkaListenerConfig.java
+++ b/kafka/kafka/src/main/java/ru/tinkoff/kora/kafka/common/consumer/KafkaListenerConfig.java
@@ -14,45 +14,81 @@ import java.util.regex.Pattern;
 @ConfigValueExtractor
 public interface KafkaListenerConfig {
 
+    /**
+     * @return Official Kafka Consumer properties.
+     */
     Properties driverProperties();
 
+    /**
+     * @return List of topics the Consumer subscribes to, either topics or topicsPattern must be specified.
+     */
     @Nullable
     List<String> topics();
 
+    /**
+     * @return Topic pattern the Consumer subscribes to, either topics or topicsPattern must be specified.
+     */
     @Nullable
     Pattern topicsPattern();
 
+    /**
+     * @return List of partitions used only for consumer name construction when group.id, topics and topicsPattern are not specified.
+     */
     @Nullable
     List<String> partitions();
 
+    /**
+     * @return Initial read position for the assign strategy when group.id is not specified: earliest, latest or a Duration to shift back from the latest offset.
+     */
     default Either<Duration, String> offset() {
         return Either.right("latest");
     }
 
+    /**
+     * @return Maximum time to wait for messages from a topic within one poll() call.
+     */
     default Duration pollTimeout() {
         return Duration.ofSeconds(5);
     }
 
+    /**
+     * @return Initial delay before consumer restart after an unexpected processing error, growing up to 60s on repeated errors.
+     */
     default Duration backoffTimeout() {
         return Duration.ofSeconds(15);
     }
 
+    /**
+     * @return Number of threads the consumer starts on, 0 means the consumer is not started.
+     */
     default int threads() {
         return 1;
     }
 
+    /**
+     * @return Partition list refresh period for the assign strategy.
+     */
     default Duration partitionRefreshInterval() {
         return Duration.ofMinutes(1);
     }
 
+    /**
+     * @return Time to wait for record processing to complete before stopping the consumer during graceful shutdown.
+     */
     default Duration shutdownWait() {
         return Duration.ofSeconds(30);
     }
 
+    /**
+     * @return Whether to call the listener with an empty ConsumerRecords batch when the signature accepts ConsumerRecords.
+     */
     default boolean allowEmptyRecords() {
         return false;
     }
 
+    /**
+     * @return Telemetry configuration of the consumer: logging, metrics and tracing.
+     */
     TelemetryConfig telemetry();
 
     default KafkaListenerConfig withDriverPropertiesOverrides(Map<String, Object> overrides) {

--- a/kafka/kafka/src/main/java/ru/tinkoff/kora/kafka/common/producer/KafkaPublisherConfig.java
+++ b/kafka/kafka/src/main/java/ru/tinkoff/kora/kafka/common/producer/KafkaPublisherConfig.java
@@ -10,21 +10,36 @@ import java.util.Properties;
 @ConfigValueExtractor
 public interface KafkaPublisherConfig {
 
+    /**
+     * @return Official Kafka Producer properties.
+     */
     Properties driverProperties();
 
+    /**
+     * @return Telemetry configuration of the producer: logging, metrics and tracing.
+     */
     TelemetryConfig telemetry();
 
     @ConfigValueExtractor
     interface TransactionConfig {
 
+        /**
+         * @return Transaction identifier prefix to which a random UUID is appended.
+         */
         default String idPrefix() {
             return "kora-app-";
         }
 
+        /**
+         * @return Maximum size of the transactional Producer pool.
+         */
         default int maxPoolSize() {
             return 10;
         }
 
+        /**
+         * @return Maximum time to wait for a free Producer from the pool.
+         */
         default Duration maxWaitTime() {
             return Duration.ofSeconds(10);
         }
@@ -33,8 +48,14 @@ public interface KafkaPublisherConfig {
     @ConfigValueExtractor
     interface TopicConfig {
 
+        /**
+         * @return Topic where the method sends data.
+         */
         String topic();
 
+        /**
+         * @return Topic partition where the method sends data, standard Kafka partitioning is used when not specified.
+         */
         @Nullable
         Integer partition();
     }

--- a/logging/logging-common/src/main/java/ru/tinkoff/kora/logging/common/LoggingConfig.java
+++ b/logging/logging-common/src/main/java/ru/tinkoff/kora/logging/common/LoggingConfig.java
@@ -2,4 +2,7 @@ package ru.tinkoff.kora.logging.common;
 
 import java.util.Map;
 
+/**
+ * @param levels Logging levels for ROOT, packages and specific classes.
+ */
 public record LoggingConfig(Map<String, String> levels) {}

--- a/micrometer/micrometer-module/src/main/java/ru/tinkoff/kora/micrometer/module/MetricsConfig.java
+++ b/micrometer/micrometer-module/src/main/java/ru/tinkoff/kora/micrometer/module/MetricsConfig.java
@@ -5,6 +5,9 @@ import ru.tinkoff.kora.telemetry.common.TelemetryConfig;
 
 @ConfigValueExtractor
 public interface MetricsConfig {
+    /**
+     * @return Metrics format according to the OpenTelemetry standard.
+     */
     default TelemetryConfig.MetricsConfig.OpentelemetrySpec opentelemetrySpec() {
         return TelemetryConfig.MetricsConfig.OpentelemetrySpec.V120;
     }

--- a/netty-common/src/main/java/ru/tinkoff/kora/netty/common/NettyTransportConfig.java
+++ b/netty-common/src/main/java/ru/tinkoff/kora/netty/common/NettyTransportConfig.java
@@ -19,6 +19,9 @@ public interface NettyTransportConfig {
     @Nullable
     EventLoop transport();
 
+    /**
+     * @return Number of worker event loop threads that process connections and network I/O, server boss event loop is not affected.
+     */
     default int threads() {
         return NettyRuntime.availableProcessors() * 2;
     }

--- a/openapi/openapi-management/src/main/java/ru/tinkoff/kora/openapi/management/OpenApiManagementConfig.java
+++ b/openapi/openapi-management/src/main/java/ru/tinkoff/kora/openapi/management/OpenApiManagementConfig.java
@@ -7,27 +7,48 @@ import java.util.List;
 @ConfigValueExtractor
 public interface OpenApiManagementConfig {
 
+    /**
+     * @return Path to an OpenAPI file or list of paths relative to application resources.
+     */
     List<String> file();
 
+    /**
+     * @return Enables serving OpenAPI files through the HTTP handler.
+     */
     default boolean enabled() {
         return false;
     }
 
+    /**
+     * @return Path where OpenAPI files are available, used as a prefix of the /openapi/{file} form when multiple files are specified.
+     */
     default String endpoint() {
         return "/openapi";
     }
 
+    /**
+     * @return Swagger UI page configuration.
+     */
     SwaggerUIConfig swaggerui();
 
+    /**
+     * @return RapiDoc page configuration.
+     */
     RapidocConfig rapidoc();
 
     @ConfigValueExtractor
     interface SwaggerUIConfig {
 
+        /**
+         * @return Enables the Swagger UI page.
+         */
         default boolean enabled() {
             return false;
         }
 
+        /**
+         * @return Path where the Swagger UI page is available.
+         */
         default String endpoint() {
             return "/swagger-ui";
         }
@@ -36,10 +57,16 @@ public interface OpenApiManagementConfig {
     @ConfigValueExtractor
     interface RapidocConfig {
 
+        /**
+         * @return Enables the RapiDoc page.
+         */
         default boolean enabled() {
             return false;
         }
 
+        /**
+         * @return Path where the RapiDoc page is available.
+         */
         default String endpoint() {
             return "/rapidoc";
         }

--- a/opentelemetry/opentelemetry-tracing-exporter-grpc/src/main/java/ru/tinkoff/kora/opentelemetry/tracing/exporter/grpc/OpentelemetryGrpcExporterConfig.java
+++ b/opentelemetry/opentelemetry-tracing-exporter-grpc/src/main/java/ru/tinkoff/kora/opentelemetry/tracing/exporter/grpc/OpentelemetryGrpcExporterConfig.java
@@ -14,37 +14,67 @@ public sealed interface OpentelemetryGrpcExporterConfig {
         $OpentelemetryGrpcExporterConfig_FromConfig_ConfigValueExtractor.FromConfig_Defaults,
         $OpentelemetryGrpcExporterConfig_FromConfig_ConfigValueExtractor.FromConfig_Impl {
 
+        /**
+         * @return OpenTelemetry Collector endpoint where traces are exported over OTLP/gRPC.
+         */
         String endpoint();
 
+        /**
+         * @return Maximum time to wait while the exporter sends data.
+         */
         default Duration exportTimeout() {
             return Duration.ofSeconds(3);
         }
 
+        /**
+         * @return Maximum time to wait for one accumulated batch of spans to be exported.
+         */
         default Duration batchExportTimeout() {
             return Duration.ofSeconds(30);
         }
 
+        /**
+         * @return Timeout for establishing a connection to the exporter.
+         */
         @Nullable
         Duration connectTimeout();
 
+        /**
+         * @return Data compression used during export, gzip or none.
+         */
         default String compression() {
             return "gzip";
         }
 
+        /**
+         * @return Retry policy applied to failed export attempts.
+         */
         RetryPolicy retryPolicy();
 
+        /**
+         * @return Delay between sending accumulated spans to the collector.
+         */
         default Duration scheduleDelay() {
             return Duration.ofSeconds(2);
         }
 
+        /**
+         * @return Maximum number of spans in one export batch.
+         */
         default int maxExportBatchSize() {
             return 512;
         }
 
+        /**
+         * @return Maximum queue size for spans waiting to be sent.
+         */
         default int maxQueueSize() {
             return 2048;
         }
 
+        /**
+         * @return Whether to export spans that were not selected by the Sampler.
+         */
         default boolean exportUnsampledSpans() {
             return false;
         }
@@ -52,18 +82,30 @@ public sealed interface OpentelemetryGrpcExporterConfig {
 
     @ConfigValueExtractor
     interface RetryPolicy {
+        /**
+         * @return Maximum number of retry attempts.
+         */
         default int maxAttempts() {
             return 5;
         }
 
+        /**
+         * @return Initial delay before a retry attempt.
+         */
         default Duration initialBackoff() {
             return Duration.ofSeconds(1);
         }
 
+        /**
+         * @return Maximum delay before a retry attempt.
+         */
         default Duration maxBackoff() {
             return Duration.ofSeconds(5);
         }
 
+        /**
+         * @return Delay multiplier between retry attempts.
+         */
         default double backoffMultiplier() {
             return 1.5d;
         }

--- a/opentelemetry/opentelemetry-tracing-exporter-http/src/main/java/ru/tinkoff/kora/opentelemetry/tracing/exporter/http/OpentelemetryHttpExporterConfig.java
+++ b/opentelemetry/opentelemetry-tracing-exporter-http/src/main/java/ru/tinkoff/kora/opentelemetry/tracing/exporter/http/OpentelemetryHttpExporterConfig.java
@@ -14,37 +14,67 @@ public sealed interface OpentelemetryHttpExporterConfig {
         $OpentelemetryHttpExporterConfig_FromConfig_ConfigValueExtractor.FromConfig_Defaults,
         $OpentelemetryHttpExporterConfig_FromConfig_ConfigValueExtractor.FromConfig_Impl {
 
+        /**
+         * @return OpenTelemetry Collector endpoint where traces are exported over OTLP/HTTP.
+         */
         String endpoint();
 
+        /**
+         * @return Maximum time to wait while the exporter sends data.
+         */
         default Duration exportTimeout() {
             return Duration.ofSeconds(3);
         }
 
+        /**
+         * @return Maximum time to wait for one accumulated batch of spans to be exported.
+         */
         default Duration batchExportTimeout() {
             return Duration.ofSeconds(30);
         }
 
+        /**
+         * @return Timeout for establishing a connection to the exporter.
+         */
         @Nullable
         Duration connectTimeout();
 
+        /**
+         * @return Data compression used during export, gzip or none.
+         */
         default String compression() {
             return "gzip";
         }
 
+        /**
+         * @return Retry policy applied to failed export attempts.
+         */
         RetryPolicy retryPolicy();
 
+        /**
+         * @return Delay between sending accumulated spans to the collector.
+         */
         default Duration scheduleDelay() {
             return Duration.ofSeconds(2);
         }
 
+        /**
+         * @return Maximum number of spans in one export batch.
+         */
         default int maxExportBatchSize() {
             return 512;
         }
 
+        /**
+         * @return Maximum queue size for spans waiting to be sent.
+         */
         default int maxQueueSize() {
             return 2048;
         }
 
+        /**
+         * @return Whether to export spans that were not selected by the Sampler.
+         */
         default boolean exportUnsampledSpans() {
             return false;
         }
@@ -52,18 +82,30 @@ public sealed interface OpentelemetryHttpExporterConfig {
 
     @ConfigValueExtractor
     interface RetryPolicy {
+        /**
+         * @return Maximum number of retry attempts.
+         */
         default int maxAttempts() {
             return 5;
         }
 
+        /**
+         * @return Initial delay before a retry attempt.
+         */
         default Duration initialBackoff() {
             return Duration.ofSeconds(1);
         }
 
+        /**
+         * @return Maximum delay before a retry attempt.
+         */
         default Duration maxBackoff() {
             return Duration.ofSeconds(5);
         }
 
+        /**
+         * @return Delay multiplier between retry attempts.
+         */
         default double backoffMultiplier() {
             return 1.5d;
         }

--- a/opentelemetry/opentelemetry-tracing/src/main/java/ru/tinkoff/kora/opentelemetry/tracing/OpentelemetryResourceConfig.java
+++ b/opentelemetry/opentelemetry-tracing/src/main/java/ru/tinkoff/kora/opentelemetry/tracing/OpentelemetryResourceConfig.java
@@ -6,6 +6,9 @@ import java.util.Map;
 
 @ConfigValueExtractor
 public interface OpentelemetryResourceConfig {
+    /**
+     * @return OpenTelemetry Resource attributes added to every exported span.
+     */
     default Map<String, String> attributes() {
         return Map.of();
     }

--- a/resilient/resilient-kora/src/main/java/ru/tinkoff/kora/resilient/circuitbreaker/CircuitBreakerConfig.java
+++ b/resilient/resilient-kora/src/main/java/ru/tinkoff/kora/resilient/circuitbreaker/CircuitBreakerConfig.java
@@ -12,6 +12,9 @@ public interface CircuitBreakerConfig {
 
     String DEFAULT = "default";
 
+    /**
+     * @return CircuitBreaker settings by configuration name.
+     */
     default Map<String, NamedConfig> circuitbreaker() {
         return Map.of();
     }
@@ -29,24 +32,45 @@ public interface CircuitBreakerConfig {
     @ConfigValueExtractor
     interface NamedConfig {
 
+        /**
+         * @return Whether CircuitBreaker is enabled.
+         */
         @Nullable
         Boolean enabled();
 
+        /**
+         * @return Percentage of failed requests required to transition to OPEN state, value must be from 1 to 100.
+         */
         @Nullable
         Integer failureRateThreshold();
 
+        /**
+         * @return Waiting time in OPEN state after which the transition to HALF_OPEN state is performed.
+         */
         @Nullable
         Duration waitDurationInOpenState();
 
+        /**
+         * @return Number of requests in HALF_OPEN state that must complete successfully to transition to CLOSED state.
+         */
         @Nullable
         Integer permittedCallsInHalfOpenState();
 
+        /**
+         * @return Maximum number of requests used to calculate failure rate threshold and determine the state.
+         */
         @Nullable
         Long slidingWindowSize();
 
+        /**
+         * @return Minimum number of requests required to start state calculation.
+         */
         @Nullable
         Long minimumRequiredCalls();
 
+        /**
+         * @return Exception filter name from CircuitBreakerPredicate#name() that determines which errors are recorded.
+         */
         default String failurePredicateName() {
             return KoraCircuitBreakerPredicate.class.getCanonicalName();
         }

--- a/resilient/resilient-kora/src/main/java/ru/tinkoff/kora/resilient/fallback/FallbackConfig.java
+++ b/resilient/resilient-kora/src/main/java/ru/tinkoff/kora/resilient/fallback/FallbackConfig.java
@@ -13,6 +13,9 @@ public interface FallbackConfig {
 
     NamedConfig DEFAULT_CONFIG = new $FallbackConfig_NamedConfig_ConfigValueExtractor.NamedConfig_Defaults();
 
+    /**
+     * @return Fallback settings by configuration name.
+     */
     default Map<String, NamedConfig> fallback() {
         return Map.of();
     }
@@ -23,9 +26,15 @@ public interface FallbackConfig {
     @ConfigValueExtractor
     interface NamedConfig {
 
+        /**
+         * @return Whether Fallback is enabled.
+         */
         @Nullable
         Boolean enabled();
 
+        /**
+         * @return Exception filter name from FallbackPredicate#name() that determines which errors trigger the fallback.
+         */
         default String failurePredicateName() {
             return KoraFallbackPredicate.class.getCanonicalName();
         }

--- a/resilient/resilient-kora/src/main/java/ru/tinkoff/kora/resilient/retry/RetryConfig.java
+++ b/resilient/resilient-kora/src/main/java/ru/tinkoff/kora/resilient/retry/RetryConfig.java
@@ -13,6 +13,9 @@ public interface RetryConfig {
 
     String DEFAULT = "default";
 
+    /**
+     * @return Retry settings by configuration name.
+     */
     default Map<String, NamedConfig> retry() {
         return Map.of();
     }
@@ -26,18 +29,33 @@ public interface RetryConfig {
     @ConfigValueExtractor
     interface NamedConfig {
 
+        /**
+         * @return Whether Retry is enabled.
+         */
         @Nullable
         Boolean enabled();
 
+        /**
+         * @return Initial delay before a repeated call.
+         */
         @Nullable
         Duration delay();
 
+        /**
+         * @return Delay increment applied to each subsequent attempt.
+         */
         @Nullable
         Duration delayStep();
 
+        /**
+         * @return Number of retry attempts performed after the initial call.
+         */
         @Nullable
         Integer attempts();
 
+        /**
+         * @return Exception filter name from RetryPredicate#name() that determines which errors are retried.
+         */
         default String failurePredicateName() {
             return KoraRetryPredicate.class.getCanonicalName();
         }

--- a/resilient/resilient-kora/src/main/java/ru/tinkoff/kora/resilient/timeout/TimeoutConfig.java
+++ b/resilient/resilient-kora/src/main/java/ru/tinkoff/kora/resilient/timeout/TimeoutConfig.java
@@ -13,6 +13,9 @@ public interface TimeoutConfig {
 
     String DEFAULT = "default";
 
+    /**
+     * @return Timeout settings by configuration name.
+     */
     default Map<String, NamedConfig> timeout() {
         return Map.of();
     }
@@ -23,9 +26,15 @@ public interface TimeoutConfig {
     @ConfigValueExtractor
     interface NamedConfig {
 
+        /**
+         * @return Whether Timeout is enabled.
+         */
         @Nullable
         Boolean enabled();
 
+        /**
+         * @return Operation time limit after which TimeoutExhaustedException is thrown.
+         */
         @Nullable
         Duration duration();
     }

--- a/scheduling/scheduling-jdk/src/main/java/ru/tinkoff/kora/scheduling/jdk/ScheduledExecutorServiceConfig.java
+++ b/scheduling/scheduling-jdk/src/main/java/ru/tinkoff/kora/scheduling/jdk/ScheduledExecutorServiceConfig.java
@@ -7,10 +7,16 @@ import java.time.Duration;
 @ConfigValueExtractor
 public interface ScheduledExecutorServiceConfig {
 
+    /**
+     * @return Maximum number of threads in the ScheduledExecutorService.
+     */
     default int threads() {
         return 2;
     }
 
+    /**
+     * @return Time to wait for tasks to complete before scheduler shutdown during graceful shutdown.
+     */
     default Duration shutdownWait() {
         return Duration.ofSeconds(30);
     }

--- a/scheduling/scheduling-quartz/src/main/java/ru/tinkoff/kora/scheduling/quartz/SchedulingQuartzConfig.java
+++ b/scheduling/scheduling-quartz/src/main/java/ru/tinkoff/kora/scheduling/quartz/SchedulingQuartzConfig.java
@@ -5,6 +5,9 @@ import ru.tinkoff.kora.config.common.annotation.ConfigValueExtractor;
 @ConfigValueExtractor
 public interface SchedulingQuartzConfig {
 
+    /**
+     * @return Whether to wait for tasks to complete before scheduler shutdown during graceful shutdown.
+     */
     default boolean waitForJobComplete() {
         return true;
     }

--- a/telemetry/telemetry-common/src/main/java/ru/tinkoff/kora/telemetry/common/TelemetryConfig.java
+++ b/telemetry/telemetry-common/src/main/java/ru/tinkoff/kora/telemetry/common/TelemetryConfig.java
@@ -7,23 +7,41 @@ import java.util.Map;
 
 @ConfigValueExtractor
 public interface TelemetryConfig {
+    /**
+     * @return Logging telemetry configuration.
+     */
     LogConfig logging();
 
+    /**
+     * @return Tracing telemetry configuration.
+     */
     TracingConfig tracing();
 
+    /**
+     * @return Metrics telemetry configuration.
+     */
     MetricsConfig metrics();
 
     @ConfigValueExtractor
     interface LogConfig {
+        /**
+         * @return Whether logging is enabled for the module.
+         */
         @Nullable
         Boolean enabled();
     }
 
     @ConfigValueExtractor
     interface TracingConfig {
+        /**
+         * @return Whether tracing is enabled for the module.
+         */
         @Nullable
         Boolean enabled();
 
+        /**
+         * @return Attributes added to every span created by the module.
+         */
         default Map<String, String> attributes() {
             return Map.of();
         }
@@ -38,9 +56,15 @@ public interface TelemetryConfig {
             V120, V123
         }
 
+        /**
+         * @return Whether metrics collection is enabled for the module.
+         */
         @Nullable
         Boolean enabled();
 
+        /**
+         * @return SLO histogram buckets for DistributionSummary and Timer metrics.
+         */
         @Nullable
         double[] slo();
 
@@ -55,6 +79,9 @@ public interface TelemetryConfig {
             };
         }
 
+        /**
+         * @return Extra common tags added to every metric reported by the module.
+         */
         default Map<String, String> tags() {
             return Map.of();
         }


### PR DESCRIPTION
## What

Adds one-line `@return` Javadoc to Kora configuration classes, taken from the official English documentation, so configuration options are readable directly in the IDE (Quick Documentation / autocomplete) without opening the docs site.

## Scope

- All **47** configuration classes annotated with `@ConfigValueExtractor` in `src/main`, including their nested configuration interfaces — HTTP client/server, gRPC client/server, JDBC / R2DBC / Vert.x / Cassandra, Flyway / Liquibase, Caffeine / Redis (Lettuce), Kafka consumer/producer, resilient (circuit breaker / retry / timeout / fallback), scheduling (JDK / Quartz), telemetry / metrics / tracing exporters, S3, Camunda 7/8, Netty, OpenAPI management, SOAP, JMS.
- Plus `DeclarativeHttpClientConfig` and `LoggingConfig` — documented in the docs but extracted without the annotation.

**483 Javadoc blocks across 49 files.**

## Format

```java
/**
 * @return Server URL where requests will be sent.
 */
String url();
```

Following the style already present in `RedisCacheConfig` / `NettyTransportConfig`:

- one-line `@return` only, no `<p>`, no `@param`, no `{@link}`;
- no default values in the text — they are already visible in the `default` method bodies;
- static helpers, private methods, constants, enums and overloads taking arguments are not documented;
- pre-existing Javadoc left untouched.

`LoggingConfig` is a `record`, so its component is documented with `@param levels` — `@return` is not valid on a record class.

## Not included

**Documentation only — 1449 insertions, 0 deletions, no code changes.**

While mapping docs onto code a few genuine defects surfaced (a dead Cassandra `coalescer.rescheduleInterval` option, unused Camunda config shapes, a stale `RetryConfig` comment, and an inconsistency around the Kafka `partitions` key). They are intentionally left out of this PR and will be submitted separately, one per module.