### PR TITLE
docs(resilient): fix default retry predicate reference in `RetryConfig`

### DIFF
--- a/resilient/resilient-kora/src/main/java/ru/tinkoff/kora/resilient/retry/RetryConfig.java
+++ b/resilient/resilient-kora/src/main/java/ru/tinkoff/kora/resilient/retry/RetryConfig.java
@@ -21,7 +21,7 @@ public interface RetryConfig {
      * {@link #delay} Attempt initial delay
      * {@link #delayStep} Delay step used to calculate next delay (previous delay + delay step)
      * {@link #attempts} Maximum number of retry attempts
-     * {@link #failurePredicateName} {@link RetryPredicate#name()} default is {@link RetryPredicate}
+     * {@link #failurePredicateName} {@link RetryPredicate#name()} default is {@link KoraRetryPredicate}
      */
     @ConfigValueExtractor
     interface NamedConfig {


### PR DESCRIPTION
## Problem

`RetryConfig.NamedConfig` Javadoc says:

```java
* {@link #failurePredicateName} {@link RetryPredicate#name()} default is {@link RetryPredicate}
```

but the actual default is the implementation, not the interface:

```java
default String failurePredicateName() {
    return KoraRetryPredicate.class.getCanonicalName();
}
```

The two sibling configs in the same module already point at their implementations — `CircuitBreakerConfig` → `KoraCircuitBreakerPredicate`, `FallbackConfig` → `KoraFallbackPredicate` — and both match their code. `RetryConfig` is the only one out of line.

## Fix

One-line Javadoc correction to `{@link KoraRetryPredicate}`. No code changes.