### PR TITLE
Improved OpenAPI Java client model generation

### DIFF
--- a/http/http-client-common/src/main/java/io/koraframework/http/client/common/request/mapper/HttpClientRequestMapperModule.java
+++ b/http/http-client-common/src/main/java/io/koraframework/http/client/common/request/mapper/HttpClientRequestMapperModule.java
@@ -36,7 +36,7 @@ public interface HttpClientRequestMapperModule {
         return new FormMultipartClientRequestMapper();
     }
 
-    @Tag(Json.class)
+    @Json
     @DefaultComponent
     default <T> JsonHttpClientRequestMapper<T> httpClientRequestJsonMapper(JsonWriter<T> writer) {
         return new JsonHttpClientRequestMapper<>(writer);

--- a/http/http-client-common/src/main/java/io/koraframework/http/client/common/response/HttpClientResponseMapperModule.java
+++ b/http/http-client-common/src/main/java/io/koraframework/http/client/common/response/HttpClientResponseMapperModule.java
@@ -40,7 +40,7 @@ public interface HttpClientResponseMapperModule {
     }
 
     @DefaultComponent
-    default <T> HttpClientResponseMapper<HttpResponseEntity<T>> httpClientResponsEentityResponseMapper(HttpClientResponseMapper<T> mapper) {
+    default <T> HttpClientResponseMapper<HttpResponseEntity<T>> httpClientResponseEntityResponseMapper(HttpClientResponseMapper<T> mapper) {
         return response -> HttpResponseEntity.of(response.code(), response.headers().toMutable(), mapper.apply(response));
     }
 
@@ -50,7 +50,7 @@ public interface HttpClientResponseMapperModule {
         return response -> HttpResponseEntity.of(response.code(), response.headers().toMutable(), delegate.apply(response));
     }
 
-    @Tag(Json.class)
+    @Json
     @DefaultComponent
     default <T> JsonHttpClientResponseMapper<T> httpClientResponseJsonMapper(JsonReader<T> reader) {
         return new JsonHttpClientResponseMapper<>(reader);

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/AbstractGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/AbstractGenerator.java
@@ -122,6 +122,7 @@ public abstract class AbstractGenerator<C, R> {
     public CodegenParams params;
     public String apiPackage;
     public String modelPackage;
+    public String outputFolder;
     public Map<String, ModelsMap> models;
     public Map<String, String> typeMapping;
     public Map<String, OperationsMap> operationsByClassName;
@@ -234,6 +235,9 @@ public abstract class AbstractGenerator<C, R> {
         }
         if (schema instanceof CodegenParameter p && p.isEnumRef) {
             return ClassName.get(modelPackage, schema.getDataType());
+        }
+        if ("Object".equals(schema.getDataType()) || schema instanceof CodegenProperty p && p.isFreeFormObject) {
+            return ClassName.get(Object.class);
         }
         if (schema.getIsLong()) {
             return TypeName.LONG;

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/KoraCodegen.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/KoraCodegen.java
@@ -50,7 +50,6 @@ import static org.openapitools.codegen.utils.StringUtils.escape;
 public class KoraCodegen extends DefaultCodegen {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KoraCodegen.class);
-
     public record TagClient(@Nullable String httpClientTag, @Nullable String telemetryTag) {}
 
     public record Interceptor(@Nullable String type, @Nullable Object tag) {}
@@ -1879,6 +1878,7 @@ public class KoraCodegen extends DefaultCodegen {
         return (frag, out) -> {
             gen.apiPackage = apiPackage;
             gen.modelPackage = modelPackage;
+            gen.outputFolder = outputFolder;
             gen.params = params;
             gen.models = models;
             gen.operationsByClassName = operationsByClassName;
@@ -1893,6 +1893,7 @@ public class KoraCodegen extends DefaultCodegen {
         return (frag, out) -> {
             gen.apiPackage = apiPackage;
             gen.modelPackage = modelPackage;
+            gen.outputFolder = outputFolder;
             gen.params = params;
             gen.models = models;
             gen.operationsByClassName = operationsByClassName;

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/AbstractJavaGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/AbstractJavaGenerator.java
@@ -202,7 +202,7 @@ public abstract class AbstractJavaGenerator<C> extends AbstractGenerator<C, Java
         var b = CodeBlock.builder();
         b.add(operation.httpMethod + " " + operation.path);
         if (operation.summary != null) {
-            b.add(": " + operation.summary);
+            b.add(" : " + operation.summary);
         }
         b.add("\n");
         if (operation.notes != null) {
@@ -230,6 +230,13 @@ public abstract class AbstractJavaGenerator<C> extends AbstractGenerator<C, Java
         }
         if (operation.isDeprecated) {
             b.add("@deprecated\n");
+        }
+        for (var response : operation.responses) {
+            b.add("@return ")
+                .add(response.message)
+                .add(" (status code ")
+                .add(response.code)
+                .add(")\n");
         }
         if (operation.externalDocs != null) {
             b.add("@see <a href=\"" + operation.externalDocs.getUrl() + "\">" + operation.summary + " Documentation</a>");

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientApiGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientApiGenerator.java
@@ -8,6 +8,8 @@ import org.openapitools.codegen.CodegenSecurity;
 import org.openapitools.codegen.model.OperationsMap;
 
 import javax.lang.model.element.Modifier;
+import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 
 public class ClientApiGenerator extends AbstractJavaGenerator<OperationsMap> {
@@ -28,7 +30,7 @@ public class ClientApiGenerator extends AbstractJavaGenerator<OperationsMap> {
                 .filter(p -> !(p.isHeaderParam && operation.implicitHeadersParams.stream().anyMatch(h -> p.paramName.equals(h.paramName))))
                 .toList();
             if (!optionalParams.isEmpty()) {
-                b.addType(buildJavaClientApiOptionalParams(ctx, operation, optionalParams));
+                writeJavaClientApiOptionalParams(ctx, operation, optionalParams);
                 b.addMethod(buildRequiredArgsCall(ctx, operation, optionalParams));
                 b.addMethod(buildRequiredArgsWithArgsCall(ctx, operation, optionalParams));
             }
@@ -135,26 +137,32 @@ public class ClientApiGenerator extends AbstractJavaGenerator<OperationsMap> {
             }
             paramsCounter++;
         }
-        b.addParameter(ClassName.get(apiPackage, ctx.get("classname").toString(), StringUtils.capitalize(operation.operationId) + "OptArgs"), "optionalArguments");
+        b.addParameter(optionalArgsClassName(ctx, operation), "optionalArguments");
         return b.addCode(");\n").build();
     }
 
-    private TypeSpec buildJavaClientApiOptionalParams(OperationsMap ctx, CodegenOperation operation, List<CodegenParameter> optionalParams) {
-        var b = MethodSpec.constructorBuilder();
-        if (operation.isDeprecated) {
-            b.addAnnotation(Deprecated.class);
-        }
-        for (var optionalParam : optionalParams) {
-            var type = asType(ctx, operation, optionalParam).box().annotated(AnnotationSpec.builder(Classes.nullable).build());
-            b.addParameter(ParameterSpec.builder(type, optionalParam.paramName)
+    private void writeJavaClientApiOptionalParams(OperationsMap ctx, CodegenOperation operation, List<CodegenParameter> optionalParams) {
+        try {
+            JavaFile.builder(apiPackage, buildJavaClientApiOptionalParams(ctx, operation, optionalParams))
                 .build()
-            );
+                .writeTo(Path.of(outputFolder));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
-        var recordClassName = ClassName.get(apiPackage, ctx.get("classname").toString(), StringUtils.capitalize(operation.operationId) + "OptArgs");
+    }
 
-        var typeSpec = TypeSpec.recordBuilder(recordClassName)
-            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-            .recordConstructor(b.build());
+    private TypeSpec buildJavaClientApiOptionalParams(OperationsMap ctx, CodegenOperation operation, List<CodegenParameter> optionalParams) {
+        var constructor = MethodSpec.constructorBuilder()
+            .addModifiers(Modifier.PRIVATE);
+        if (operation.isDeprecated) {
+            constructor.addAnnotation(Deprecated.class);
+        }
+        var recordClassName = optionalArgsClassName(ctx, operation);
+
+        var typeSpec = TypeSpec.classBuilder(recordClassName.simpleName())
+            .addAnnotation(generated())
+            .addModifiers(Modifier.PUBLIC, Modifier.FINAL);
+
         var empty = MethodSpec.methodBuilder("empty")
             .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
             .returns(recordClassName)
@@ -188,6 +196,20 @@ public class ClientApiGenerator extends AbstractJavaGenerator<OperationsMap> {
         defaults.addCode(");\n");
         typeSpec.addMethod(defaults.build());
 
+        var accessors = new java.util.ArrayList<MethodSpec>();
+        for (var optionalParam : optionalParams) {
+            var type = asType(ctx, operation, optionalParam).box().annotated(AnnotationSpec.builder(Classes.nullable).build());
+            constructor.addParameter(ParameterSpec.builder(type, optionalParam.paramName).build());
+            constructor.addStatement("this.$N = $N", optionalParam.paramName, optionalParam.paramName);
+            typeSpec.addField(FieldSpec.builder(type, optionalParam.paramName, Modifier.PRIVATE).build());
+            accessors.add(MethodSpec.methodBuilder(optionalParam.paramName)
+                .addModifiers(Modifier.PUBLIC)
+                .returns(type)
+                .addStatement("return this.$N", optionalParam.paramName)
+                .build());
+        }
+        typeSpec.addMethod(constructor.build());
+        accessors.forEach(typeSpec::addMethod);
 
         for (var optionalParam : optionalParams) {
             var type = asType(ctx, operation, optionalParam).box();
@@ -195,19 +217,16 @@ public class ClientApiGenerator extends AbstractJavaGenerator<OperationsMap> {
                 .returns(recordClassName)
                 .addModifiers(Modifier.PUBLIC)
                 .addParameter(type, optionalParam.paramName)
-                .addCode("return new $T(", recordClassName);
-            for (int i = 0; i < optionalParams.size(); i++) {
-                if (i > 0) {
-                    wither.addCode(", ");
-                }
-                var p = optionalParams.get(i);
-                wither.addCode(p.paramName);
-            }
-            wither.addCode(");\n");
+                .addStatement("this.$N = $N", optionalParam.paramName, optionalParam.paramName)
+                .addStatement("return this");
             typeSpec.addMethod(wither.build());
         }
 
         return typeSpec.build();
+    }
+
+    private ClassName optionalArgsClassName(OperationsMap ctx, CodegenOperation operation) {
+        return ClassName.get(apiPackage, ctx.get("classname").toString() + StringUtils.capitalize(operation.operationId) + "OptArgs");
     }
 
 

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ModelGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ModelGenerator.java
@@ -1,14 +1,20 @@
 package io.koraframework.openapi.generator.javagen;
 
 import com.palantir.javapoet.*;
+import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.CodegenModel;
 import org.openapitools.codegen.CodegenProperty;
 import org.openapitools.codegen.model.ModelsMap;
 
 import javax.lang.model.element.Modifier;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.nio.file.Path;
 import java.util.*;
 
 public class ModelGenerator extends AbstractJavaGenerator<ModelsMap> {
+    private record Field(String name, String jsonName, TypeName type, boolean required, boolean nullable, String description, String defaultValue, String example) {}
+
     @Override
     public JavaFile generate(ModelsMap ctx) {
         var models = ctx.getModels();
@@ -24,6 +30,8 @@ public class ModelGenerator extends AbstractJavaGenerator<ModelsMap> {
         } else {
             type = buildRecord(ctx, model);
         }
+
+        writeEnumMapperModules(ctx);
 
         return JavaFile.builder(modelPackage, type).build();
     }
@@ -59,10 +67,14 @@ public class ModelGenerator extends AbstractJavaGenerator<ModelsMap> {
     private TypeSpec buildRecord(ModelsMap ctx, CodegenModel model) {
         var b = TypeSpec.recordBuilder(model.getClassname())
             .addAnnotation(generated())
-            .addModifiers(Modifier.PUBLIC)
-            .addJavadoc(Objects.requireNonNullElse(model.description, "") + "\n");
+            .addModifiers(Modifier.PUBLIC);
+        if (model.description == null || model.description.isBlank()) {
+            b.addJavadoc("$L\n", model.classname);
+        } else {
+            b.addJavadoc("$L - $L\n", model.classname, model.description);
+        }
         for (var field : model.allVars) {
-            b.addJavadoc("@param $N $L, $L\n", field.name, Objects.requireNonNullElse(field.description, field.baseName), field.example == null ? "" : "(example: " + field.example + ")");
+            b.addJavadoc("@param $N $L$L\n", field.name, Objects.requireNonNullElse(field.description, field.baseName), fieldJavadocMetadata(field));
         }
         if (params.enableValidation) {
             b.addAnnotation(Classes.valid);
@@ -139,7 +151,6 @@ public class ModelGenerator extends AbstractJavaGenerator<ModelsMap> {
         b.addSuperinterfaces(superinterfaces);
         var constructor = MethodSpec.constructorBuilder()
             .addModifiers(Modifier.PUBLIC);
-        record Field(String name, String jsonName, TypeName type, boolean required, boolean nullable) {}
         var fields = new ArrayList<Field>();
         for (var field : model.allVars) {
             if (parentFields.containsKey(field.name)) {
@@ -165,13 +176,16 @@ public class ModelGenerator extends AbstractJavaGenerator<ModelsMap> {
                 enumModel.name = enumSource.enumName;
                 enumModel.allowableValues = enumSource.allowableValues;
                 enumModel.dataType = enumSource.dataType;
+                enumModel.description = enumSource.description;
+                enumModel.vendorExtensions = enumSource.vendorExtensions;
                 enumModel.isString = enumSource.isString;
                 enumModel.isLong = enumSource.isLong;
                 enumModel.isInteger = enumSource.isInteger;
 
-                var enumTypeSpec = buildEnum(ctx, enumModel);
+                var enumClassName = ClassName.get(modelPackage, model.getClassname(), enumModel.name);
+                var enumTypeSpec = buildEnum(enumModel);
                 b.addType(enumTypeSpec);
-                fieldType = ClassName.get(modelPackage, model.getClassname(), enumModel.name);
+                fieldType = enumClassName;
                 if (field.isNullable && !field.required) {
                     fieldType = ParameterizedTypeName.get(Classes.jsonNullable, fieldType);
                 } else if (field.isNullable || !field.required) {
@@ -186,7 +200,7 @@ public class ModelGenerator extends AbstractJavaGenerator<ModelsMap> {
             if (validation != null) {
                 p.addAnnotation(validation);
             }
-            fields.add(new Field(field.name, field.baseName, fieldType, field.required, field.isNullable));
+            fields.add(new Field(field.name, field.baseName, fieldType, field.required, field.isNullable, field.description, field.defaultValue, field.example));
             if (field.required && field.isNullable) {
                 p.addAnnotation(AnnotationSpec.builder(Classes.jsonInclude).addMember("value", "$T.ALWAYS", Classes.jsonInclude.nestedClass("IncludeType")).build());
             }
@@ -248,8 +262,71 @@ public class ModelGenerator extends AbstractJavaGenerator<ModelsMap> {
             c.addCode(");\n");
             b.addMethod(c.build());
         }
+        for (var field : fields) {
+            b.addMethod(buildWithMethod(model, fields, field));
+        }
 
         return b.recordConstructor(constructor.build()).build();
+    }
+
+    private MethodSpec buildWithMethod(CodegenModel model, List<Field> fields, Field field) {
+        var method = MethodSpec.methodBuilder("with" + capitalize(field.name()))
+            .addModifiers(Modifier.PUBLIC)
+            .addParameter(field.type(), field.name())
+            .returns(ClassName.get(modelPackage, model.getClassname()));
+        buildWithMethodJavadoc(method, field);
+        method.addCode("if ($L) return this; ", fieldEquals(field));
+        method.addCode("return new $T(", ClassName.get(modelPackage, model.getClassname()));
+        for (var i = 0; i < fields.size(); i++) {
+            if (i > 0) {
+                method.addCode(", ");
+            }
+            var current = fields.get(i);
+            method.addCode("$N", current.name().equals(field.name()) ? field.name() : "this." + current.name());
+        }
+        method.addCode(");\n");
+        return method.build();
+    }
+
+    private String fieldJavadocMetadata(CodegenProperty field) {
+        var metadata = new ArrayList<String>();
+        if (field.defaultValue != null) {
+            metadata.add("default: " + field.defaultValue);
+        }
+        if (field.example != null) {
+            metadata.add("example: " + field.example);
+        }
+        return metadata.isEmpty() ? "" : " (" + String.join(", ", metadata) + ")";
+    }
+
+    private void buildWithMethodJavadoc(MethodSpec.Builder method, Field field) {
+        var javadoc = new ArrayList<String>();
+        if (field.description() != null && !field.description().equals(field.jsonName()) && !field.description().equals(field.name())) {
+            javadoc.add(field.description());
+        }
+        if (field.defaultValue() != null) {
+            javadoc.add("default: " + field.defaultValue());
+        }
+        if (field.example() != null) {
+            javadoc.add("example: " + field.example());
+        }
+        if (!javadoc.isEmpty()) {
+            method.addJavadoc("($L)", String.join(", ", javadoc));
+        }
+    }
+
+    private CodeBlock fieldEquals(Field field) {
+        var type = field.type().withoutAnnotations();
+        if (type.equals(TypeName.FLOAT)) {
+            return CodeBlock.of("$T.compare(this.$N, $N) == 0", Float.class, field.name(), field.name());
+        }
+        if (type.equals(TypeName.DOUBLE)) {
+            return CodeBlock.of("$T.compare(this.$N, $N) == 0", Double.class, field.name(), field.name());
+        }
+        if (type.isPrimitive()) {
+            return CodeBlock.of("this.$N == $N", field.name(), field.name());
+        }
+        return CodeBlock.of("$T.equals(this.$N, $N)", Objects.class, field.name(), field.name());
     }
 
     private TypeName fieldType(CodegenProperty field) {
@@ -264,17 +341,27 @@ public class ModelGenerator extends AbstractJavaGenerator<ModelsMap> {
     }
 
     private TypeSpec buildEnum(ModelsMap ctx, CodegenModel model) {
-        var contextModel = ctx.getModels().getFirst().getModel();
-        var enumClassName = contextModel == model ? ClassName.get(modelPackage, model.name) : ClassName.get(modelPackage, contextModel.classname, model.name);
-        var b = TypeSpec.enumBuilder(enumClassName)
+        return buildEnum(model);
+    }
+
+    private TypeSpec buildEnum(CodegenModel model) {
+        var b = TypeSpec.enumBuilder(model.name)
             .addAnnotation(generated())
             .addModifiers(Modifier.PUBLIC);
+        if (model.description != null && !model.description.isBlank()) {
+            b.addJavadoc("$L\n", model.description);
+        }
         @SuppressWarnings("unchecked")
         var enumVars = (List<Map<String, Object>>) model.allowableValues.get("enumVars");
-        for (var enumVar : enumVars) {
+        for (var i = 0; i < enumVars.size(); i++) {
+            var enumVar = enumVars.get(i);
             var enumName = enumVar.get("name").toString();
-            b.addEnumConstant(enumName, TypeSpec.anonymousClassBuilder("Constants.$L", enumName)
-                .build());
+            var enumConstant = TypeSpec.anonymousClassBuilder("$L", enumVar.get("value"));
+            var description = enumValueDescription(model, enumVar, i);
+            if (description != null && !description.isBlank()) {
+                enumConstant.addJavadoc("$L\n", description);
+            }
+            b.addEnumConstant(enumName, enumConstant.build());
         }
         b.addField(enumValueType(model), "value", Modifier.PRIVATE, Modifier.FINAL);
         b.addMethod(MethodSpec.constructorBuilder()
@@ -293,97 +380,207 @@ public class ModelGenerator extends AbstractJavaGenerator<ModelsMap> {
             .returns(String.class)
             .addStatement("return String.valueOf(value)")
             .build());
-        var constants = TypeSpec.classBuilder("Constants")
-            .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
-            .addAnnotation(generated());
-        for (var enumVar : enumVars) {
-            var enumName = enumVar.get("name").toString();
-            constants.addField(FieldSpec.builder(enumValueType(model), enumName, Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL).initializer("$L", enumVar.get("value")).build());
+        return b.build();
+    }
+
+    private void writeEnumMapperModules(ModelsMap ctx) {
+        var model = ctx.getModels().getFirst().getModel();
+        var modules = new LinkedHashMap<String, JavaFile>();
+        if (model.isEnum) {
+            var enumClassName = ClassName.get(modelPackage, model.name);
+            modules.put(enumMapperModuleName(enumClassName), buildEnumMapperModuleFile(enumClassName, model));
         }
-        b.addType(constants.build());
+        if (model.discriminator != null) {
+            return;
+        }
+        for (var field : model.allVars) {
+            if (!field.isInnerEnum) {
+                continue;
+            }
+            var enumModel = enumModel(field);
+            var enumClassName = ClassName.get(modelPackage, model.getClassname(), enumModel.name);
+            modules.put(enumMapperModuleName(enumClassName), buildEnumMapperModuleFile(enumClassName, enumModel));
+        }
+        for (var module : modules.values()) {
+            try {
+                module.writeTo(Path.of(outputFolder));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
 
-        b.addType(TypeSpec.classBuilder("JsonWriter")
-            .addAnnotation(generated())
-            .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
-            .addAnnotation(Classes.component)
-            .addSuperinterface(ParameterizedTypeName.get(Classes.jsonWriter, enumClassName))
-            .addField(ParameterizedTypeName.get(Classes.enumJsonWriter, enumClassName, enumValueType(model)), "delegate", Modifier.PRIVATE, Modifier.FINAL)
-            .addMethod(MethodSpec.constructorBuilder()
-                .addModifiers(Modifier.PUBLIC)
-                .addParameter(ParameterizedTypeName.get(Classes.jsonWriter, enumValueType(model)), "delegate")
-                .addStatement("this.delegate = new $T<>($T.values(), $T::getValue, delegate)", Classes.enumJsonWriter, enumClassName, enumClassName)
-                .build())
-            .addMethod(MethodSpec.methodBuilder("write")
-                .addModifiers(Modifier.PUBLIC)
-                .addAnnotation(Override.class)
-                .addParameter(Classes.jsonGenerator, "gen")
-                .addParameter(enumClassName.annotated(AnnotationSpec.builder(Classes.nullable).build()), "value")
-                .addStatement("this.delegate.write(gen, value)")
-                .build())
-            .build());
+    private CodegenModel enumModel(CodegenProperty field) {
+        var enumModel = new CodegenModel();
+        var enumSource = field;
+        if (field.isContainer) {
+            enumSource = field.items;
+        }
+        enumModel.name = enumSource.enumName;
+        enumModel.allowableValues = enumSource.allowableValues;
+        enumModel.dataType = enumSource.dataType;
+        enumModel.description = enumSource.description;
+        enumModel.vendorExtensions = enumSource.vendorExtensions;
+        enumModel.isString = enumSource.isString;
+        enumModel.isLong = enumSource.isLong;
+        enumModel.isInteger = enumSource.isInteger;
+        return enumModel;
+    }
 
-        b.addType(TypeSpec.classBuilder("JsonReader")
+    private String enumValueDescription(CodegenModel model, Map<String, Object> enumVar, int index) {
+        var enumDescription = enumVar.get("description");
+        if (enumDescription != null) {
+            return enumDescription.toString();
+        }
+        enumDescription = enumVar.get("enumDescription");
+        if (enumDescription != null) {
+            return enumDescription.toString();
+        }
+        if (model.vendorExtensions == null) {
+            return null;
+        }
+        for (var extension : List.of("x-enum-descriptions", "x-enumDescriptions", "x-enum-var-descriptions")) {
+            var descriptions = model.vendorExtensions.get(extension);
+            var description = enumValueDescription(descriptions, enumVar, index);
+            if (description != null) {
+                return description;
+            }
+        }
+        return null;
+    }
+
+    private String enumValueDescription(Object descriptions, Map<String, Object> enumVar, int index) {
+        if (descriptions instanceof List<?> list) {
+            if (index >= list.size()) {
+                return null;
+            }
+            var description = list.get(index);
+            return description == null ? null : description.toString();
+        }
+        if (descriptions instanceof Map<?, ?> map) {
+            var description = map.get(enumVar.get("value"));
+            if (description == null) {
+                description = map.get(enumVar.get("name"));
+            }
+            return description == null ? null : description.toString();
+        }
+        return null;
+    }
+
+    private JavaFile buildEnumMapperModuleFile(ClassName enumClassName, CodegenModel model) {
+        var module = buildEnumMapperModule(enumMapperModuleName(enumClassName), enumClassName, model);
+        return JavaFile.builder(modelPackage, module).build();
+    }
+
+    private String enumMapperModuleName(ClassName enumClassName) {
+        return "$" + String.join("", enumClassName.simpleNames()) + "MapperModule";
+    }
+
+    private TypeSpec buildEnumMapperModule(String moduleName, ClassName enumClassName, CodegenModel model) {
+        var enumValueType = enumValueType(model);
+        var enumSimpleName = enumClassName.simpleName();
+        var module = TypeSpec.interfaceBuilder(moduleName)
             .addAnnotation(generated())
-            .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
-            .addAnnotation(Classes.component)
-            .addSuperinterface(ParameterizedTypeName.get(Classes.jsonReader, enumClassName))
-            .addField(ParameterizedTypeName.get(Classes.enumJsonReader, enumClassName, enumValueType(model)), "delegate", Modifier.PRIVATE, Modifier.FINAL)
-            .addMethod(MethodSpec.constructorBuilder()
-                .addModifiers(Modifier.PUBLIC)
-                .addParameter(ParameterizedTypeName.get(Classes.jsonReader, enumValueType(model)), "delegate")
-                .addStatement("this.delegate = new $T<>($T.values(), $T::getValue, delegate)", Classes.enumJsonReader, enumClassName, enumClassName)
-                .build())
-            .addMethod(MethodSpec.methodBuilder("read")
-                .addModifiers(Modifier.PUBLIC)
-                .addAnnotation(Override.class)
-                .addParameter(Classes.jsonParser, "parser")
-                .addStatement("return this.delegate.read(parser)")
-                .returns(enumClassName.annotated(AnnotationSpec.builder(Classes.nullable).build()))
-                .build())
-            .build()
-        );
+            .addAnnotation(Classes.module)
+            .addModifiers(Modifier.PUBLIC);
+
+        var jsonWriter = MethodSpec.methodBuilder(StringUtils.uncapitalize(enumSimpleName) + "JsonWriter")
+            .addModifiers(Modifier.PUBLIC, Modifier.DEFAULT)
+            .addAnnotation(Classes.defaultComponent)
+            .returns(ParameterizedTypeName.get(Classes.jsonWriter, enumClassName));
+        if (isInlineEnumJsonValueType(enumValueType)) {
+            jsonWriter.addStatement("return new $T<>($T.values(), $T::getValue, $L)", Classes.enumJsonWriter, enumClassName, enumClassName, enumJsonWriter(enumValueType));
+        } else {
+            jsonWriter
+                .addParameter(ParameterizedTypeName.get(Classes.jsonWriter, enumValueType), "delegate")
+                .addStatement("return new $T<>($T.values(), $T::getValue, delegate)", Classes.enumJsonWriter, enumClassName, enumClassName);
+        }
+        module.addMethod(jsonWriter.build());
+
+        var jsonReader = MethodSpec.methodBuilder(StringUtils.uncapitalize(enumSimpleName) + "JsonReader")
+            .addModifiers(Modifier.PUBLIC, Modifier.DEFAULT)
+            .addAnnotation(Classes.defaultComponent)
+            .returns(ParameterizedTypeName.get(Classes.jsonReader, enumClassName));
+        if (isInlineEnumJsonValueType(enumValueType)) {
+            jsonReader.addStatement("return new $T<>($T.values(), $T::getValue, $L)", Classes.enumJsonReader, enumClassName, enumClassName, enumJsonReader(enumValueType));
+        } else {
+            jsonReader
+                .addParameter(ParameterizedTypeName.get(Classes.jsonReader, enumValueType), "delegate")
+                .addStatement("return new $T<>($T.values(), $T::getValue, delegate)", Classes.enumJsonReader, enumClassName, enumClassName);
+        }
+        module.addMethod(jsonReader.build());
 
         if (params.codegenMode.isClient()) {
-            b.addType(TypeSpec.classBuilder("StringParameterConverter")
-                .addAnnotation(generated())
-                .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
-                .addAnnotation(Classes.component)
-                .addSuperinterface(ParameterizedTypeName.get(Classes.stringParameterConverter, enumClassName))
-                .addField(ParameterizedTypeName.get(Classes.enumStringParameterConverter, enumClassName), "delegate", Modifier.PRIVATE, Modifier.FINAL)
-                .addMethod(MethodSpec.constructorBuilder()
-                    .addModifiers(Modifier.PUBLIC)
-                    .addStatement("this.delegate = new $T<>($T.values(), v -> String.valueOf(v.getValue()))", Classes.enumStringParameterConverter, enumClassName)
-                    .build())
-                .addMethod(MethodSpec.methodBuilder("convert")
-                    .addModifiers(Modifier.PUBLIC)
-                    .addAnnotation(Override.class)
-                    .addParameter(enumClassName, "value")
-                    .addStatement("return this.delegate.convert(value)")
-                    .returns(String.class)
-                    .build())
+            module.addMethod(MethodSpec.methodBuilder(StringUtils.uncapitalize(enumSimpleName) + "StringParameterConverter")
+                .addModifiers(Modifier.PUBLIC, Modifier.DEFAULT)
+                .addAnnotation(Classes.defaultComponent)
+                .returns(ParameterizedTypeName.get(Classes.stringParameterConverter, enumClassName))
+                .addStatement("return new $T<>($T.values(), v -> String.valueOf(v.getValue()))", Classes.enumStringParameterConverter, enumClassName)
                 .build());
         } else {
-            b.addType(TypeSpec.classBuilder("StringParameterReader")
-                .addAnnotation(generated())
-                .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
-                .addAnnotation(Classes.component)
-                .addSuperinterface(ParameterizedTypeName.get(Classes.stringParameterReader, enumClassName))
-                .addField(ParameterizedTypeName.get(Classes.enumStringParameterReader, enumClassName), "delegate", Modifier.PRIVATE, Modifier.FINAL)
-                .addMethod(MethodSpec.constructorBuilder()
-                    .addModifiers(Modifier.PUBLIC)
-                    .addStatement("this.delegate = new $T<>($T.values(), v -> String.valueOf(v.getValue()))", Classes.enumStringParameterReader, enumClassName)
-                    .build())
-                .addMethod(MethodSpec.methodBuilder("read")
-                    .addModifiers(Modifier.PUBLIC)
-                    .addAnnotation(Override.class)
-                    .addParameter(String.class, "value")
-                    .addStatement("return this.delegate.read(value)")
-                    .returns(enumClassName)
-                    .build())
+            module.addMethod(MethodSpec.methodBuilder(StringUtils.uncapitalize(enumSimpleName) + "StringParameterReader")
+                .addModifiers(Modifier.PUBLIC, Modifier.DEFAULT)
+                .addAnnotation(Classes.defaultComponent)
+                .returns(ParameterizedTypeName.get(Classes.stringParameterReader, enumClassName))
+                .addStatement("return new $T<>($T.values(), v -> String.valueOf(v.getValue()))", Classes.enumStringParameterReader, enumClassName)
                 .build());
         }
 
-        return b.build();
+        return module.build();
+    }
+
+    private boolean isInlineEnumJsonValueType(TypeName enumValueType) {
+        return enumValueType.equals(ClassName.get(String.class))
+               || enumValueType.equals(TypeName.INT.box())
+               || enumValueType.equals(TypeName.LONG.box());
+    }
+
+    private CodeBlock enumJsonWriter(TypeName enumValueType) {
+        if (enumValueType.equals(ClassName.get(String.class))) {
+            return CodeBlock.of("(gen, object) -> {\n"
+                                + "  if (object == null) {\n"
+                                + "    gen.writeNull();\n"
+                                + "  } else {\n"
+                                + "    gen.writeString(object);\n"
+                                + "  }\n"
+                                + "}");
+        }
+        if (enumValueType.equals(TypeName.INT.box()) || enumValueType.equals(TypeName.LONG.box())) {
+            return CodeBlock.of("(gen, object) -> {\n"
+                                + "  if (object == null) {\n"
+                                + "    gen.writeNull();\n"
+                                + "  } else {\n"
+                                + "    gen.writeNumber(object);\n"
+                                + "  }\n"
+                                + "}");
+        }
+        throw new RuntimeException("Illegal enum value type: " + enumValueType);
+    }
+
+    private CodeBlock enumJsonReader(TypeName enumValueType) {
+        var streamReadException = ClassName.get("tools.jackson.core.exc", "StreamReadException");
+        if (enumValueType.equals(ClassName.get(String.class))) {
+            return CodeBlock.of("parser -> switch (parser.currentToken()) {\n"
+                                + "  case VALUE_NULL -> null;\n"
+                                + "  case VALUE_STRING -> parser.getString();\n"
+                                + "  default -> throw new $T(parser, $S + parser.currentToken());\n"
+                                + "}", streamReadException, "Expecting VALUE_STRING token, got ");
+        }
+        if (enumValueType.equals(TypeName.INT.box())) {
+            return CodeBlock.of("parser -> switch (parser.currentToken()) {\n"
+                                + "  case VALUE_NULL -> null;\n"
+                                + "  case VALUE_NUMBER_INT -> parser.getIntValue();\n"
+                                + "  default -> throw new $T(parser, $S + parser.currentToken());\n"
+                                + "}", streamReadException, "Expecting VALUE_NUMBER_INT token, got ");
+        }
+        if (enumValueType.equals(TypeName.LONG.box())) {
+            return CodeBlock.of("parser -> switch (parser.currentToken()) {\n"
+                                + "  case VALUE_NULL -> null;\n"
+                                + "  case VALUE_NUMBER_INT -> parser.getLongValue();\n"
+                                + "  default -> throw new $T(parser, $S + parser.currentToken());\n"
+                                + "}", streamReadException, "Expecting VALUE_NUMBER_INT token, got ");
+        }
+        throw new RuntimeException("Illegal enum value type: " + enumValueType);
     }
 
     private TypeName enumValueType(CodegenModel model) {
@@ -396,7 +593,22 @@ public class ModelGenerator extends AbstractJavaGenerator<ModelsMap> {
         if (model.isInteger || "Integer".equals(model.dataType)) {
             return TypeName.INT.box();
         }
+        if ("Boolean".equals(model.dataType)) {
+            return TypeName.BOOLEAN.box();
+        }
+        if ("Float".equals(model.dataType)) {
+            return TypeName.FLOAT.box();
+        }
+        if ("Double".equals(model.dataType)) {
+            return TypeName.DOUBLE.box();
+        }
+        if ("BigDecimal".equals(model.dataType)) {
+            return ClassName.get(BigDecimal.class);
+        }
+        if (model.dataType != null && !model.dataType.isBlank()) {
+            return ClassName.bestGuess(model.dataType);
+        }
 
-        throw new RuntimeException("Illegal enum value type: " + model);
+        return ClassName.get(Object.class);
     }
 }

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/AbstractKotlinGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/AbstractKotlinGenerator.kt
@@ -228,7 +228,7 @@ abstract class AbstractKotlinGenerator<C : Any> : AbstractGenerator<C, FileSpec>
         val b = CodeBlock.builder()
         b.add(operation.httpMethod + " " + operation.path)
         if (operation.summary != null) {
-            b.add(": " + operation.summary)
+            b.add(" : " + operation.summary)
         }
         b.add("\n")
         if (operation.notes != null) {
@@ -257,6 +257,13 @@ abstract class AbstractKotlinGenerator<C : Any> : AbstractGenerator<C, FileSpec>
         if (operation.isDeprecated) {
             b.add("@deprecated\n")
         }
+        for (response in operation.responses) {
+            b.add("@return ")
+                .add(response.message)
+                .add(" (status code ")
+                .add(response.code)
+                .add(")\n")
+        }
         if (operation.externalDocs != null) {
             b.add("@see <a href=\"" + operation.externalDocs.url + "\">" + operation.summary + " Documentation</a>")
         }
@@ -273,8 +280,8 @@ abstract class AbstractKotlinGenerator<C : Any> : AbstractGenerator<C, FileSpec>
         com.palantir.javapoet.TypeName.SHORT.box() -> SHORT
         com.palantir.javapoet.TypeName.BYTE.box() -> BYTE
         com.palantir.javapoet.TypeName.DOUBLE.box() -> DOUBLE
-        com.palantir.javapoet.TypeName.BOOLEAN.box() -> FLOAT
-        com.palantir.javapoet.TypeName.FLOAT.box() -> BOOLEAN
+        com.palantir.javapoet.TypeName.FLOAT.box() -> FLOAT
+        com.palantir.javapoet.TypeName.BOOLEAN.box() -> BOOLEAN
         else -> ClassName(packageName(), simpleNames())
     }
 
@@ -304,5 +311,3 @@ abstract class AbstractKotlinGenerator<C : Any> : AbstractGenerator<C, FileSpec>
     protected fun jsonAnnotation() = AnnotationSpec.builder(Classes.json.asKt()).build()
 
 }
-
-

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ModelGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ModelGenerator.kt
@@ -137,6 +137,9 @@ class ModelGenerator : AbstractKotlinGenerator<ModelsMap>() {
                 enumModel.isString = enumSource.isString
                 enumModel.isLong = enumSource.isLong
                 enumModel.isInteger = enumSource.isInteger
+                enumModel.isDouble = enumSource.isDouble
+                enumModel.isFloat = enumSource.isFloat
+                enumModel.isBoolean = enumSource.isBoolean
                 val enumTypeSpec = buildEnum(ctx, enumModel)
                 b.addType(enumTypeSpec)
                 fieldType = ClassName(modelPackage, model.getClassname(), enumModel.name)
@@ -383,7 +386,19 @@ class ModelGenerator : AbstractKotlinGenerator<ModelsMap>() {
         if (model.isInteger || "Integer" == model.dataType) {
             return INT
         }
-        throw RuntimeException("Illegal enum value type")
+        if (model.isDouble || "Double" == model.dataType) {
+            return DOUBLE
+        }
+        if (model.isFloat || "Float" == model.dataType) {
+            return FLOAT
+        }
+        if (model.isBoolean || "Boolean" == model.dataType) {
+            return BOOLEAN
+        }
+        if (model.dataType != null && model.dataType.isNotBlank()) {
+            return ClassName.bestGuess(model.dataType)
+        }
+        return Any::class.asTypeName()
     }
 
 

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/BaseOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/BaseOpenapiTest.java
@@ -6,8 +6,10 @@ import org.openapitools.codegen.config.CodegenConfigurator;
 
 import javax.annotation.Nullable;
 import java.io.File;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -192,6 +194,15 @@ public abstract class BaseOpenapiTest {
 
         var clientOptInput = configurator.toClientOptInput();
         var generator = new DefaultGenerator();
-        return generator.opts(clientOptInput).generate();
+        var generatedFiles = new ArrayList<>(generator.opts(clientOptInput).generate());
+        var generatedPaths = new HashSet<>(generatedFiles.stream().map(file -> file.toPath().toAbsolutePath()).toList());
+        try (var files = Files.walk(openapiSourcesDir)) {
+            files.filter(Files::isRegularFile)
+                .map(Path::toAbsolutePath)
+                .filter(path -> !generatedPaths.contains(path))
+                .map(Path::toFile)
+                .forEach(generatedFiles::add);
+        }
+        return generatedFiles;
     }
 }

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientJavaOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientJavaOpenapiTest.java
@@ -110,4 +110,166 @@ public class HttpClientJavaOpenapiTest extends BaseJavaOpenapiTest {
         assertTrue(content.contains("return 400"));
         assertTrue(content.contains("return this.content().details()"));
     }
+
+    @Test
+    void javadocsIncludeOpenapiModelAndOperationMetadata() throws Exception {
+        var files = generate(
+            "petstoreV2_javadocs",
+            "java-client",
+            getClass().getResource("/example/petstoreV2.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+        );
+
+        var petContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("Pet.java"))
+            .findFirst()
+            .orElseThrow());
+        var apiContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("PetApi.java"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(petContent.contains("* Pet - A pet for sale in the pet store"));
+        assertTrue(petContent.contains("* @param status pet status in the store"));
+        assertTrue(petContent.contains("* @param name name (example: doggie)"));
+        assertTrue(apiContent.contains("* POST /pet : Add a new pet to the store"));
+        assertTrue(apiContent.contains("* @param body Pet object that needs to be added to the store (required)"));
+        assertTrue(apiContent.contains("* @return Invalid input (status code 405)"));
+    }
+
+    @Test
+    void enumMappersAreGeneratedAsModuleFactories() throws Exception {
+        var files = generate(
+            "petstoreV3_filter",
+            "java-client",
+            getClass().getResource("/example/petstoreV3_filter.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+        );
+
+        var petDogContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("PetDog.java"))
+            .findFirst()
+            .orElseThrow());
+
+        var moduleContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("$PetDogBreedEnumMapperModule.java"))
+            .findFirst()
+            .orElseThrow());
+
+        assertFalse(petDogContent.contains("MapperModule"));
+        assertTrue(petDogContent.contains("DINGO_DON(\"Dingo-Don\")"));
+        assertTrue(petDogContent.contains("NUMBER_5(5)"));
+        assertFalse(petDogContent.contains("Constants."));
+        assertFalse(petDogContent.contains("public static final class Constants"));
+        assertFalse(petDogContent.contains("public static final class JsonWriter"));
+        assertFalse(petDogContent.contains("public static final class JsonReader"));
+        assertFalse(petDogContent.contains("public static final class StringParameterConverter"));
+        assertTrue(petDogContent.contains("* Dingo breed"));
+        assertTrue(petDogContent.contains("* enum with int value"));
+
+        assertTrue(moduleContent.contains("public interface $PetDogBreedEnumMapperModule"));
+        assertTrue(moduleContent.contains("@DefaultComponent"));
+        assertTrue(moduleContent.contains("default JsonWriter<PetDog.BreedEnum> breedEnumJsonWriter()"));
+        assertTrue(moduleContent.contains("default JsonReader<PetDog.BreedEnum> breedEnumJsonReader()"));
+        assertTrue(moduleContent.contains("default HttpClientParameterWriter<PetDog.BreedEnum> breedEnumStringParameterConverter()"));
+        assertTrue(moduleContent.contains("new EnumJsonWriter<>(PetDog.BreedEnum.values(), PetDog.BreedEnum::getValue, (gen, object) ->"));
+        assertTrue(moduleContent.contains("new EnumJsonReader<>(PetDog.BreedEnum.values(), PetDog.BreedEnum::getValue, parser -> switch (parser.currentToken())"));
+    }
+
+    @Test
+    void enumMappersUseJsonDelegateForNonInlineValueTypes() throws Exception {
+        var files = generate(
+            "petstoreV3_enum",
+            "java-client",
+            getClass().getResource("/example/petstoreV3_enum.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+        );
+
+        var moduleContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("$PetNonReqDoubleEnumMapperModule.java"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(moduleContent.contains("default JsonWriter<Pet.NonReqDoubleEnum> nonReqDoubleEnumJsonWriter(JsonWriter<Double> delegate)"));
+        assertTrue(moduleContent.contains("return new EnumJsonWriter<>(Pet.NonReqDoubleEnum.values(), Pet.NonReqDoubleEnum::getValue, delegate)"));
+        assertTrue(moduleContent.contains("default JsonReader<Pet.NonReqDoubleEnum> nonReqDoubleEnumJsonReader(JsonReader<Double> delegate)"));
+        assertTrue(moduleContent.contains("return new EnumJsonReader<>(Pet.NonReqDoubleEnum.values(), Pet.NonReqDoubleEnum::getValue, delegate)"));
+        assertFalse(moduleContent.contains("parser -> switch"));
+    }
+
+    @Test
+    void recordsGetWithBuilderMethods() throws Exception {
+        var files = generate(
+            "petstoreV3_enum",
+            "java-client",
+            getClass().getResource("/example/petstoreV3_enum.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+        );
+
+        var content = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("Pet.java"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(content.contains("public Pet withId(long id)"));
+        assertTrue(content.contains("if (this.id == id) return this; return new Pet(id, this.nullableType"));
+        assertTrue(content.contains("public Pet withNonReqDouble(@Nullable NonReqDoubleEnum nonReqDouble)"));
+        assertTrue(content.contains("if (Objects.equals(this.nonReqDouble, nonReqDouble)) return this; return new Pet(this.id, this.nullableType"));
+        assertFalse(content.contains("* (nonReqDouble)"));
+
+        var filesWithDefaults = generate(
+            "petstoreV3_types",
+            "java-client",
+            getClass().getResource("/example/petstoreV3_types.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+        );
+
+        var contentWithDefaults = Files.readString(filesWithDefaults.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("Pet.java"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(contentWithDefaults.contains("* (default: 1)"));
+    }
+
+    @Test
+    void optionalArgsAreGeneratedAsMutableClasses() throws Exception {
+        var files = generate(
+            "petstoreV3_request_parameters",
+            "java-client",
+            getClass().getResource("/example/petstoreV3_request_parameters.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+        );
+
+        var apiContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("PetsApi.java"))
+            .findFirst()
+            .orElseThrow());
+        var optionalArgsContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("PetsApiListPetsOptArgs.java"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(apiContent.contains("PetsApiListPetsOptArgs optionalArguments"));
+        assertFalse(apiContent.contains("final class ListPetsOptArgs"));
+        assertTrue(optionalArgsContent.contains("public final class PetsApiListPetsOptArgs"));
+        assertFalse(optionalArgsContent.contains("record PetsApiListPetsOptArgs"));
+        assertTrue(optionalArgsContent.contains("public static PetsApiListPetsOptArgs empty()"));
+        assertTrue(optionalArgsContent.contains("public static PetsApiListPetsOptArgs defaults()"));
+        assertTrue(optionalArgsContent.contains("private PetsApiListPetsOptArgs("));
+        assertTrue(optionalArgsContent.contains("private @Nullable Integer intOptional;"));
+        assertTrue(optionalArgsContent.contains("public @Nullable Integer intOptional()"));
+        assertTrue(optionalArgsContent.contains("this.intOptional = intOptional;"));
+        assertTrue(optionalArgsContent.contains("public PetsApiListPetsOptArgs withIntOptional(Integer intOptional)"));
+        assertTrue(optionalArgsContent.contains("return this;"));
+    }
 }

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpServerJavaOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpServerJavaOpenapiTest.java
@@ -1,7 +1,12 @@
 package io.koraframework.openapi.generator;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+
+import java.nio.file.Files;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class HttpServerJavaOpenapiTest extends BaseJavaOpenapiTest {
     @ParameterizedTest
@@ -13,5 +18,33 @@ public class HttpServerJavaOpenapiTest extends BaseJavaOpenapiTest {
             params.spec(),
             params.options()
         );
+    }
+
+    @Test
+    void javadocsIncludeOpenapiOperationMetadata() throws Exception {
+        var files = generate(
+            "petstoreV2_javadocs",
+            "java-server",
+            getClass().getResource("/example/petstoreV2.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+        );
+
+        var apiContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("PetApiController.java"))
+            .findFirst()
+            .orElseThrow());
+        var delegateContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("PetApiDelegate.java"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(apiContent.contains("* POST /pet : Add a new pet to the store"));
+        assertTrue(apiContent.contains("* @param body Pet object that needs to be added to the store (required)"));
+        assertTrue(apiContent.contains("* @return Invalid input (status code 405)"));
+        assertTrue(delegateContent.contains("* POST /pet : Add a new pet to the store"));
+        assertTrue(delegateContent.contains("* @param body Pet object that needs to be added to the store (required)"));
+        assertTrue(delegateContent.contains("* @return Invalid input (status code 405)"));
     }
 }

--- a/openapi/openapi-generator/src/test/resources/example/petstoreV3_enum.yaml
+++ b/openapi/openapi-generator/src/test/resources/example/petstoreV3_enum.yaml
@@ -104,6 +104,10 @@ components:
         nonReqInt:
           type: integer
           enum: [ 5, 7, 8, 10 ]
+        nonReqDouble:
+          type: number
+          format: double
+          enum: [ 1.5, 2.5 ]
         nonReqArrayInt:
           type: array
           items:

--- a/openapi/openapi-generator/src/test/resources/example/petstoreV3_filter.yaml
+++ b/openapi/openapi-generator/src/test/resources/example/petstoreV3_filter.yaml
@@ -351,6 +351,11 @@ components:
             breed:
               type: string
               enum: [ Dingo-Don, Husky, Retriever, Shepherd ]
+              x-enum-descriptions:
+                - Dingo breed
+                - Husky breed
+                - Retriever breed
+                - Shepherd breed
             int-breed:
               description: "enum with int value"
               type: int
@@ -550,4 +555,3 @@ security:
   - oAuth:
       - pets:write
       - pets:read
-


### PR DESCRIPTION
- Move enum JSON/request mappers into top-level `@Module` factories
- Restore richer OpenAPI javadocs for models, operations, and enums
- Generate record with-methods and top-level mutable optional args
- Add focused OpenAPI fixtures and regression tests