### PR TITLE
Added cache enablement config with disabled no-op behavior

### DIFF
--- a/cache/cache-annotation-processor/src/test/java/io/koraframework/cache/annotation/processor/CacheRunner.java
+++ b/cache/cache-annotation-processor/src/test/java/io/koraframework/cache/annotation/processor/CacheRunner.java
@@ -26,6 +26,7 @@ final class CacheRunner {
         var config = Mockito.mock(CaffeineCacheConfig.class);
         var telemetry = Mockito.mock(CaffeineCacheTelemetryConfig.class);
         when(config.telemetry()).thenReturn(telemetry);
+        when(config.enabled()).thenReturn(true);
         when(config.maximumSize()).thenReturn(100_000L);
         when(config.expireAfterAccess()).thenReturn(null);
         when(config.expireAfterWrite()).thenReturn(null);
@@ -37,6 +38,7 @@ final class CacheRunner {
 
     public static RedisCacheConfig getRedisConfig() {
         var config = Mockito.mock(RedisCacheConfig.class);
+        when(config.enabled()).thenReturn(true);
         when(config.keyPrefix()).thenReturn("pref");
         when(config.telemetry()).thenReturn(new $RedisCacheTelemetryConfig_ConfigValueMapper.RedisCacheTelemetryConfig_Impl(
             new $RedisCacheTelemetryConfig_RedisCacheLoggingConfig_ConfigValueMapper.RedisCacheLoggingConfig_Defaults(),

--- a/cache/cache-caffeine/src/main/java/io/koraframework/cache/caffeine/AbstractCaffeineCache.java
+++ b/cache/cache-caffeine/src/main/java/io/koraframework/cache/caffeine/AbstractCaffeineCache.java
@@ -20,6 +20,7 @@ public abstract class AbstractCaffeineCache<K, V> implements CaffeineCache<K, V>
 
     private final Cache<K, V> caffeine;
     private final CaffeineCacheTelemetry telemetry;
+    private final boolean enabled;
 
     protected AbstractCaffeineCache(String cacheConfigPath,
                                     CaffeineCacheConfig config,
@@ -27,12 +28,16 @@ public abstract class AbstractCaffeineCache<K, V> implements CaffeineCache<K, V>
                                     CaffeineCacheTelemetryFactory telemetryFactory) {
         this.caffeine = factory.build(cacheConfigPath, config);
         this.telemetry = telemetryFactory.get(cacheConfigPath, getClass(), config.telemetry());
+        this.enabled = config.enabled();
     }
 
     @Override
     @Nullable
     public V get(K key) {
         if (key == null) {
+            return null;
+        }
+        if (!enabled) {
             return null;
         }
 
@@ -55,6 +60,9 @@ public abstract class AbstractCaffeineCache<K, V> implements CaffeineCache<K, V>
         if (keys == null || keys.isEmpty()) {
             return Collections.emptyMap();
         }
+        if (!enabled) {
+            return Collections.emptyMap();
+        }
 
         var observation = this.telemetry.observe(GET_MANY);
         observation.observeKeys(keys);
@@ -72,6 +80,10 @@ public abstract class AbstractCaffeineCache<K, V> implements CaffeineCache<K, V>
 
     @Override
     public Map<K, V> getAll() {
+        if (!enabled) {
+            return Collections.emptyMap();
+        }
+
         var observation = this.telemetry.observe(GET_ALL);
         try {
             var values = Collections.unmodifiableMap(caffeine.asMap());
@@ -88,6 +100,9 @@ public abstract class AbstractCaffeineCache<K, V> implements CaffeineCache<K, V>
     @Override
     public V computeIfAbsent(K key, Function<K, @Nullable V> mappingFunction) {
         if (key == null) {
+            return mappingFunction.apply(key);
+        }
+        if (!enabled) {
             return mappingFunction.apply(key);
         }
 
@@ -111,6 +126,9 @@ public abstract class AbstractCaffeineCache<K, V> implements CaffeineCache<K, V>
         if (keys == null || keys.isEmpty()) {
             return mappingFunction.apply(Collections.emptySet());
         }
+        if (!enabled) {
+            return mappingFunction.apply(Set.copyOf(keys));
+        }
 
         var observation = this.telemetry.observe(COMPUTE_IF_ABSENT_MANY);
         observation.observeKeys(keys);
@@ -133,6 +151,9 @@ public abstract class AbstractCaffeineCache<K, V> implements CaffeineCache<K, V>
         if (key == null || value == null) {
             return value;
         }
+        if (!enabled) {
+            return value;
+        }
 
         var observation = this.telemetry.observe(PUT);
         observation.observeKey(key);
@@ -152,6 +173,9 @@ public abstract class AbstractCaffeineCache<K, V> implements CaffeineCache<K, V>
     public Map<K, V> put(Map<K, V> keyAndValues) {
         if (keyAndValues == null || keyAndValues.isEmpty()) {
             return Collections.emptyMap();
+        }
+        if (!enabled) {
+            return keyAndValues;
         }
 
         var observation = this.telemetry.observe(PUT_MANY);
@@ -173,6 +197,9 @@ public abstract class AbstractCaffeineCache<K, V> implements CaffeineCache<K, V>
         if (key == null) {
             return;
         }
+        if (!enabled) {
+            return;
+        }
 
         var observation = this.telemetry.observe(INVALIDATE);
         observation.observeKey(key);
@@ -191,6 +218,9 @@ public abstract class AbstractCaffeineCache<K, V> implements CaffeineCache<K, V>
         if (keys == null || keys.isEmpty()) {
             return;
         }
+        if (!enabled) {
+            return;
+        }
 
         var observation = this.telemetry.observe(INVALIDATE_MANY);
         observation.observeKeys(keys);
@@ -206,6 +236,10 @@ public abstract class AbstractCaffeineCache<K, V> implements CaffeineCache<K, V>
 
     @Override
     public void invalidateAll() {
+        if (!enabled) {
+            return;
+        }
+
         var observation = this.telemetry.observe(INVALIDATE_ALL);
         try {
             observation.observeKeys(List.of());

--- a/cache/cache-caffeine/src/main/java/io/koraframework/cache/caffeine/CaffeineCacheConfig.java
+++ b/cache/cache-caffeine/src/main/java/io/koraframework/cache/caffeine/CaffeineCacheConfig.java
@@ -10,6 +10,10 @@ import java.time.Duration;
 @ConfigMapper
 public interface CaffeineCacheConfig {
 
+    default boolean enabled() {
+        return true;
+    }
+
     @Nullable
     Duration expireAfterWrite();
 

--- a/cache/cache-caffeine/src/test/java/io/koraframework/cache/caffeine/CacheRunner.java
+++ b/cache/cache-caffeine/src/test/java/io/koraframework/cache/caffeine/CacheRunner.java
@@ -15,6 +15,7 @@ abstract class CacheRunner extends Assertions implements CaffeineCacheModule {
         var config = Mockito.mock(CaffeineCacheConfig.class);
         var telemetry = Mockito.mock(CaffeineCacheTelemetryConfig.class);
         when(config.telemetry()).thenReturn(telemetry);
+        when(config.enabled()).thenReturn(true);
         when(config.maximumSize()).thenReturn(100_000L);
         when(config.expireAfterAccess()).thenReturn(null);
         when(config.expireAfterWrite()).thenReturn(null);
@@ -24,8 +25,14 @@ abstract class CacheRunner extends Assertions implements CaffeineCacheModule {
         return config;
     }
     protected DummyCache createCache() {
+        return createCache(true);
+    }
+
+    protected DummyCache createCache(boolean enabled) {
         try {
-            return new DummyCache(getConfig(), caffeineCacheFactory(null), defaultCaffeineCacheTelemetryFactory(null, null, null, null));
+            var config = getConfig();
+            when(config.enabled()).thenReturn(enabled);
+            return new DummyCache(config, caffeineCacheFactory(null), defaultCaffeineCacheTelemetryFactory(null, null, null, null));
         } catch (Exception e) {
             throw new IllegalStateException(e);
         }

--- a/cache/cache-caffeine/src/test/java/io/koraframework/cache/caffeine/SyncCacheTests.java
+++ b/cache/cache-caffeine/src/test/java/io/koraframework/cache/caffeine/SyncCacheTests.java
@@ -5,6 +5,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import io.koraframework.cache.caffeine.testdata.DummyCache;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class SyncCacheTests extends CacheRunner {
 
@@ -80,5 +84,28 @@ class SyncCacheTests extends CacheRunner {
         // then
         final String fromCache = cache.get(key);
         assertNull(fromCache);
+    }
+
+    @Test
+    void operationsAreDisabledWhenConfigDisabled() {
+        // given
+        var disabledCache = createCache(false);
+
+        // when
+        assertEquals("1", disabledCache.put("1", "1"));
+        assertEquals(Map.of("2", "2"), disabledCache.put(Map.of("2", "2")));
+
+        // then
+        assertNull(disabledCache.get("1"));
+        assertTrue(disabledCache.get(List.of("1", "2")).isEmpty());
+        assertTrue(disabledCache.getAll().isEmpty());
+
+        // when
+        assertEquals("3", disabledCache.computeIfAbsent("3", k -> "3"));
+        assertEquals(Map.of("4", "4"), disabledCache.computeIfAbsent(Set.of("4"), keys -> Map.of("4", "4")));
+
+        // then
+        assertNull(disabledCache.get("3"));
+        assertTrue(disabledCache.get(List.of("4")).isEmpty());
     }
 }

--- a/cache/cache-redis-common/src/main/java/io/koraframework/cache/redis/AbstractRedisCache.java
+++ b/cache/cache-redis-common/src/main/java/io/koraframework/cache/redis/AbstractRedisCache.java
@@ -27,6 +27,7 @@ public abstract class AbstractRedisCache<K, V> implements RedisCache<K, V> {
 
     private final RedisCacheClient redisClient;
     private final RedisCacheTelemetry telemetry;
+    private final boolean enabled;
 
     private final RedisCacheKeyMapper<K> keyMapper;
     private final RedisCacheValueMapper<V> valueMapper;
@@ -45,6 +46,7 @@ public abstract class AbstractRedisCache<K, V> implements RedisCache<K, V> {
                                  RedisCacheValueMapper<V> valueMapper) {
         this.redisClient = redisClient;
         this.telemetry = telemetryFactory.get(cacheConfigPath, getClass(), config.telemetry());
+        this.enabled = config.enabled();
         this.keyMapper = keyMapper;
         this.valueMapper = valueMapper;
         this.expireAfterAccessMillis = (config.expireAfterAccess() == null)
@@ -72,6 +74,9 @@ public abstract class AbstractRedisCache<K, V> implements RedisCache<K, V> {
     @Override
     public V get(K key) {
         if (key == null) {
+            return null;
+        }
+        if (!enabled) {
             return null;
         }
 
@@ -105,6 +110,9 @@ public abstract class AbstractRedisCache<K, V> implements RedisCache<K, V> {
     @Override
     public Map<K, V> get(Collection<K> keys) {
         if (keys == null || keys.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        if (!enabled) {
             return Collections.emptyMap();
         }
 
@@ -152,6 +160,9 @@ public abstract class AbstractRedisCache<K, V> implements RedisCache<K, V> {
         if (key == null || value == null) {
             return null;
         }
+        if (!enabled) {
+            return value;
+        }
 
         var observation = this.telemetry.observe(Operation.PUT);
         return ScopedValue
@@ -185,6 +196,9 @@ public abstract class AbstractRedisCache<K, V> implements RedisCache<K, V> {
     public Map<K, V> put(Map<K, V> keyAndValues) {
         if (keyAndValues == null || keyAndValues.isEmpty()) {
             return Collections.emptyMap();
+        }
+        if (!enabled) {
+            return keyAndValues;
         }
 
         var observation = this.telemetry.observe(Operation.PUT_MANY);
@@ -231,6 +245,9 @@ public abstract class AbstractRedisCache<K, V> implements RedisCache<K, V> {
     @Override
     public V computeIfAbsent(K key, Function<K, @Nullable V> mappingFunction) {
         if (key == null) {
+            return mappingFunction.apply(key);
+        }
+        if (!enabled) {
             return mappingFunction.apply(key);
         }
 
@@ -289,6 +306,9 @@ public abstract class AbstractRedisCache<K, V> implements RedisCache<K, V> {
     public Map<K, V> computeIfAbsent(Collection<K> keys, Function<Set<K>, Map<K, V>> mappingFunction) {
         if (keys == null || keys.isEmpty()) {
             return mappingFunction.apply(Collections.emptySet());
+        }
+        if (!enabled) {
+            return mappingFunction.apply(Set.copyOf(keys));
         }
 
         var observation = this.telemetry.observe(Operation.COMPUTE_IF_ABSENT_MANY);
@@ -370,6 +390,9 @@ public abstract class AbstractRedisCache<K, V> implements RedisCache<K, V> {
         if (key == null) {
             return;
         }
+        if (!enabled) {
+            return;
+        }
 
         var observation = this.telemetry.observe(Operation.INVALIDATE);
         ScopedValue
@@ -393,6 +416,9 @@ public abstract class AbstractRedisCache<K, V> implements RedisCache<K, V> {
     @Override
     public void invalidate(Collection<K> keys) {
         if (keys == null || keys.isEmpty()) {
+            return;
+        }
+        if (!enabled) {
             return;
         }
 
@@ -420,6 +446,10 @@ public abstract class AbstractRedisCache<K, V> implements RedisCache<K, V> {
 
     @Override
     public void invalidateAll() {
+        if (!enabled) {
+            return;
+        }
+
         var observation = this.telemetry.observe(Operation.INVALIDATE_ALL);
         ScopedValue
             .where(Observation.VALUE, observation)

--- a/cache/cache-redis-common/src/main/java/io/koraframework/cache/redis/RedisCacheConfig.java
+++ b/cache/cache-redis-common/src/main/java/io/koraframework/cache/redis/RedisCacheConfig.java
@@ -10,6 +10,10 @@ import java.time.Duration;
 @ConfigMapper
 public interface RedisCacheConfig {
 
+    default boolean enabled() {
+        return true;
+    }
+
     /**
      * Key prefix allow to avoid key collision in single Redis database between multiple caches
      *

--- a/cache/cache-redis-lettuce/src/test/java/io/koraframework/cache/redis/CacheRunner.java
+++ b/cache/cache-redis-lettuce/src/test/java/io/koraframework/cache/redis/CacheRunner.java
@@ -21,7 +21,18 @@ public abstract class CacheRunner extends Assertions implements LettuceRedisCach
 
     public static RedisCacheConfig getConfig(@Nullable Duration expireWrite,
                                              @Nullable Duration expireRead) {
+        return getConfig(expireWrite, expireRead, true);
+    }
+
+    public static RedisCacheConfig getConfig(@Nullable Duration expireWrite,
+                                             @Nullable Duration expireRead,
+                                             boolean enabled) {
         return new RedisCacheConfig() {
+
+            @Override
+            public boolean enabled() {
+                return enabled;
+            }
 
             @Override
             public String keyPrefix() {
@@ -96,8 +107,12 @@ public abstract class CacheRunner extends Assertions implements LettuceRedisCach
     }
 
     private DummyCache createDummyCache(RedisParams redisParams, Duration expireWrite, Duration expireRead) throws Exception {
+        return createDummyCache(redisParams, expireWrite, expireRead, true);
+    }
+
+    private DummyCache createDummyCache(RedisParams redisParams, Duration expireWrite, Duration expireRead, boolean enabled) throws Exception {
         var lettuceClient = createLettuce(redisParams);
-        return new DummyCache(getConfig(expireWrite, expireRead), lettuceClient, defaultRedisCacheTelemetryFactory(null, null, null, null),
+        return new DummyCache(getConfig(expireWrite, expireRead, enabled), lettuceClient, defaultRedisCacheTelemetryFactory(null, null, null, null),
             stringRedisCacheKeyMapper(), stringRedisCacheValueMapper());
     }
 
@@ -111,5 +126,9 @@ public abstract class CacheRunner extends Assertions implements LettuceRedisCach
 
     protected DummyCache createCacheExpireRead(RedisParams redisParams, Duration expireRead) throws Exception {
         return createDummyCache(redisParams, null, expireRead);
+    }
+
+    protected DummyCache createCacheDisabled(RedisParams redisParams) throws Exception {
+        return createDummyCache(redisParams, null, null, false);
     }
 }

--- a/cache/cache-redis-lettuce/src/test/java/io/koraframework/cache/redis/SyncCacheTests.java
+++ b/cache/cache-redis-lettuce/src/test/java/io/koraframework/cache/redis/SyncCacheTests.java
@@ -4,7 +4,12 @@ import io.koraframework.test.redis.RedisParams;
 import io.koraframework.test.redis.RedisTestContainer;
 import io.lettuce.core.FlushMode;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @RedisTestContainer
@@ -17,5 +22,27 @@ class SyncCacheTests extends AbstractSyncCacheTests {
         if (cache == null) {
             cache = createCache(redisParams);
         }
+    }
+
+    @Test
+    void operationsAreDisabledWhenConfigDisabled() throws Exception {
+        // given
+        var disabledCache = createCacheDisabled(redisParams);
+
+        // when
+        assertEquals("1", disabledCache.put("1", "1"));
+        assertEquals(Map.of("2", "2"), disabledCache.put(Map.of("2", "2")));
+
+        // then
+        assertNull(disabledCache.get("1"));
+        assertTrue(disabledCache.get(List.of("1", "2")).isEmpty());
+
+        // when
+        assertEquals("3", disabledCache.computeIfAbsent("3", k -> "3"));
+        assertEquals(Map.of("4", "4"), disabledCache.computeIfAbsent(Set.of("4"), keys -> Map.of("4", "4")));
+
+        // then
+        assertNull(disabledCache.get("3"));
+        assertTrue(disabledCache.get(List.of("4")).isEmpty());
     }
 }

--- a/cache/cache-symbol-processor/src/test/kotlin/io/koraframework/cache/symbol/processor/CacheRunner.kt
+++ b/cache/cache-symbol-processor/src/test/kotlin/io/koraframework/cache/symbol/processor/CacheRunner.kt
@@ -28,6 +28,7 @@ class CacheRunner {
             val config = Mockito.mock(CaffeineCacheConfig::class.java)
             val telemetry = Mockito.mock(CaffeineCacheTelemetryConfig::class.java)
             `when`(config.telemetry()).thenReturn(telemetry)
+            `when`(config.enabled()).thenReturn(true)
             `when`(config.maximumSize()).thenReturn(100000L)
             `when`(config.expireAfterAccess()).thenReturn(null)
             `when`(config.expireAfterWrite()).thenReturn(null)


### PR DESCRIPTION
Added cache enablement config with disabled no-op behavior

## EN

Added `enabled` cache configuration for Caffeine and Redis caches with default-enabled behavior for backward compatibility. When disabled, cache reads always miss, writes and invalidations are skipped, and `computeIfAbsent` returns loader results without storing them.

---

## RU

Добавлена настройка `enabled` для Caffeine и Redis кешей, по умолчанию кеши остаются включенными для обратной совместимости. При отключении чтение всегда возвращает промах, запись и инвалидация не выполняются, а `computeIfAbsent` возвращает результат загрузчика без сохранения в кеш.

---

- Added `enabled` support to cache configuration with a default value of `true`, preserving existing behavior unless explicitly disabled.

---

## Design

The `enabled` flag is owned by provider-specific cache configs: `CaffeineCacheConfig` and `RedisCacheConfig`. Both expose a default method returning `true`, so existing applications and generated config mappings keep current behavior without requiring config changes.

Runtime cache implementations check the flag before performing cache operations. Disabled caches do not call the underlying Caffeine or Redis client for reads, writes, compute storage, or invalidation, so the cache layer behaves as bypassed.

`computeIfAbsent` keeps the application contract useful while disabled: it still invokes the provided loader and returns its result, but does not persist it.

Example configuration:

```yaml
cache:
  myCache:
    enabled: false
```