### PR TITLE
Improved telemetry no-op metrics with shared zero-allocation registry

### DIFF
--- a/cache/cache-caffeine/src/main/java/io/koraframework/cache/caffeine/telemetry/impl/DefaultCaffeineCacheTelemetryFactory.java
+++ b/cache/cache-caffeine/src/main/java/io/koraframework/cache/caffeine/telemetry/impl/DefaultCaffeineCacheTelemetryFactory.java
@@ -3,8 +3,8 @@ package io.koraframework.cache.caffeine.telemetry.impl;
 import io.koraframework.cache.caffeine.telemetry.CaffeineCacheTelemetry;
 import io.koraframework.cache.caffeine.telemetry.CaffeineCacheTelemetryConfig;
 import io.koraframework.cache.caffeine.telemetry.CaffeineCacheTelemetryFactory;
+import io.koraframework.micrometer.common.NoopMeterRegistry;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.TracerProvider;
 import org.jspecify.annotations.Nullable;
@@ -12,7 +12,7 @@ import org.jspecify.annotations.Nullable;
 public class DefaultCaffeineCacheTelemetryFactory implements CaffeineCacheTelemetryFactory {
 
     public static final Tracer NOOP_TRACER = TracerProvider.noop().get("caffeine");
-    public static final MeterRegistry NOOP_METER_REGISTRY = new CompositeMeterRegistry();
+    public static final MeterRegistry NOOP_METER_REGISTRY = NoopMeterRegistry.INSTANCE;
 
     @Nullable
     private final Tracer tracer;

--- a/cache/cache-redis-common/src/main/java/io/koraframework/cache/redis/telemetry/impl/DefaultRedisCacheTelemetryFactory.java
+++ b/cache/cache-redis-common/src/main/java/io/koraframework/cache/redis/telemetry/impl/DefaultRedisCacheTelemetryFactory.java
@@ -3,8 +3,8 @@ package io.koraframework.cache.redis.telemetry.impl;
 import io.koraframework.cache.redis.telemetry.RedisCacheTelemetry;
 import io.koraframework.cache.redis.telemetry.RedisCacheTelemetryConfig;
 import io.koraframework.cache.redis.telemetry.RedisCacheTelemetryFactory;
+import io.koraframework.micrometer.common.NoopMeterRegistry;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.TracerProvider;
 import org.jspecify.annotations.Nullable;
@@ -12,7 +12,7 @@ import org.jspecify.annotations.Nullable;
 public class DefaultRedisCacheTelemetryFactory implements RedisCacheTelemetryFactory {
 
     public static final Tracer NOOP_TRACER = TracerProvider.noop().get("redis-lettuce");
-    public static final MeterRegistry NOOP_METER_REGISTRY = new CompositeMeterRegistry();
+    public static final MeterRegistry NOOP_METER_REGISTRY = NoopMeterRegistry.INSTANCE;
 
     @Nullable
     private final Tracer tracer;

--- a/core/common/build.gradle
+++ b/core/common/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     api project(":core:application-graph")
     api libs.slf4j.api
-    api libs.micrometer.core
+    api project(":telemetry:micrometer-common")
     api libs.opentelemetry.api
 }
 

--- a/database/database-cassandra/src/test/java/io/koraframework/database/cassandra/CassandraTestUtils.java
+++ b/database/database-cassandra/src/test/java/io/koraframework/database/cassandra/CassandraTestUtils.java
@@ -8,7 +8,7 @@ import io.koraframework.database.common.telemetry.impl.DefaultDatabaseTelemetryF
 import io.koraframework.database.common.telemetry.impl.NoopDatabaseLoggerFactory;
 import io.koraframework.database.common.telemetry.impl.NoopDatabaseMetricsFactory;
 import io.koraframework.test.cassandra.CassandraParams;
-import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.koraframework.micrometer.common.NoopMeterRegistry;
 import io.opentelemetry.api.trace.TracerProvider;
 
 import java.time.Duration;
@@ -63,7 +63,7 @@ final class CassandraTestUtils {
                 new $DatabaseTelemetryConfig_DatabaseTracingConfig_ConfigValueMapper.DatabaseTracingConfig_Impl(true, Map.of())
             )
         );
-        return new CassandraSession(config, new DefaultDatabaseTelemetryFactory(TracerProvider.noop().get(""), new CompositeMeterRegistry(), NoopDatabaseLoggerFactory.INSTANCE, NoopDatabaseMetricsFactory.INSTANCE), null, null);
+        return new CassandraSession(config, new DefaultDatabaseTelemetryFactory(TracerProvider.noop().get(""), NoopMeterRegistry.INSTANCE, NoopDatabaseLoggerFactory.INSTANCE, NoopDatabaseMetricsFactory.INSTANCE), null, null);
     }
 
     static void withDb(CassandraParams params, Consumer<CassandraSession> consumer) {

--- a/database/database-common/src/main/java/io/koraframework/database/common/telemetry/impl/DefaultDatabaseTelemetryFactory.java
+++ b/database/database-common/src/main/java/io/koraframework/database/common/telemetry/impl/DefaultDatabaseTelemetryFactory.java
@@ -3,8 +3,8 @@ package io.koraframework.database.common.telemetry.impl;
 import io.koraframework.database.common.telemetry.DatabaseTelemetry;
 import io.koraframework.database.common.telemetry.DatabaseTelemetryConfig;
 import io.koraframework.database.common.telemetry.DatabaseTelemetryFactory;
+import io.koraframework.micrometer.common.NoopMeterRegistry;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.TracerProvider;
 import org.jspecify.annotations.Nullable;
@@ -12,7 +12,7 @@ import org.jspecify.annotations.Nullable;
 public class DefaultDatabaseTelemetryFactory implements DatabaseTelemetryFactory {
 
     public static final Tracer NOOP_TRACER = TracerProvider.noop().get("database");
-    public static final MeterRegistry NOOP_METER_REGISTRY = new CompositeMeterRegistry();
+    public static final MeterRegistry NOOP_METER_REGISTRY = NoopMeterRegistry.INSTANCE;
 
     @Nullable
     private final Tracer tracer;

--- a/database/database-flyway/src/test/java/io/koraframework/database/flyway/FlywayJdbcDataSourceInterceptorTest.java
+++ b/database/database-flyway/src/test/java/io/koraframework/database/flyway/FlywayJdbcDataSourceInterceptorTest.java
@@ -11,7 +11,7 @@ import io.koraframework.database.jdbc.$JdbcDatabaseConfig_ConfigValueMapper;
 import io.koraframework.database.jdbc.JdbcDataSource;
 import io.koraframework.test.postgres.PostgresParams;
 import io.koraframework.test.postgres.PostgresTestContainer;
-import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.koraframework.micrometer.common.NoopMeterRegistry;
 import io.opentelemetry.api.trace.TracerProvider;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -49,7 +49,7 @@ public class FlywayJdbcDataSourceInterceptorTest {
                 new $DatabaseTelemetryConfig_DatabaseTracingConfig_ConfigValueMapper.DatabaseTracingConfig_Impl(true, Map.of())
             )
         );
-        var database = new JdbcDataSource(config, new DefaultDatabaseTelemetryFactory(TracerProvider.noop().get(""), new CompositeMeterRegistry(), NoopDatabaseLoggerFactory.INSTANCE, NoopDatabaseMetricsFactory.INSTANCE), null);
+        var database = new JdbcDataSource(config, new DefaultDatabaseTelemetryFactory(TracerProvider.noop().get(""), NoopMeterRegistry.INSTANCE, NoopDatabaseLoggerFactory.INSTANCE, NoopDatabaseMetricsFactory.INSTANCE), null);
         database.init();
         try {
 

--- a/database/database-jdbc/src/test/java/io/koraframework/database/jdbc/JdbcDataSourceTest.java
+++ b/database/database-jdbc/src/test/java/io/koraframework/database/jdbc/JdbcDataSourceTest.java
@@ -11,7 +11,7 @@ import io.koraframework.database.common.telemetry.impl.NoopDatabaseLoggerFactory
 import io.koraframework.database.common.telemetry.impl.NoopDatabaseMetricsFactory;
 import io.koraframework.test.postgres.PostgresParams;
 import io.koraframework.test.postgres.PostgresTestContainer;
-import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.koraframework.micrometer.common.NoopMeterRegistry;
 import io.opentelemetry.api.trace.TracerProvider;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -62,7 +62,7 @@ class JdbcDataSourceTest {
                 new $DatabaseTelemetryConfig_DatabaseTracingConfig_ConfigValueMapper.DatabaseTracingConfig_Impl(true, Map.of())
             )
         );
-        var db = new JdbcDataSource(config, new DefaultDatabaseTelemetryFactory(TracerProvider.noop().get(""), new CompositeMeterRegistry(), NoopDatabaseLoggerFactory.INSTANCE, NoopDatabaseMetricsFactory.INSTANCE), null);
+        var db = new JdbcDataSource(config, new DefaultDatabaseTelemetryFactory(TracerProvider.noop().get(""), NoopMeterRegistry.INSTANCE, NoopDatabaseLoggerFactory.INSTANCE, NoopDatabaseMetricsFactory.INSTANCE), null);
         db.init();
         try {
             consumer.accept(db);

--- a/database/database-jdbc/src/test/java/io/koraframework/database/jdbc/JdbcQueryExecutorTest.java
+++ b/database/database-jdbc/src/test/java/io/koraframework/database/jdbc/JdbcQueryExecutorTest.java
@@ -11,7 +11,7 @@ import io.koraframework.database.common.telemetry.impl.NoopDatabaseMetricsFactor
 import io.koraframework.database.jdbc.mapper.result.JdbcRowMapper;
 import io.koraframework.test.postgres.PostgresParams;
 import io.koraframework.test.postgres.PostgresTestContainer;
-import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.koraframework.micrometer.common.NoopMeterRegistry;
 import io.opentelemetry.api.trace.TracerProvider;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -52,7 +52,7 @@ class JdbcQueryExecutorTest {
                 new $DatabaseTelemetryConfig_DatabaseTracingConfig_ConfigValueMapper.DatabaseTracingConfig_Impl(true, Map.of())
             )
         );
-        var db = new JdbcDataSource(config, new DefaultDatabaseTelemetryFactory(TracerProvider.noop().get(""), new CompositeMeterRegistry(), NoopDatabaseLoggerFactory.INSTANCE, NoopDatabaseMetricsFactory.INSTANCE), null);
+        var db = new JdbcDataSource(config, new DefaultDatabaseTelemetryFactory(TracerProvider.noop().get(""), NoopMeterRegistry.INSTANCE, NoopDatabaseLoggerFactory.INSTANCE, NoopDatabaseMetricsFactory.INSTANCE), null);
         db.init();
         try {
             consumer.accept(db);

--- a/database/database-liquibase/src/test/java/io.koraframework.database.liquibase/LiquibaseJdbcDataSourceInterceptorTest.java
+++ b/database/database-liquibase/src/test/java/io.koraframework.database.liquibase/LiquibaseJdbcDataSourceInterceptorTest.java
@@ -11,7 +11,7 @@ import io.koraframework.database.jdbc.$JdbcDatabaseConfig_ConfigValueMapper;
 import io.koraframework.database.jdbc.JdbcDataSource;
 import io.koraframework.test.postgres.PostgresParams;
 import io.koraframework.test.postgres.PostgresTestContainer;
-import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.koraframework.micrometer.common.NoopMeterRegistry;
 import io.opentelemetry.api.trace.TracerProvider;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -50,7 +50,7 @@ public class LiquibaseJdbcDataSourceInterceptorTest {
             )
         );
 
-        var database = new JdbcDataSource(config, new DefaultDatabaseTelemetryFactory(TracerProvider.noop().get(""), new CompositeMeterRegistry(), NoopDatabaseLoggerFactory.INSTANCE, NoopDatabaseMetricsFactory.INSTANCE), null);
+        var database = new JdbcDataSource(config, new DefaultDatabaseTelemetryFactory(TracerProvider.noop().get(""), NoopMeterRegistry.INSTANCE, NoopDatabaseLoggerFactory.INSTANCE, NoopDatabaseMetricsFactory.INSTANCE), null);
         database.init();
         try {
             var interceptor = new LiquibaseJdbcDatabaseInterceptor(new LiquibaseConfig() {});

--- a/experimental/camunda-engine-bpmn/src/main/java/io/koraframework/camunda/engine/bpmn/telemetry/impl/DefaultCamundaEngineTelemetryFactory.java
+++ b/experimental/camunda-engine-bpmn/src/main/java/io/koraframework/camunda/engine/bpmn/telemetry/impl/DefaultCamundaEngineTelemetryFactory.java
@@ -3,8 +3,8 @@ package io.koraframework.camunda.engine.bpmn.telemetry.impl;
 import io.koraframework.camunda.engine.bpmn.telemetry.CamundaEngineTelemetry;
 import io.koraframework.camunda.engine.bpmn.telemetry.CamundaEngineTelemetryConfig;
 import io.koraframework.camunda.engine.bpmn.telemetry.CamundaEngineTelemetryFactory;
+import io.koraframework.micrometer.common.NoopMeterRegistry;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.TracerProvider;
 import org.jspecify.annotations.Nullable;
@@ -12,7 +12,7 @@ import org.jspecify.annotations.Nullable;
 public class DefaultCamundaEngineTelemetryFactory implements CamundaEngineTelemetryFactory {
 
     public static final Tracer NOOP_TRACER = TracerProvider.noop().get("camunda-engine-bpmn");
-    public static final MeterRegistry NOOP_METER_REGISTRY = new CompositeMeterRegistry();
+    public static final MeterRegistry NOOP_METER_REGISTRY = NoopMeterRegistry.INSTANCE;
 
     @Nullable
     private final Tracer tracer;

--- a/experimental/camunda-rest-undertow/src/main/java/io/koraframework/camunda/rest/telemetry/impl/DefaultCamundaRestTelemetryFactory.java
+++ b/experimental/camunda-rest-undertow/src/main/java/io/koraframework/camunda/rest/telemetry/impl/DefaultCamundaRestTelemetryFactory.java
@@ -3,8 +3,8 @@ package io.koraframework.camunda.rest.telemetry.impl;
 import io.koraframework.camunda.rest.telemetry.CamundaRestTelemetry;
 import io.koraframework.camunda.rest.telemetry.CamundaRestTelemetryConfig;
 import io.koraframework.camunda.rest.telemetry.CamundaRestTelemetryFactory;
+import io.koraframework.micrometer.common.NoopMeterRegistry;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.TracerProvider;
 import org.jspecify.annotations.Nullable;
@@ -12,7 +12,7 @@ import org.jspecify.annotations.Nullable;
 public class DefaultCamundaRestTelemetryFactory implements CamundaRestTelemetryFactory {
 
     public static final Tracer NOOP_TRACER = TracerProvider.noop().get("camunda-rest");
-    public static final MeterRegistry NOOP_METER_REGISTRY = new CompositeMeterRegistry();
+    public static final MeterRegistry NOOP_METER_REGISTRY = NoopMeterRegistry.INSTANCE;
 
     @Nullable
     private final Tracer tracer;

--- a/experimental/camunda-zeebe-worker/src/main/java/io/koraframework/camunda/zeebe/worker/telemetry/impl/DefaultZeebeWorkerTelemetryFactory.java
+++ b/experimental/camunda-zeebe-worker/src/main/java/io/koraframework/camunda/zeebe/worker/telemetry/impl/DefaultZeebeWorkerTelemetryFactory.java
@@ -3,8 +3,8 @@ package io.koraframework.camunda.zeebe.worker.telemetry.impl;
 import io.koraframework.camunda.zeebe.worker.telemetry.ZeebeWorkerTelemetry;
 import io.koraframework.camunda.zeebe.worker.telemetry.ZeebeWorkerTelemetryConfig;
 import io.koraframework.camunda.zeebe.worker.telemetry.ZeebeWorkerTelemetryFactory;
+import io.koraframework.micrometer.common.NoopMeterRegistry;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.TracerProvider;
 import org.jspecify.annotations.Nullable;
@@ -12,7 +12,7 @@ import org.jspecify.annotations.Nullable;
 public class DefaultZeebeWorkerTelemetryFactory implements ZeebeWorkerTelemetryFactory {
 
     public static final Tracer NOOP_TRACER = TracerProvider.noop().get("zeebe-worker");
-    public static final MeterRegistry NOOP_METER_REGISTRY = new CompositeMeterRegistry();
+    public static final MeterRegistry NOOP_METER_REGISTRY = NoopMeterRegistry.INSTANCE;
 
     @Nullable
     private final MeterRegistry meterRegistry;

--- a/experimental/s3-client-kora/src/main/java/io/koraframework/s3/client/kora/telemetry/impl/DefaultS3ClientTelemetryFactory.java
+++ b/experimental/s3-client-kora/src/main/java/io/koraframework/s3/client/kora/telemetry/impl/DefaultS3ClientTelemetryFactory.java
@@ -3,8 +3,8 @@ package io.koraframework.s3.client.kora.telemetry.impl;
 import io.koraframework.s3.client.kora.telemetry.S3ClientTelemetry;
 import io.koraframework.s3.client.kora.telemetry.S3ClientTelemetryConfig;
 import io.koraframework.s3.client.kora.telemetry.S3ClientTelemetryFactory;
+import io.koraframework.micrometer.common.NoopMeterRegistry;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.TracerProvider;
 import org.jspecify.annotations.Nullable;
@@ -12,7 +12,7 @@ import org.jspecify.annotations.Nullable;
 public class DefaultS3ClientTelemetryFactory implements S3ClientTelemetryFactory {
 
     public static final Tracer NOOP_TRACER = TracerProvider.noop().get("s3-client-kora-telemetry");
-    public static final MeterRegistry NOOP_METER_REGISTRY = new CompositeMeterRegistry();
+    public static final MeterRegistry NOOP_METER_REGISTRY = NoopMeterRegistry.INSTANCE;
 
     @Nullable
     private final Tracer tracer;

--- a/grpc/grpc-client/src/main/java/io/koraframework/grpc/client/telemetry/impl/DefaultGrpcClientTelemetryFactory.java
+++ b/grpc/grpc-client/src/main/java/io/koraframework/grpc/client/telemetry/impl/DefaultGrpcClientTelemetryFactory.java
@@ -4,8 +4,8 @@ import io.grpc.ServiceDescriptor;
 import io.koraframework.grpc.client.telemetry.GrpcClientTelemetry;
 import io.koraframework.grpc.client.telemetry.GrpcClientTelemetryConfig;
 import io.koraframework.grpc.client.telemetry.GrpcClientTelemetryFactory;
+import io.koraframework.micrometer.common.NoopMeterRegistry;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.TracerProvider;
 import org.jspecify.annotations.Nullable;
@@ -15,7 +15,7 @@ import java.net.URI;
 public class DefaultGrpcClientTelemetryFactory implements GrpcClientTelemetryFactory {
 
     public static final Tracer NOOP_TRACER = TracerProvider.noop().get("grpc-client");
-    public static final MeterRegistry NOOP_METER_REGISTRY = new CompositeMeterRegistry();
+    public static final MeterRegistry NOOP_METER_REGISTRY = NoopMeterRegistry.INSTANCE;
 
     @Nullable
     private final Tracer tracer;

--- a/grpc/grpc-server/src/main/java/io/koraframework/grpc/server/telemetry/impl/DefaultGrpcServerTelemetryFactory.java
+++ b/grpc/grpc-server/src/main/java/io/koraframework/grpc/server/telemetry/impl/DefaultGrpcServerTelemetryFactory.java
@@ -3,8 +3,8 @@ package io.koraframework.grpc.server.telemetry.impl;
 import io.koraframework.grpc.server.telemetry.GrpcServerTelemetry;
 import io.koraframework.grpc.server.telemetry.GrpcServerTelemetryConfig;
 import io.koraframework.grpc.server.telemetry.GrpcServerTelemetryFactory;
+import io.koraframework.micrometer.common.NoopMeterRegistry;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.TracerProvider;
 import org.jspecify.annotations.Nullable;
@@ -12,7 +12,7 @@ import org.jspecify.annotations.Nullable;
 public class DefaultGrpcServerTelemetryFactory implements GrpcServerTelemetryFactory {
 
     public static final Tracer NOOP_TRACER = TracerProvider.noop().get("grpc-server");
-    public static final MeterRegistry NOOP_METER_REGISTRY = new CompositeMeterRegistry();
+    public static final MeterRegistry NOOP_METER_REGISTRY = NoopMeterRegistry.INSTANCE;
 
     @Nullable
     private final Tracer tracer;

--- a/http/http-client-common/src/main/java/io/koraframework/http/client/common/telemetry/impl/DefaultHttpClientTelemetryFactory.java
+++ b/http/http-client-common/src/main/java/io/koraframework/http/client/common/telemetry/impl/DefaultHttpClientTelemetryFactory.java
@@ -3,8 +3,8 @@ package io.koraframework.http.client.common.telemetry.impl;
 import io.koraframework.http.client.common.telemetry.HttpClientTelemetry;
 import io.koraframework.http.client.common.telemetry.HttpClientTelemetryConfig;
 import io.koraframework.http.client.common.telemetry.HttpClientTelemetryFactory;
+import io.koraframework.micrometer.common.NoopMeterRegistry;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.TracerProvider;
 import org.jspecify.annotations.Nullable;
@@ -12,7 +12,7 @@ import org.jspecify.annotations.Nullable;
 public class DefaultHttpClientTelemetryFactory implements HttpClientTelemetryFactory {
 
     public static final Tracer NOOP_TRACER = TracerProvider.noop().get("http-client");
-    public static final MeterRegistry NOOP_METER_REGISTRY = new CompositeMeterRegistry();
+    public static final MeterRegistry NOOP_METER_REGISTRY = NoopMeterRegistry.INSTANCE;
 
     @Nullable
     private final Tracer tracer;

--- a/http/http-server-common/src/main/java/io/koraframework/http/server/common/telemetry/impl/DefaultHttpServerTelemetryFactory.java
+++ b/http/http-server-common/src/main/java/io/koraframework/http/server/common/telemetry/impl/DefaultHttpServerTelemetryFactory.java
@@ -3,8 +3,8 @@ package io.koraframework.http.server.common.telemetry.impl;
 import io.koraframework.http.server.common.telemetry.HttpServerTelemetry;
 import io.koraframework.http.server.common.telemetry.HttpServerTelemetryConfig;
 import io.koraframework.http.server.common.telemetry.HttpServerTelemetryFactory;
+import io.koraframework.micrometer.common.NoopMeterRegistry;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.TracerProvider;
 import org.jspecify.annotations.Nullable;
@@ -12,7 +12,7 @@ import org.jspecify.annotations.Nullable;
 public class DefaultHttpServerTelemetryFactory implements HttpServerTelemetryFactory {
 
     public static final Tracer NOOP_TRACER = TracerProvider.noop().get("http-server");
-    public static final MeterRegistry NOOP_METER_REGISTRY = new CompositeMeterRegistry();
+    public static final MeterRegistry NOOP_METER_REGISTRY = NoopMeterRegistry.INSTANCE;
 
     @Nullable
     private final MeterRegistry meterRegistry;

--- a/http/http-server-common/src/main/java/module-info.java
+++ b/http/http-server-common/src/main/java/module-info.java
@@ -5,6 +5,7 @@ module kora.http.server.common {
     requires transitive kora.http.common;
     requires transitive kora.logging.common;
     requires transitive kora.telemetry.common;
+    requires kora.micrometer.common;
 
     exports io.koraframework.http.server.common;
     exports io.koraframework.http.server.common.annotation;

--- a/http/soap-client/src/main/java/io/koraframework/soap/client/common/telemetry/impl/DefaultSoapClientTelemetryFactory.java
+++ b/http/soap-client/src/main/java/io/koraframework/soap/client/common/telemetry/impl/DefaultSoapClientTelemetryFactory.java
@@ -3,8 +3,8 @@ package io.koraframework.soap.client.common.telemetry.impl;
 import io.koraframework.soap.client.common.telemetry.SoapClientTelemetry;
 import io.koraframework.soap.client.common.telemetry.SoapClientTelemetryConfig;
 import io.koraframework.soap.client.common.telemetry.SoapClientTelemetryFactory;
+import io.koraframework.micrometer.common.NoopMeterRegistry;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.TracerProvider;
 import org.jspecify.annotations.Nullable;
@@ -13,7 +13,7 @@ import io.koraframework.soap.client.common.SoapMethodDescriptor;
 public class DefaultSoapClientTelemetryFactory implements SoapClientTelemetryFactory {
 
     public static final Tracer NOOP_TRACER = TracerProvider.noop().get("soap-client");
-    public static final MeterRegistry NOOP_METER_REGISTRY = new CompositeMeterRegistry();
+    public static final MeterRegistry NOOP_METER_REGISTRY = NoopMeterRegistry.INSTANCE;
 
     @Nullable
     private final Tracer tracer;

--- a/jms/src/main/java/io/koraframework/jms/telemetry/impl/DefaultJmsConsumerTelemetryFactory.java
+++ b/jms/src/main/java/io/koraframework/jms/telemetry/impl/DefaultJmsConsumerTelemetryFactory.java
@@ -3,8 +3,8 @@ package io.koraframework.jms.telemetry.impl;
 import io.koraframework.jms.telemetry.JmsConsumerTelemetry;
 import io.koraframework.jms.telemetry.JmsConsumerTelemetryConfig;
 import io.koraframework.jms.telemetry.JmsConsumerTelemetryFactory;
+import io.koraframework.micrometer.common.NoopMeterRegistry;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.TracerProvider;
 import org.jspecify.annotations.Nullable;
@@ -12,7 +12,7 @@ import org.jspecify.annotations.Nullable;
 public class DefaultJmsConsumerTelemetryFactory implements JmsConsumerTelemetryFactory {
 
     public static final Tracer NOOP_TRACER = TracerProvider.noop().get("jms-consumer");
-    public static final MeterRegistry NOOP_METER_REGISTRY = new CompositeMeterRegistry();
+    public static final MeterRegistry NOOP_METER_REGISTRY = NoopMeterRegistry.INSTANCE;
 
     @Nullable
     private final Tracer tracer;

--- a/kafka/kafka/src/main/java/io/koraframework/kafka/common/consumer/telemetry/impl/DefaultKafkaConsumerTelemetryFactory.java
+++ b/kafka/kafka/src/main/java/io/koraframework/kafka/common/consumer/telemetry/impl/DefaultKafkaConsumerTelemetryFactory.java
@@ -3,8 +3,8 @@ package io.koraframework.kafka.common.consumer.telemetry.impl;
 import io.koraframework.kafka.common.consumer.telemetry.KafkaConsumerTelemetry;
 import io.koraframework.kafka.common.consumer.telemetry.KafkaConsumerTelemetryConfig;
 import io.koraframework.kafka.common.consumer.telemetry.KafkaConsumerTelemetryFactory;
+import io.koraframework.micrometer.common.NoopMeterRegistry;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.TracerProvider;
 import org.jspecify.annotations.Nullable;
@@ -14,7 +14,7 @@ import java.util.Properties;
 public class DefaultKafkaConsumerTelemetryFactory implements KafkaConsumerTelemetryFactory {
 
     public static final Tracer NOOP_TRACER = TracerProvider.noop().get("kafka-listener");
-    public static final MeterRegistry NOOP_METER_REGISTRY = new CompositeMeterRegistry();
+    public static final MeterRegistry NOOP_METER_REGISTRY = NoopMeterRegistry.INSTANCE;
 
     @Nullable
     private final Tracer tracer;

--- a/kafka/kafka/src/main/java/io/koraframework/kafka/common/consumer/telemetry/impl/NoopKafkaConsumerTelemetry.java
+++ b/kafka/kafka/src/main/java/io/koraframework/kafka/common/consumer/telemetry/impl/NoopKafkaConsumerTelemetry.java
@@ -2,15 +2,15 @@ package io.koraframework.kafka.common.consumer.telemetry.impl;
 
 import io.koraframework.kafka.common.consumer.telemetry.KafkaConsumerPollObservation;
 import io.koraframework.kafka.common.consumer.telemetry.KafkaConsumerTelemetry;
+import io.koraframework.micrometer.common.NoopMeterRegistry;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import org.apache.kafka.common.TopicPartition;
 
 public final class NoopKafkaConsumerTelemetry implements KafkaConsumerTelemetry {
 
     public static final NoopKafkaConsumerTelemetry INSTANCE = new NoopKafkaConsumerTelemetry();
 
-    private final MeterRegistry meterRegistry = new CompositeMeterRegistry();
+    private final MeterRegistry meterRegistry = NoopMeterRegistry.INSTANCE;
 
     @Override
     public MeterRegistry meterRegistry() {

--- a/kafka/kafka/src/main/java/io/koraframework/kafka/common/producer/telemetry/impl/DefaultKafkaPublisherTelemetryFactory.java
+++ b/kafka/kafka/src/main/java/io/koraframework/kafka/common/producer/telemetry/impl/DefaultKafkaPublisherTelemetryFactory.java
@@ -3,8 +3,8 @@ package io.koraframework.kafka.common.producer.telemetry.impl;
 import io.koraframework.kafka.common.producer.telemetry.KafkaPublisherTelemetry;
 import io.koraframework.kafka.common.producer.telemetry.KafkaPublisherTelemetryConfig;
 import io.koraframework.kafka.common.producer.telemetry.KafkaPublisherTelemetryFactory;
+import io.koraframework.micrometer.common.NoopMeterRegistry;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.TracerProvider;
 import org.jspecify.annotations.Nullable;
@@ -14,7 +14,7 @@ import java.util.Properties;
 public class DefaultKafkaPublisherTelemetryFactory implements KafkaPublisherTelemetryFactory {
 
     public static final Tracer NOOP_TRACER = TracerProvider.noop().get("kafka-publisher");
-    public static final MeterRegistry NOOP_METER_REGISTRY = new CompositeMeterRegistry();
+    public static final MeterRegistry NOOP_METER_REGISTRY = NoopMeterRegistry.INSTANCE;
 
     @Nullable
     private final Tracer tracer;

--- a/kafka/kafka/src/main/java/io/koraframework/kafka/common/producer/telemetry/impl/NoopKafkaPublisherTelemetry.java
+++ b/kafka/kafka/src/main/java/io/koraframework/kafka/common/producer/telemetry/impl/NoopKafkaPublisherTelemetry.java
@@ -3,14 +3,14 @@ package io.koraframework.kafka.common.producer.telemetry.impl;
 import io.koraframework.kafka.common.producer.telemetry.KafkaPublisherRecordObservation;
 import io.koraframework.kafka.common.producer.telemetry.KafkaPublisherTelemetry;
 import io.koraframework.kafka.common.producer.telemetry.KafkaPublisherTransactionObservation;
+import io.koraframework.micrometer.common.NoopMeterRegistry;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 
 public final class NoopKafkaPublisherTelemetry implements KafkaPublisherTelemetry {
 
     public static final NoopKafkaPublisherTelemetry INSTANCE = new NoopKafkaPublisherTelemetry();
 
-    private final MeterRegistry meterRegistry = new CompositeMeterRegistry();
+    private final MeterRegistry meterRegistry = NoopMeterRegistry.INSTANCE;
 
     private NoopKafkaPublisherTelemetry() {}
 

--- a/resilient/resilient-kora/src/main/java/io/koraframework/resilient/circuitbreaker/telemetry/impl/DefaultCircuitBreakerTelemetryFactory.java
+++ b/resilient/resilient-kora/src/main/java/io/koraframework/resilient/circuitbreaker/telemetry/impl/DefaultCircuitBreakerTelemetryFactory.java
@@ -1,8 +1,8 @@
 package io.koraframework.resilient.circuitbreaker.telemetry.impl;
 
 import io.koraframework.resilient.circuitbreaker.telemetry.*;
+import io.koraframework.micrometer.common.NoopMeterRegistry;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.TracerProvider;
 import org.jspecify.annotations.Nullable;
@@ -10,7 +10,7 @@ import org.jspecify.annotations.Nullable;
 public class DefaultCircuitBreakerTelemetryFactory implements CircuitBreakerTelemetryFactory {
 
     public static final Tracer NOOP_TRACER = TracerProvider.noop().get("resilient-circuitbreaker");
-    public static final MeterRegistry NOOP_METER_REGISTRY = new CompositeMeterRegistry();
+    public static final MeterRegistry NOOP_METER_REGISTRY = NoopMeterRegistry.INSTANCE;
 
     @Nullable
     private final Tracer tracer;

--- a/resilient/resilient-kora/src/main/java/io/koraframework/resilient/fallback/telemetry/impl/DefaultFallbackTelemetryFactory.java
+++ b/resilient/resilient-kora/src/main/java/io/koraframework/resilient/fallback/telemetry/impl/DefaultFallbackTelemetryFactory.java
@@ -1,8 +1,8 @@
 package io.koraframework.resilient.fallback.telemetry.impl;
 
 import io.koraframework.resilient.fallback.telemetry.*;
+import io.koraframework.micrometer.common.NoopMeterRegistry;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.TracerProvider;
 import org.jspecify.annotations.Nullable;
@@ -10,7 +10,7 @@ import org.jspecify.annotations.Nullable;
 public class DefaultFallbackTelemetryFactory implements FallbackTelemetryFactory {
 
     public static final Tracer NOOP_TRACER = TracerProvider.noop().get("resilient-fallback");
-    public static final MeterRegistry NOOP_METER_REGISTRY = new CompositeMeterRegistry();
+    public static final MeterRegistry NOOP_METER_REGISTRY = NoopMeterRegistry.INSTANCE;
 
     @Nullable
     private final Tracer tracer;

--- a/resilient/resilient-kora/src/main/java/io/koraframework/resilient/ratelimiter/telemetry/impl/DefaultRateLimiterTelemetryFactory.java
+++ b/resilient/resilient-kora/src/main/java/io/koraframework/resilient/ratelimiter/telemetry/impl/DefaultRateLimiterTelemetryFactory.java
@@ -1,8 +1,8 @@
 package io.koraframework.resilient.ratelimiter.telemetry.impl;
 
 import io.koraframework.resilient.ratelimiter.telemetry.*;
+import io.koraframework.micrometer.common.NoopMeterRegistry;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.TracerProvider;
 import org.jspecify.annotations.Nullable;
@@ -10,7 +10,7 @@ import org.jspecify.annotations.Nullable;
 public class DefaultRateLimiterTelemetryFactory implements RateLimiterTelemetryFactory {
 
     public static final Tracer NOOP_TRACER = TracerProvider.noop().get("resilient-ratelimiter");
-    public static final MeterRegistry NOOP_METER_REGISTRY = new CompositeMeterRegistry();
+    public static final MeterRegistry NOOP_METER_REGISTRY = NoopMeterRegistry.INSTANCE;
 
     @Nullable
     private final Tracer tracer;

--- a/resilient/resilient-kora/src/main/java/io/koraframework/resilient/retry/telemetry/impl/DefaultRetryTelemetryFactory.java
+++ b/resilient/resilient-kora/src/main/java/io/koraframework/resilient/retry/telemetry/impl/DefaultRetryTelemetryFactory.java
@@ -1,8 +1,8 @@
 package io.koraframework.resilient.retry.telemetry.impl;
 
 import io.koraframework.resilient.retry.telemetry.*;
+import io.koraframework.micrometer.common.NoopMeterRegistry;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.TracerProvider;
 import org.jspecify.annotations.Nullable;
@@ -10,7 +10,7 @@ import org.jspecify.annotations.Nullable;
 public class DefaultRetryTelemetryFactory implements RetryTelemetryFactory {
 
     public static final Tracer NOOP_TRACER = TracerProvider.noop().get("resilient-retry");
-    public static final MeterRegistry NOOP_METER_REGISTRY = new CompositeMeterRegistry();
+    public static final MeterRegistry NOOP_METER_REGISTRY = NoopMeterRegistry.INSTANCE;
 
     @Nullable
     private final Tracer tracer;

--- a/resilient/resilient-kora/src/main/java/io/koraframework/resilient/timeout/telemetry/impl/DefaultTimeoutTelemetryFactory.java
+++ b/resilient/resilient-kora/src/main/java/io/koraframework/resilient/timeout/telemetry/impl/DefaultTimeoutTelemetryFactory.java
@@ -1,8 +1,8 @@
 package io.koraframework.resilient.timeout.telemetry.impl;
 
 import io.koraframework.resilient.timeout.telemetry.*;
+import io.koraframework.micrometer.common.NoopMeterRegistry;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.TracerProvider;
 import org.jspecify.annotations.Nullable;
@@ -10,7 +10,7 @@ import org.jspecify.annotations.Nullable;
 public class DefaultTimeoutTelemetryFactory implements TimeoutTelemetryFactory {
 
     public static final Tracer NOOP_TRACER = TracerProvider.noop().get("resilient-timeout");
-    public static final MeterRegistry NOOP_METER_REGISTRY = new CompositeMeterRegistry();
+    public static final MeterRegistry NOOP_METER_REGISTRY = NoopMeterRegistry.INSTANCE;
 
     @Nullable
     private final Tracer tracer;

--- a/scheduling/scheduling-common/src/main/java/io/koraframework/scheduling/common/telemetry/impl/DefaultSchedulingTelemetryFactory.java
+++ b/scheduling/scheduling-common/src/main/java/io/koraframework/scheduling/common/telemetry/impl/DefaultSchedulingTelemetryFactory.java
@@ -5,8 +5,8 @@ import io.koraframework.scheduling.common.telemetry.SchedulingTelemetry;
 import io.koraframework.scheduling.common.SchedulingJobConfig;
 import io.koraframework.scheduling.common.telemetry.SchedulingTelemetryConfig;
 import io.koraframework.scheduling.common.telemetry.SchedulingTelemetryFactory;
+import io.koraframework.micrometer.common.NoopMeterRegistry;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.TracerProvider;
 import org.jspecify.annotations.Nullable;
@@ -14,7 +14,7 @@ import org.jspecify.annotations.Nullable;
 public class DefaultSchedulingTelemetryFactory implements SchedulingTelemetryFactory {
 
     public static final Tracer NOOP_TRACER = TracerProvider.noop().get("scheduling-telemetry");
-    public static final MeterRegistry NOOP_METER_REGISTRY = new CompositeMeterRegistry();
+    public static final MeterRegistry NOOP_METER_REGISTRY = NoopMeterRegistry.INSTANCE;
 
     private final SchedulingTelemetryConfig config;
     @Nullable

--- a/settings.gradle
+++ b/settings.gradle
@@ -30,6 +30,7 @@ include(
     'json:json-annotation-processor',
     'json:json-symbol-processor',
     'telemetry:telemetry-common',
+    'telemetry:micrometer-common',
     'telemetry:micrometer-module',
     'telemetry:opentelemetry-common',
     'telemetry:opentelemetry-tracing',

--- a/telemetry/micrometer-common/build.gradle
+++ b/telemetry/micrometer-common/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+    api libs.micrometer.core
+}

--- a/telemetry/micrometer-common/src/main/java/io/koraframework/micrometer/common/NoopMeterRegistry.java
+++ b/telemetry/micrometer-common/src/main/java/io/koraframework/micrometer/common/NoopMeterRegistry.java
@@ -1,0 +1,448 @@
+package io.koraframework.micrometer.common;
+
+import io.micrometer.core.instrument.*;
+import io.micrometer.core.instrument.config.MeterFilter;
+import io.micrometer.core.instrument.config.NamingConvention;
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
+import io.micrometer.core.instrument.distribution.pause.NoPauseDetector;
+import io.micrometer.core.instrument.distribution.pause.PauseDetector;
+import io.micrometer.core.instrument.noop.*;
+import io.micrometer.core.instrument.search.RequiredSearch;
+import io.micrometer.core.instrument.search.Search;
+import org.jspecify.annotations.Nullable;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
+import java.util.function.DoubleSupplier;
+import java.util.function.Function;
+import java.util.function.IntSupplier;
+import java.util.function.LongSupplier;
+import java.util.function.Supplier;
+import java.util.function.ToDoubleFunction;
+import java.util.function.ToLongFunction;
+
+public final class NoopMeterRegistry extends MeterRegistry {
+
+    private static final Meter.Id NOOP_ID = new Meter.Id("noop", Tags.empty(), null, null, Meter.Type.OTHER);
+    private static final Gauge NOOP_GAUGE = new NoopGauge(NOOP_ID);
+    private static final TimeGauge NOOP_TIME_GAUGE = new NoopTimeGauge(NOOP_ID);
+    private static final Counter NOOP_COUNTER = new NoopCounter(NOOP_ID);
+    private static final FunctionCounter NOOP_FUNCTION_COUNTER = new NoopFunctionCounter(NOOP_ID);
+    private static final Timer NOOP_TIMER = new NoopTimer(NOOP_ID) {
+        @Override
+        public Runnable wrap(Runnable f) {
+            return f;
+        }
+
+        @Override
+        public <T> Callable<T> wrap(Callable<T> f) {
+            return f;
+        }
+
+        @Override
+        public <T> Supplier<T> wrap(Supplier<T> f) {
+            return f;
+        }
+    };
+    private static final FunctionTimer NOOP_FUNCTION_TIMER = new NoopFunctionTimer(NOOP_ID);
+    private static final DistributionSummary NOOP_DISTRIBUTION_SUMMARY = new NoopDistributionSummary(NOOP_ID);
+    private static final Meter NOOP_METER = new NoopMeter(NOOP_ID);
+    private static final LongTaskTimer.Sample NOOP_LONG_TASK_TIMER_SAMPLE = new LongTaskTimer.Sample() {
+        @Override
+        public long stop() {
+            return 0;
+        }
+
+        @Override
+        public double duration(TimeUnit unit) {
+            return 0;
+        }
+    };
+    private static final LongTaskTimer NOOP_LONG_TASK_TIMER = new NoopLongTaskTimer(NOOP_ID) {
+        @Override
+        public Sample start() {
+            return NOOP_LONG_TASK_TIMER_SAMPLE;
+        }
+
+        @Override
+        public <T> T record(Supplier<T> f) {
+            return f.get();
+        }
+
+        @Override
+        public boolean record(BooleanSupplier f) {
+            return f.getAsBoolean();
+        }
+
+        @Override
+        public int record(IntSupplier f) {
+            return f.getAsInt();
+        }
+
+        @Override
+        public long record(LongSupplier f) {
+            return f.getAsLong();
+        }
+
+        @Override
+        public double record(DoubleSupplier f) {
+            return f.getAsDouble();
+        }
+
+        @Override
+        public <T> T recordCallable(Callable<T> f) throws Exception {
+            return f.call();
+        }
+
+        @Override
+        public void record(Consumer<Sample> f) {
+            f.accept(NOOP_LONG_TASK_TIMER_SAMPLE);
+        }
+
+        @Override
+        public void record(Runnable f) {
+            f.run();
+        }
+    };
+
+    public static final NoopMeterRegistry INSTANCE = new NoopMeterRegistry();
+
+    private final Config config = new NoopConfig();
+    private final More more = new NoopMore();
+    private final Search noopSearch;
+    private final RequiredSearch noopRequiredSearch;
+
+    private NoopMeterRegistry() {
+        super(Clock.SYSTEM);
+        this.noopSearch = Search.in(this).name("noop");
+        this.noopRequiredSearch = RequiredSearch.in(this).name("noop");
+    }
+
+    @Override
+    protected <T> TimeGauge newTimeGauge(Meter.Id id, @Nullable T obj, TimeUnit valueFunctionUnit, ToDoubleFunction<T> valueFunction) {
+        return NOOP_TIME_GAUGE;
+    }
+
+    @Override
+    public @Nullable <T> T gauge(String name, Iterable<Tag> tags, @Nullable T stateObject, ToDoubleFunction<T> valueFunction) {
+        return stateObject;
+    }
+
+    @Override
+    public <T extends Number> T gauge(String name, Iterable<Tag> tags, T number) {
+        return number;
+    }
+
+    @Override
+    public <T extends Number> T gauge(String name, T number) {
+        return number;
+    }
+
+    @Override
+    public <T> T gauge(String name, T stateObject, ToDoubleFunction<T> valueFunction) {
+        return stateObject;
+    }
+
+    @Override
+    public <T extends Collection<?>> T gaugeCollectionSize(String name, Iterable<Tag> tags, T collection) {
+        return collection;
+    }
+
+    @Override
+    public <T extends Map<?, ?>> T gaugeMapSize(String name, Iterable<Tag> tags, T map) {
+        return map;
+    }
+
+    @Override
+    protected <T> Gauge newGauge(Meter.Id id, T object, ToDoubleFunction<T> valueFunction) {
+        return NOOP_GAUGE;
+    }
+
+    @Override
+    public Counter counter(String name, Iterable<Tag> tags) {
+        return NOOP_COUNTER;
+    }
+
+    @Override
+    public Counter counter(String name, String... tags) {
+        return NOOP_COUNTER;
+    }
+
+    @Override
+    public Counter counter(String name, Tags tags) {
+        return NOOP_COUNTER;
+    }
+
+    @Override
+    protected Counter newCounter(Meter.Id id) {
+        return NOOP_COUNTER;
+    }
+
+    @Override
+    protected <T> FunctionCounter newFunctionCounter(Meter.Id id, T object, ToDoubleFunction<T> countFunction) {
+        return NOOP_FUNCTION_COUNTER;
+    }
+
+    @Override
+    public Timer timer(String name, Iterable<Tag> tags) {
+        return NOOP_TIMER;
+    }
+
+    @Override
+    public Timer timer(String name, String... tags) {
+        return NOOP_TIMER;
+    }
+
+    @Override
+    public Timer timer(String name, Tags tags) {
+        return NOOP_TIMER;
+    }
+
+    @Override
+    protected Timer newTimer(Meter.Id id, DistributionStatisticConfig distributionStatisticConfig, PauseDetector pauseDetector) {
+        return NOOP_TIMER;
+    }
+
+    @Override
+    protected <T> FunctionTimer newFunctionTimer(Meter.Id id, T object, ToLongFunction<T> countFunction, ToDoubleFunction<T> totalTimeFunction, TimeUnit totalTimeFunctionUnit) {
+        return NOOP_FUNCTION_TIMER;
+    }
+
+    @Override
+    public DistributionSummary summary(String name, Iterable<Tag> tags) {
+        return NOOP_DISTRIBUTION_SUMMARY;
+    }
+
+    @Override
+    public DistributionSummary summary(String name, String... tags) {
+        return NOOP_DISTRIBUTION_SUMMARY;
+    }
+
+    public DistributionSummary summary(String name, Tags tags) {
+        return NOOP_DISTRIBUTION_SUMMARY;
+    }
+
+    @Override
+    public More more() {
+        return this.more;
+    }
+
+    @Override
+    protected DistributionSummary newDistributionSummary(Meter.Id id, DistributionStatisticConfig distributionStatisticConfig, double scale) {
+        return NOOP_DISTRIBUTION_SUMMARY;
+    }
+
+    @Override
+    protected Meter newMeter(Meter.Id id, Meter.Type type, Iterable<Measurement> measurements) {
+        return NOOP_METER;
+    }
+
+    @Override
+    public List<Meter> getMeters() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void forEachMeter(Consumer<? super Meter> consumer) {
+        // do nothing
+    }
+
+    @Override
+    public Config config() {
+        return this.config;
+    }
+
+    @Override
+    protected String getConventionName(Meter.Id id) {
+        return id.getName();
+    }
+
+    @Override
+    protected List<Tag> getConventionTags(Meter.Id id) {
+        return id.getTags();
+    }
+
+    @Override
+    public Search find(String name) {
+        return noopSearch;
+    }
+
+    @Override
+    public RequiredSearch get(String name) {
+        return noopRequiredSearch;
+    }
+
+    @Override
+    public @Nullable Meter remove(Meter meter) {
+        return null;
+    }
+
+    @Override
+    public @Nullable Meter removeByPreFilterId(Meter.Id preFilterId) {
+        return null;
+    }
+
+    @Override
+    public @Nullable Meter remove(Meter.Id mappedId) {
+        return null;
+    }
+
+    @Override
+    public void clear() {
+        // do nothing
+    }
+
+    @Override
+    public void close() {
+        // do nothing
+    }
+
+    @Override
+    protected void meterRegistrationFailed(Meter.Id id, @Nullable String reason) {
+        // do nothing
+    }
+
+    @Override
+    public boolean isClosed() {
+        return true;
+    }
+
+    @Override
+    protected TimeUnit getBaseTimeUnit() {
+        return TimeUnit.NANOSECONDS;
+    }
+
+    @Override
+    protected DistributionStatisticConfig defaultHistogramConfig() {
+        return DistributionStatisticConfig.DEFAULT;
+    }
+
+    @Override
+    protected LongTaskTimer newLongTaskTimer(Meter.Id id, DistributionStatisticConfig distributionStatisticConfig) {
+        return NOOP_LONG_TASK_TIMER;
+    }
+
+    private final class NoopMore extends More {
+
+        @Override
+        public LongTaskTimer longTaskTimer(String name, String... tags) {
+            return NOOP_LONG_TASK_TIMER;
+        }
+
+        @Override
+        public LongTaskTimer longTaskTimer(String name, Iterable<Tag> tags) {
+            return NOOP_LONG_TASK_TIMER;
+        }
+
+        @Override
+        public LongTaskTimer longTaskTimer(String name, Tags tags) {
+            return NOOP_LONG_TASK_TIMER;
+        }
+
+        @Override
+        public <T> FunctionCounter counter(String name, Iterable<Tag> tags, T obj, ToDoubleFunction<T> countFunction) {
+            return NOOP_FUNCTION_COUNTER;
+        }
+
+        @Override
+        public <T extends Number> FunctionCounter counter(String name, Iterable<Tag> tags, T number) {
+            return NOOP_FUNCTION_COUNTER;
+        }
+
+        @Override
+        public <T> FunctionTimer timer(String name, Iterable<Tag> tags, T obj, ToLongFunction<T> countFunction, ToDoubleFunction<T> totalTimeFunction, TimeUnit totalTimeFunctionUnit) {
+            return NOOP_FUNCTION_TIMER;
+        }
+
+        @Override
+        public <T> TimeGauge timeGauge(String name, Iterable<Tag> tags, T obj, TimeUnit timeFunctionUnit, ToDoubleFunction<T> timeFunction) {
+            return NOOP_TIME_GAUGE;
+        }
+    }
+
+    private final class NoopConfig extends Config {
+
+        @Override
+        public Config commonTags(Iterable<Tag> tags) {
+            return this;
+        }
+
+        @Override
+        public Config commonTags(String... tags) {
+            return this;
+        }
+
+        @Override
+        public synchronized Config meterFilter(MeterFilter filter) {
+            return this;
+        }
+
+        @Override
+        public Config onMeterAdded(Consumer<Meter> meterAddedListener) {
+            return this;
+        }
+
+        @Override
+        public Config onMeterRemoved(Consumer<Meter> meterRemovedListener) {
+            return this;
+        }
+
+        @Override
+        public Config onMeterRegistrationFailed(BiConsumer<Meter.Id, String> meterRegistrationFailedListener) {
+            return this;
+        }
+
+        @Override
+        public Config namingConvention(NamingConvention convention) {
+            return this;
+        }
+
+        @Override
+        public NamingConvention namingConvention() {
+            return NamingConvention.snakeCase;
+        }
+
+        @Override
+        public Clock clock() {
+            return Clock.SYSTEM;
+        }
+
+        @Override
+        public Config pauseDetector(PauseDetector detector) {
+            return this;
+        }
+
+        @Override
+        public PauseDetector pauseDetector() {
+            return NoPauseDetector.INSTANCE;
+        }
+
+        @Override
+        public Config withHighCardinalityTagsDetector() {
+            return this;
+        }
+
+        @Override
+        public Config withHighCardinalityTagsDetector(long threshold, Duration delay) {
+            return this;
+        }
+
+        @Override
+        public Config withHighCardinalityTagsDetector(Function<MeterRegistry, HighCardinalityTagsDetector> highCardinalityTagsDetectorFactory) {
+            return this;
+        }
+
+        @Override
+        public @Nullable HighCardinalityTagsDetector highCardinalityTagsDetector() {
+            return null;
+        }
+    }
+}

--- a/telemetry/micrometer-common/src/main/java/io/koraframework/micrometer/common/package-info.java
+++ b/telemetry/micrometer-common/src/main/java/io/koraframework/micrometer/common/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package io.koraframework.micrometer.common;
+
+import org.jspecify.annotations.NullMarked;

--- a/telemetry/micrometer-module/build.gradle
+++ b/telemetry/micrometer-module/build.gradle
@@ -1,11 +1,7 @@
 dependencies {
-    api libs.micrometer.core
     api libs.micrometer.registry.prometheus
     api libs.opentelemetry.api
     api libs.opentelemetry.micrometer.meter.provider
     api project(":telemetry:telemetry-common")
-
-    annotationProcessor project(':config:config-annotation-processor')
-
-    compileOnly project(':resilient:resilient-kora')
+    api project(":telemetry:micrometer-common")
 }


### PR DESCRIPTION
Improved disabled metrics handling by using the shared NoopMeterRegistry instance across telemetry factories instead of allocating CompositeMeterRegistry instances.

- Added micrometer-common as the shared home for the no-op meter registry.
- Improved cache, database, HTTP, gRPC, JMS, Kafka, resilient, scheduling, Camunda, and S3 telemetry factories to reuse NoopMeterRegistry.INSTANCE.
- Removed remaining CompositeMeterRegistry no-op usages from test helpers and Kafka no-op telemetry implementations.