### PR TITLE
Added OpenAPI security fallback modes with anonymous access

### DIFF
--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/CodegenParams.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/CodegenParams.java
@@ -30,6 +30,7 @@ public class CodegenParams {
     public static final String IMPLICIT_HEADERS_REGEX = "implicitHeadersRegex";
     public static final String FORCE_INCLUDE_OPTIONAL = "forceIncludeOptional";
     public static final String RAW_BODY_MODE = "rawBodyMode";
+    public static final String USE_SECURITY_DECLARATION_ORDER = "useSecurityDeclarationOrder";
     
     public CodegenMode codegenMode = CodegenMode.JAVA_CLIENT;
     public boolean enableValidation = false;
@@ -49,6 +50,7 @@ public class CodegenParams {
     public @Nullable Pattern implicitHeadersRegex = null;
     public boolean forceIncludeOptional = false;
     public RawBodyMode rawBodyMode = RawBodyMode.BYTES;
+    public boolean useSecurityDeclarationOrder = false;
 
     static List<CliOption> cliOptions() {
         var cliOptions = new ArrayList<CliOption>();
@@ -68,6 +70,7 @@ public class CodegenParams {
         cliOptions.add(CliOption.newString(DELEGATE_METHOD_BODY_MODE, "Delegate method generation mode"));
         cliOptions.add(CliOption.newString(FORCE_INCLUDE_OPTIONAL, "If enabled forces Nullable and NonRequired fields to be included ALWAYS even if null, can't be enabled with enableJsonNullable simultaneously"));
         cliOptions.add(CliOption.newString(RAW_BODY_MODE, "Bare object request and response body mode (one of BYTES, BODY, OBJECT)"));
+        cliOptions.add(CliOption.newBoolean(USE_SECURITY_DECLARATION_ORDER, "Use OpenAPI security requirement declaration order when generating auth tags and interceptors"));
         return cliOptions;
     }
 
@@ -148,6 +151,9 @@ public class CodegenParams {
         }
         if (additionalProperties.containsKey(RAW_BODY_MODE)) {
             params.rawBodyMode = RawBodyMode.of(additionalProperties.get(RAW_BODY_MODE).toString());
+        }
+        if (additionalProperties.containsKey(USE_SECURITY_DECLARATION_ORDER)) {
+            params.useSecurityDeclarationOrder = Boolean.parseBoolean(additionalProperties.get(USE_SECURITY_DECLARATION_ORDER).toString());
         }
         return params;
     }

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/KoraCodegen.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/KoraCodegen.java
@@ -1391,7 +1391,7 @@ public class KoraCodegen extends DefaultCodegen {
         if (openAPI == null) {
             return;
         }
-        security.fromOpenapi(openAPI);
+        security.fromOpenapi(openAPI, params.useSecurityDeclarationOrder);
         var securitySchemas = openAPI.getComponents().getSecuritySchemes();
         if (params.codegenMode.isJava()) {
             var modelPackage = modelFileFolder() + File.separator + "package-info.java";

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/SecurityData.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/SecurityData.java
@@ -9,12 +9,12 @@ public class SecurityData {
     // securityRequirement = Set<Map<String, Set<String>>> in operation/security
 
 
-    public Map<Set<Map<String, Set<String>>>, String> interceptorTagBySecurityRequirement = new HashMap<>();
-    public Map<String, Set<Map<String, Set<String>>>> securityRequirementByOperation = new HashMap<>();
+    public Map<Set<Map<String, Set<String>>>, String> interceptorTagBySecurityRequirement = new LinkedHashMap<>();
+    public Map<String, Set<Map<String, Set<String>>>> securityRequirementByOperation = new LinkedHashMap<>();
 
-    public Map<Set<String>, String> principalExtractorTagBySecurityRequirementNames = new HashMap<>();
+    public Map<Set<String>, String> principalExtractorTagBySecurityRequirementNames = new LinkedHashMap<>();
 
-    public void fromOpenapi(OpenAPI openAPI) {
+    public void fromOpenapi(OpenAPI openAPI, boolean useSecurityDeclarationOrder) {
         if (openAPI.getPaths() != null) {
             for (var pathname : openAPI.getPaths().keySet()) {
                 var path = openAPI.getPaths().get(pathname);
@@ -23,16 +23,16 @@ public class SecurityData {
                 }
                 for (var operation : path.readOperations()) {
                     if (operation.getSecurity() != null) {
-                        var normalizedOperationSchema = new LinkedHashSet<Map<String, Set<String>>>();
+                        var normalizedOperationSchema = newSecurityRequirementsSet(useSecurityDeclarationOrder);
                         for (var securityRequirement : operation.getSecurity()) {
-                            var normalized = normalizeSecurityRequirement(securityRequirement);
+                            var normalized = normalizeSecurityRequirement(securityRequirement, useSecurityDeclarationOrder);
                             normalizedOperationSchema.add(normalized);
                         }
                         securityRequirementByOperation.put(operation.getOperationId(), normalizedOperationSchema);
                     } else if (openAPI.getSecurity() != null) {
-                        var normalizedOperationSchema = new LinkedHashSet<Map<String, Set<String>>>();
+                        var normalizedOperationSchema = newSecurityRequirementsSet(useSecurityDeclarationOrder);
                         for (var securityRequirement : openAPI.getSecurity()) {
-                            var normalized = normalizeSecurityRequirement(securityRequirement);
+                            var normalized = normalizeSecurityRequirement(securityRequirement, useSecurityDeclarationOrder);
                             normalizedOperationSchema.add(normalized);
                         }
                         securityRequirementByOperation.put(operation.getOperationId(), normalizedOperationSchema);
@@ -41,23 +41,121 @@ public class SecurityData {
             }
         }
         for (var requirement : securityRequirementByOperation.values()) {
-            if (!requirement.isEmpty()) {
+            if (hasNonAnonymousRequirements(requirement)) {
                 interceptorTagBySecurityRequirement.putIfAbsent(requirement, "OperationSecuritySchemaTag" + interceptorTagBySecurityRequirement.size());
             }
         }
         for (var securitySchema : securityRequirementByOperation.values()) {
             for (var requirement : securitySchema) {
-                principalExtractorTagBySecurityRequirementNames.putIfAbsent(new LinkedHashSet<>(requirement.keySet()), "SecurityRequirementTag" + principalExtractorTagBySecurityRequirementNames.size());
+                if (requirement.isEmpty()) {
+                    continue;
+                }
+                principalExtractorTagBySecurityRequirementNames.putIfAbsent(newSecurityNamesSet(requirement.keySet(), useSecurityDeclarationOrder), "SecurityRequirementTag" + principalExtractorTagBySecurityRequirementNames.size());
             }
         }
     }
 
-    private static Map<String, Set<String>> normalizeSecurityRequirement(Map<String, List<String>> schema) {
-        var setSchema = new HashMap<String, Set<String>>();
+    public static boolean hasNonAnonymousRequirements(Set<? extends Map<String, ? extends Set<String>>> requirements) {
+        if (requirements == null) {
+            return false;
+        }
+        return requirements.stream().anyMatch(requirement -> !requirement.isEmpty());
+    }
+
+    public static boolean hasAnonymousRequirement(Collection<? extends Map<String, ? extends Set<String>>> requirements) {
+        if (requirements == null) {
+            return false;
+        }
+        return requirements.stream().anyMatch(Map::isEmpty);
+    }
+
+    private static Set<Map<String, Set<String>>> newSecurityRequirementsSet(boolean useSecurityDeclarationOrder) {
+        return useSecurityDeclarationOrder
+            ? new OrderedSet<>()
+            : new LinkedHashSet<>();
+    }
+
+    private static Set<String> newSecurityNamesSet(Collection<String> names, boolean useSecurityDeclarationOrder) {
+        return useSecurityDeclarationOrder
+            ? new OrderedSet<>(names)
+            : new LinkedHashSet<>(names);
+    }
+
+    private static Map<String, Set<String>> normalizeSecurityRequirement(Map<String, List<String>> schema, boolean useSecurityDeclarationOrder) {
+        var setSchema = useSecurityDeclarationOrder
+            ? new OrderedMap<String, Set<String>>()
+            : new TreeMap<String, Set<String>>();
         for (var entry : schema.entrySet()) {
-            setSchema.put(entry.getKey(), new HashSet<>(entry.getValue()));
+            var scopes = useSecurityDeclarationOrder
+                ? new LinkedHashSet<>(entry.getValue())
+                : new TreeSet<>(entry.getValue());
+            setSchema.put(entry.getKey(), scopes);
         }
         return setSchema;
+    }
+
+    private static final class OrderedMap<K, V> extends LinkedHashMap<K, V> {
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof Map<?, ?> other) || size() != other.size()) {
+                return false;
+            }
+            var thisIterator = entrySet().iterator();
+            var otherIterator = other.entrySet().iterator();
+            while (thisIterator.hasNext() && otherIterator.hasNext()) {
+                if (!Objects.equals(thisIterator.next(), otherIterator.next())) {
+                    return false;
+                }
+            }
+            return !thisIterator.hasNext() && !otherIterator.hasNext();
+        }
+
+        @Override
+        public int hashCode() {
+            return orderedHash(entrySet());
+        }
+    }
+
+    private static final class OrderedSet<E> extends LinkedHashSet<E> {
+        private OrderedSet() {}
+
+        private OrderedSet(Collection<? extends E> values) {
+            super(values);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof Set<?> other) || size() != other.size()) {
+                return false;
+            }
+            var thisIterator = iterator();
+            var otherIterator = other.iterator();
+            while (thisIterator.hasNext() && otherIterator.hasNext()) {
+                if (!Objects.equals(thisIterator.next(), otherIterator.next())) {
+                    return false;
+                }
+            }
+            return !thisIterator.hasNext() && !otherIterator.hasNext();
+        }
+
+        @Override
+        public int hashCode() {
+            return orderedHash(this);
+        }
+    }
+
+    private static int orderedHash(Collection<?> values) {
+        var result = 1;
+        for (var value : values) {
+            result = 31 * result + Objects.hashCode(value);
+        }
+        return result;
     }
 
 }

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientApiGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientApiGenerator.java
@@ -12,6 +12,8 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 
+import static io.koraframework.openapi.generator.SecurityData.hasNonAnonymousRequirements;
+
 public class ClientApiGenerator extends AbstractJavaGenerator<OperationsMap> {
 
     @Override
@@ -266,7 +268,7 @@ public class ClientApiGenerator extends AbstractJavaGenerator<OperationsMap> {
         }
         if (!params.authAsMethodArgument) {
             var requirement = this.security.securityRequirementByOperation.get(operation.operationId);
-            if (requirement != null && !requirement.isEmpty()) {
+            if (hasNonAnonymousRequirements(requirement)) {
                 var interceptorTag = this.security.interceptorTagBySecurityRequirement.get(requirement);
                 var annotation = AnnotationSpec.builder(Classes.interceptWith)
                     .addMember("value", "$T.class", Classes.httpClientInterceptor)

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientSecuritySchemaGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientSecuritySchemaGenerator.java
@@ -8,6 +8,8 @@ import org.slf4j.LoggerFactory;
 import javax.lang.model.element.Modifier;
 import java.util.*;
 
+import static io.koraframework.openapi.generator.SecurityData.hasAnonymousRequirement;
+
 public class ClientSecuritySchemaGenerator extends AbstractJavaGenerator<Map<String, Object>> {
     @Override
     public JavaFile generate(Map<String, Object> ctx) {
@@ -170,7 +172,11 @@ public class ClientSecuritySchemaGenerator extends AbstractJavaGenerator<Map<Str
             .addException(Exception.class);
 
         var securitySchemaSeen = new HashSet<String>();
+        var allowAnonymous = hasAnonymousRequirement(security);
         for (var securityRequirement : security) {
+            if (securityRequirement.isEmpty()) {
+                continue;
+            }
             for (var entry : securityRequirement.entrySet()) {
                 var securitySchemaName = entry.getKey();
                 var scopes = entry.getValue();
@@ -206,7 +212,9 @@ public class ClientSecuritySchemaGenerator extends AbstractJavaGenerator<Map<Str
             }
             intercept.endControlFlow();
         }
-        intercept.addStatement("log.warn($S)", "Security schema is defined for api but no data was provided");
+        if (!allowAnonymous) {
+            intercept.addStatement("log.warn($S)", "Security schema is defined for api but no data was provided");
+        }
         intercept.addStatement("return chain.process(request)");
         b.addMethod(intercept.build());
         return b.build();

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ServerApiGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ServerApiGenerator.java
@@ -8,6 +8,8 @@ import org.openapitools.codegen.model.OperationsMap;
 
 import javax.lang.model.element.Modifier;
 
+import static io.koraframework.openapi.generator.SecurityData.hasNonAnonymousRequirements;
+
 public class ServerApiGenerator extends AbstractJavaGenerator<OperationsMap> {
     @Override
     public JavaFile generate(OperationsMap ctx) {
@@ -122,7 +124,7 @@ public class ServerApiGenerator extends AbstractJavaGenerator<OperationsMap> {
     @Nullable
     protected AnnotationSpec buildServerMethodAuth(CodegenOperation operation) {
         var securityRequirement = security.securityRequirementByOperation.get(operation.operationId);
-        if (securityRequirement == null || securityRequirement.isEmpty()) {
+        if (!hasNonAnonymousRequirements(securityRequirement)) {
             return null;
         }
         var operationSecurityRequirement = security.securityRequirementByOperation.get(operation.operationId);

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ServerSecuritySchemaGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ServerSecuritySchemaGenerator.java
@@ -6,6 +6,8 @@ import org.openapitools.codegen.CodegenSecurity;
 import javax.lang.model.element.Modifier;
 import java.util.*;
 
+import static io.koraframework.openapi.generator.SecurityData.hasAnonymousRequirement;
+
 public class ServerSecuritySchemaGenerator extends AbstractJavaGenerator<Map<String, Object>> {
 
     @Override
@@ -88,6 +90,9 @@ public class ServerSecuritySchemaGenerator extends AbstractJavaGenerator<Map<Str
             .addCode("return new $T(", interceptorClass);
         var seen = new HashSet<String>();
         for (var securityRequirement : security) {
+            if (securityRequirement.isEmpty()) {
+                continue;
+            }
             var principalExtractorTag = this.security.principalExtractorTagBySecurityRequirementNames.get(securityRequirement.keySet());
             if (!seen.add(principalExtractorTag)) {
                 continue;
@@ -127,6 +132,9 @@ public class ServerSecuritySchemaGenerator extends AbstractJavaGenerator<Map<Str
             .addModifiers(Modifier.PUBLIC);
         var seen = new HashSet<String>();
         for (var securityRequirement : security) {
+            if (securityRequirement.isEmpty()) {
+                continue;
+            }
             var principalExtractorTag = this.security.principalExtractorTagBySecurityRequirementNames.get(securityRequirement.keySet());
             if (!seen.add(principalExtractorTag)) {
                 continue;
@@ -147,7 +155,11 @@ public class ServerSecuritySchemaGenerator extends AbstractJavaGenerator<Map<Str
 
         var securitySchemaSeen = new HashSet<String>();
         var securityRequirementSeen = new HashSet<String>();
+        var allowAnonymous = hasAnonymousRequirement(security);
         for (var securityRequirement : security) {
+            if (securityRequirement.isEmpty()) {
+                continue;
+            }
             for (var entry : securityRequirement.entrySet()) {
                 var securitySchemaName = entry.getKey();
                 var scopes = entry.getValue();
@@ -207,7 +219,11 @@ public class ServerSecuritySchemaGenerator extends AbstractJavaGenerator<Map<Str
 
             intercept.addCode("\n");
         }
-        intercept.addStatement("throw $T.of(403, $S)", Classes.httpServerResponseException, "Forbidden");
+        if (allowAnonymous) {
+            intercept.addStatement("return chain.process(request)");
+        } else {
+            intercept.addStatement("throw $T.of(401, $S)", Classes.httpServerResponseException, "Unauthorized");
+        }
         b.addMethod(intercept.build());
         return b.build();
     }

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ClientApiGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ClientApiGenerator.kt
@@ -1,6 +1,7 @@
 package io.koraframework.openapi.generator.kotlingen
 
 import com.squareup.kotlinpoet.*
+import io.koraframework.openapi.generator.SecurityData
 import org.apache.commons.lang3.StringUtils
 import org.openapitools.codegen.CodegenOperation
 import org.openapitools.codegen.model.OperationsMap
@@ -43,6 +44,20 @@ class ClientApiGenerator() : AbstractKotlinGenerator<OperationsMap>() {
 //        this.buildMethodAuth(operation, Classes.httpClientInterceptor.asKt())?.let {
 //            b.addAnnotation(it)
 //        }
+        if (!params.authAsMethodArgument) {
+            val requirement = security.securityRequirementByOperation[operation.operationId]
+            if (SecurityData.hasNonAnonymousRequirements(requirement)) {
+                val interceptorTag = security.interceptorTagBySecurityRequirement[requirement]
+                if (interceptorTag != null) {
+                    b.addAnnotation(
+                        AnnotationSpec.builder(Classes.interceptWith.asKt())
+                            .addMember("value = %T::class", Classes.httpClientInterceptor.asKt())
+                            .addMember("tag = %T::class", ClassName(apiPackage, "ApiSecurity", interceptorTag))
+                            .build()
+                    )
+                }
+            }
+        }
         b.addAnnotations(this.buildInterceptors(tag, Classes.httpClientInterceptor.asKt()))
         if (operation.isDeprecated) {
             b.addAnnotation(AnnotationSpec.builder(Deprecated::class.asClassName()).addMember("%S", "deprecated").build())

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ClientSecuritySchemaGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ClientSecuritySchemaGenerator.kt
@@ -2,6 +2,7 @@ package io.koraframework.openapi.generator.kotlingen
 
 import com.squareup.kotlinpoet.*
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import io.koraframework.openapi.generator.SecurityData
 import org.openapitools.codegen.CodegenSecurity
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -173,7 +174,11 @@ class ClientSecuritySchemaGenerator : AbstractKotlinGenerator<Map<String, Any>>(
 
         val securitySchemaSeen = mutableSetOf<String>()
         val fullConditionSeen = mutableSetOf<CodeBlock>()
+        val allowAnonymous = SecurityData.hasAnonymousRequirement(security)
         for (securityRequirement in security) {
+            if (securityRequirement.isEmpty()) {
+                continue
+            }
             for (securitySchemaName in securityRequirement.keys) {
                 if (securitySchemaSeen.add(securitySchemaName)) {
                     intercept.addStatement("val %N = this.%N.getToken(request)", securitySchemaName, securitySchemaName)
@@ -202,7 +207,9 @@ class ClientSecuritySchemaGenerator : AbstractKotlinGenerator<Map<String, Any>>(
             intercept.addStatement("return chain.process(b.build())")
             intercept.endControlFlow()
         }
-        intercept.addStatement("log.warn(%S)", "Security schema is defined for api but no data was provided")
+        if (!allowAnonymous) {
+            intercept.addStatement("log.warn(%S)", "Security schema is defined for api but no data was provided")
+        }
         intercept.addStatement("return chain.process(request)")
         b.addFunction(intercept.build())
         return b.build()

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ServerApiGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ServerApiGenerator.kt
@@ -1,6 +1,7 @@
 package io.koraframework.openapi.generator.kotlingen
 
 import com.squareup.kotlinpoet.*
+import io.koraframework.openapi.generator.SecurityData
 import org.apache.commons.lang3.StringUtils
 import org.openapitools.codegen.CodegenOperation
 import org.openapitools.codegen.model.OperationsMap
@@ -115,7 +116,7 @@ class ServerApiGenerator() : AbstractKotlinGenerator<OperationsMap>() {
 
     private fun buildMethodAuth(operation: CodegenOperation): AnnotationSpec? {
         val securityRequirement = security.securityRequirementByOperation[operation.operationId]
-        if (securityRequirement.isNullOrEmpty()) {
+        if (!SecurityData.hasNonAnonymousRequirements(securityRequirement)) {
             return null
         }
         val operationSecurityRequirement = security.securityRequirementByOperation[operation.operationId]

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ServerSecuritySchemaGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ServerSecuritySchemaGenerator.kt
@@ -2,6 +2,7 @@ package io.koraframework.openapi.generator.kotlingen
 
 import com.squareup.kotlinpoet.*
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import io.koraframework.openapi.generator.SecurityData
 import org.openapitools.codegen.CodegenSecurity
 
 
@@ -82,6 +83,9 @@ class ServerSecuritySchemaGenerator : AbstractKotlinGenerator<Map<String, Any>>(
         val constructor = FunSpec.constructorBuilder()
         val seen = hashSetOf<String>()
         for (securityRequirement in security) {
+            if (securityRequirement.isEmpty()) {
+                continue
+            }
             val principalExtractorTag = this.security.principalExtractorTagBySecurityRequirementNames[securityRequirement.keys]!!
             if (!seen.add(principalExtractorTag)) {
                 continue
@@ -103,7 +107,11 @@ class ServerSecuritySchemaGenerator : AbstractKotlinGenerator<Map<String, Any>>(
 
         val securitySchemaSeen = mutableSetOf<String>()
         val securityRequirementSeen = mutableSetOf<String>()
+        val allowAnonymous = SecurityData.hasAnonymousRequirement(security)
         for (securityRequirement in security) {
+            if (securityRequirement.isEmpty()) {
+                continue
+            }
             for ((securitySchemaName, scopes) in securityRequirement.entries) {
                 if (securitySchemaSeen.add(securitySchemaName)) {
                     val securitySchema = authMethods.first { s -> s.name.equals(securitySchemaName) }
@@ -168,7 +176,11 @@ class ServerSecuritySchemaGenerator : AbstractKotlinGenerator<Map<String, Any>>(
             intercept.addCode("\n");
         }
 
-        intercept.addStatement("throw %T.of(403, %S)", Classes.httpServerResponseException.asKt(), "Forbidden")
+        if (allowAnonymous) {
+            intercept.addStatement("return chain.process(request)")
+        } else {
+            intercept.addStatement("throw %T.of(401, %S)", Classes.httpServerResponseException.asKt(), "Unauthorized")
+        }
         b.addFunction(intercept.build())
         return b.build()
     }
@@ -183,6 +195,9 @@ class ServerSecuritySchemaGenerator : AbstractKotlinGenerator<Map<String, Any>>(
             .addCode("return %T(", interceptorClass)
         val seen = mutableSetOf<String>()
         for (securityRequirement in security) {
+            if (securityRequirement.isEmpty()) {
+                continue
+            }
             val principalExtractorTag = this.security.principalExtractorTagBySecurityRequirementNames.get(securityRequirement.keys)!!
             if (!seen.add(principalExtractorTag)) {
                 continue

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/BaseOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/BaseOpenapiTest.java
@@ -31,6 +31,7 @@ public abstract class BaseOpenapiTest {
             public String clientConfig = "test";
             @Nullable
             public String clientConfigPrefix;
+            public boolean useSecurityDeclarationOrder;
 
             public Options setAuthAsArg(boolean authAsArg) {
                 this.authAsArg = authAsArg;
@@ -72,6 +73,11 @@ public abstract class BaseOpenapiTest {
                 return this;
             }
 
+            public Options setUseSecurityDeclarationOrder(boolean useSecurityDeclarationOrder) {
+                this.useSecurityDeclarationOrder = useSecurityDeclarationOrder;
+                return this;
+            }
+
             @Override
             public String toString() {
                 return "Options{" +
@@ -83,6 +89,7 @@ public abstract class BaseOpenapiTest {
                        ", rawBodyMode='" + rawBodyMode + '\'' +
                        ", clientConfig='" + clientConfig + '\'' +
                        ", clientConfigPrefix='" + clientConfigPrefix + '\'' +
+                       ", useSecurityDeclarationOrder=" + useSecurityDeclarationOrder +
                        '}';
             }
         }
@@ -109,6 +116,8 @@ public abstract class BaseOpenapiTest {
             "/example/petstoreV3_security_cookie.yaml",
             "/example/petstoreV3_security_oauth.yaml",
             "/example/petstoreV3_security_multi.yaml",
+            "/example/petstoreV3_security_anonymous.yaml",
+            "/example/petstoreV3_security_order.yaml",
             "/example/petstoreV3_single_response.yaml",
             "/example/petstoreV3_same_response_model.yaml",
             "/example/petstoreV3_bare_object.yaml",
@@ -199,6 +208,7 @@ public abstract class BaseOpenapiTest {
             .addAdditionalProperty("enableServerValidation", name.contains("validation"))
             .addAdditionalProperty("authAsMethodArgument", options.authAsArg)
             .addAdditionalProperty("implicitHeaders", options.implicitHeaders)
+            .addAdditionalProperty("useSecurityDeclarationOrder", options.useSecurityDeclarationOrder)
             .addAdditionalProperty("requestInDelegateParams", options.includeServerRequest)
             .addAdditionalProperty("requestInDelegateParams", options.includeServerRequest);
 

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientJavaOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientJavaOpenapiTest.java
@@ -274,6 +274,72 @@ public class HttpClientJavaOpenapiTest extends BaseJavaOpenapiTest {
     }
 
     @Test
+    void anonymousSecurityDoesNotRequireClientInterceptor() throws Exception {
+        var files = generate(
+            "petstoreV3_security_anonymous",
+            "java-client",
+            getClass().getResource("/example/petstoreV3_security_anonymous.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+        );
+
+        var apiContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("PublicApi.java"))
+            .findFirst()
+            .orElseThrow());
+        var securityContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("ApiSecurity.java"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(apiContent.indexOf("tag = ApiSecurity.OperationSecuritySchemaTag0.class") < apiContent.indexOf("optionalAccess("));
+        assertTrue(apiContent.lastIndexOf("OperationSecuritySchemaTag") < apiContent.indexOf("publicAccess("));
+        assertFalse(securityContent.contains("if ()"));
+        assertFalse(securityContent.contains("Security schema is defined for api but no data was provided"));
+        assertTrue(securityContent.contains("return chain.process(request);"));
+    }
+
+    @Test
+    void securityDeclarationOrderCanBePreservedForClientInterceptors() throws Exception {
+        var defaultFiles = generate(
+            "petstoreV3_security_order_default",
+            "java-client",
+            getClass().getResource("/example/petstoreV3_security_order.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+        );
+        var orderedFiles = generate(
+            "petstoreV3_security_order_ordered",
+            "java-client",
+            getClass().getResource("/example/petstoreV3_security_order.yaml").toExternalForm(),
+            new SwaggerParams.Options().setUseSecurityDeclarationOrder(true)
+        );
+
+        var defaultApiContent = Files.readString(defaultFiles.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("PetsApi.java"))
+            .findFirst()
+            .orElseThrow());
+        var orderedApiContent = Files.readString(orderedFiles.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("PetsApi.java"))
+            .findFirst()
+            .orElseThrow());
+        var orderedSecurityContent = Files.readString(orderedFiles.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("ApiSecurity.java"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(defaultApiContent.contains("ApiSecurity.OperationSecuritySchemaTag0.class"));
+        assertFalse(defaultApiContent.contains("ApiSecurity.OperationSecuritySchemaTag1.class"));
+        assertTrue(orderedApiContent.contains("ApiSecurity.OperationSecuritySchemaTag0.class"));
+        assertTrue(orderedApiContent.contains("ApiSecurity.OperationSecuritySchemaTag1.class"));
+        assertTrue(orderedSecurityContent.contains("OperationSecuritySchemaTag0HttpClientInterceptor"));
+        assertTrue(orderedSecurityContent.contains("OperationSecuritySchemaTag1HttpClientInterceptor"));
+    }
+
+    @Test
     void bareObjectPropertiesAreGeneratedAsObject() throws Exception {
         var files = generate(
             "petstoreV3_bare_object_bytes_default",

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientKotlinOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientKotlinOpenapiTest.java
@@ -134,6 +134,33 @@ public class HttpClientKotlinOpenapiTest extends BaseKotlinOpenapiTest {
     }
 
     @Test
+    void anonymousSecurityDoesNotRequireClientInterceptor() throws Exception {
+        var files = generate(
+            "petstoreV3_security_anonymous",
+            "kotlin-client",
+            getClass().getResource("/example/petstoreV3_security_anonymous.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+        );
+
+        var apiContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("PublicApi.kt"))
+            .findFirst()
+            .orElseThrow());
+        var securityContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("ApiSecurity.kt"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(apiContent.indexOf("tag = ApiSecurity.OperationSecuritySchemaTag0::class") < apiContent.indexOf("optionalAccess("));
+        assertTrue(apiContent.lastIndexOf("OperationSecuritySchemaTag") < apiContent.indexOf("publicAccess("));
+        assertFalse(securityContent.contains("if ()"));
+        assertFalse(securityContent.contains("Security schema is defined for api but no data was provided"));
+        assertTrue(securityContent.contains("return chain.process(request)"));
+    }
+
+    @Test
     void bareObjectRequestAndResponseAreGeneratedAsHttpBodyTypes() throws Exception {
         var files = generate(
             "petstoreV3_bare_object_body",

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpServerJavaOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpServerJavaOpenapiTest.java
@@ -49,6 +49,52 @@ public class HttpServerJavaOpenapiTest extends BaseJavaOpenapiTest {
     }
 
     @Test
+    void anonymousSecurityDoesNotRequireServerInterceptor() throws Exception {
+        var files = generate(
+            "petstoreV3_security_anonymous",
+            "java-server",
+            getClass().getResource("/example/petstoreV3_security_anonymous.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+        );
+
+        var controllerContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("PublicApiController.java"))
+            .findFirst()
+            .orElseThrow());
+        var securityContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("ApiSecurity.java"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(controllerContent.indexOf("tag = ApiSecurity.OperationSecuritySchemaTag0.class") < controllerContent.indexOf("optionalAccess("));
+        assertTrue(controllerContent.lastIndexOf("OperationSecuritySchemaTag") < controllerContent.indexOf("publicAccess("));
+        assertFalse(securityContent.contains("SecurityRequirementTag1"));
+        assertTrue(securityContent.contains("return chain.process(request);"));
+        assertFalse(securityContent.contains("Unauthorized"));
+    }
+
+    @Test
+    void serverAuthFallbackUsesUnauthorized() throws Exception {
+        var files = generate(
+            "petstoreV3_security_api_key",
+            "java-server",
+            getClass().getResource("/example/petstoreV3_security_api_key.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+        );
+
+        var securityContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("ApiSecurity.java"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(securityContent.contains("throw HttpServerResponseException.of(401, \"Unauthorized\")"));
+        assertFalse(securityContent.contains("Forbidden"));
+    }
+
+    @Test
     void bareObjectRequestAndResponseAreGeneratedAsHttpBodyTypes() throws Exception {
         var files = generate(
             "petstoreV3_bare_object_body",

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpServerKotlinOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpServerKotlinOpenapiTest.java
@@ -21,6 +21,52 @@ public class HttpServerKotlinOpenapiTest extends BaseKotlinOpenapiTest {
     }
 
     @Test
+    void anonymousSecurityDoesNotRequireServerInterceptor() throws Exception {
+        var files = generate(
+            "petstoreV3_security_anonymous",
+            "kotlin-server",
+            getClass().getResource("/example/petstoreV3_security_anonymous.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+        );
+
+        var controllerContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("PublicApiController.kt"))
+            .findFirst()
+            .orElseThrow());
+        var securityContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("ApiSecurity.kt"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(controllerContent.indexOf("tag = ApiSecurity.OperationSecuritySchemaTag0::class") < controllerContent.indexOf("optionalAccess("));
+        assertTrue(controllerContent.lastIndexOf("OperationSecuritySchemaTag") < controllerContent.indexOf("publicAccess("));
+        assertFalse(securityContent.contains("SecurityRequirementTag1"));
+        assertTrue(securityContent.contains("return chain.process(request)"));
+        assertFalse(securityContent.contains("Unauthorized"));
+    }
+
+    @Test
+    void serverAuthFallbackUsesUnauthorized() throws Exception {
+        var files = generate(
+            "petstoreV3_security_api_key",
+            "kotlin-server",
+            getClass().getResource("/example/petstoreV3_security_api_key.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+        );
+
+        var securityContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("ApiSecurity.kt"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(securityContent.contains("throw HttpServerResponseException.of(401, \"Unauthorized\")"));
+        assertFalse(securityContent.contains("Forbidden"));
+    }
+
+    @Test
     void bareObjectRequestAndResponseAreGeneratedAsHttpBodyTypes() throws Exception {
         var files = generate(
             "petstoreV3_bare_object_body",

--- a/openapi/openapi-generator/src/test/resources/example/petstoreV3_security_anonymous.yaml
+++ b/openapi/openapi-generator/src/test/resources/example/petstoreV3_security_anonymous.yaml
@@ -1,0 +1,35 @@
+openapi: 3.0.3
+
+info:
+  title: Anonymous security
+  version: 1.0.0
+
+paths:
+  /public:
+    get:
+      operationId: publicAccess
+      tags:
+        - public
+      security:
+        - {}
+      responses:
+        '200':
+          description: Ok
+  /optional:
+    get:
+      operationId: optionalAccess
+      tags:
+        - public
+      security:
+        - sec1: []
+        - {}
+      responses:
+        '200':
+          description: Ok
+
+components:
+  securitySchemes:
+    sec1:
+      type: apiKey
+      in: header
+      name: X-SEC-1

--- a/openapi/openapi-generator/src/test/resources/example/petstoreV3_security_order.yaml
+++ b/openapi/openapi-generator/src/test/resources/example/petstoreV3_security_order.yaml
@@ -1,0 +1,40 @@
+openapi: 3.0.3
+
+info:
+  title: Security order
+  version: 1.0.0
+
+paths:
+  /pets12:
+    get:
+      operationId: pets12
+      tags:
+        - pets
+      security:
+        - sec1: []
+          sec2: []
+      responses:
+        '200':
+          description: Ok
+  /pets21:
+    get:
+      operationId: pets21
+      tags:
+        - pets
+      security:
+        - sec2: []
+          sec1: []
+      responses:
+        '200':
+          description: Ok
+
+components:
+  securitySchemes:
+    sec1:
+      type: apiKey
+      in: header
+      name: X-SEC-1
+    sec2:
+      type: apiKey
+      in: header
+      name: X-SEC-2


### PR DESCRIPTION
Added OpenAPI security fallback modes with anonymous access and declaration order control

## EN

Added anonymous OpenAPI security requirement handling so `{}` requirements do not force generated client or server interceptors, while optional auth keeps anonymous fallback behavior. Server auth fallback now returns `401 Unauthorized` instead of `403 Forbidden` when no anonymous fallback is available, and `useSecurityDeclarationOrder` can preserve declared security scheme order for generated auth tags and interceptors.

---

## RU

Добавлена поддержка anonymous OpenAPI security requirement: `{}` больше не заставляет генерировать client/server interceptors, а optional auth сохраняет fallback на anonymous access. Server auth fallback теперь возвращает `401 Unauthorized` вместо `403 Forbidden`, а флаг `useSecurityDeclarationOrder` позволяет учитывать порядок объявления security schemes при генерации auth tags и interceptors.

---

- Added anonymous OpenAPI security requirement support with preserved anonymous fallback for optional auth.
- Added `useSecurityDeclarationOrder` to preserve declared security scheme order when generating auth tags and interceptors.
- Improved server auth fallback to use `401 Unauthorized` instead of `403 Forbidden` when anonymous access is not allowed.

---

## Design

OpenAPI security requirements can include an empty object `{}` to explicitly allow anonymous access. The generator now treats that empty requirement as a real fallback rule, but excludes it from generated auth extractor/interceptor components because there is no credential to extract.

For anonymous-only operations, no auth interceptor is generated:

```yaml
security:
  - {}
```

For optional auth, the generated interceptor tries configured credentials first and falls through to normal request processing when credentials are absent:

```yaml
security:
  - sec1: []
  - {}
```

For secured operations without anonymous fallback, generated server interceptors now fail with `401 Unauthorized` when no requirement matches. This better reflects missing/invalid authentication data than `403 Forbidden`.

The new `useSecurityDeclarationOrder` option controls normalization of security requirements. By default, equivalent security requirement sets are normalized and reused. When enabled, declaration order is preserved so requirements like `sec1 + sec2` and `sec2 + sec1` can produce distinct generated auth tags/interceptors when contract order matters.