### PR TITLE
Improved OpenAPI generated response contracts with override-friendly mappers

### DIFF
--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ApiResponseGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ApiResponseGenerator.java
@@ -1,8 +1,6 @@
 package io.koraframework.openapi.generator.javagen;
 
 import com.palantir.javapoet.*;
-import org.openapitools.codegen.CodegenModel;
-import org.openapitools.codegen.CodegenProperty;
 import org.openapitools.codegen.CodegenResponse;
 import org.openapitools.codegen.model.OperationsMap;
 
@@ -92,11 +90,6 @@ public class ApiResponseGenerator extends AbstractJavaGenerator<OperationsMap> {
             }
             var dataType = entry.getKey();
             var contentType = asType(entry.getValue().getFirst());
-            var model = model(dataType);
-            var occupiedNames = model == null
-                ? Set.<String>of()
-                : model.vars.stream().map(property -> property.name).collect(Collectors.toSet());
-            var statusCodeMethod = statusCodeMethod(occupiedNames);
             var className = responseClassName.nestedClass(responseClassName.simpleName().replaceAll("ApiResponse$", "") + sanitizeSharedResponseName(dataType) + "ApiResponse");
             var type = TypeSpec.interfaceBuilder(className)
                 .addAnnotation(generated())
@@ -105,56 +98,14 @@ public class ApiResponseGenerator extends AbstractJavaGenerator<OperationsMap> {
                 .addMethod(MethodSpec.methodBuilder("content")
                     .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
                     .returns(contentType)
-                    .build());
-            if (model != null) {
-                for (var property : model.vars) {
-                    if ("content".equals(property.name) || Objects.equals(property.name, statusCodeMethod)) {
-                        continue;
-                    }
-                    type.addMethod(MethodSpec.methodBuilder(property.name)
-                        .addModifiers(Modifier.PUBLIC, Modifier.DEFAULT)
-                        .returns(fieldType(property))
-                        .addStatement("return this.content().$N()", property.name)
-                        .build());
-                }
-            }
-            if (statusCodeMethod != null) {
-                type.addMethod(MethodSpec.methodBuilder(statusCodeMethod)
+                    .build())
+                .addMethod(MethodSpec.methodBuilder("statusCode")
                     .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
                     .returns(TypeName.INT)
                     .build());
-            }
-            result.put(dataType, new SharedResponse(className, type.build(), statusCodeMethod));
+            result.put(dataType, new SharedResponse(className, type.build(), "statusCode"));
         }
         return result;
-    }
-
-    private CodegenModel model(String dataType) {
-        var model = models.get(dataType);
-        if (model != null && !model.getModels().isEmpty()) {
-            return model.getModels().getFirst().getModel();
-        }
-        for (var modelMap : models.values()) {
-            if (modelMap.getModels().isEmpty()) {
-                continue;
-            }
-            var codegenModel = modelMap.getModels().getFirst().getModel();
-            if (dataType.equals(codegenModel.classname)) {
-                return codegenModel;
-            }
-        }
-        return null;
-    }
-
-    private TypeName fieldType(CodegenProperty field) {
-        var type = asType(field);
-        if (field.isNullable && !field.required) {
-            return ParameterizedTypeName.get(Classes.jsonNullable, type.box());
-        } else if (!field.required || field.isNullable) {
-            return type.box().annotated(AnnotationSpec.builder(Classes.nullable).build());
-        } else {
-            return type;
-        }
     }
 
     private static String sanitizeSharedResponseName(String dataType) {
@@ -163,22 +114,6 @@ public class ApiResponseGenerator extends AbstractJavaGenerator<OperationsMap> {
             return "Content";
         }
         return capitalize(name);
-    }
-
-    private static String statusCodeMethod(Set<String> occupiedNames) {
-        var candidates = List.of("statusCode", "httpStatusCode", "statusCodeMethod", "httpStatusCodeMethod");
-        for (var candidate : candidates) {
-            if (!occupiedNames.contains(candidate)) {
-                return candidate;
-            }
-        }
-        for (var candidate : candidates) {
-            var underscored = "_" + candidate;
-            if (!occupiedNames.contains(underscored)) {
-                return underscored;
-            }
-        }
-        return null;
     }
 
     private record SharedResponse(ClassName className, TypeSpec type, String statusCodeMethod) {}

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientResponseMapperGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientResponseMapperGenerator.java
@@ -31,8 +31,8 @@ public class ClientResponseMapperGenerator extends AbstractJavaGenerator<Operati
         var className = mappers.nestedClass(capitalize(operation.operationId) + response.code + "ApiResponseMapper");
         var b = TypeSpec.classBuilder(className)
             .addAnnotation(generated())
-            .addAnnotation(Classes.component)
-            .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
+            .addAnnotation(Classes.defaultComponent)
+            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
             .addSuperinterface(ParameterizedTypeName.get(Classes.httpClientResponseMapper, responseType));
         MethodSpec.Builder constructor = null;
         if (response.dataType != null) {

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ServerResponseMapperGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ServerResponseMapperGenerator.java
@@ -28,12 +28,13 @@ public class ServerResponseMapperGenerator extends AbstractJavaGenerator<Operati
         var className = ClassName.get(ctx.get("classname") + "ServerResponseMappers", capitalize(operation.operationId) + "ApiResponseMapper");
         var responseClassName = ClassName.get(apiPackage, ctx.get("classname") + "Responses", capitalize(operation.operationId) + "ApiResponse");
         var b = TypeSpec.classBuilder(className)
-            .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
+            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
             .addAnnotation(generated())
-            .addAnnotation(Classes.component)
+            .addAnnotation(Classes.defaultComponent)
             .addSuperinterface(ParameterizedTypeName.get(Classes.httpServerResponseMapper, responseClassName));
         var constructor = MethodSpec.constructorBuilder()
             .addModifiers(Modifier.PUBLIC);
+        var hasConstructorParameters = false;
         for (var response : operation.responses) {
             if (!response.isBinary && response.dataType != null) {
                 var mapperType = ParameterizedTypeName.get(Classes.httpServerResponseMapper, ParameterizedTypeName.get(Classes.httpResponseEntity, asType(response)));
@@ -45,9 +46,12 @@ public class ServerResponseMapperGenerator extends AbstractJavaGenerator<Operati
                 }
                 constructor.addParameter(param.build());
                 constructor.addStatement("this.$N = $N", mapperName, mapperName);
+                hasConstructorParameters = true;
             }
         }
-        b.addMethod(constructor.build());
+        if (hasConstructorParameters) {
+            b.addMethod(constructor.build());
+        }
         var m = MethodSpec.methodBuilder("apply")
             .addModifiers(Modifier.PUBLIC)
             .addAnnotation(Override.class)

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ApiResponseGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ApiResponseGenerator.kt
@@ -1,9 +1,6 @@
 package io.koraframework.openapi.generator.kotlingen
 
 import com.squareup.kotlinpoet.*
-import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
-import org.openapitools.codegen.CodegenModel
-import org.openapitools.codegen.CodegenProperty
 import org.openapitools.codegen.CodegenResponse
 import org.openapitools.codegen.model.OperationsMap
 
@@ -95,49 +92,14 @@ class ApiResponseGenerator : AbstractKotlinGenerator<OperationsMap>() {
             .filterValues { it.size > 1 }
             .mapValues { (dataType, responsesByType) ->
                 val contentType = asType(responsesByType.first()).asKt()
-                val model = model(dataType)
-                val occupiedNames = model?.vars.orEmpty().map { it.name }.toSet()
-                val statusCodeProperty = statusCodeProperty(occupiedNames)
                 val className = responseClassName.nestedClass(responseClassName.simpleName.removeSuffix("ApiResponse") + sanitizeSharedResponseName(dataType) + "ApiResponse")
                 val type = TypeSpec.interfaceBuilder(className)
                     .addAnnotation(generated())
                     .addSuperinterface(responseClassName)
                     .addProperty(PropertySpec.builder("content", contentType).build())
-                model?.vars.orEmpty().forEach { property ->
-                    if (property.name != "content" && property.name != statusCodeProperty) {
-                        type.addProperty(
-                            PropertySpec.builder(property.name, fieldType(property))
-                                .getter(FunSpec.getterBuilder().addStatement("return content.%N", property.name).build())
-                                .build()
-                        )
-                    }
-                }
-                if (statusCodeProperty != null) {
-                    type.addProperty(PropertySpec.builder(statusCodeProperty, INT).build())
-                }
-                SharedResponse(className, type.build(), statusCodeProperty)
+                    .addProperty(PropertySpec.builder("statusCode", INT).build())
+                SharedResponse(className, type.build(), "statusCode")
             }
-    }
-
-    private fun model(dataType: String): CodegenModel? {
-        val model = models[dataType]
-        if (model != null && model.models.isNotEmpty()) {
-            return model.models.first().model
-        }
-        return models.values
-            .asSequence()
-            .filter { it.models.isNotEmpty() }
-            .map { it.models.first().model }
-            .firstOrNull { it.classname == dataType }
-    }
-
-    private fun fieldType(field: CodegenProperty): TypeName {
-        val type = asType(field).asKt()
-        return when {
-            field.isNullable && !field.required -> Classes.jsonNullable.asKt().parameterizedBy(type)
-            !field.required || field.isNullable -> type.copy(nullable = true)
-            else -> type
-        }
     }
 
     private fun sanitizeSharedResponseName(dataType: String): String {
@@ -145,21 +107,5 @@ class ApiResponseGenerator : AbstractKotlinGenerator<OperationsMap>() {
         return if (name.isBlank()) "Content" else capitalize(name)
     }
 
-    private fun statusCodeProperty(occupiedNames: Set<String>): String? {
-        val candidates = listOf("statusCode", "httpStatusCode", "statusCodeMethod", "httpStatusCodeMethod")
-        for (candidate in candidates) {
-            if (!occupiedNames.contains(candidate)) {
-                return candidate
-            }
-        }
-        for (candidate in candidates) {
-            val underscored = "_$candidate"
-            if (!occupiedNames.contains(underscored)) {
-                return underscored
-            }
-        }
-        return null
-    }
-
-    private data class SharedResponse(val className: ClassName, val type: TypeSpec, val statusCodeProperty: String?)
+    private data class SharedResponse(val className: ClassName, val type: TypeSpec, val statusCodeProperty: String)
 }

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ClientResponseMapperGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ClientResponseMapperGenerator.kt
@@ -26,7 +26,8 @@ class ClientResponseMapperGenerator : AbstractKotlinGenerator<OperationsMap>() {
         val className = mappers.nestedClass(capitalize(operation.operationId) + response.code + "ApiResponseMapper")
         val b = TypeSpec.classBuilder(className)
             .addAnnotation(generated())
-            .addAnnotation(Classes.component.asKt())
+            .addAnnotation(Classes.defaultComponent.asKt())
+            .addModifiers(KModifier.OPEN)
             .addSuperinterface(Classes.httpClientResponseMapper.asKt().parameterizedBy(responseType))
         val constructor = FunSpec.constructorBuilder()
         response.dataType?.let {
@@ -77,7 +78,10 @@ class ClientResponseMapperGenerator : AbstractKotlinGenerator<OperationsMap>() {
         }
         apply.addStatement("return %T(%L)", responseWithCodeType, newArgs.build())
 
-        b.primaryConstructor(constructor.build())
+        val constructorSpec = constructor.build()
+        if (constructorSpec.parameters.isNotEmpty()) {
+            b.primaryConstructor(constructorSpec)
+        }
         b.addFunction(apply.build())
         return b.build()
     }

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ServerResponseMappersGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ServerResponseMappersGenerator.kt
@@ -26,7 +26,8 @@ class ServerResponseMappersGenerator : AbstractKotlinGenerator<OperationsMap>() 
         val responseClassName = ClassName(apiPackage, ctx.get("classname").toString() + "Responses", capitalize(operation.operationId) + "ApiResponse");
         val b = TypeSpec.classBuilder(className)
             .addAnnotation(generated())
-            .addAnnotation(Classes.component.asKt())
+            .addAnnotation(Classes.defaultComponent.asKt())
+            .addModifiers(KModifier.OPEN)
             .addSuperinterface(Classes.httpServerResponseMapper.asKt().parameterizedBy(responseClassName));
 
         val constructor = FunSpec.constructorBuilder()
@@ -42,7 +43,10 @@ class ServerResponseMappersGenerator : AbstractKotlinGenerator<OperationsMap>() 
                 constructor.addParameter(param.build())
             }
         }
-        b.primaryConstructor(constructor.build())
+        val constructorSpec = constructor.build()
+        if (constructorSpec.parameters.isNotEmpty()) {
+            b.primaryConstructor(constructorSpec)
+        }
         val m = FunSpec.builder("apply")
             .addModifiers(KModifier.OVERRIDE)
             .addParameter("request", Classes.httpServerRequest.asKt())

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientJavaOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientJavaOpenapiTest.java
@@ -103,12 +103,12 @@ public class HttpClientJavaOpenapiTest extends BaseJavaOpenapiTest {
 
         assertTrue(content.contains("sealed interface GetErrorsModelErrorApiResponse extends GetErrorsApiResponse"));
         assertTrue(content.contains("ModelError content()"));
-        assertTrue(content.contains("default String message()"));
-        assertTrue(content.contains("default @Nullable String details()"));
-        assertTrue(content.contains("int _statusCode()"));
+        assertFalse(content.contains("default String message()"));
+        assertFalse(content.contains("default @Nullable String details()"));
+        assertTrue(content.contains("int statusCode()"));
         assertTrue(content.contains("record GetErrors400ApiResponse(ModelError content) implements GetErrorsModelErrorApiResponse"));
         assertTrue(content.contains("return 400"));
-        assertTrue(content.contains("return this.content().details()"));
+        assertFalse(content.contains("return this.content().details()"));
     }
 
     @Test
@@ -408,6 +408,9 @@ public class HttpClientJavaOpenapiTest extends BaseJavaOpenapiTest {
         assertTrue(responseMapperContent.contains("private final HttpClientResponseMapper<HttpBodyInput> delegate"));
         assertTrue(responseMapperContent.contains("private final HttpClientResponseMapper<ErrorMessage> delegate"));
         assertFalse(responseMapperContent.contains("@Json HttpClientResponseMapper<HttpBodyInput>"));
+        assertTrue(responseMapperContent.contains("@DefaultComponent"));
+        assertTrue(responseMapperContent.contains("class StoreInventory200ApiResponseMapper"));
+        assertFalse(responseMapperContent.contains("public static final class StoreInventory200ApiResponseMapper"));
     }
 
     @Test

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientKotlinOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientKotlinOpenapiTest.java
@@ -103,13 +103,13 @@ public class HttpClientKotlinOpenapiTest extends BaseKotlinOpenapiTest {
 
         assertTrue(content.contains("public interface GetErrorsModelErrorApiResponse : GetErrorsApiResponse"));
         assertTrue(content.contains("public val content: ModelError"));
-        assertTrue(content.contains("public val message: String"));
-        assertTrue(content.contains("public val details: String?"));
-        assertTrue(content.contains("public val _statusCode: Int"));
+        assertFalse(content.contains("public val message: String"));
+        assertFalse(content.contains("public val details: String?"));
+        assertTrue(content.contains("public val statusCode: Int"));
         assertTrue(content.contains("public data class GetErrors400ApiResponse("));
         assertTrue(content.contains(": GetErrorsModelErrorApiResponse"));
         assertTrue(content.contains("get() = 400"));
-        assertTrue(content.contains("get() = content.details"));
+        assertFalse(content.contains("get() = content.details"));
     }
 
     @Test
@@ -291,5 +291,7 @@ public class HttpClientKotlinOpenapiTest extends BaseKotlinOpenapiTest {
         assertTrue(responsesContent.contains("public data class RawObject400ApiResponse("));
         assertTrue(responsesContent.contains("public data class RawObject500ApiResponse("));
         assertTrue(responseMapperContent.contains("HttpClientResponseMapper<ByteArray>"));
+        assertTrue(responseMapperContent.contains("@DefaultComponent"));
+        assertTrue(responseMapperContent.contains("public open class StoreInventory200ApiResponseMapper"));
     }
 }

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpServerJavaOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpServerJavaOpenapiTest.java
@@ -95,6 +95,25 @@ public class HttpServerJavaOpenapiTest extends BaseJavaOpenapiTest {
     }
 
     @Test
+    void serverResponseMapperWithoutDelegatesDoesNotGenerateEmptyConstructor() throws Exception {
+        var files = generate(
+            "petstoreV3_discriminator",
+            "java-server",
+            getClass().getResource("/example/petstoreV3_discriminator.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+        );
+
+        var responseMapperContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("DefaultApiServerResponseMappers.java"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(responseMapperContent.contains("class PetsPatchApiResponseMapper"));
+        assertFalse(responseMapperContent.contains("public PetsPatchApiResponseMapper()"));
+    }
+
+    @Test
     void bareObjectRequestAndResponseAreGeneratedAsHttpBodyTypes() throws Exception {
         var files = generate(
             "petstoreV3_bare_object_body",
@@ -147,6 +166,9 @@ public class HttpServerJavaOpenapiTest extends BaseJavaOpenapiTest {
         assertTrue(responsesContent.contains("record RawObject500ApiResponse("));
         assertTrue(responseMapperContent.contains("HttpServerResponseMapper<HttpResponseEntity<HttpBodyOutput>> response200Delegate"));
         assertTrue(responseMapperContent.contains("HttpServerResponseMapper<HttpResponseEntity<ErrorMessage>> response400Delegate"));
+        assertTrue(responseMapperContent.contains("@DefaultComponent"));
+        assertTrue(responseMapperContent.contains("class StoreInventoryApiResponseMapper"));
+        assertFalse(responseMapperContent.contains("public static final class StoreInventoryApiResponseMapper"));
     }
 
     @Test

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpServerKotlinOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpServerKotlinOpenapiTest.java
@@ -67,6 +67,25 @@ public class HttpServerKotlinOpenapiTest extends BaseKotlinOpenapiTest {
     }
 
     @Test
+    void serverResponseMapperWithoutDelegatesDoesNotGenerateEmptyConstructor() throws Exception {
+        var files = generate(
+            "petstoreV3_discriminator",
+            "kotlin-server",
+            getClass().getResource("/example/petstoreV3_discriminator.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+        );
+
+        var responseMapperContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("DefaultApiServerResponseMappers.kt"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(responseMapperContent.contains("public open class PetsPatchApiResponseMapper :"));
+        assertFalse(responseMapperContent.contains("PetsPatchApiResponseMapper()"));
+    }
+
+    @Test
     void bareObjectRequestAndResponseAreGeneratedAsHttpBodyTypes() throws Exception {
         var files = generate(
             "petstoreV3_bare_object_body",
@@ -114,6 +133,8 @@ public class HttpServerKotlinOpenapiTest extends BaseKotlinOpenapiTest {
         assertTrue(responsesContent.contains("public val content: ErrorMessage"));
         assertTrue(responseMapperContent.contains("HttpServerResponseMapper<HttpResponseEntity<HttpBodyOutput>>"));
         assertTrue(responseMapperContent.contains("HttpServerResponseMapper<HttpResponseEntity<ErrorMessage>>"));
+        assertTrue(responseMapperContent.contains("@DefaultComponent"));
+        assertTrue(responseMapperContent.contains("public open class StoreInventoryApiResponseMapper"));
     }
 
     @Test


### PR DESCRIPTION
Improved HTTP header reuse and OpenAPI generated response contracts

## EN

Improved generated OpenAPI response contracts and HTTP header handling by making generated response mappers override-friendly default components, simplifying shared response interfaces, and avoiding unnecessary mutable empty headers. Generated shared response interfaces now keep only the shared `content` and `statusCode` contract without duplicating model fields.

---

## RU

Улучшена генерация OpenAPI response-контрактов и работа с HTTP headers: generated response mappers теперь являются переопределяемыми `DefaultComponent`, shared response interfaces стали проще, а пустые headers не создают лишние mutable-объекты. Shared response interfaces теперь содержат только общий `content` и `statusCode`, без дублирования полей модели.

---

- Improved generated client and server response mappers to use `@DefaultComponent` and remain extendable instead of final.
- Removed empty generated response mapper constructors when no delegate mapper dependencies are required.
- Removed duplicated model-field passthrough methods from shared response interfaces while preserving sealed response hierarchies and using `statusCode` as the shared status accessor.

---

## Design

Generated OpenAPI response mappers are framework defaults now. They are emitted with `@DefaultComponent`, so user-provided components with the same type can override them in the graph, while generated defaults remain available when no override exists.

Java generated mapper classes are no longer `final`, and Kotlin mapper classes are generated as `open`. This keeps the default implementation usable for extension and replacement scenarios.

Shared response interfaces still model common response shapes for multiple status codes with the same response body type, but they no longer duplicate fields from the model as passthrough methods. Instead, users access model fields through `content`.

```java
sealed interface GetErrorsModelErrorApiResponse extends GetErrorsApiResponse {
    ModelError content();

    int statusCode();
}
```

Empty response mapper constructors are omitted when no delegate mappers are needed, so generated code avoids noisy constructors like `PetsPatchApiResponseMapper()`.