### PR TITLE
Added OpenAPI generator `extensions` as successor for `interceptors`

### DIFF
--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/CodegenParams.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/CodegenParams.java
@@ -1,7 +1,7 @@
 package io.koraframework.openapi.generator;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import org.jspecify.annotations.Nullable;
@@ -20,8 +20,8 @@ public class CodegenParams {
     public static final String SECURITY_CONFIG_PREFIX = "securityConfigPrefix";
     public static final String CLIENT_TAGS = "tags";
     public static final String REQUEST_DELEGATE_PARAMS = "requestInDelegateParams";
-    public static final String INTERCEPTORS = "interceptors";
-    public static final String ADDITIONAL_CONTRACT_ANNOTATIONS = "additionalContractAnnotations";
+    public static final String EXTENSIONS = "extensions";
+    public static final String SERVER_CONFIG_PREFIX = "serverConfigPrefix";
     public static final String AUTH_AS_METHOD_ARGUMENT = "authAsMethodArgument";
     public static final String FILTER_WITH_MODELS = "filterWithModels";
     public static final String PREFIX_PATH = "prefixPath";
@@ -40,11 +40,11 @@ public class CodegenParams {
     public @Nullable String clientConfigPrefix = null;
     public String securityConfigPrefix = null;
     public Map<String, KoraCodegen.TagClient> clientTags = new HashMap<>();
-    public Map<String, List<KoraCodegen.Interceptor>> interceptors = new HashMap<>();
-    public Map<String, List<KoraCodegen.AdditionalAnnotation>> additionalContractAnnotations = new HashMap<>();
+    public GeneratorExtensions extensions = new GeneratorExtensions(null, new HashMap<>(), new HashMap<>());
     public boolean requestInDelegateParams = false;
     public boolean filterWithModels = false;
     public @Nullable String prefixPath = "";
+    public String serverConfigPrefix = "httpServer.controller.%{ControllerTypeNameInCamelCase}";
     public DelegateMethodBodyMode delegateMethodBodyMode = DelegateMethodBodyMode.NONE;
     public boolean implicitHeaders = false;
     public @Nullable Pattern implicitHeadersRegex = null;
@@ -60,10 +60,10 @@ public class CodegenParams {
         cliOptions.add(CliOption.newString(CLIENT_CONFIG, "Generated client config path"));
         cliOptions.add(CliOption.newString(CLIENT_CONFIG_PREFIX, "Generated client config prefix for per-client config paths"));
         cliOptions.add(CliOption.newString(CLIENT_TAGS, "Json containing http client tags configuration for apis"));
-        cliOptions.add(CliOption.newString(INTERCEPTORS, "Json containing interceptors for HTTP server/client"));
+        cliOptions.add(CliOption.newString(EXTENSIONS, "Json containing generator extensions for annotations and interceptors"));
+        cliOptions.add(CliOption.newString(SERVER_CONFIG_PREFIX, "Generated server controller config prefix for extension annotation substitution"));
         cliOptions.add(CliOption.newBoolean(ENABLE_VALIDATION, "Generate validation related annotation on models and controllers"));
         cliOptions.add(CliOption.newBoolean(REQUEST_DELEGATE_PARAMS, "Generate HttpServerRequest parameter in delegate methods"));
-        cliOptions.add(CliOption.newString(ADDITIONAL_CONTRACT_ANNOTATIONS, "Additional annotations for HTTP client/server methods"));
         cliOptions.add(CliOption.newBoolean(AUTH_AS_METHOD_ARGUMENT, "HTTP client authorization as method argument"));
         cliOptions.add(CliOption.newBoolean(FILTER_WITH_MODELS, "If enabled then when openapiNormalizer FILTER option is specified, will try to filter not only operations, but all unused models as well"));
         cliOptions.add(CliOption.newString(PREFIX_PATH, "Path prefix for HTTP Server controllers"));
@@ -87,25 +87,8 @@ public class CodegenParams {
                 throw new RuntimeException(e);
             }
         }
-        if (additionalProperties.containsKey(INTERCEPTORS)) {
-            var interceptorJson = additionalProperties.get(INTERCEPTORS).toString();
-            try {
-                params.interceptors = new ObjectMapper().readerFor(TypeFactory.defaultInstance()
-                        .constructType(new TypeReference<Map<String, List<KoraCodegen.Interceptor>>>() {}))
-                    .readValue(interceptorJson);
-            } catch (JsonProcessingException e) {
-                throw new RuntimeException(e);
-            }
-        }
-        if (additionalProperties.containsKey(ADDITIONAL_CONTRACT_ANNOTATIONS)) {
-            var json = additionalProperties.get(ADDITIONAL_CONTRACT_ANNOTATIONS).toString();
-            try {
-                params.additionalContractAnnotations = new ObjectMapper().readerFor(TypeFactory.defaultInstance()
-                        .constructType(new TypeReference<Map<String, List<KoraCodegen.AdditionalAnnotation>>>() {}))
-                    .readValue(json);
-            } catch (JsonProcessingException e) {
-                throw new RuntimeException(e);
-            }
+        if (additionalProperties.containsKey(EXTENSIONS)) {
+            params.extensions = parseExtensions(additionalProperties.get(EXTENSIONS).toString());
         }
         if (additionalProperties.containsKey(PRIMARY_AUTH)) {
             params.primaryAuth = additionalProperties.get(PRIMARY_AUTH).toString();
@@ -134,6 +117,9 @@ public class CodegenParams {
         if (additionalProperties.containsKey(PREFIX_PATH)) {
             params.prefixPath = additionalProperties.get(PREFIX_PATH).toString();
         }
+        if (additionalProperties.containsKey(SERVER_CONFIG_PREFIX)) {
+            params.serverConfigPrefix = additionalProperties.get(SERVER_CONFIG_PREFIX).toString();
+        }
         if (additionalProperties.containsKey(DELEGATE_METHOD_BODY_MODE)) {
             params.delegateMethodBodyMode = DelegateMethodBodyMode.of(additionalProperties.get(DELEGATE_METHOD_BODY_MODE).toString());
         }
@@ -157,6 +143,85 @@ public class CodegenParams {
         }
         return params;
     }
+
+    private static GeneratorExtensions parseExtensions(String json) {
+        var objectMapper = new ObjectMapper();
+        try {
+            var root = objectMapper.readTree(json);
+            return new GeneratorExtensions(
+                parseExtension(root.get("*")),
+                parseExtensionMap(root.get("tags")),
+                parseExtensionMap(root.get("operations"))
+            );
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static Map<String, GeneratorExtension> parseExtensionMap(@Nullable JsonNode node) {
+        if (node == null || node.isNull()) {
+            return new HashMap<>();
+        }
+        var result = new HashMap<String, GeneratorExtension>();
+        node.fields().forEachRemaining(entry -> result.put(entry.getKey(), parseExtension(entry.getValue())));
+        return result;
+    }
+
+    private static @Nullable GeneratorExtension parseExtension(@Nullable JsonNode node) {
+        if (node == null || node.isNull()) {
+            return null;
+        }
+        return new GeneratorExtension(
+            parseStringList(node.get("additionalMethodAnnotations")),
+            parseStringList(node.get("additionalTypeAnnotations")),
+            parseStringList(node.get("additionalModelTypeAnnotations")),
+            parseStringList(node.get("additionalEnumTypeAnnotations")),
+            text(node.get("interceptorType")),
+            parseStringList(node.get("interceptorTag")),
+            parseClientMapping(node.get("clientMapping"))
+        );
+    }
+
+    private static @Nullable ClientMapping parseClientMapping(@Nullable JsonNode node) {
+        if (node == null || node.isNull()) {
+            return null;
+        }
+        var type = text(node.get("type"));
+        if (type == null || type.isBlank()) {
+            return null;
+        }
+        return new ClientMapping(type);
+    }
+
+    private static @Nullable String text(@Nullable JsonNode node) {
+        return node == null || node.isNull() ? null : node.asText();
+    }
+
+    private static List<String> parseStringList(@Nullable JsonNode node) {
+        if (node == null || node.isNull()) {
+            return List.of();
+        }
+        if (node.isArray()) {
+            var result = new ArrayList<String>();
+            node.forEach(value -> result.add(value.asText()));
+            return result;
+        }
+        return List.of(node.asText());
+    }
+
+    public record GeneratorExtensions(@Nullable GeneratorExtension global,
+                                      Map<String, GeneratorExtension> tags,
+                                      Map<String, GeneratorExtension> operations) {}
+
+    public record GeneratorExtension(List<String> additionalMethodAnnotations,
+                                     List<String> additionalTypeAnnotations,
+                                     List<String> additionalModelTypeAnnotations,
+                                     List<String> additionalEnumTypeAnnotations,
+                                     @Nullable String interceptorType,
+                                     List<String> interceptorTag,
+                                     @Nullable ClientMapping clientMapping) {}
+
+    public record ClientMapping(String type) {}
 
     public enum RawBodyMode {
         BYTES,

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/KoraCodegen.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/KoraCodegen.java
@@ -52,10 +52,6 @@ public class KoraCodegen extends DefaultCodegen {
     private static final Logger LOGGER = LoggerFactory.getLogger(KoraCodegen.class);
     public record TagClient(@Nullable String httpClientTag, @Nullable String telemetryTag) {}
 
-    public record Interceptor(@Nullable String type, @Nullable Object tag) {}
-
-    public record AdditionalAnnotation(@Nullable String annotation) {}
-
     @Override
     public String getName() {
         return "kora";

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/AbstractJavaGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/AbstractJavaGenerator.java
@@ -2,8 +2,8 @@ package io.koraframework.openapi.generator.javagen;
 
 import com.palantir.javapoet.*;
 import io.koraframework.openapi.generator.AbstractGenerator;
+import io.koraframework.openapi.generator.CodegenParams;
 import io.koraframework.openapi.generator.KoraCodegen;
-import org.apache.commons.lang3.NotImplementedException;
 import org.apache.commons.lang3.StringUtils;
 import org.jspecify.annotations.Nullable;
 import org.openapitools.codegen.CodegenOperation;
@@ -15,6 +15,7 @@ import javax.lang.model.element.Modifier;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Consumer;
 
 public abstract class AbstractJavaGenerator<C> extends AbstractGenerator<C, JavaFile> {
     protected AnnotationSpec generated() {
@@ -58,24 +59,28 @@ public abstract class AbstractJavaGenerator<C> extends AbstractGenerator<C, Java
             .addMember("value", "$T.class", ClassName.get(apiPackage, "ApiSecurity", tag)).build();
     }
 
-    protected List<AnnotationSpec> buildInterceptors(String tag, ClassName defaultInterceptorType) {
-        var interceptors = params.interceptors.getOrDefault(tag, params.interceptors.get("*"));
-        if (interceptors == null) {
-            return List.of();
-        }
+    protected List<AnnotationSpec> buildInterceptors(OperationsMap ctx, CodegenOperation operation, ClassName defaultInterceptorType) {
+        var extensions = resolveExtensions(ctx, operation);
         var result = new ArrayList<AnnotationSpec>();
-        for (var interceptor : interceptors) {
-            var type = interceptor.type() == null
-                ? defaultInterceptorType
-                : ClassName.bestGuess(interceptor.type());
-            var interceptorTag = (String) interceptor.tag();
-            var ann = AnnotationSpec
-                .builder(Classes.interceptWith)
-                .addMember("value", "$T.class", type);
-            if (interceptorTag != null) {
-                ann.addMember("tag", "$T.class", ClassName.bestGuess(interceptorTag));
+        for (var extension : extensions) {
+            if (extension.interceptorType() == null && extension.interceptorTag().isEmpty()) {
+                continue;
             }
-            result.add(ann.build());
+            var type = extension.interceptorType() == null
+                ? defaultInterceptorType
+                : ClassName.bestGuess(extension.interceptorType());
+            if (extension.interceptorTag().isEmpty()) {
+                result.add(AnnotationSpec.builder(Classes.interceptWith)
+                    .addMember("value", "$T.class", type)
+                    .build());
+            } else {
+                for (var interceptorTag : extension.interceptorTag()) {
+                    result.add(AnnotationSpec.builder(Classes.interceptWith)
+                        .addMember("value", "$T.class", type)
+                        .addMember("tag", "$T.class", ClassName.bestGuess(interceptorTag))
+                        .build());
+                }
+            }
         }
         return result;
     }
@@ -252,19 +257,122 @@ public abstract class AbstractJavaGenerator<C> extends AbstractGenerator<C, Java
         return b.build();
     }
 
-    protected List<AnnotationSpec> buildAdditionalAnnotations(String tag) {
+    protected List<AnnotationSpec> buildAdditionalMethodAnnotations(OperationsMap ctx, CodegenOperation operation) {
         var result = new ArrayList<AnnotationSpec>();
-        var additionalAnnotations = params.additionalContractAnnotations.get(tag);
-        if (additionalAnnotations == null) {
-            additionalAnnotations = params.additionalContractAnnotations.getOrDefault("*", List.of());
-        }
-        for (var additionalAnnotation : additionalAnnotations) {
-            if (additionalAnnotation.annotation() != null && !additionalAnnotation.annotation().isBlank()) {
-                // TODO parse text to to annotation spec
-                throw new NotImplementedException();
-            }
+        var configPath = params.codegenMode.isClient()
+            ? clientConfigPath(ctx.get("classname").toString())
+            : serverConfigPath(ctx.get("classname") + "Controller");
+        for (var extension : resolveExtensions(ctx, operation)) {
+            addAnnotations(result, extension.additionalMethodAnnotations(), configPath);
         }
         return result;
+    }
+
+    protected List<AnnotationSpec> buildAdditionalModelTypeAnnotations() {
+        var result = new ArrayList<AnnotationSpec>();
+        addTypeAnnotations(extension -> {
+            addAnnotations(result, extension.additionalTypeAnnotations(), null);
+            addAnnotations(result, extension.additionalModelTypeAnnotations(), null);
+        });
+        return result;
+    }
+
+    protected List<AnnotationSpec> buildAdditionalEnumTypeAnnotations() {
+        var result = new ArrayList<AnnotationSpec>();
+        addTypeAnnotations(extension -> {
+            addAnnotations(result, extension.additionalTypeAnnotations(), null);
+            addAnnotations(result, extension.additionalEnumTypeAnnotations(), null);
+        });
+        return result;
+    }
+
+    private void addTypeAnnotations(Consumer<CodegenParams.GeneratorExtension> consumer) {
+        if (params.extensions.global() != null) {
+            consumer.accept(params.extensions.global());
+        }
+    }
+
+    private void addAnnotations(List<AnnotationSpec> result, List<String> annotations, @Nullable String configPath) {
+        for (var annotation : annotations) {
+            if (annotation != null && !annotation.isBlank()) {
+                result.add(parseAnnotation(annotation, configPath));
+            }
+        }
+    }
+
+    protected List<CodegenParams.GeneratorExtension> resolveExtensions(OperationsMap ctx, CodegenOperation operation) {
+        var result = new ArrayList<CodegenParams.GeneratorExtension>();
+        if (params.extensions.global() != null) {
+            result.add(params.extensions.global());
+        }
+        var tagExtension = params.extensions.tags().get(ctx.get("baseName").toString());
+        if (tagExtension != null) {
+            result.add(tagExtension);
+        }
+        var operationExtension = params.extensions.operations().get(operation.operationId);
+        if (operationExtension != null) {
+            result.add(operationExtension);
+        }
+        return result;
+    }
+
+    private AnnotationSpec parseAnnotation(String annotation, @Nullable String configPath) {
+        var value = configPath == null ? annotation : annotation.replace("%{configPath}", configPath);
+        value = value.strip();
+        if (value.startsWith("@")) {
+            value = value.substring(1);
+        }
+        var argumentsStart = value.indexOf('(');
+        if (argumentsStart < 0) {
+            return AnnotationSpec.builder(ClassName.bestGuess(value)).build();
+        }
+        var type = value.substring(0, argumentsStart).strip();
+        var arguments = value.substring(argumentsStart + 1, value.lastIndexOf(')')).strip();
+        var builder = AnnotationSpec.builder(ClassName.bestGuess(type));
+        if (!arguments.isBlank()) {
+            for (var argument : splitAnnotationArguments(arguments)) {
+                var eq = argument.indexOf('=');
+                if (eq < 0) {
+                    builder.addMember("value", "$L", argument.strip());
+                } else {
+                    builder.addMember(argument.substring(0, eq).strip(), "$L", argument.substring(eq + 1).strip());
+                }
+            }
+        }
+        return builder.build();
+    }
+
+    private List<String> splitAnnotationArguments(String arguments) {
+        var result = new ArrayList<String>();
+        var start = 0;
+        var depth = 0;
+        var inString = false;
+        for (int i = 0; i < arguments.length(); i++) {
+            var c = arguments.charAt(i);
+            if (c == '"' && (i == 0 || arguments.charAt(i - 1) != '\\')) {
+                inString = !inString;
+            } else if (!inString && (c == '(' || c == '{' || c == '[')) {
+                depth++;
+            } else if (!inString && (c == ')' || c == '}' || c == ']')) {
+                depth--;
+            } else if (!inString && depth == 0 && c == ',') {
+                result.add(arguments.substring(start, i));
+                start = i + 1;
+            }
+        }
+        result.add(arguments.substring(start));
+        return result;
+    }
+
+    private String clientConfigPath(String clientName) {
+        if (params.clientConfigPrefix != null && !params.clientConfigPrefix.isBlank()) {
+            return params.clientConfigPrefix + "." + StringUtils.uncapitalize(clientName);
+        }
+        return params.clientConfig;
+    }
+
+    private String serverConfigPath(String controllerTypeName) {
+        return params.serverConfigPrefix.replace("%{ControllerTypeNameInCamelCase}", StringUtils.uncapitalize(controllerTypeName));
     }
 
     protected List<AnnotationSpec> buildImplicitHeaders(CodegenOperation operation) {

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientApiGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientApiGenerator.java
@@ -1,6 +1,7 @@
 package io.koraframework.openapi.generator.javagen;
 
 import com.palantir.javapoet.*;
+import io.koraframework.openapi.generator.CodegenParams;
 import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.CodegenOperation;
 import org.openapitools.codegen.CodegenParameter;
@@ -249,22 +250,28 @@ public class ClientApiGenerator extends AbstractJavaGenerator<OperationsMap> {
 
 
     private MethodSpec buildMethod(OperationsMap ctx, CodegenOperation operation) {
-        var tag = ctx.get("baseName").toString();
         var b = MethodSpec.methodBuilder(operation.operationId)
             .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
             .addJavadoc(buildMethodJavadoc(ctx, operation));
         if (operation.isDeprecated) {
             b.addAnnotation(Deprecated.class);
         }
-        this.buildAdditionalAnnotations(tag).forEach(b::addAnnotation);
+        this.buildAdditionalMethodAnnotations(ctx, operation).forEach(b::addAnnotation);
         this.buildImplicitHeaders(operation).forEach(b::addAnnotation);
         b.addAnnotation(this.buildHttpRoute(operation));
-        for (var response : operation.responses) {
-            b.addAnnotation(AnnotationSpec.builder(Classes.responseCodeMapper)
-                .addMember("code", "$L", response.isDefault ? "-1" : response.code)
-                .addMember("mapper", "$T.class", ClassName.get(apiPackage, ctx.get("classname") + "ClientResponseMappers", StringUtils.capitalize(operation.operationId) + response.code + "ApiResponseMapper"))
-                .build()
-            );
+        var clientMapping = clientMapping(ctx, operation);
+        if (clientMapping != null) {
+            b.addAnnotation(AnnotationSpec.builder(Classes.mapping)
+                .addMember("value", "$T.class", ClassName.bestGuess(clientMapping.type()))
+                .build());
+        } else {
+            for (var response : operation.responses) {
+                b.addAnnotation(AnnotationSpec.builder(Classes.responseCodeMapper)
+                    .addMember("code", "$L", response.isDefault ? "-1" : response.code)
+                    .addMember("mapper", "$T.class", ClassName.get(apiPackage, ctx.get("classname") + "ClientResponseMappers", StringUtils.capitalize(operation.operationId) + response.code + "ApiResponseMapper"))
+                    .build()
+                );
+            }
         }
         if (!params.authAsMethodArgument) {
             var requirement = this.security.securityRequirementByOperation.get(operation.operationId);
@@ -278,7 +285,7 @@ public class ClientApiGenerator extends AbstractJavaGenerator<OperationsMap> {
             }
         }
 
-        this.buildInterceptors(tag, Classes.httpClientInterceptor).forEach(b::addAnnotation);
+        this.buildInterceptors(ctx, operation, Classes.httpClientInterceptor).forEach(b::addAnnotation);
         b.returns(ClassName.get(apiPackage, ctx.get("classname") + "Responses", StringUtils.capitalize(operation.operationId) + "ApiResponse"));
         if (operation.hasAuthMethods && params.authAsMethodArgument) {
             for (var param : this.buildAuthParameters(operation)) {
@@ -313,6 +320,16 @@ public class ClientApiGenerator extends AbstractJavaGenerator<OperationsMap> {
             b.addParameter(parameter);
         }
         return b.build();
+    }
+
+    private CodegenParams.ClientMapping clientMapping(OperationsMap ctx, CodegenOperation operation) {
+        CodegenParams.ClientMapping result = null;
+        for (var extension : resolveExtensions(ctx, operation)) {
+            if (extension.clientMapping() != null) {
+                result = extension.clientMapping();
+            }
+        }
+        return result;
     }
 
     private ParameterSpec httpHeadersParameter() {

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ModelGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ModelGenerator.java
@@ -43,6 +43,7 @@ public class ModelGenerator extends AbstractJavaGenerator<ModelsMap> {
             .addJavadoc(Objects.requireNonNullElse(model.description, model.classname))
             .addAnnotation(Classes.json)
             .addAnnotation(AnnotationSpec.builder(Classes.jsonDiscriminatorField).addMember("value", "$S", model.discriminator.getPropertyBaseName()).build());
+        buildAdditionalModelTypeAnnotations().forEach(b::addAnnotation);
         if (params.enableValidation) {
             b.addAnnotation(Classes.valid);
         }
@@ -68,6 +69,7 @@ public class ModelGenerator extends AbstractJavaGenerator<ModelsMap> {
         var b = TypeSpec.recordBuilder(model.getClassname())
             .addAnnotation(generated())
             .addModifiers(Modifier.PUBLIC);
+        buildAdditionalModelTypeAnnotations().forEach(b::addAnnotation);
         if (model.description == null || model.description.isBlank()) {
             b.addJavadoc("$L\n", model.classname);
         } else {
@@ -348,6 +350,7 @@ public class ModelGenerator extends AbstractJavaGenerator<ModelsMap> {
         var b = TypeSpec.enumBuilder(model.name)
             .addAnnotation(generated())
             .addModifiers(Modifier.PUBLIC);
+        buildAdditionalEnumTypeAnnotations().forEach(b::addAnnotation);
         if (model.description != null && !model.description.isBlank()) {
             b.addJavadoc("$L\n", model.description);
         }

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ServerApiDelegateGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ServerApiDelegateGenerator.java
@@ -26,7 +26,6 @@ public class ServerApiDelegateGenerator extends AbstractJavaGenerator<Operations
     }
 
     private MethodSpec buildMethod(OperationsMap ctx, CodegenOperation operation) {
-        var tag = ctx.get("baseName").toString();
         var b = MethodSpec.methodBuilder(operation.operationId)
             .addModifiers(Modifier.PUBLIC)
             .addJavadoc(buildMethodJavadoc(ctx, operation))
@@ -39,7 +38,7 @@ public class ServerApiDelegateGenerator extends AbstractJavaGenerator<Operations
         } else {
             b.addModifiers(Modifier.ABSTRACT);
         }
-        this.buildAdditionalAnnotations(tag).forEach(b::addAnnotation);
+        this.buildAdditionalMethodAnnotations(ctx, operation).forEach(b::addAnnotation);
         this.buildImplicitHeaders(operation).forEach(b::addAnnotation);
         b.addAnnotation(this.buildHttpRoute(operation));
         if (params.delegateMethodBodyMode == DelegateMethodBodyMode.THROW_EXCEPTION) {

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ServerApiGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ServerApiGenerator.java
@@ -22,7 +22,7 @@ public class ServerApiGenerator extends AbstractJavaGenerator<OperationsMap> {
         } else {
             b.addAnnotation(AnnotationSpec.builder(Classes.httpController).build());
         }
-        var allowAspects = params.enableValidation || !params.additionalContractAnnotations.isEmpty();
+        var allowAspects = params.enableValidation || hasAdditionalMethodAnnotations();
         if (!allowAspects) {
             b.addModifiers(Modifier.FINAL);
         }
@@ -44,8 +44,13 @@ public class ServerApiGenerator extends AbstractJavaGenerator<OperationsMap> {
         return JavaFile.builder(apiPackage, b.build()).build();
     }
 
+    private boolean hasAdditionalMethodAnnotations() {
+        return params.extensions.global() != null && !params.extensions.global().additionalMethodAnnotations().isEmpty()
+               || params.extensions.tags().values().stream().anyMatch(extension -> !extension.additionalMethodAnnotations().isEmpty())
+               || params.extensions.operations().values().stream().anyMatch(extension -> !extension.additionalMethodAnnotations().isEmpty());
+    }
+
     private MethodSpec buildMethod(OperationsMap ctx, CodegenOperation operation) {
-        var tag = ctx.get("baseName").toString();
         var b = MethodSpec.methodBuilder(operation.operationId)
             .addModifiers(Modifier.PUBLIC)
             .addJavadoc(buildMethodJavadoc(ctx, operation))
@@ -53,7 +58,7 @@ public class ServerApiGenerator extends AbstractJavaGenerator<OperationsMap> {
         if (operation.isDeprecated) {
             b.addAnnotation(Deprecated.class);
         }
-        this.buildAdditionalAnnotations(tag).forEach(b::addAnnotation);
+        this.buildAdditionalMethodAnnotations(ctx, operation).forEach(b::addAnnotation);
         this.buildImplicitHeaders(operation).forEach(b::addAnnotation);
         b.addAnnotation(this.buildHttpRoute(operation));
         var auth = buildServerMethodAuth(operation);
@@ -64,7 +69,7 @@ public class ServerApiGenerator extends AbstractJavaGenerator<OperationsMap> {
             b.addAnnotation(AnnotationSpec.builder(Classes.interceptWith).addMember("value", "$T.class", Classes.validationHttpServerInterceptor).build());
             b.addAnnotation(AnnotationSpec.builder(Classes.validate).build());
         }
-        this.buildInterceptors(tag, Classes.httpServerInterceptor).forEach(b::addAnnotation);
+        this.buildInterceptors(ctx, operation, Classes.httpServerInterceptor).forEach(b::addAnnotation);
         b.addAnnotation(AnnotationSpec.builder(Classes.mapping)
             .addMember("value", "$T.class", ClassName.get(apiPackage, ctx.get("classname").toString() + "ServerResponseMappers", StringUtils.capitalize(operation.operationId) + "ApiResponseMapper"))
             .build());

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/AbstractKotlinGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/AbstractKotlinGenerator.kt
@@ -7,6 +7,7 @@ import com.palantir.javapoet.WildcardTypeName
 import com.squareup.kotlinpoet.*
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import io.koraframework.openapi.generator.AbstractGenerator
+import io.koraframework.openapi.generator.CodegenParams
 import io.koraframework.openapi.generator.KoraCodegen
 import org.apache.commons.lang3.StringUtils
 import org.openapitools.codegen.CodegenOperation
@@ -16,18 +17,33 @@ import org.openapitools.codegen.model.OperationsMap
 
 
 abstract class AbstractKotlinGenerator<C : Any> : AbstractGenerator<C, FileSpec>() {
-    protected fun buildAdditionalAnnotations(tag: String): List<AnnotationSpec> {
-
-
-        var additionalAnnotations = params.additionalContractAnnotations[tag]
-        if (additionalAnnotations == null) {
-            additionalAnnotations = params.additionalContractAnnotations["*"]
+    protected fun buildAdditionalMethodAnnotations(ctx: OperationsMap, operation: CodegenOperation): List<AnnotationSpec> {
+        val configPath = if (params.codegenMode.isClient) {
+            clientConfigPath(ctx["classname"].toString())
+        } else {
+            serverConfigPath(ctx["classname"].toString() + "Controller")
         }
         val result = mutableListOf<AnnotationSpec>()
-        for (additionalAnnotation in additionalAnnotations.orEmpty()) {
-            if (additionalAnnotation.annotation?.isBlank() == true) {
-                TODO("parse text to to annotation spec")
-            }
+        for (extension in resolveExtensions(ctx, operation)) {
+            result.addAnnotations(extension.additionalMethodAnnotations(), configPath)
+        }
+        return result
+    }
+
+    protected fun buildAdditionalModelTypeAnnotations(): List<AnnotationSpec> {
+        val result = mutableListOf<AnnotationSpec>()
+        params.extensions.global()?.let {
+            result.addAnnotations(it.additionalTypeAnnotations(), null)
+            result.addAnnotations(it.additionalModelTypeAnnotations(), null)
+        }
+        return result
+    }
+
+    protected fun buildAdditionalEnumTypeAnnotations(): List<AnnotationSpec> {
+        val result = mutableListOf<AnnotationSpec>()
+        params.extensions.global()?.let {
+            result.addAnnotations(it.additionalTypeAnnotations(), null)
+            result.addAnnotations(it.additionalEnumTypeAnnotations(), null)
         }
         return result
     }
@@ -90,26 +106,108 @@ abstract class AbstractKotlinGenerator<C : Any> : AbstractGenerator<C, FileSpec>
             .build()
     }
 
-    protected fun buildInterceptors(tag: String, defaultInterceptorType: ClassName): List<AnnotationSpec> {
-        val interceptors = params.interceptors.getOrDefault(tag, params.interceptors["*"])
-        if (interceptors == null) {
-            return listOf<AnnotationSpec>()
-        }
+    protected fun buildInterceptors(ctx: OperationsMap, operation: CodegenOperation, defaultInterceptorType: ClassName): List<AnnotationSpec> {
         val result = mutableListOf<AnnotationSpec>()
-        for (interceptor in interceptors) {
-            val type = interceptor.type
+        for (extension in resolveExtensions(ctx, operation)) {
+            if (extension.interceptorType() == null && extension.interceptorTag().isEmpty()) {
+                continue
+            }
+            val type = extension.interceptorType()
                 ?.let { com.palantir.javapoet.ClassName.bestGuess(it).asKt() }
                 ?: defaultInterceptorType
-            val interceptorTag = interceptor.tag
-            val ann = AnnotationSpec
-                .builder(Classes.interceptWith.asKt())
-                .addMember("value = %T::class", type)
-            if (interceptorTag != null) {
-                ann.addMember("tag = %T::class", com.palantir.javapoet.ClassName.bestGuess(interceptor.tag as String).asKt())
+            if (extension.interceptorTag().isEmpty()) {
+                result.add(
+                    AnnotationSpec.builder(Classes.interceptWith.asKt())
+                        .addMember("value = %T::class", type)
+                        .build()
+                )
+            } else {
+                for (interceptorTag in extension.interceptorTag()) {
+                    result.add(
+                        AnnotationSpec.builder(Classes.interceptWith.asKt())
+                            .addMember("value = %T::class", type)
+                            .addMember("tag = %T::class", com.palantir.javapoet.ClassName.bestGuess(interceptorTag).asKt())
+                            .build()
+                    )
+                }
             }
-            result.add(ann.build())
         }
         return result
+    }
+
+    protected fun resolveExtensions(ctx: OperationsMap, operation: CodegenOperation): List<CodegenParams.GeneratorExtension> {
+        val result = mutableListOf<CodegenParams.GeneratorExtension>()
+        params.extensions.global()?.let(result::add)
+        params.extensions.tags()[ctx["baseName"].toString()]?.let(result::add)
+        params.extensions.operations()[operation.operationId]?.let(result::add)
+        return result
+    }
+
+    private fun MutableList<AnnotationSpec>.addAnnotations(annotations: List<String>, configPath: String?) {
+        for (annotation in annotations) {
+            if (annotation.isNotBlank()) {
+                add(parseAnnotation(annotation, configPath))
+            }
+        }
+    }
+
+    private fun parseAnnotation(annotation: String, configPath: String?): AnnotationSpec {
+        var value = configPath?.let { annotation.replace("%{configPath}", it) } ?: annotation
+        value = value.trim()
+        if (value.startsWith("@")) {
+            value = value.substring(1)
+        }
+        val argumentsStart = value.indexOf('(')
+        if (argumentsStart < 0) {
+            return AnnotationSpec.builder(com.palantir.javapoet.ClassName.bestGuess(value).asKt()).build()
+        }
+        val type = value.substring(0, argumentsStart).trim()
+        val arguments = value.substring(argumentsStart + 1, value.lastIndexOf(')')).trim()
+        val builder = AnnotationSpec.builder(com.palantir.javapoet.ClassName.bestGuess(type).asKt())
+        if (arguments.isNotBlank()) {
+            for (argument in splitAnnotationArguments(arguments)) {
+                val eq = argument.indexOf('=')
+                if (eq < 0) {
+                    builder.addMember("%L", argument.trim())
+                } else {
+                    builder.addMember("%N = %L", argument.substring(0, eq).trim(), argument.substring(eq + 1).trim())
+                }
+            }
+        }
+        return builder.build()
+    }
+
+    private fun splitAnnotationArguments(arguments: String): List<String> {
+        val result = mutableListOf<String>()
+        var start = 0
+        var depth = 0
+        var inString = false
+        for (i in arguments.indices) {
+            val c = arguments[i]
+            if (c == '"' && (i == 0 || arguments[i - 1] != '\\')) {
+                inString = !inString
+            } else if (!inString && (c == '(' || c == '{' || c == '[')) {
+                depth++
+            } else if (!inString && (c == ')' || c == '}' || c == ']')) {
+                depth--
+            } else if (!inString && depth == 0 && c == ',') {
+                result.add(arguments.substring(start, i))
+                start = i + 1
+            }
+        }
+        result.add(arguments.substring(start))
+        return result
+    }
+
+    private fun clientConfigPath(clientName: String): String? {
+        params.clientConfigPrefix?.takeIf { it.isNotBlank() }?.let {
+            return it + "." + StringUtils.uncapitalize(clientName)
+        }
+        return params.clientConfig
+    }
+
+    private fun serverConfigPath(controllerTypeName: String): String {
+        return params.serverConfigPrefix.replace("%{ControllerTypeNameInCamelCase}", StringUtils.uncapitalize(controllerTypeName))
     }
 
 

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ClientApiGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ClientApiGenerator.kt
@@ -1,6 +1,7 @@
 package io.koraframework.openapi.generator.kotlingen
 
 import com.squareup.kotlinpoet.*
+import io.koraframework.openapi.generator.CodegenParams
 import io.koraframework.openapi.generator.SecurityData
 import org.apache.commons.lang3.StringUtils
 import org.openapitools.codegen.CodegenOperation
@@ -23,23 +24,31 @@ class ClientApiGenerator() : AbstractKotlinGenerator<OperationsMap>() {
     }
 
     private fun buildFunction(ctx: OperationsMap, operation: CodegenOperation): FunSpec {
-        val tag = ctx.get("baseName").toString()
         val b = FunSpec.builder(operation.operationId)
             .addModifiers(KModifier.ABSTRACT)
             .addKdoc(buildFunctionKdoc(ctx, operation))
-        buildAdditionalAnnotations(tag).forEach { b.addAnnotation(it) }
+        buildAdditionalMethodAnnotations(ctx, operation).forEach { b.addAnnotation(it) }
         b.addAnnotations(this.buildImplicitHeaders(operation))
         b.addAnnotation(buildRouteAnnotation(operation))
-        for (response in operation.responses) {
+        val clientMapping = clientMapping(ctx, operation)
+        if (clientMapping != null) {
             b.addAnnotation(
-                AnnotationSpec.builder(Classes.responseCodeMapper.asKt())
-                    .addMember("code = %L", if (response.isDefault) "-1" else response.code)
-                    .addMember(
-                        "mapper = %T::class",
-                        ClassName(apiPackage, ctx.get("classname").toString() + "ClientResponseMappers", (StringUtils.capitalize(operation.operationId) + response.code) + "ApiResponseMapper")
-                    )
+                AnnotationSpec.builder(Classes.mapping.asKt())
+                    .addMember("value = %T::class", com.palantir.javapoet.ClassName.bestGuess(clientMapping.type()).asKt())
                     .build()
             )
+        } else {
+            for (response in operation.responses) {
+                b.addAnnotation(
+                    AnnotationSpec.builder(Classes.responseCodeMapper.asKt())
+                        .addMember("code = %L", if (response.isDefault) "-1" else response.code)
+                        .addMember(
+                            "mapper = %T::class",
+                            ClassName(apiPackage, ctx.get("classname").toString() + "ClientResponseMappers", (StringUtils.capitalize(operation.operationId) + response.code) + "ApiResponseMapper")
+                        )
+                        .build()
+                )
+            }
         }
 //        this.buildMethodAuth(operation, Classes.httpClientInterceptor.asKt())?.let {
 //            b.addAnnotation(it)
@@ -58,7 +67,7 @@ class ClientApiGenerator() : AbstractKotlinGenerator<OperationsMap>() {
                 }
             }
         }
-        b.addAnnotations(this.buildInterceptors(tag, Classes.httpClientInterceptor.asKt()))
+        b.addAnnotations(this.buildInterceptors(ctx, operation, Classes.httpClientInterceptor.asKt()))
         if (operation.isDeprecated) {
             b.addAnnotation(AnnotationSpec.builder(Deprecated::class.asClassName()).addMember("%S", "deprecated").build())
         }
@@ -95,6 +104,16 @@ class ClientApiGenerator() : AbstractKotlinGenerator<OperationsMap>() {
             b.addParameter(parameter)
         }
         return b.build()
+    }
+
+    private fun clientMapping(ctx: OperationsMap, operation: CodegenOperation): CodegenParams.ClientMapping? {
+        var result: CodegenParams.ClientMapping? = null
+        for (extension in resolveExtensions(ctx, operation)) {
+            extension.clientMapping()?.let {
+                result = it
+            }
+        }
+        return result
     }
 
     private fun httpHeadersParameter(): ParameterSpec {

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ModelGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ModelGenerator.kt
@@ -24,6 +24,7 @@ class ModelGenerator : AbstractKotlinGenerator<ModelsMap>() {
             return b.build()
         }
         b.addModifiers(KModifier.DATA)
+        buildAdditionalModelTypeAnnotations().forEach { b.addAnnotation(it) }
         for (field in model.allVars) {
             b.addKdoc("@param %N %L, %L\n", field.name, field.description ?: field.baseName, if (field.example == null) "" else "(example: " + field.example + ")")
         }
@@ -217,6 +218,7 @@ class ModelGenerator : AbstractKotlinGenerator<ModelsMap>() {
                     .addMember("value = %S", model.discriminator.propertyBaseName)
                     .build()
             )
+        buildAdditionalModelTypeAnnotations().forEach { b.addAnnotation(it) }
         if (params.enableValidation) {
             b.addAnnotation(Classes.valid.asKt())
         }
@@ -241,6 +243,7 @@ class ModelGenerator : AbstractKotlinGenerator<ModelsMap>() {
             ClassName(modelPackage, contextModel.classname, model.name)
         val b = TypeSpec.enumBuilder(enumClassName)
             .addAnnotation(generated())
+        buildAdditionalEnumTypeAnnotations().forEach { b.addAnnotation(it) }
         val enumVars = model.allowableValues["enumVars"] as List<Map<String, Any>>
         for (enumVar in enumVars) {
             val enumName = enumVar["name"].toString()

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ServerApiDelegateGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ServerApiDelegateGenerator.kt
@@ -21,13 +21,12 @@ class ServerApiDelegateGenerator : AbstractKotlinGenerator<OperationsMap>() {
     }
 
     private fun buildFunction(ctx: OperationsMap, operation: CodegenOperation): FunSpec {
-        val tag = ctx.get("baseName").toString()
         val b = FunSpec.builder(operation.operationId)
             .addKdoc(buildFunctionKdoc(ctx, operation))
         if (operation.isDeprecated) {
             b.addAnnotation(AnnotationSpec.builder(Deprecated::class).addMember("%S", "deprecated").build())
         }
-        this.buildAdditionalAnnotations(tag).forEach(b::addAnnotation)
+        this.buildAdditionalMethodAnnotations(ctx, operation).forEach(b::addAnnotation)
         this.buildImplicitHeaders(operation).forEach(b::addAnnotation)
         b.addAnnotation(this.buildRouteAnnotation(operation))
         if (params.delegateMethodBodyMode == DelegateMethodBodyMode.THROW_EXCEPTION) {

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ServerApiGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ServerApiGenerator.kt
@@ -16,7 +16,7 @@ class ServerApiGenerator() : AbstractKotlinGenerator<OperationsMap>() {
         } else {
             b.addAnnotation(AnnotationSpec.builder(Classes.httpController.asKt()).build())
         }
-        val allowAspects = params.enableValidation || !params.additionalContractAnnotations.isEmpty()
+        val allowAspects = params.enableValidation || hasAdditionalMethodAnnotations()
         if (allowAspects) {
             b.addModifiers(KModifier.OPEN)
         }
@@ -36,15 +36,20 @@ class ServerApiGenerator() : AbstractKotlinGenerator<OperationsMap>() {
         return FileSpec.get(apiPackage, b.build())
     }
 
+    private fun hasAdditionalMethodAnnotations(): Boolean {
+        return params.extensions.global()?.additionalMethodAnnotations()?.isNotEmpty() == true
+            || params.extensions.tags().values.any { it.additionalMethodAnnotations().isNotEmpty() }
+            || params.extensions.operations().values.any { it.additionalMethodAnnotations().isNotEmpty() }
+    }
+
     private fun buildFunction(ctx: OperationsMap, operation: CodegenOperation): FunSpec {
-        val tag = ctx["baseName"] as String
         val b = FunSpec.builder(operation.operationId)
             .addKdoc(buildFunctionKdoc(ctx, operation))
-        val allowAspects = params.enableValidation || !params.additionalContractAnnotations.isEmpty()
+        val allowAspects = params.enableValidation || hasAdditionalMethodAnnotations()
         if (allowAspects) {
             b.addModifiers(KModifier.OPEN)
         }
-        buildAdditionalAnnotations(tag).forEach { b.addAnnotation(it) }
+        buildAdditionalMethodAnnotations(ctx, operation).forEach { b.addAnnotation(it) }
         this.buildImplicitHeaders(operation).forEach { b.addAnnotation(it) }
         b.addAnnotation(buildRouteAnnotation(operation))
         buildMethodAuth(operation)?.let { auth ->
@@ -54,7 +59,7 @@ class ServerApiGenerator() : AbstractKotlinGenerator<OperationsMap>() {
             b.addAnnotation(AnnotationSpec.builder(Classes.interceptWith.asKt()).addMember("value = %T::class", Classes.validationHttpServerInterceptor.asKt()).build())
             b.addAnnotation(AnnotationSpec.builder(Classes.validate.asKt()).build())
         }
-        this.buildInterceptors(tag, Classes.httpServerInterceptor.asKt()).forEach(b::addAnnotation)
+        this.buildInterceptors(ctx, operation, Classes.httpServerInterceptor.asKt()).forEach(b::addAnnotation)
         b.addAnnotation(
             AnnotationSpec.builder(Classes.mapping.asKt())
                 .addMember("value = %T::class", ClassName(apiPackage, ctx.get("classname") as String + "ServerResponseMappers", StringUtils.capitalize(operation.operationId) + "ApiResponseMapper"))

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/BaseOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/BaseOpenapiTest.java
@@ -187,14 +187,14 @@ public abstract class BaseOpenapiTest {
                 "skipFormModel", "false"
             ))
             .addAdditionalProperty("mode", mode)
-            .addAdditionalProperty("additionalModelTypeAnnotations", "@io.koraframework.json.common.annotation.JsonInclude(io.koraframework.json.common.annotation.JsonInclude.IncludeType.ALWAYS)")
-            .addAdditionalProperty("interceptors", """
+            .addAdditionalProperty("extensions", """
                 {
-                  "*": [
-                    {
-                      "tag": "java.lang.String"
-                    }
-                  ]
+                  "*": {
+                    "additionalModelTypeAnnotations": [
+                      "@io.koraframework.json.common.annotation.JsonInclude(io.koraframework.json.common.annotation.JsonInclude.IncludeType.ALWAYS)"
+                    ],
+                    "interceptorTag": "java.lang.String"
+                  }
                 }
                 """)
             .addAdditionalProperty("tags", """


### PR DESCRIPTION
Added OpenAPI generator extensions with scoped annotations and interceptors

## EN

Added unified OpenAPI generator extensions for generated contract customization, replacing legacy interceptor and annotation options with explicit global, tag, and operation scopes. **Breaking:** `interceptors` and `additionalContractAnnotations` are removed; use `extensions` instead.

---

## RU

Добавлена единая модель `extensions` для настройки generated OpenAPI contracts: дополнительные аннотации, interceptor annotations и override client response mapper теперь задаются через global/tag/operation scopes. **Breaking:** старые опции `interceptors` и `additionalContractAnnotations` удалены без обратной совместимости.

---

- Added `extensions` with `*`, `tags`, and `operations` scopes for generated method annotations, interceptors, and client response mapper overrides.
- Added type-level extension annotations for generated models and enums through global extension scope.
- Added `%{configPath}` substitution for method annotations and `serverConfigPrefix` for generated server config paths.
- Removed legacy interceptor and additional contract annotation options in favor of the unified extension model.

---

## Design

### Extension Model

The generator now accepts one customization entry point: `extensions`.

It has three scopes:

```json
{
  "*": {},
  "tags": {
    "pets": {}
  },
  "operations": {
    "findPetsByStatus": {}
  }
}
```

Resolution order is:

```text
global (*) -> tag -> operation
```

For additive settings, every matching scope contributes generated annotations. For override-like settings, such as `clientMapping.type`, the most specific resolved value wins because operation scope is processed last.

### Method Annotations

`additionalMethodAnnotations` adds annotations to generated client/server API methods and server delegates.

```json
{
  "*": {
    "additionalMethodAnnotations": [
      "@com.example.Trace(\"%{configPath}\")"
    ]
  },
  "operations": {
    "findPetsByStatus": {
      "additionalMethodAnnotations": [
        "@com.example.OperationMarker"
      ]
    }
  }
}
```

Generated Java shape:

```java
@com.example.Trace("clients.petApi")
@com.example.OperationMarker
@HttpRoute(method = "GET", path = "/pet/findByStatus")
FindPetsByStatusApiResponse findPetsByStatus(...);
```

Generated Kotlin shape follows the same contract:

```kotlin
@com.example.Trace("clients.petApi")
@com.example.OperationMarker
@HttpRoute(method = "GET", path = "/pet/findByStatus")
fun findPetsByStatus(...): FindPetsByStatusApiResponse
```

### Config Path Substitution

`%{configPath}` is substituted only inside `additionalMethodAnnotations`, because only generated methods have client/server config context.

For clients, config path is resolved from existing client configuration options:

```text
clientConfig = "clients.petstore"
clientConfigPrefix = "clients"
```

If `clientConfigPrefix` is set, generated client path is:

```text
<clientConfigPrefix>.<uncapitalize(ClientTypeName)>
```

Example:

```text
clients.petApi
```

If only `clientConfig` is set, the exact value is used:

```text
clients.petstore
```

For servers, config path is based on `serverConfigPrefix`.

Default:

```text
httpServer.controller.%{ControllerTypeNameInCamelCase}
```

For `DefaultApiController`, this becomes:

```text
httpServer.controller.defaultApiController
```

Custom server prefix example:

```text
serverConfigPrefix = "controllers.%{ControllerTypeNameInCamelCase}"
```

Result:

```text
controllers.defaultApiController
```

### Interceptors

`interceptorType` and `interceptorTag` generate `@InterceptWith`.

Default interceptor type depends on generation mode:

```text
client -> HttpClientInterceptor
server -> HttpServerInterceptor
```

Tagged default interceptor:

```json
{
  "*": {
    "interceptorTag": "java.lang.String"
  }
}
```

Generated Java:

```java
@InterceptWith(value = HttpClientInterceptor.class, tag = String.class)
```

Custom interceptor type:

```json
{
  "operations": {
    "findPetsByStatus": {
      "interceptorType": "com.example.CustomInterceptor",
      "interceptorTag": [
        "com.example.PublicApi",
        "com.example.PetsApi"
      ]
    }
  }
}
```

Generated Java:

```java
@InterceptWith(value = CustomInterceptor.class, tag = PublicApi.class)
@InterceptWith(value = CustomInterceptor.class, tag = PetsApi.class)
```

If `interceptorType` is set without `interceptorTag`, the generator emits an untagged interceptor annotation.

### Model And Enum Type Annotations

Type annotations are generated from global extension scope.

```json
{
  "*": {
    "additionalTypeAnnotations": [
      "@com.example.GeneratedContract"
    ],
    "additionalModelTypeAnnotations": [
      "@io.koraframework.json.common.annotation.JsonInclude(io.koraframework.json.common.annotation.JsonInclude.IncludeType.ALWAYS)"
    ],
    "additionalEnumTypeAnnotations": [
      "@com.example.GeneratedEnum"
    ]
  }
}
```

Model classes get `additionalTypeAnnotations` and `additionalModelTypeAnnotations`.

```java
@com.example.GeneratedContract
@JsonInclude(JsonInclude.IncludeType.ALWAYS)
public record Pet(...) {}
```

Enum classes get `additionalTypeAnnotations` and `additionalEnumTypeAnnotations`.

```java
@com.example.GeneratedContract
@com.example.GeneratedEnum
public enum PetStatus {
    AVAILABLE
}
```

Tag and operation scopes are intentionally not used for models/enums because model and enum generation is not owned by a single operation.

### Client Response Mapping Override

By default, generated clients keep per-status response mappers:

```java
@ResponseCodeMapper(code = 200, mapper = PetsApiClientResponseMappers.FindPets200ApiResponseMapper.class)
@ResponseCodeMapper(code = 404, mapper = PetsApiClientResponseMappers.FindPets404ApiResponseMapper.class)
FindPetsApiResponse findPets(...);
```

`clientMapping.type` replaces those generated `@ResponseCodeMapper` annotations with one explicit `@Mapping`.

```json
{
  "operations": {
    "findPets": {
      "clientMapping": {
        "type": "com.example.FindPetsResponseMapper"
      }
    }
  }
}
```

Generated Java:

```java
@Mapping(FindPetsResponseMapper.class)
FindPetsApiResponse findPets(...);
```

Generated Kotlin:

```kotlin
@Mapping(FindPetsResponseMapper::class)
fun findPets(...): FindPetsApiResponse
```

This is useful when a project wants full control over response mapping for a specific operation while preserving generated request contracts and response types.

### Compatibility

This PR intentionally removes old options:

```text
interceptors
additionalContractAnnotations
```

The replacement is `extensions`. There is no fallback parsing for the legacy options because the previous contract was not merged and does not need compatibility preservation.

### Verification

```bash
.\gradlew.bat :openapi:openapi-generator:testClasses --console plain
.\gradlew.bat :openapi:openapi-generator:test --console plain
```