### PR TITLE
Added OpenAPI client successful response mode with typed error exceptions

### DIFF
--- a/openapi/openapi-generator/build.gradle
+++ b/openapi/openapi-generator/build.gradle
@@ -101,6 +101,8 @@ sourceSets {
             addOpenapiDir("petstoreV3_types")
             addOpenapiDir("petstoreV3_validation")
             addOpenapiDir("petstoreV3_validation_enable_json_nullable")
+            addOpenapiDir("petstoreV3_client_successful_response")
+            addOpenapiDir("petstoreV3_client_successful_response_successful")
         }
     }
 }

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/AbstractGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/AbstractGenerator.java
@@ -79,6 +79,8 @@ public abstract class AbstractGenerator<C, R> {
 
         public static final ClassName httpClientResponse = ClassName.get("io.koraframework.http.client.common.response", "HttpClientResponse");
         public static final ClassName httpClientResponseMapper = ClassName.get("io.koraframework.http.client.common.response", "HttpClientResponseMapper");
+        public static final ClassName httpClientResponseException = ClassName.get("io.koraframework.http.client.common.exception", "HttpClientResponseException");
+        public static final ClassName simpleHttpClientResponse = ClassName.get("io.koraframework.http.client.common.response", "SimpleHttpClientResponse");
         public static final ClassName stringParameterConverter = ClassName.get("io.koraframework.http.client.common.request", "HttpClientParameterWriter");
         public static final ClassName enumStringParameterConverter = ClassName.get("io.koraframework.http.client.common.request.mapper", "EnumHttpClientParameterWriter");
 

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/CodegenParams.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/CodegenParams.java
@@ -31,6 +31,7 @@ public class CodegenParams {
     public static final String FORCE_INCLUDE_OPTIONAL = "forceIncludeOptional";
     public static final String RAW_BODY_MODE = "rawBodyMode";
     public static final String USE_SECURITY_DECLARATION_ORDER = "useSecurityDeclarationOrder";
+    public static final String CLIENT_RESPONSE_MODE = "clientResponseMode";
     
     public CodegenMode codegenMode = CodegenMode.JAVA_CLIENT;
     public boolean enableValidation = false;
@@ -51,6 +52,7 @@ public class CodegenParams {
     public boolean forceIncludeOptional = false;
     public RawBodyMode rawBodyMode = RawBodyMode.BYTES;
     public boolean useSecurityDeclarationOrder = false;
+    public ClientResponseMode clientResponseMode = ClientResponseMode.SEALED;
 
     static List<CliOption> cliOptions() {
         var cliOptions = new ArrayList<CliOption>();
@@ -71,6 +73,7 @@ public class CodegenParams {
         cliOptions.add(CliOption.newString(FORCE_INCLUDE_OPTIONAL, "If enabled forces Nullable and NonRequired fields to be included ALWAYS even if null, can't be enabled with enableJsonNullable simultaneously"));
         cliOptions.add(CliOption.newString(RAW_BODY_MODE, "Bare object request and response body mode (one of BYTES, BODY, OBJECT)"));
         cliOptions.add(CliOption.newBoolean(USE_SECURITY_DECLARATION_ORDER, "Use OpenAPI security requirement declaration order when generating auth tags and interceptors"));
+        cliOptions.add(CliOption.newString(CLIENT_RESPONSE_MODE, "HTTP client response generation mode (one of SEALED, SUCCESSFUL)"));
         return cliOptions;
     }
 
@@ -140,6 +143,9 @@ public class CodegenParams {
         }
         if (additionalProperties.containsKey(USE_SECURITY_DECLARATION_ORDER)) {
             params.useSecurityDeclarationOrder = Boolean.parseBoolean(additionalProperties.get(USE_SECURITY_DECLARATION_ORDER).toString());
+        }
+        if (additionalProperties.containsKey(CLIENT_RESPONSE_MODE)) {
+            params.clientResponseMode = ClientResponseMode.of(additionalProperties.get(CLIENT_RESPONSE_MODE).toString());
         }
         return params;
     }
@@ -230,6 +236,15 @@ public class CodegenParams {
 
         public static RawBodyMode of(String value) {
             return RawBodyMode.valueOf(value.toUpperCase(Locale.ROOT));
+        }
+    }
+
+    public enum ClientResponseMode {
+        SEALED,
+        SUCCESSFUL;
+
+        public static ClientResponseMode of(String value) {
+            return ClientResponseMode.valueOf(value.toUpperCase(Locale.ROOT));
         }
     }
 }

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientApiGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientApiGenerator.java
@@ -5,12 +5,14 @@ import io.koraframework.openapi.generator.CodegenParams;
 import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.CodegenOperation;
 import org.openapitools.codegen.CodegenParameter;
+import org.openapitools.codegen.CodegenResponse;
 import org.openapitools.codegen.CodegenSecurity;
 import org.openapitools.codegen.model.OperationsMap;
 
 import javax.lang.model.element.Modifier;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.LinkedHashMap;
 import java.util.List;
 
 import static io.koraframework.openapi.generator.CodegenParams.ClientResponseMode.SUCCESSFUL;
@@ -25,9 +27,6 @@ public class ClientApiGenerator extends AbstractJavaGenerator<OperationsMap> {
             .addAnnotation(buildHttpClientAnnotation(ctx));
         for (var operation : ctx.getOperations().getOperation()) {
             b.addMethod(buildMethod(ctx, operation));
-            if (usesSuccessfulResponseMapper(ctx, operation)) {
-                b.addType(buildResponseException(ctx, operation));
-            }
             if (operation.getHasFormParams()) {
                 b.addType(buildFormParamsRecord(ctx, operation));
             }
@@ -41,6 +40,9 @@ public class ClientApiGenerator extends AbstractJavaGenerator<OperationsMap> {
                 b.addMethod(buildRequiredArgsCall(ctx, operation, optionalParams));
                 b.addMethod(buildRequiredArgsWithArgsCall(ctx, operation, optionalParams));
             }
+        }
+        for (var response : successfulResponseExceptionResponses(ctx)) {
+            b.addType(buildResponseException(ctx, response));
         }
 
         return JavaFile.builder(apiPackage, b.build()).build();
@@ -391,33 +393,59 @@ public class ClientApiGenerator extends AbstractJavaGenerator<OperationsMap> {
         return ClassName.get(apiPackage, ctx.get("classname") + "Responses", StringUtils.capitalize(operation.operationId) + "ApiResponse");
     }
 
-    private TypeSpec buildResponseException(OperationsMap ctx, CodegenOperation operation) {
-        var responseType = fullResponseType(ctx, operation);
+    private List<CodegenResponse> successfulResponseExceptionResponses(OperationsMap ctx) {
+        var responses = new LinkedHashMap<String, CodegenResponse>();
+        for (var operation : ctx.getOperations().getOperation()) {
+            if (!usesSuccessfulResponseMapper(ctx, operation)) {
+                continue;
+            }
+            for (var response : operation.responses) {
+                if (isErrorResponse(response)) {
+                    responses.putIfAbsent(response.dataType == null ? "" : response.dataType, response);
+                }
+            }
+        }
+        return List.copyOf(responses.values());
+    }
+
+    private boolean isErrorResponse(CodegenResponse response) {
+        if (response.isDefault) {
+            return true;
+        }
+        var code = Integer.parseInt(response.code);
+        return code < 200 || code >= 300;
+    }
+
+    private TypeSpec buildResponseException(OperationsMap ctx, CodegenResponse response) {
+        var bodyType = ArrayTypeName.of(TypeName.BYTE);
         var constructor = MethodSpec.constructorBuilder()
             .addModifiers(Modifier.PUBLIC)
             .addParameter(TypeName.INT, "code")
-            .addParameter(Classes.httpHeaders, "headers")
-            .addParameter(responseType, "response")
-            .addParameter(ArrayTypeName.of(TypeName.BYTE), "body")
-            .addStatement("super(code, headers, body)")
-            .addStatement("this.response = response")
-            .build();
-        return TypeSpec.classBuilder(responseExceptionSimpleName(ctx, operation))
+            .addParameter(Classes.httpHeaders, "headers");
+        var b = TypeSpec.classBuilder(responseExceptionSimpleName(ctx, response))
             .addAnnotation(generated())
             .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-            .superclass(Classes.httpClientResponseException)
-            .addField(responseType, "response", Modifier.PRIVATE, Modifier.FINAL)
-            .addMethod(constructor)
-            .addMethod(MethodSpec.methodBuilder("getResponse")
+            .superclass(Classes.httpClientResponseException);
+        if (response.dataType != null) {
+            var contentType = asType(response);
+            constructor.addParameter(contentType, "content");
+            b.addField(contentType, "content", Modifier.PRIVATE, Modifier.FINAL);
+        }
+        constructor.addParameter(bodyType, "body")
+            .addStatement("super(code, headers, body)");
+        if (response.dataType != null) {
+            constructor.addStatement("this.content = content");
+            b.addMethod(MethodSpec.methodBuilder("getContent")
                 .addModifiers(Modifier.PUBLIC)
-                .returns(responseType)
-                .addStatement("return this.response")
-                .build())
-            .build();
+                .returns(asType(response))
+                .addStatement("return this.content")
+                .build());
+        }
+        return b.addMethod(constructor.build()).build();
     }
 
-    static String responseExceptionSimpleName(OperationsMap ctx, CodegenOperation operation) {
-        return ctx.get("classname") + StringUtils.capitalize(operation.operationId) + "HttpClientResponseException";
+    static String responseExceptionSimpleName(OperationsMap ctx, CodegenResponse response) {
+        return ctx.get("classname") + (response.dataType == null ? "NoContent" : sanitizeSharedResponseName(response.dataType)) + "HttpClientResponseException";
     }
 
     private static String sanitizeSharedResponseName(String dataType) {

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientApiGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientApiGenerator.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 
+import static io.koraframework.openapi.generator.CodegenParams.ClientResponseMode.SUCCESSFUL;
 import static io.koraframework.openapi.generator.SecurityData.hasNonAnonymousRequirements;
 
 public class ClientApiGenerator extends AbstractJavaGenerator<OperationsMap> {
@@ -24,6 +25,9 @@ public class ClientApiGenerator extends AbstractJavaGenerator<OperationsMap> {
             .addAnnotation(buildHttpClientAnnotation(ctx));
         for (var operation : ctx.getOperations().getOperation()) {
             b.addMethod(buildMethod(ctx, operation));
+            if (usesSuccessfulResponseMapper(ctx, operation)) {
+                b.addType(buildResponseException(ctx, operation));
+            }
             if (operation.getHasFormParams()) {
                 b.addType(buildFormParamsRecord(ctx, operation));
             }
@@ -43,7 +47,7 @@ public class ClientApiGenerator extends AbstractJavaGenerator<OperationsMap> {
     }
 
     private MethodSpec buildRequiredArgsCall(OperationsMap ctx, CodegenOperation operation, List<CodegenParameter> optionalParams) {
-        var returnType = ClassName.get(apiPackage, ctx.get("classname") + "Responses", StringUtils.capitalize(operation.operationId) + "ApiResponse");
+        var returnType = clientReturnType(ctx, operation);
         var b = MethodSpec.methodBuilder(operation.operationId)
             .addModifiers(Modifier.PUBLIC, Modifier.DEFAULT)
             .returns(returnType)
@@ -102,7 +106,7 @@ public class ClientApiGenerator extends AbstractJavaGenerator<OperationsMap> {
     }
 
     private MethodSpec buildRequiredArgsWithArgsCall(OperationsMap ctx, CodegenOperation operation, List<CodegenParameter> optionalParams) {
-        var returnType = ClassName.get(apiPackage, ctx.get("classname") + "Responses", StringUtils.capitalize(operation.operationId) + "ApiResponse");
+        var returnType = clientReturnType(ctx, operation);
         var b = MethodSpec.methodBuilder(operation.operationId)
             .addModifiers(Modifier.PUBLIC, Modifier.DEFAULT)
             .returns(returnType)
@@ -264,6 +268,10 @@ public class ClientApiGenerator extends AbstractJavaGenerator<OperationsMap> {
             b.addAnnotation(AnnotationSpec.builder(Classes.mapping)
                 .addMember("value", "$T.class", ClassName.bestGuess(clientMapping.type()))
                 .build());
+        } else if (usesSuccessfulResponseMapper(ctx, operation)) {
+            b.addAnnotation(AnnotationSpec.builder(Classes.mapping)
+                .addMember("value", "$T.class", ClassName.get(apiPackage, ctx.get("classname") + "ClientResponseMappers", StringUtils.capitalize(operation.operationId) + "SuccessfulResponseMapper"))
+                .build());
         } else {
             for (var response : operation.responses) {
                 b.addAnnotation(AnnotationSpec.builder(Classes.responseCodeMapper)
@@ -286,7 +294,7 @@ public class ClientApiGenerator extends AbstractJavaGenerator<OperationsMap> {
         }
 
         this.buildInterceptors(ctx, operation, Classes.httpClientInterceptor).forEach(b::addAnnotation);
-        b.returns(ClassName.get(apiPackage, ctx.get("classname") + "Responses", StringUtils.capitalize(operation.operationId) + "ApiResponse"));
+        b.returns(clientReturnType(ctx, operation));
         if (operation.hasAuthMethods && params.authAsMethodArgument) {
             for (var param : this.buildAuthParameters(operation)) {
                 b.addParameter(param);
@@ -336,6 +344,85 @@ public class ClientApiGenerator extends AbstractJavaGenerator<OperationsMap> {
         return ParameterSpec.builder(Classes.httpHeaders, "additionalHeaders")
             .addAnnotation(AnnotationSpec.builder(Classes.header).build())
             .build();
+    }
+
+    private TypeName clientReturnType(OperationsMap ctx, CodegenOperation operation) {
+        var responseClassName = fullResponseType(ctx, operation);
+        if (params.clientResponseMode != SUCCESSFUL) {
+            return responseClassName;
+        }
+        var successfulResponses = operation.responses.stream()
+            .filter(response -> !response.isDefault)
+            .filter(response -> {
+                var code = Integer.parseInt(response.code);
+                return code >= 200 && code < 300;
+            })
+            .toList();
+        if (successfulResponses.size() == 1) {
+            var response = successfulResponses.getFirst();
+            return operation.responses.size() == 1
+                ? responseClassName
+                : responseClassName.nestedClass(StringUtils.capitalize(operation.operationId) + response.code + "ApiResponse");
+        }
+        if (successfulResponses.size() > 1) {
+            var dataType = successfulResponses.getFirst().dataType;
+            if (dataType != null && successfulResponses.stream().allMatch(response -> dataType.equals(response.dataType))) {
+                return responseClassName.nestedClass(responseClassName.simpleName().replaceAll("ApiResponse$", "") + sanitizeSharedResponseName(dataType) + "ApiResponse");
+            }
+        }
+        return responseClassName;
+    }
+
+    private boolean usesSuccessfulResponseMapper(OperationsMap ctx, CodegenOperation operation) {
+        return params.clientResponseMode == SUCCESSFUL && hasErrorResponses(operation);
+    }
+
+    private boolean hasErrorResponses(CodegenOperation operation) {
+        return operation.responses.stream().anyMatch(response -> {
+            if (response.isDefault) {
+                return true;
+            }
+            var code = Integer.parseInt(response.code);
+            return code < 200 || code >= 300;
+        });
+    }
+
+    private ClassName fullResponseType(OperationsMap ctx, CodegenOperation operation) {
+        return ClassName.get(apiPackage, ctx.get("classname") + "Responses", StringUtils.capitalize(operation.operationId) + "ApiResponse");
+    }
+
+    private TypeSpec buildResponseException(OperationsMap ctx, CodegenOperation operation) {
+        var responseType = fullResponseType(ctx, operation);
+        var constructor = MethodSpec.constructorBuilder()
+            .addModifiers(Modifier.PUBLIC)
+            .addParameter(TypeName.INT, "code")
+            .addParameter(Classes.httpHeaders, "headers")
+            .addParameter(responseType, "response")
+            .addParameter(ArrayTypeName.of(TypeName.BYTE), "body")
+            .addStatement("super(code, headers, body)")
+            .addStatement("this.response = response")
+            .build();
+        return TypeSpec.classBuilder(responseExceptionSimpleName(ctx, operation))
+            .addAnnotation(generated())
+            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+            .superclass(Classes.httpClientResponseException)
+            .addField(responseType, "response", Modifier.PRIVATE, Modifier.FINAL)
+            .addMethod(constructor)
+            .addMethod(MethodSpec.methodBuilder("getResponse")
+                .addModifiers(Modifier.PUBLIC)
+                .returns(responseType)
+                .addStatement("return this.response")
+                .build())
+            .build();
+    }
+
+    static String responseExceptionSimpleName(OperationsMap ctx, CodegenOperation operation) {
+        return ctx.get("classname") + StringUtils.capitalize(operation.operationId) + "HttpClientResponseException";
+    }
+
+    private static String sanitizeSharedResponseName(String dataType) {
+        var name = dataType.replaceAll("[^a-zA-Z0-9]", "");
+        return name.isBlank() ? "Content" : StringUtils.capitalize(name);
     }
 
     protected List<ParameterSpec> buildAuthParameters(CodegenOperation op) {

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientResponseMapperGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientResponseMapperGenerator.java
@@ -102,7 +102,6 @@ public class ClientResponseMapperGenerator extends AbstractJavaGenerator<Operati
     private TypeSpec operationResponseMapper(OperationsMap ctx, ClassName mappers, CodegenOperation operation) {
         var returnType = clientReturnType(ctx, operation);
         var className = mappers.nestedClass(capitalize(operation.operationId) + "SuccessfulResponseMapper");
-        var exceptionType = ClassName.get(apiPackage, ctx.get("classname").toString(), ClientApiGenerator.responseExceptionSimpleName(ctx, operation));
         var b = TypeSpec.classBuilder(className)
             .addAnnotation(generated())
             .addAnnotation(Classes.defaultComponent)
@@ -136,14 +135,14 @@ public class ClientResponseMapperGenerator extends AbstractJavaGenerator<Operati
             if (code >= 200 && code < 300) {
                 apply.addStatement("return ($T) this.$N.apply(response)", returnType, responseMapperFieldName(operation, response));
             } else {
-                addErrorResponseMapping(apply, fullResponseType(ctx, operation), exceptionType, responseMapperFieldName(operation, response));
+                addErrorResponseMapping(ctx, apply, operation, response);
             }
             apply.endControlFlow();
         }
         apply.beginControlFlow("default ->");
         var defaultResponse = operation.responses.stream().filter(response -> response.isDefault).findFirst();
         if (defaultResponse.isPresent()) {
-            addErrorResponseMapping(apply, fullResponseType(ctx, operation), exceptionType, responseMapperFieldName(operation, defaultResponse.get()));
+            addErrorResponseMapping(ctx, apply, operation, defaultResponse.get());
         } else {
             apply.addStatement("throw $T.fromResponse(response)", Classes.httpClientResponseException);
         }
@@ -156,15 +155,22 @@ public class ClientResponseMapperGenerator extends AbstractJavaGenerator<Operati
             .build();
     }
 
-    private void addErrorResponseMapping(MethodSpec.Builder apply, ClassName responseType, ClassName exceptionType, String mapperFieldName) {
+    private void addErrorResponseMapping(OperationsMap ctx, MethodSpec.Builder apply, CodegenOperation operation, CodegenResponse response) {
+        var responseType = fullResponseType(ctx, operation);
+        var responseWithCodeType = responseWithCodeType(ctx, operation, response);
+        var exceptionType = ClassName.get(apiPackage, ctx.get("classname").toString(), ClientApiGenerator.responseExceptionSimpleName(ctx, response));
         apply.addStatement("var _bufferedResponse = bufferedResponse(response)")
             .addStatement("$T _response", responseType)
             .beginControlFlow("try")
-            .addStatement("_response = this.$N.apply(_bufferedResponse.response())", mapperFieldName)
+            .addStatement("_response = this.$N.apply(_bufferedResponse.response())", responseMapperFieldName(operation, response))
             .nextControlFlow("catch ($T e)", Exception.class)
             .addStatement("throw responseException(response, _bufferedResponse.body(), e)")
-            .endControlFlow()
-            .addStatement("throw new $T(response.code(), response.headers(), _response, _bufferedResponse.body())", exceptionType);
+            .endControlFlow();
+        if (response.dataType != null) {
+            apply.addStatement("throw new $T(response.code(), response.headers(), (($T) _response).content(), _bufferedResponse.body())", exceptionType, responseWithCodeType);
+        } else {
+            apply.addStatement("throw new $T(response.code(), response.headers(), _bufferedResponse.body())", exceptionType);
+        }
     }
 
     private TypeSpec bufferedResponseType() {
@@ -265,6 +271,13 @@ public class ClientResponseMapperGenerator extends AbstractJavaGenerator<Operati
 
     private ClassName fullResponseType(OperationsMap ctx, CodegenOperation operation) {
         return ClassName.get(apiPackage, ctx.get("classname") + "Responses", capitalize(operation.operationId) + "ApiResponse");
+    }
+
+    private ClassName responseWithCodeType(OperationsMap ctx, CodegenOperation operation, CodegenResponse response) {
+        var responseType = fullResponseType(ctx, operation);
+        return operation.responses.size() == 1
+            ? responseType
+            : responseType.nestedClass(capitalize(operation.operationId) + (response.isDefault ? "Default" : response.code) + "ApiResponse");
     }
 
     private static String sanitizeSharedResponseName(String dataType) {

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientResponseMapperGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientResponseMapperGenerator.java
@@ -8,6 +8,7 @@ import org.openapitools.codegen.model.OperationsMap;
 import javax.lang.model.element.Modifier;
 import java.io.IOException;
 
+import static io.koraframework.openapi.generator.CodegenParams.ClientResponseMode.SUCCESSFUL;
 import static io.koraframework.openapi.generator.KoraCodegen.isContentJson;
 
 public class ClientResponseMapperGenerator extends AbstractJavaGenerator<OperationsMap> {
@@ -20,6 +21,9 @@ public class ClientResponseMapperGenerator extends AbstractJavaGenerator<Operati
         for (var operation : ctx.getOperations().getOperation()) {
             for (var response : operation.responses) {
                 b.addType(responseMapper(ctx, className, operation, response));
+            }
+            if (usesSuccessfulResponseMapper(ctx, operation)) {
+                b.addType(operationResponseMapper(ctx, className, operation));
             }
         }
 
@@ -93,5 +97,178 @@ public class ClientResponseMapperGenerator extends AbstractJavaGenerator<Operati
         }
 
         return b.addMethod(apply.addStatement("return new $T($L)", responseWithCodeType, newArgs.build()).build()).build();
+    }
+
+    private TypeSpec operationResponseMapper(OperationsMap ctx, ClassName mappers, CodegenOperation operation) {
+        var returnType = clientReturnType(ctx, operation);
+        var className = mappers.nestedClass(capitalize(operation.operationId) + "SuccessfulResponseMapper");
+        var exceptionType = ClassName.get(apiPackage, ctx.get("classname").toString(), ClientApiGenerator.responseExceptionSimpleName(ctx, operation));
+        var b = TypeSpec.classBuilder(className)
+            .addAnnotation(generated())
+            .addAnnotation(Classes.defaultComponent)
+            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+            .addSuperinterface(ParameterizedTypeName.get(Classes.httpClientResponseMapper, returnType));
+        var constructor = MethodSpec.constructorBuilder()
+            .addModifiers(Modifier.PUBLIC);
+        for (var response : operation.responses) {
+            var mapperType = responseMapperClassName(mappers, operation, response);
+            var fieldName = responseMapperFieldName(operation, response);
+            b.addField(mapperType, fieldName, Modifier.PRIVATE, Modifier.FINAL);
+            constructor.addParameter(mapperType, fieldName);
+            constructor.addStatement("this.$N = $N", fieldName, fieldName);
+        }
+        b.addMethod(constructor.build());
+
+        var apply = MethodSpec.methodBuilder("apply")
+            .addAnnotation(Override.class)
+            .addModifiers(Modifier.PUBLIC)
+            .returns(returnType)
+            .addParameter(Classes.httpClientResponse, "response")
+            .addException(IOException.class)
+            .addStatement("var _code = response.code()");
+        apply.beginControlFlow("switch (_code)");
+        for (var response : operation.responses) {
+            if (response.isDefault) {
+                continue;
+            }
+            var code = Integer.parseInt(response.code);
+            apply.beginControlFlow("case $L ->", code);
+            if (code >= 200 && code < 300) {
+                apply.addStatement("return ($T) this.$N.apply(response)", returnType, responseMapperFieldName(operation, response));
+            } else {
+                addErrorResponseMapping(apply, fullResponseType(ctx, operation), exceptionType, responseMapperFieldName(operation, response));
+            }
+            apply.endControlFlow();
+        }
+        apply.beginControlFlow("default ->");
+        var defaultResponse = operation.responses.stream().filter(response -> response.isDefault).findFirst();
+        if (defaultResponse.isPresent()) {
+            addErrorResponseMapping(apply, fullResponseType(ctx, operation), exceptionType, responseMapperFieldName(operation, defaultResponse.get()));
+        } else {
+            apply.addStatement("throw $T.fromResponse(response)", Classes.httpClientResponseException);
+        }
+        apply.endControlFlow();
+        apply.endControlFlow();
+        return b.addType(bufferedResponseType())
+            .addMethod(bufferedResponseMethod())
+            .addMethod(responseExceptionMethod())
+            .addMethod(apply.build())
+            .build();
+    }
+
+    private void addErrorResponseMapping(MethodSpec.Builder apply, ClassName responseType, ClassName exceptionType, String mapperFieldName) {
+        apply.addStatement("var _bufferedResponse = bufferedResponse(response)")
+            .addStatement("$T _response", responseType)
+            .beginControlFlow("try")
+            .addStatement("_response = this.$N.apply(_bufferedResponse.response())", mapperFieldName)
+            .nextControlFlow("catch ($T e)", Exception.class)
+            .addStatement("throw responseException(response, _bufferedResponse.body(), e)")
+            .endControlFlow()
+            .addStatement("throw new $T(response.code(), response.headers(), _response, _bufferedResponse.body())", exceptionType);
+    }
+
+    private TypeSpec bufferedResponseType() {
+        var bodyType = ArrayTypeName.of(TypeName.BYTE);
+        var constructor = MethodSpec.constructorBuilder()
+            .addParameter(bodyType, "body")
+            .addParameter(Classes.httpClientResponse, "response")
+            .build();
+        return TypeSpec.recordBuilder("BufferedResponse")
+            .addModifiers(Modifier.PRIVATE, Modifier.STATIC)
+            .recordConstructor(constructor)
+            .build();
+    }
+
+    private MethodSpec bufferedResponseMethod() {
+        return MethodSpec.methodBuilder("bufferedResponse")
+            .addModifiers(Modifier.PRIVATE, Modifier.STATIC)
+            .returns(ClassName.bestGuess("BufferedResponse"))
+            .addParameter(Classes.httpClientResponse, "response")
+            .addException(IOException.class)
+            .beginControlFlow("try (var body = response.body())")
+            .addStatement("var contentType = body.contentType()")
+            .addStatement("var full = body.getFullContentIfAvailable()")
+            .beginControlFlow("if (full != null)")
+            .addStatement("var bytes = new byte[full.remaining()]")
+            .addStatement("full.get(bytes)")
+            .addStatement("return new BufferedResponse(bytes, new $T(response.code(), response.headers(), $T.of(contentType, bytes)))", Classes.simpleHttpClientResponse, Classes.httpBody)
+            .endControlFlow()
+            .beginControlFlow("try (var is = body.asInputStream())")
+            .addStatement("var bytes = is.readAllBytes()")
+            .addStatement("return new BufferedResponse(bytes, new $T(response.code(), response.headers(), $T.of(contentType, bytes)))", Classes.simpleHttpClientResponse, Classes.httpBody)
+            .endControlFlow()
+            .endControlFlow()
+            .build();
+    }
+
+    private MethodSpec responseExceptionMethod() {
+        return MethodSpec.methodBuilder("responseException")
+            .addModifiers(Modifier.PRIVATE, Modifier.STATIC)
+            .returns(Classes.httpClientResponseException)
+            .addParameter(Classes.httpClientResponse, "response")
+            .addParameter(ArrayTypeName.of(TypeName.BYTE), "body")
+            .addParameter(Exception.class, "cause")
+            .addStatement("var exception = new $T(response.code(), response.headers(), body)", Classes.httpClientResponseException)
+            .addStatement("exception.addSuppressed(cause)")
+            .addStatement("return exception")
+            .build();
+    }
+
+    private ClassName responseMapperClassName(ClassName mappers, CodegenOperation operation, CodegenResponse response) {
+        return mappers.nestedClass(capitalize(operation.operationId) + response.code + "ApiResponseMapper");
+    }
+
+    private String responseMapperFieldName(CodegenOperation operation, CodegenResponse response) {
+        return operation.operationId + capitalize(response.isDefault ? "Default" : response.code) + "ResponseMapper";
+    }
+
+    private boolean usesSuccessfulResponseMapper(OperationsMap ctx, CodegenOperation operation) {
+        return params.clientResponseMode == SUCCESSFUL && hasErrorResponses(operation);
+    }
+
+    private boolean hasErrorResponses(CodegenOperation operation) {
+        return operation.responses.stream().anyMatch(response -> {
+            if (response.isDefault) {
+                return true;
+            }
+            var code = Integer.parseInt(response.code);
+            return code < 200 || code >= 300;
+        });
+    }
+
+    private TypeName clientReturnType(OperationsMap ctx, CodegenOperation operation) {
+        var responseClassName = fullResponseType(ctx, operation);
+        if (params.clientResponseMode != SUCCESSFUL) {
+            return responseClassName;
+        }
+        var successfulResponses = operation.responses.stream()
+            .filter(response -> !response.isDefault)
+            .filter(response -> {
+                var code = Integer.parseInt(response.code);
+                return code >= 200 && code < 300;
+            })
+            .toList();
+        if (successfulResponses.size() == 1) {
+            var response = successfulResponses.getFirst();
+            return operation.responses.size() == 1
+                ? responseClassName
+                : responseClassName.nestedClass(capitalize(operation.operationId) + response.code + "ApiResponse");
+        }
+        if (successfulResponses.size() > 1) {
+            var dataType = successfulResponses.getFirst().dataType;
+            if (dataType != null && successfulResponses.stream().allMatch(response -> dataType.equals(response.dataType))) {
+                return responseClassName.nestedClass(responseClassName.simpleName().replaceAll("ApiResponse$", "") + sanitizeSharedResponseName(dataType) + "ApiResponse");
+            }
+        }
+        return responseClassName;
+    }
+
+    private ClassName fullResponseType(OperationsMap ctx, CodegenOperation operation) {
+        return ClassName.get(apiPackage, ctx.get("classname") + "Responses", capitalize(operation.operationId) + "ApiResponse");
+    }
+
+    private static String sanitizeSharedResponseName(String dataType) {
+        var name = dataType.replaceAll("[^a-zA-Z0-9]", "");
+        return name.isBlank() ? "Content" : capitalize(name);
     }
 }

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/AbstractKotlinGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/AbstractKotlinGenerator.kt
@@ -383,6 +383,7 @@ abstract class AbstractKotlinGenerator<C : Any> : AbstractGenerator<C, FileSpec>
         com.palantir.javapoet.ClassName.get("java.math", "BigDecimal") -> java.math.BigDecimal::class.asClassName()
         com.palantir.javapoet.ClassName.get("io.koraframework.http.common.body", "HttpBodyInput") -> ClassName("io.koraframework.http.common.body", "HttpBodyInput")
         com.palantir.javapoet.ClassName.get("io.koraframework.http.common.body", "HttpBodyOutput") -> ClassName("io.koraframework.http.common.body", "HttpBodyOutput")
+        com.palantir.javapoet.ClassName.get("io.koraframework.http.client.common.exception", "HttpClientResponseException") -> ClassName("io.koraframework.http.client.common.exception", "HttpClientResponseException")
         com.palantir.javapoet.TypeName.INT.box() -> INT
         com.palantir.javapoet.TypeName.LONG.box() -> LONG
         com.palantir.javapoet.TypeName.SHORT.box() -> SHORT

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ClientApiGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ClientApiGenerator.kt
@@ -3,6 +3,7 @@ package io.koraframework.openapi.generator.kotlingen
 import com.squareup.kotlinpoet.*
 import io.koraframework.openapi.generator.CodegenParams
 import io.koraframework.openapi.generator.SecurityData
+import io.koraframework.openapi.generator.CodegenParams.ClientResponseMode.SUCCESSFUL
 import org.apache.commons.lang3.StringUtils
 import org.openapitools.codegen.CodegenOperation
 import org.openapitools.codegen.model.OperationsMap
@@ -15,6 +16,9 @@ class ClientApiGenerator() : AbstractKotlinGenerator<OperationsMap>() {
             .addAnnotation(buildHttpClientAnnotation(ctx))
         for (operation in ctx.operations.operation) {
             b.addFunction(buildFunction(ctx, operation))
+            if (usesSuccessfulResponseMapper(ctx, operation)) {
+                b.addType(buildResponseException(ctx, operation))
+            }
             if (operation.hasFormParams) {
                 b.addType(buildFormParamsRecord(ctx, operation))
             }
@@ -35,6 +39,12 @@ class ClientApiGenerator() : AbstractKotlinGenerator<OperationsMap>() {
             b.addAnnotation(
                 AnnotationSpec.builder(Classes.mapping.asKt())
                     .addMember("value = %T::class", com.palantir.javapoet.ClassName.bestGuess(clientMapping.type()).asKt())
+                    .build()
+            )
+        } else if (usesSuccessfulResponseMapper(ctx, operation)) {
+            b.addAnnotation(
+                AnnotationSpec.builder(Classes.mapping.asKt())
+                    .addMember("value = %T::class", ClassName(apiPackage, ctx.get("classname").toString() + "ClientResponseMappers", StringUtils.capitalize(operation.operationId) + "SuccessfulResponseMapper"))
                     .build()
             )
         } else {
@@ -71,7 +81,7 @@ class ClientApiGenerator() : AbstractKotlinGenerator<OperationsMap>() {
         if (operation.isDeprecated) {
             b.addAnnotation(AnnotationSpec.builder(Deprecated::class.asClassName()).addMember("%S", "deprecated").build())
         }
-        b.returns(ClassName(apiPackage, ctx.get("classname").toString() + "Responses", StringUtils.capitalize(operation.operationId) + "ApiResponse"))
+        b.returns(clientReturnType(ctx, operation))
         if (operation.hasAuthMethods && params.authAsMethodArgument) {
             b.addParameter(this.buildAuthParameter(operation));
         }
@@ -120,6 +130,82 @@ class ClientApiGenerator() : AbstractKotlinGenerator<OperationsMap>() {
         return ParameterSpec.builder("additionalHeaders", Classes.httpHeaders.asKt())
             .addAnnotation(AnnotationSpec.builder(Classes.header.asKt()).build())
             .build()
+    }
+
+    private fun clientReturnType(ctx: OperationsMap, operation: CodegenOperation): TypeName {
+        val responseClassName = fullResponseType(ctx, operation)
+        if (params.clientResponseMode != SUCCESSFUL) {
+            return responseClassName
+        }
+        val successfulResponses = operation.responses
+            .filter { !it.isDefault }
+            .filter {
+                val code = it.code.toInt()
+                code >= 200 && code < 300
+            }
+        if (successfulResponses.size == 1) {
+            val response = successfulResponses.first()
+            return if (operation.responses.size == 1)
+                responseClassName
+            else
+                responseClassName.nestedClass(StringUtils.capitalize(operation.operationId) + response.code + "ApiResponse")
+        }
+        if (successfulResponses.size > 1) {
+            val dataType = successfulResponses.first().dataType
+            if (dataType != null && successfulResponses.all { dataType == it.dataType }) {
+                return responseClassName.nestedClass(responseClassName.simpleName.removeSuffix("ApiResponse") + sanitizeSharedResponseName(dataType) + "ApiResponse")
+            }
+        }
+        return responseClassName
+    }
+
+    private fun usesSuccessfulResponseMapper(ctx: OperationsMap, operation: CodegenOperation): Boolean {
+        return params.clientResponseMode == SUCCESSFUL && hasErrorResponses(operation)
+    }
+
+    private fun hasErrorResponses(operation: CodegenOperation): Boolean {
+        return operation.responses.any {
+            if (it.isDefault) {
+                true
+            } else {
+                val code = it.code.toInt()
+                code < 200 || code >= 300
+            }
+        }
+    }
+
+    private fun fullResponseType(ctx: OperationsMap, operation: CodegenOperation): ClassName {
+        return ClassName(apiPackage, ctx.get("classname").toString() + "Responses", StringUtils.capitalize(operation.operationId) + "ApiResponse")
+    }
+
+    private fun buildResponseException(ctx: OperationsMap, operation: CodegenOperation): TypeSpec {
+        val responseType = fullResponseType(ctx, operation)
+        val constructor = FunSpec.constructorBuilder()
+            .addParameter("code", INT)
+            .addParameter("headers", Classes.httpHeaders.asKt())
+            .addParameter("response", responseType)
+            .addParameter("body", BYTE_ARRAY)
+            .build()
+        return TypeSpec.classBuilder(responseExceptionSimpleName(ctx, operation))
+            .addAnnotation(generated())
+            .superclass(Classes.httpClientResponseException.asKt())
+            .addSuperclassConstructorParameter("code")
+            .addSuperclassConstructorParameter("headers")
+            .addSuperclassConstructorParameter("body")
+            .primaryConstructor(constructor)
+            .addProperty(PropertySpec.builder("response", responseType).initializer("response").build())
+            .build()
+    }
+
+    private fun sanitizeSharedResponseName(dataType: String): String {
+        val name = dataType.replace(Regex("[^a-zA-Z0-9]"), "")
+        return if (name.isBlank()) "Content" else StringUtils.capitalize(name)
+    }
+
+    companion object {
+        fun responseExceptionSimpleName(ctx: OperationsMap, operation: CodegenOperation): String {
+            return ctx.get("classname").toString() + StringUtils.capitalize(operation.operationId) + "HttpClientResponseException"
+        }
     }
 
     private fun buildAuthParameter(op: CodegenOperation): ParameterSpec {

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ClientApiGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ClientApiGenerator.kt
@@ -6,6 +6,7 @@ import io.koraframework.openapi.generator.SecurityData
 import io.koraframework.openapi.generator.CodegenParams.ClientResponseMode.SUCCESSFUL
 import org.apache.commons.lang3.StringUtils
 import org.openapitools.codegen.CodegenOperation
+import org.openapitools.codegen.CodegenResponse
 import org.openapitools.codegen.model.OperationsMap
 import kotlin.text.get
 
@@ -16,13 +17,11 @@ class ClientApiGenerator() : AbstractKotlinGenerator<OperationsMap>() {
             .addAnnotation(buildHttpClientAnnotation(ctx))
         for (operation in ctx.operations.operation) {
             b.addFunction(buildFunction(ctx, operation))
-            if (usesSuccessfulResponseMapper(ctx, operation)) {
-                b.addType(buildResponseException(ctx, operation))
-            }
             if (operation.hasFormParams) {
                 b.addType(buildFormParamsRecord(ctx, operation))
             }
         }
+        successfulResponseExceptionResponses(ctx).forEach { b.addType(buildResponseException(ctx, it)) }
 
         return FileSpec.get(apiPackage, b.build())
     }
@@ -178,23 +177,46 @@ class ClientApiGenerator() : AbstractKotlinGenerator<OperationsMap>() {
         return ClassName(apiPackage, ctx.get("classname").toString() + "Responses", StringUtils.capitalize(operation.operationId) + "ApiResponse")
     }
 
-    private fun buildResponseException(ctx: OperationsMap, operation: CodegenOperation): TypeSpec {
-        val responseType = fullResponseType(ctx, operation)
+    private fun successfulResponseExceptionResponses(ctx: OperationsMap): List<CodegenResponse> {
+        val responses = LinkedHashMap<String, CodegenResponse>()
+        for (operation in ctx.operations.operation) {
+            if (!usesSuccessfulResponseMapper(ctx, operation)) {
+                continue
+            }
+            for (response in operation.responses) {
+                if (isErrorResponse(response)) {
+                    responses.putIfAbsent(response.dataType ?: "", response)
+                }
+            }
+        }
+        return responses.values.toList()
+    }
+
+    private fun isErrorResponse(response: CodegenResponse): Boolean {
+        if (response.isDefault) {
+            return true
+        }
+        val code = response.code.toInt()
+        return code < 200 || code >= 300
+    }
+
+    private fun buildResponseException(ctx: OperationsMap, response: CodegenResponse): TypeSpec {
         val constructor = FunSpec.constructorBuilder()
             .addParameter("code", INT)
             .addParameter("headers", Classes.httpHeaders.asKt())
-            .addParameter("response", responseType)
-            .addParameter("body", BYTE_ARRAY)
-            .build()
-        return TypeSpec.classBuilder(responseExceptionSimpleName(ctx, operation))
+        val b = TypeSpec.classBuilder(responseExceptionSimpleName(ctx, response))
             .addAnnotation(generated())
             .superclass(Classes.httpClientResponseException.asKt())
             .addSuperclassConstructorParameter("code")
             .addSuperclassConstructorParameter("headers")
             .addSuperclassConstructorParameter("body")
-            .primaryConstructor(constructor)
-            .addProperty(PropertySpec.builder("response", responseType).initializer("response").build())
-            .build()
+        if (response.dataType != null) {
+            val contentType = asType(response).asKt()
+            constructor.addParameter("content", contentType)
+            b.addProperty(PropertySpec.builder("content", contentType).initializer("content").build())
+        }
+        constructor.addParameter("body", BYTE_ARRAY)
+        return b.primaryConstructor(constructor.build()).build()
     }
 
     private fun sanitizeSharedResponseName(dataType: String): String {
@@ -203,8 +225,12 @@ class ClientApiGenerator() : AbstractKotlinGenerator<OperationsMap>() {
     }
 
     companion object {
-        fun responseExceptionSimpleName(ctx: OperationsMap, operation: CodegenOperation): String {
-            return ctx.get("classname").toString() + StringUtils.capitalize(operation.operationId) + "HttpClientResponseException"
+        fun responseExceptionSimpleName(ctx: OperationsMap, response: CodegenResponse): String {
+            val responseName = response.dataType?.let {
+                val name = it.replace(Regex("[^a-zA-Z0-9]"), "")
+                if (name.isBlank()) "Content" else StringUtils.capitalize(name)
+            } ?: "NoContent"
+            return ctx.get("classname").toString() + responseName + "HttpClientResponseException"
         }
     }
 

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ClientResponseMapperGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ClientResponseMapperGenerator.kt
@@ -2,6 +2,7 @@ package io.koraframework.openapi.generator.kotlingen
 
 import com.squareup.kotlinpoet.*
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import io.koraframework.openapi.generator.CodegenParams.ClientResponseMode.SUCCESSFUL
 import org.openapitools.codegen.CodegenOperation
 import org.openapitools.codegen.CodegenResponse
 import org.openapitools.codegen.model.OperationsMap
@@ -15,6 +16,9 @@ class ClientResponseMapperGenerator : AbstractKotlinGenerator<OperationsMap>() {
         for (operation in ctx.operations.operation) {
             for (response in operation.responses) {
                 b.addType(responseMapper(ctx, className, operation, response))
+            }
+            if (usesSuccessfulResponseMapper(ctx, operation)) {
+                b.addType(operationResponseMapper(ctx, className, operation))
             }
         }
 
@@ -84,5 +88,172 @@ class ClientResponseMapperGenerator : AbstractKotlinGenerator<OperationsMap>() {
         }
         b.addFunction(apply.build())
         return b.build()
+    }
+
+    private fun operationResponseMapper(ctx: OperationsMap, mappers: ClassName, operation: CodegenOperation): TypeSpec {
+        val returnType = clientReturnType(ctx, operation)
+        val className = mappers.nestedClass(capitalize(operation.operationId) + "SuccessfulResponseMapper")
+        val exceptionType = ClassName(apiPackage, ctx["classname"].toString(), ClientApiGenerator.responseExceptionSimpleName(ctx, operation))
+        val b = TypeSpec.classBuilder(className)
+            .addAnnotation(generated())
+            .addAnnotation(Classes.defaultComponent.asKt())
+            .addModifiers(KModifier.OPEN)
+            .addSuperinterface(Classes.httpClientResponseMapper.asKt().parameterizedBy(returnType))
+        val constructor = FunSpec.constructorBuilder()
+        for (response in operation.responses) {
+            val mapperType = responseMapperClassName(mappers, operation, response)
+            val fieldName = responseMapperFieldName(operation, response)
+            constructor.addParameter(fieldName, mapperType)
+            b.addProperty(PropertySpec.builder(fieldName, mapperType).initializer(fieldName).build())
+        }
+        b.primaryConstructor(constructor.build())
+        val apply = FunSpec.builder("apply")
+            .addModifiers(KModifier.OVERRIDE)
+            .returns(returnType)
+            .addParameter("response", Classes.httpClientResponse.asKt())
+            .addStatement("val _code = response.code()")
+            .beginControlFlow("return when (_code)")
+        for (response in operation.responses) {
+            if (response.isDefault) {
+                continue
+            }
+            val code = response.code.toInt()
+            if (code >= 200 && code < 300) {
+                apply.addStatement("%L -> this.%N.apply(response) as %T", code, responseMapperFieldName(operation, response), returnType)
+            } else {
+                apply.beginControlFlow("%L ->", code)
+                addErrorResponseMapping(apply, fullResponseType(ctx, operation), exceptionType, responseMapperFieldName(operation, response))
+                apply.endControlFlow()
+            }
+        }
+        val defaultResponse = operation.responses.firstOrNull { it.isDefault }
+        if (defaultResponse != null) {
+            apply.beginControlFlow("else ->")
+            addErrorResponseMapping(apply, fullResponseType(ctx, operation), exceptionType, responseMapperFieldName(operation, defaultResponse))
+            apply.endControlFlow()
+        } else {
+            apply.addStatement("else -> throw %T.fromResponse(response)", Classes.httpClientResponseException.asKt())
+        }
+        apply.endControlFlow()
+        b.addType(bufferedResponseType())
+        b.addFunction(bufferedResponseFunction())
+        b.addFunction(responseExceptionFunction())
+        b.addFunction(apply.build())
+        return b.build()
+    }
+
+    private fun addErrorResponseMapping(apply: FunSpec.Builder, responseType: ClassName, exceptionType: ClassName, mapperFieldName: String) {
+        apply.addStatement("val _bufferedResponse = bufferedResponse(response)")
+            .addCode("val _response: %T = try {\n", responseType)
+            .addCode("  this.%N.apply(_bufferedResponse.response)\n", mapperFieldName)
+            .addCode("} catch (e: Exception) {\n")
+            .addCode("  throw responseException(response, _bufferedResponse.body, e)\n")
+            .addCode("}\n")
+            .addStatement("throw %T(response.code(), response.headers(), _response, _bufferedResponse.body)", exceptionType)
+    }
+
+    private fun bufferedResponseType(): TypeSpec {
+        return TypeSpec.classBuilder("BufferedResponse")
+            .addModifiers(KModifier.PRIVATE, KModifier.DATA)
+            .primaryConstructor(
+                FunSpec.constructorBuilder()
+                    .addParameter("body", BYTE_ARRAY)
+                    .addParameter("response", Classes.httpClientResponse.asKt())
+                    .build()
+            )
+            .addProperty(PropertySpec.builder("body", BYTE_ARRAY).initializer("body").build())
+            .addProperty(PropertySpec.builder("response", Classes.httpClientResponse.asKt()).initializer("response").build())
+            .build()
+    }
+
+    private fun bufferedResponseFunction(): FunSpec {
+        return FunSpec.builder("bufferedResponse")
+            .addModifiers(KModifier.PRIVATE)
+            .returns(ClassName("", "BufferedResponse"))
+            .addParameter("response", Classes.httpClientResponse.asKt())
+            .addCode("response.body().use { body ->\n")
+            .addCode("  val contentType = body.contentType()\n")
+            .addCode("  val full = body.getFullContentIfAvailable()\n")
+            .beginControlFlow("if (full != null)")
+            .addStatement("val bytes = ByteArray(full.remaining())")
+            .addStatement("full.get(bytes)")
+            .addStatement("return BufferedResponse(bytes, %T(response.code(), response.headers(), %T.of(contentType, bytes)))", Classes.simpleHttpClientResponse.asKt(), Classes.httpBody.asKt())
+            .endControlFlow()
+            .addCode("  val bytes = body.asInputStream().use { it.readAllBytes() }\n")
+            .addCode("  return BufferedResponse(bytes, %T(response.code(), response.headers(), %T.of(contentType, bytes)))\n", Classes.simpleHttpClientResponse.asKt(), Classes.httpBody.asKt())
+            .addCode("}\n")
+            .build()
+    }
+
+    private fun responseExceptionFunction(): FunSpec {
+        return FunSpec.builder("responseException")
+            .addModifiers(KModifier.PRIVATE)
+            .returns(Classes.httpClientResponseException.asKt())
+            .addParameter("response", Classes.httpClientResponse.asKt())
+            .addParameter("body", BYTE_ARRAY)
+            .addParameter("cause", Exception::class)
+            .addStatement("val exception = %T(response.code(), response.headers(), body)", Classes.httpClientResponseException.asKt())
+            .addStatement("exception.addSuppressed(cause)")
+            .addStatement("return exception")
+            .build()
+    }
+
+    private fun responseMapperClassName(mappers: ClassName, operation: CodegenOperation, response: CodegenResponse): ClassName {
+        return mappers.nestedClass(capitalize(operation.operationId) + response.code + "ApiResponseMapper")
+    }
+
+    private fun responseMapperFieldName(operation: CodegenOperation, response: CodegenResponse): String {
+        return operation.operationId + capitalize(if (response.isDefault) "Default" else response.code) + "ResponseMapper"
+    }
+
+    private fun usesSuccessfulResponseMapper(ctx: OperationsMap, operation: CodegenOperation): Boolean {
+        return params.clientResponseMode == SUCCESSFUL && hasErrorResponses(operation)
+    }
+
+    private fun hasErrorResponses(operation: CodegenOperation): Boolean {
+        return operation.responses.any {
+            if (it.isDefault) {
+                true
+            } else {
+                val code = it.code.toInt()
+                code < 200 || code >= 300
+            }
+        }
+    }
+
+    private fun clientReturnType(ctx: OperationsMap, operation: CodegenOperation): TypeName {
+        val responseClassName = fullResponseType(ctx, operation)
+        if (params.clientResponseMode != SUCCESSFUL) {
+            return responseClassName
+        }
+        val successfulResponses = operation.responses
+            .filter { !it.isDefault }
+            .filter {
+                val code = it.code.toInt()
+                code >= 200 && code < 300
+            }
+        if (successfulResponses.size == 1) {
+            val response = successfulResponses.first()
+            return if (operation.responses.size == 1)
+                responseClassName
+            else
+                responseClassName.nestedClass(capitalize(operation.operationId) + response.code + "ApiResponse")
+        }
+        if (successfulResponses.size > 1) {
+            val dataType = successfulResponses.first().dataType
+            if (dataType != null && successfulResponses.all { dataType == it.dataType }) {
+                return responseClassName.nestedClass(responseClassName.simpleName.removeSuffix("ApiResponse") + sanitizeSharedResponseName(dataType) + "ApiResponse")
+            }
+        }
+        return responseClassName
+    }
+
+    private fun fullResponseType(ctx: OperationsMap, operation: CodegenOperation): ClassName {
+        return ClassName(apiPackage, ctx["classname"].toString() + "Responses", capitalize(operation.operationId) + "ApiResponse")
+    }
+
+    private fun sanitizeSharedResponseName(dataType: String): String {
+        val name = dataType.replace(Regex("[^a-zA-Z0-9]"), "")
+        return if (name.isBlank()) "Content" else capitalize(name)
     }
 }

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ClientResponseMapperGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ClientResponseMapperGenerator.kt
@@ -93,7 +93,6 @@ class ClientResponseMapperGenerator : AbstractKotlinGenerator<OperationsMap>() {
     private fun operationResponseMapper(ctx: OperationsMap, mappers: ClassName, operation: CodegenOperation): TypeSpec {
         val returnType = clientReturnType(ctx, operation)
         val className = mappers.nestedClass(capitalize(operation.operationId) + "SuccessfulResponseMapper")
-        val exceptionType = ClassName(apiPackage, ctx["classname"].toString(), ClientApiGenerator.responseExceptionSimpleName(ctx, operation))
         val b = TypeSpec.classBuilder(className)
             .addAnnotation(generated())
             .addAnnotation(Classes.defaultComponent.asKt())
@@ -122,14 +121,14 @@ class ClientResponseMapperGenerator : AbstractKotlinGenerator<OperationsMap>() {
                 apply.addStatement("%L -> this.%N.apply(response) as %T", code, responseMapperFieldName(operation, response), returnType)
             } else {
                 apply.beginControlFlow("%L ->", code)
-                addErrorResponseMapping(apply, fullResponseType(ctx, operation), exceptionType, responseMapperFieldName(operation, response))
+                addErrorResponseMapping(ctx, apply, operation, response)
                 apply.endControlFlow()
             }
         }
         val defaultResponse = operation.responses.firstOrNull { it.isDefault }
         if (defaultResponse != null) {
             apply.beginControlFlow("else ->")
-            addErrorResponseMapping(apply, fullResponseType(ctx, operation), exceptionType, responseMapperFieldName(operation, defaultResponse))
+            addErrorResponseMapping(ctx, apply, operation, defaultResponse)
             apply.endControlFlow()
         } else {
             apply.addStatement("else -> throw %T.fromResponse(response)", Classes.httpClientResponseException.asKt())
@@ -142,14 +141,21 @@ class ClientResponseMapperGenerator : AbstractKotlinGenerator<OperationsMap>() {
         return b.build()
     }
 
-    private fun addErrorResponseMapping(apply: FunSpec.Builder, responseType: ClassName, exceptionType: ClassName, mapperFieldName: String) {
+    private fun addErrorResponseMapping(ctx: OperationsMap, apply: FunSpec.Builder, operation: CodegenOperation, response: CodegenResponse) {
+        val responseType = fullResponseType(ctx, operation)
+        val responseWithCodeType = responseWithCodeType(ctx, operation, response)
+        val exceptionType = ClassName(apiPackage, ctx["classname"].toString(), ClientApiGenerator.responseExceptionSimpleName(ctx, response))
         apply.addStatement("val _bufferedResponse = bufferedResponse(response)")
             .addCode("val _response: %T = try {\n", responseType)
-            .addCode("  this.%N.apply(_bufferedResponse.response)\n", mapperFieldName)
+            .addCode("  this.%N.apply(_bufferedResponse.response)\n", responseMapperFieldName(operation, response))
             .addCode("} catch (e: Exception) {\n")
             .addCode("  throw responseException(response, _bufferedResponse.body, e)\n")
             .addCode("}\n")
-            .addStatement("throw %T(response.code(), response.headers(), _response, _bufferedResponse.body)", exceptionType)
+        if (response.dataType != null) {
+            apply.addStatement("throw %T(response.code(), response.headers(), (_response as %T).content, _bufferedResponse.body)", exceptionType, responseWithCodeType)
+        } else {
+            apply.addStatement("throw %T(response.code(), response.headers(), _bufferedResponse.body)", exceptionType)
+        }
     }
 
     private fun bufferedResponseType(): TypeSpec {
@@ -250,6 +256,14 @@ class ClientResponseMapperGenerator : AbstractKotlinGenerator<OperationsMap>() {
 
     private fun fullResponseType(ctx: OperationsMap, operation: CodegenOperation): ClassName {
         return ClassName(apiPackage, ctx["classname"].toString() + "Responses", capitalize(operation.operationId) + "ApiResponse")
+    }
+
+    private fun responseWithCodeType(ctx: OperationsMap, operation: CodegenOperation, response: CodegenResponse): ClassName {
+        val responseType = fullResponseType(ctx, operation)
+        return if (operation.responses.size == 1)
+            responseType
+        else
+            responseType.nestedClass(capitalize(operation.operationId) + (if (response.isDefault) "Default" else response.code) + "ApiResponse")
     }
 
     private fun sanitizeSharedResponseName(dataType: String): String {

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/BaseOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/BaseOpenapiTest.java
@@ -32,6 +32,8 @@ public abstract class BaseOpenapiTest {
             @Nullable
             public String clientConfigPrefix;
             public boolean useSecurityDeclarationOrder;
+            @Nullable
+            public String clientResponseMode;
 
             public Options setAuthAsArg(boolean authAsArg) {
                 this.authAsArg = authAsArg;
@@ -78,6 +80,11 @@ public abstract class BaseOpenapiTest {
                 return this;
             }
 
+            public Options setClientResponseMode(@Nullable String clientResponseMode) {
+                this.clientResponseMode = clientResponseMode;
+                return this;
+            }
+
             @Override
             public String toString() {
                 return "Options{" +
@@ -90,6 +97,7 @@ public abstract class BaseOpenapiTest {
                        ", clientConfig='" + clientConfig + '\'' +
                        ", clientConfigPrefix='" + clientConfigPrefix + '\'' +
                        ", useSecurityDeclarationOrder=" + useSecurityDeclarationOrder +
+                       ", clientResponseMode='" + clientResponseMode + '\'' +
                        '}';
             }
         }
@@ -121,6 +129,7 @@ public abstract class BaseOpenapiTest {
             "/example/petstoreV3_single_response.yaml",
             "/example/petstoreV3_same_response_model.yaml",
             "/example/petstoreV3_bare_object.yaml",
+            "/example/petstoreV3_client_successful_response.yaml",
             "/example/petstoreV3_responses.yaml",
             "/example/petstoreV3_types.yaml",
             "/example/petstoreV3_validation.yaml",
@@ -145,6 +154,9 @@ public abstract class BaseOpenapiTest {
 
             if (name.equals("petstoreV3")) {
                 result.add(new SwaggerParams(fileName, name + "_default_delegate", new SwaggerParams.Options().setDefaultDelegate(true)));
+            }
+            if (name.equals("petstoreV3_client_successful_response")) {
+                result.add(new SwaggerParams(fileName, name + "_successful", new SwaggerParams.Options().setClientResponseMode("SUCCESSFUL")));
             }
         }
 
@@ -220,6 +232,9 @@ public abstract class BaseOpenapiTest {
         }
         if (options.rawBodyMode != null) {
             configurator.addAdditionalProperty("rawBodyMode", options.rawBodyMode);
+        }
+        if (options.clientResponseMode != null) {
+            configurator.addAdditionalProperty("clientResponseMode", options.clientResponseMode);
         }
 
         if (options.defaultDelegate) {

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientJavaOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientJavaOpenapiTest.java
@@ -111,22 +111,27 @@ public class HttpClientJavaOpenapiTest extends BaseJavaOpenapiTest {
         assertTrue(apiContent.contains("FindPetPetApiResponse findPet("));
         assertTrue(apiContent.contains("AmbiguousPetApiResponse ambiguousPet("));
         assertTrue(apiContent.contains("@Mapping(PetsApiClientResponseMappers.AmbiguousPetSuccessfulResponseMapper.class)"));
-        assertTrue(apiContent.contains("class PetsApiCreatePetHttpClientResponseException extends HttpClientResponseException"));
-        assertTrue(apiContent.contains("CreatePetApiResponse response"));
+        assertTrue(apiContent.contains("class PetsApiModelErrorHttpClientResponseException extends HttpClientResponseException"));
+        assertTrue(apiContent.contains("private final ModelError content"));
+        assertTrue(apiContent.contains("ModelError getContent()"));
         assertTrue(apiContent.contains("byte[] body"));
         assertTrue(apiContent.contains("super(code, headers, body)"));
+        assertFalse(apiContent.contains("PetsApiCreatePetHttpClientResponseException"));
+        assertFalse(apiContent.contains("PetsApiFindPetHttpClientResponseException"));
+        assertFalse(apiContent.contains("PetsApiAmbiguousPetHttpClientResponseException"));
         assertTrue(mapperContent.contains("class CreatePetSuccessfulResponseMapper implements HttpClientResponseMapper<"));
         assertTrue(mapperContent.contains("CreatePet200ApiResponse"));
         assertTrue(mapperContent.contains("case 400 ->"));
         assertTrue(mapperContent.contains("var _bufferedResponse = bufferedResponse(response)"));
         assertTrue(mapperContent.contains("this.createPet400ResponseMapper.apply(_bufferedResponse.response())"));
         assertTrue(mapperContent.contains("throw responseException(response, _bufferedResponse.body(), e)"));
-        assertTrue(mapperContent.contains("throw new PetsApi.PetsApiCreatePetHttpClientResponseException(response.code(), response.headers(), _response, _bufferedResponse.body())"));
+        assertTrue(mapperContent.contains("throw new PetsApi.PetsApiModelErrorHttpClientResponseException"));
+        assertTrue(mapperContent.contains("((PetsApiResponses.CreatePetApiResponse.CreatePet400ApiResponse) _response).content()"));
         assertTrue(mapperContent.contains("new SimpleHttpClientResponse(response.code(), response.headers(), HttpBody.of(contentType, bytes))"));
         assertTrue(mapperContent.contains("class FindPetSuccessfulResponseMapper implements HttpClientResponseMapper<"));
         assertTrue(mapperContent.contains("FindPetPetApiResponse"));
         assertTrue(mapperContent.contains("class AmbiguousPetSuccessfulResponseMapper implements HttpClientResponseMapper<"));
-        assertTrue(mapperContent.contains("throw new PetsApi.PetsApiAmbiguousPetHttpClientResponseException(response.code(), response.headers(), _response, _bufferedResponse.body())"));
+        assertTrue(mapperContent.contains("((PetsApiResponses.AmbiguousPetApiResponse.AmbiguousPet400ApiResponse) _response).content()"));
     }
 
     @Test

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientJavaOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientJavaOpenapiTest.java
@@ -87,6 +87,49 @@ public class HttpClientJavaOpenapiTest extends BaseJavaOpenapiTest {
     }
 
     @Test
+    void successfulClientResponseModeReturnsSuccessAndThrowsTypedException() throws Exception {
+        var files = generate(
+            "petstoreV3_client_successful_response",
+            "java-client",
+            getClass().getResource("/example/petstoreV3_client_successful_response.yaml").toExternalForm(),
+            new SwaggerParams.Options().setClientResponseMode("SUCCESSFUL")
+        );
+
+        var apiContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("PetsApi.java"))
+            .findFirst()
+            .orElseThrow());
+        var mapperContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("PetsApiClientResponseMappers.java"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(apiContent.contains("@Mapping(PetsApiClientResponseMappers.CreatePetSuccessfulResponseMapper.class)"));
+        assertTrue(apiContent.contains("CreatePet200ApiResponse createPet("));
+        assertTrue(apiContent.contains("FindPetPetApiResponse findPet("));
+        assertTrue(apiContent.contains("AmbiguousPetApiResponse ambiguousPet("));
+        assertTrue(apiContent.contains("@Mapping(PetsApiClientResponseMappers.AmbiguousPetSuccessfulResponseMapper.class)"));
+        assertTrue(apiContent.contains("class PetsApiCreatePetHttpClientResponseException extends HttpClientResponseException"));
+        assertTrue(apiContent.contains("CreatePetApiResponse response"));
+        assertTrue(apiContent.contains("byte[] body"));
+        assertTrue(apiContent.contains("super(code, headers, body)"));
+        assertTrue(mapperContent.contains("class CreatePetSuccessfulResponseMapper implements HttpClientResponseMapper<"));
+        assertTrue(mapperContent.contains("CreatePet200ApiResponse"));
+        assertTrue(mapperContent.contains("case 400 ->"));
+        assertTrue(mapperContent.contains("var _bufferedResponse = bufferedResponse(response)"));
+        assertTrue(mapperContent.contains("this.createPet400ResponseMapper.apply(_bufferedResponse.response())"));
+        assertTrue(mapperContent.contains("throw responseException(response, _bufferedResponse.body(), e)"));
+        assertTrue(mapperContent.contains("throw new PetsApi.PetsApiCreatePetHttpClientResponseException(response.code(), response.headers(), _response, _bufferedResponse.body())"));
+        assertTrue(mapperContent.contains("new SimpleHttpClientResponse(response.code(), response.headers(), HttpBody.of(contentType, bytes))"));
+        assertTrue(mapperContent.contains("class FindPetSuccessfulResponseMapper implements HttpClientResponseMapper<"));
+        assertTrue(mapperContent.contains("FindPetPetApiResponse"));
+        assertTrue(mapperContent.contains("class AmbiguousPetSuccessfulResponseMapper implements HttpClientResponseMapper<"));
+        assertTrue(mapperContent.contains("throw new PetsApi.PetsApiAmbiguousPetHttpClientResponseException(response.code(), response.headers(), _response, _bufferedResponse.body())"));
+    }
+
+    @Test
     void sameResponseModelGetsSharedInterface() throws Exception {
         var files = generate(
             "petstoreV3_same_response_model",

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientKotlinOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientKotlinOpenapiTest.java
@@ -87,6 +87,50 @@ public class HttpClientKotlinOpenapiTest extends BaseKotlinOpenapiTest {
     }
 
     @Test
+    void successfulClientResponseModeReturnsSuccessAndThrowsTypedException() throws Exception {
+        var files = generate(
+            "petstoreV3_client_successful_response",
+            "kotlin-client",
+            getClass().getResource("/example/petstoreV3_client_successful_response.yaml").toExternalForm(),
+            new SwaggerParams.Options().setClientResponseMode("SUCCESSFUL")
+        );
+
+        var apiContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("PetsApi.kt"))
+            .findFirst()
+            .orElseThrow());
+        var mapperContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("PetsApiClientResponseMappers.kt"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(apiContent.contains("@Mapping(value = PetsApiClientResponseMappers.CreatePetSuccessfulResponseMapper::class)"));
+        assertTrue(apiContent.contains("public fun createPet("));
+        assertTrue(apiContent.contains("CreatePet200ApiResponse"));
+        assertTrue(apiContent.contains("FindPetPetApiResponse"));
+        assertTrue(apiContent.contains("AmbiguousPetApiResponse"));
+        assertTrue(apiContent.contains("@Mapping(value = PetsApiClientResponseMappers.AmbiguousPetSuccessfulResponseMapper::class)"));
+        assertTrue(apiContent.contains("public class PetsApiCreatePetHttpClientResponseException("));
+        assertTrue(apiContent.contains("val response:"));
+        assertTrue(apiContent.contains("CreatePetApiResponse"));
+        assertTrue(apiContent.contains("body: ByteArray"));
+        assertTrue(apiContent.contains("HttpClientResponseException(code, headers, body)"));
+        assertTrue(mapperContent.contains("public open class CreatePetSuccessfulResponseMapper("));
+        assertTrue(mapperContent.contains("HttpClientResponseMapper<"));
+        assertTrue(mapperContent.contains("CreatePet200ApiResponse"));
+        assertTrue(mapperContent.contains("val _bufferedResponse = bufferedResponse(response)"));
+        assertTrue(mapperContent.contains("this.createPet400ResponseMapper.apply(_bufferedResponse.response)"));
+        assertTrue(mapperContent.contains("throw responseException(response, _bufferedResponse.body, e)"));
+        assertTrue(mapperContent.contains("throw PetsApi.PetsApiCreatePetHttpClientResponseException(response.code(), response.headers(), _response, _bufferedResponse.body)"));
+        assertTrue(mapperContent.contains("SimpleHttpClientResponse(response.code(), response.headers(), HttpBody.of(contentType, bytes))"));
+        assertTrue(mapperContent.contains("FindPetPetApiResponse"));
+        assertTrue(mapperContent.contains("public open class AmbiguousPetSuccessfulResponseMapper("));
+        assertTrue(mapperContent.contains("throw PetsApi.PetsApiAmbiguousPetHttpClientResponseException(response.code(), response.headers(), _response, _bufferedResponse.body)"));
+    }
+
+    @Test
     void sameResponseModelGetsSharedInterface() throws Exception {
         var files = generate(
             "petstoreV3_same_response_model",

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientKotlinOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientKotlinOpenapiTest.java
@@ -112,22 +112,25 @@ public class HttpClientKotlinOpenapiTest extends BaseKotlinOpenapiTest {
         assertTrue(apiContent.contains("FindPetPetApiResponse"));
         assertTrue(apiContent.contains("AmbiguousPetApiResponse"));
         assertTrue(apiContent.contains("@Mapping(value = PetsApiClientResponseMappers.AmbiguousPetSuccessfulResponseMapper::class)"));
-        assertTrue(apiContent.contains("public class PetsApiCreatePetHttpClientResponseException("));
-        assertTrue(apiContent.contains("val response:"));
-        assertTrue(apiContent.contains("CreatePetApiResponse"));
+        assertTrue(apiContent.contains("public class PetsApiModelErrorHttpClientResponseException("));
+        assertTrue(apiContent.contains("public val content: ModelError"));
         assertTrue(apiContent.contains("body: ByteArray"));
         assertTrue(apiContent.contains("HttpClientResponseException(code, headers, body)"));
+        assertFalse(apiContent.contains("PetsApiCreatePetHttpClientResponseException"));
+        assertFalse(apiContent.contains("PetsApiFindPetHttpClientResponseException"));
+        assertFalse(apiContent.contains("PetsApiAmbiguousPetHttpClientResponseException"));
         assertTrue(mapperContent.contains("public open class CreatePetSuccessfulResponseMapper("));
         assertTrue(mapperContent.contains("HttpClientResponseMapper<"));
         assertTrue(mapperContent.contains("CreatePet200ApiResponse"));
         assertTrue(mapperContent.contains("val _bufferedResponse = bufferedResponse(response)"));
         assertTrue(mapperContent.contains("this.createPet400ResponseMapper.apply(_bufferedResponse.response)"));
         assertTrue(mapperContent.contains("throw responseException(response, _bufferedResponse.body, e)"));
-        assertTrue(mapperContent.contains("throw PetsApi.PetsApiCreatePetHttpClientResponseException(response.code(), response.headers(), _response, _bufferedResponse.body)"));
+        assertTrue(mapperContent.contains("throw PetsApi.PetsApiModelErrorHttpClientResponseException"));
+        assertTrue(mapperContent.contains("(_response as PetsApiResponses.CreatePetApiResponse.CreatePet400ApiResponse).content"));
         assertTrue(mapperContent.contains("SimpleHttpClientResponse(response.code(), response.headers(), HttpBody.of(contentType, bytes))"));
         assertTrue(mapperContent.contains("FindPetPetApiResponse"));
         assertTrue(mapperContent.contains("public open class AmbiguousPetSuccessfulResponseMapper("));
-        assertTrue(mapperContent.contains("throw PetsApi.PetsApiAmbiguousPetHttpClientResponseException(response.code(), response.headers(), _response, _bufferedResponse.body)"));
+        assertTrue(mapperContent.contains("(_response as PetsApiResponses.AmbiguousPetApiResponse.AmbiguousPet400ApiResponse).content"));
     }
 
     @Test

--- a/openapi/openapi-generator/src/test/resources/example/petstoreV3_client_successful_response.yaml
+++ b/openapi/openapi-generator/src/test/resources/example/petstoreV3_client_successful_response.yaml
@@ -1,0 +1,102 @@
+openapi: 3.0.3
+
+info:
+  title: Client successful response mode
+  version: 1.0.0
+
+paths:
+  /pets:
+    post:
+      operationId: createPet
+      tags:
+        - pets
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+      responses:
+        '200':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /pets/shared:
+    get:
+      operationId: findPet
+      tags:
+        - pets
+      responses:
+        '200':
+          description: Full
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        '206':
+          description: Partial
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /pets/ambiguous:
+    get:
+      operationId: ambiguousPet
+      tags:
+        - pets
+      responses:
+        '200':
+          description: Full
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        '204':
+          description: Empty
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+    Error:
+      type: object
+      required:
+        - message
+      properties:
+        message:
+          type: string


### PR DESCRIPTION
Added OpenAPI client successful response mode with typed error exceptions

## EN

Added `clientResponseMode=SUCCESSFUL` for generated OpenAPI clients so successful calls can return narrowed success response types while error responses are exposed through typed per-operation exceptions. The default remains `SEALED`, preserving existing generated client contracts unless the new mode is explicitly enabled.

---

## RU

Добавлен режим `clientResponseMode=SUCCESSFUL` для OpenAPI клиентов: успешные ответы могут возвращаться как суженные success-типы, а error/default ответы превращаются в типизированные per-operation exception. Поведение по умолчанию остается `SEALED`, поэтому существующие контракты без явного включения нового режима не меняются.

---

- Added `clientResponseMode=SEALED | SUCCESSFUL`, with `SEALED` as the default compatibility mode.
- Added narrowed successful client return types in `SUCCESSFUL` mode when the OpenAPI response set allows it.
- Added operation-level `*SuccessfulResponseMapper` generation for operations with error/default responses, including cases where successful responses are ambiguous and the return type stays sealed.
- Added typed per-operation client response exceptions that carry the parsed error response and preserve buffered raw response body bytes.

---

## Design

`clientResponseMode` controls the shape of generated client contracts.

In default `SEALED` mode, the generator keeps the old behavior: every operation returns the full sealed response hierarchy and each status code is mapped through `@ResponseCodeMapper`.

```java
@ResponseCodeMapper(code = 200, mapper = PetsApiClientResponseMappers.CreatePet200ApiResponseMapper.class)
@ResponseCodeMapper(code = 400, mapper = PetsApiClientResponseMappers.CreatePet400ApiResponseMapper.class)
PetsApiResponses.CreatePetApiResponse createPet(@Json Pet pet);
```

In `SUCCESSFUL` mode, operations with error/default responses use one operation-level mapper. If the successful response shape is unambiguous, the method return type is narrowed to the successful subtype.

```java
@Mapping(PetsApiClientResponseMappers.CreatePetSuccessfulResponseMapper.class)
PetsApiResponses.CreatePetApiResponse.CreatePet200ApiResponse createPet(@Json Pet pet);
```

If success responses are ambiguous, for example `200` with body and `204` without body, the method keeps the sealed return type but still uses one operation-level mapper. This keeps success typing correct while giving the same error-exception behavior.

```java
@Mapping(PetsApiClientResponseMappers.AmbiguousPetSuccessfulResponseMapper.class)
PetsApiResponses.AmbiguousPetApiResponse ambiguousPet();
```

The generated `*SuccessfulResponseMapper` owns response dispatch for the operation:
- `2xx` responses are returned normally.
- declared error/default responses are parsed into their generated response subtype and wrapped into a typed per-operation exception.
- unknown responses still use the standard `HttpClientResponseException` fallback.

Error bodies are buffered before parsing. The mapper replays the buffered body through `SimpleHttpClientResponse`, so typed error parsing can consume the body while the thrown exception still exposes the original bytes. If parsing fails, the generated mapper throws `HttpClientResponseException` with the buffered body and adds the parsing failure as suppressed.

```java
try {
  _response = this.createPet400ResponseMapper.apply(_bufferedResponse.response());
} catch (Exception e) {
  throw responseException(response, _bufferedResponse.body(), e);
}
throw new PetsApi.PetsApiCreatePetHttpClientResponseException(
    response.code(),
    response.headers(),
    _response,
    _bufferedResponse.body()
);
```

The typed exception keeps both layers of information: structured generated response for declared errors and raw body bytes through the base `HttpClientResponseException`.

```java
class PetsApiModelErrorHttpClientResponseException extends HttpClientResponseException {
    private final ModelError content;

    public PetsApiModelErrorHttpClientResponseException(int code, HttpHeaders headers,
        ModelError content, byte[] body) {
      super(code, headers, body);
      this.content = content;
    }

    public ModelError getContent() {
      return this.content;
    }
  }
```