### PR TITLE
Fixed OpenAPI generator handle multipart byte fields

### DIFF
--- a/openapi/openapi-generator/src/main/java/ru/tinkoff/kora/openapi/generator/KoraCodegen.java
+++ b/openapi/openapi-generator/src/main/java/ru/tinkoff/kora/openapi/generator/KoraCodegen.java
@@ -2454,6 +2454,18 @@ public class KoraCodegen extends DefaultCodegen {
                 if (formParam.isFile && Boolean.TRUE.equals(formParam.isArray)) {
                     hasFileArrayFormParams = true;
                 }
+                var isByteArray = "byte[]".equals(formParam.dataType) || "ByteArray".equals(formParam.dataType);
+                var isByteArrayArray = Boolean.TRUE.equals(formParam.isArray)
+                                       && ("byte[]".equals(formParam.baseType)
+                                           || "ByteArray".equals(formParam.baseType)
+                                           || formParam.dataType.contains("byte[]")
+                                           || formParam.dataType.contains("ByteArray"));
+                if (isByteArray) {
+                    formParam.vendorExtensions.put("isByteArray", true);
+                }
+                if (isByteArrayArray) {
+                    formParam.vendorExtensions.put("isByteArrayArray", true);
+                }
                 boolean isEnum = formParam.isEnum || (formParam.allowableValues != null && !formParam.allowableValues.isEmpty());
                 if (formParam.isModel || isEnum) {
                     formParam.vendorExtensions.put("requiresMapper", true);
@@ -2496,6 +2508,8 @@ public class KoraCodegen extends DefaultCodegen {
                             "last", false
                         )));
                     }
+                } else if (isByteArray || isByteArrayArray) {
+                    // Multipart byte fields are base64-encoded string parts in OpenAPI.
                 } else if (formParam.isString
                            || formParam.isBoolean
                            || formParam.isDouble

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaClientRequestMappers.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaClientRequestMappers.mustache
@@ -51,11 +51,22 @@ public interface {{classname}}ClientRequestMappers {
           l.add(file);
       }{{/isArray}}{{/isFile}}{{^isFile}}
       if (value.{{paramName}}() != null) {
+          {{#vendorExtensions.isByteArrayArray}}for (var item : value.{{paramName}}()) {
+              l.add(ru.tinkoff.kora.http.common.form.FormMultipart.data(
+              "{{baseName}}",
+                java.util.Base64.getEncoder().encodeToString(item)
+              ));
+          }{{/vendorExtensions.isByteArrayArray}}{{^vendorExtensions.isByteArrayArray}}{{#vendorExtensions.isByteArray}}
+          l.add(ru.tinkoff.kora.http.common.form.FormMultipart.data(
+          "{{baseName}}",
+            java.util.Base64.getEncoder().encodeToString(value.{{paramName}}())
+          ));{{/vendorExtensions.isByteArray}}{{^vendorExtensions.isByteArray}}
           var buf = java.nio.charset.StandardCharsets.UTF_8.encode(java.util.Objects.toString(value.{{paramName}}()));
           var part = ru.tinkoff.kora.http.common.form.FormMultipart.data(
           "{{baseName}}",
             java.util.Objects.toString(value.{{paramName}}())
           );
+          l.add(part);{{/vendorExtensions.isByteArray}}{{/vendorExtensions.isByteArrayArray}}
       }{{/isFile}}{{/formParams}}
       return MultipartWriter.write(l);{{/vendorExtensions.multipartForm}}
     }

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaServerRequestMappers.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaServerRequestMappers.mustache
@@ -59,8 +59,9 @@ public interface {{classname}}ServerRequestMappers { {{#operations}}{{#operation
       class {{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}FormParamState { {{#formParams}}{{#isFile}}{{#isArray}}
         java.util.List<ru.tinkoff.kora.http.common.form.FormMultipart.FormPart.MultipartFile> {{paramName}}All = new java.util.ArrayList<>();{{/isArray}}{{^isArray}}
         @jakarta.annotation.Nullable
-        ru.tinkoff.kora.http.common.form.FormMultipart.FormPart.MultipartFile {{paramName}} = null;{{/isArray}}{{/isFile}}{{^isFile}}
-        {{{dataType}}} {{paramName}} = null;{{/isFile}}{{/formParams}}
+        ru.tinkoff.kora.http.common.form.FormMultipart.FormPart.MultipartFile {{paramName}} = null;{{/isArray}}{{/isFile}}{{^isFile}}{{#vendorExtensions.isByteArrayArray}}
+        {{{dataType}}} {{paramName}} = new java.util.ArrayList<>();{{/vendorExtensions.isByteArrayArray}}{{^vendorExtensions.isByteArrayArray}}
+        {{{dataType}}} {{paramName}} = null;{{/vendorExtensions.isByteArrayArray}}{{/isFile}}{{/formParams}}
       }
 
       return MultipartReader.read(request).thenApply(parts -> {
@@ -70,14 +71,14 @@ public interface {{classname}}ServerRequestMappers { {{#operations}}{{#operation
             case "{{baseName}}": {{#isFile}}
               {{#isArray}}state.{{paramName}}All.add(part);{{/isArray}}{{^isArray}}state.{{paramName}} = part;{{/isArray}}
               break;{{/isFile}}{{^isFile}}
-              state.{{paramName}} = new String(part.content(), java.nio.charset.StandardCharsets.UTF_8);
+              {{#vendorExtensions.isByteArrayArray}}state.{{paramName}}.add(java.util.Base64.getDecoder().decode(part.content()));{{/vendorExtensions.isByteArrayArray}}{{^vendorExtensions.isByteArrayArray}}{{#vendorExtensions.isByteArray}}state.{{paramName}} = java.util.Base64.getDecoder().decode(part.content());{{/vendorExtensions.isByteArray}}{{^vendorExtensions.isByteArray}}state.{{paramName}} = new String(part.content(), java.nio.charset.StandardCharsets.UTF_8);{{/vendorExtensions.isByteArray}}{{/vendorExtensions.isByteArrayArray}}
               break;{{/isFile}}{{/formParams}}
             default:
               break;
           }
         }
         {{#formParams}}{{#required}}
-        if ({{#isArray}}state.{{paramName}}All.isEmpty(){{/isArray}}{{^isArray}}state.{{paramName}} == null{{/isArray}}) {
+        if ({{#isArray}}{{#isFile}}state.{{paramName}}All.isEmpty(){{/isFile}}{{^isFile}}{{#vendorExtensions.isByteArrayArray}}state.{{paramName}}.isEmpty(){{/vendorExtensions.isByteArrayArray}}{{^vendorExtensions.isByteArrayArray}}state.{{paramName}} == null{{/vendorExtensions.isByteArrayArray}}{{/isFile}}{{/isArray}}{{^isArray}}state.{{paramName}} == null{{/isArray}}) {
           throw ru.tinkoff.kora.http.server.common.HttpServerResponseException.of(400, "Form key '{{baseName}}' is required");
         }
         {{/required}}{{/formParams}}

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinClientRequestMappers.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinClientRequestMappers.mustache
@@ -35,7 +35,9 @@ interface {{classname}}ClientRequestMappers {
         }
       }{{/isArray}}{{/isFile}}{{^isFile}}
       if (value.{{paramName}} != null) {
-        l += ru.tinkoff.kora.http.common.form.FormMultipart.data("{{baseName}}", "${value.{{paramName}}}")
+        {{#vendorExtensions.isByteArrayArray}}for (item in value.{{paramName}}) {
+          l += ru.tinkoff.kora.http.common.form.FormMultipart.data("{{baseName}}", java.util.Base64.getEncoder().encodeToString(item))
+        }{{/vendorExtensions.isByteArrayArray}}{{^vendorExtensions.isByteArrayArray}}{{#vendorExtensions.isByteArray}}l += ru.tinkoff.kora.http.common.form.FormMultipart.data("{{baseName}}", java.util.Base64.getEncoder().encodeToString(value.{{paramName}})){{/vendorExtensions.isByteArray}}{{^vendorExtensions.isByteArray}}l += ru.tinkoff.kora.http.common.form.FormMultipart.data("{{baseName}}", "${value.{{paramName}}}"){{/vendorExtensions.isByteArray}}{{/vendorExtensions.isByteArrayArray}}
       }{{/isFile}}
       {{/formParams}}
       return MultipartWriter.write(l) {{/vendorExtensions.multipartForm}}

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinServerRequestMappers.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinServerRequestMappers.mustache
@@ -39,8 +39,9 @@ interface {{classname}}ServerRequestMappers { {{#operations}}{{#operation}}{{#ha
 
       class {{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}FormParamState { {{#formParams}}{{#isFile}}{{#isArray}}
         val {{paramName}}All = mutableListOf<ru.tinkoff.kora.http.common.form.FormMultipart.FormPart.MultipartFile>(){{/isArray}}{{^isArray}}
-        var {{paramName}}: ru.tinkoff.kora.http.common.form.FormMultipart.FormPart.MultipartFile? = null {{/isArray}}{{/isFile}}{{^isFile}}
-        var {{paramName}}: {{{dataType}}}? = null{{/isFile}}{{/formParams}}
+        var {{paramName}}: ru.tinkoff.kora.http.common.form.FormMultipart.FormPart.MultipartFile? = null {{/isArray}}{{/isFile}}{{^isFile}}{{#vendorExtensions.isByteArrayArray}}
+        val {{paramName}} = mutableListOf<ByteArray>(){{/vendorExtensions.isByteArrayArray}}{{^vendorExtensions.isByteArrayArray}}
+        var {{paramName}}: {{{dataType}}}? = null{{/vendorExtensions.isByteArrayArray}}{{/isFile}}{{/formParams}}
       }
 
       return MultipartReader.read(request).thenApply { parts ->
@@ -49,13 +50,13 @@ interface {{classname}}ServerRequestMappers { {{#operations}}{{#operation}}{{#ha
             when (part.name()) { {{#formParams}}
               "{{baseName}}" -> { {{#isFile}}
                 {{#isArray}}state.{{paramName}}All.add(part){{/isArray}}{{^isArray}}state.{{paramName}} = part{{/isArray}}{{/isFile}}{{^isFile}}
-                state.{{paramName}} = part.content().decodeToString(){{/isFile}}
+                {{#vendorExtensions.isByteArrayArray}}state.{{paramName}}.add(java.util.Base64.getDecoder().decode(part.content())){{/vendorExtensions.isByteArrayArray}}{{^vendorExtensions.isByteArrayArray}}{{#vendorExtensions.isByteArray}}state.{{paramName}} = java.util.Base64.getDecoder().decode(part.content()){{/vendorExtensions.isByteArray}}{{^vendorExtensions.isByteArray}}state.{{paramName}} = part.content().decodeToString(){{/vendorExtensions.isByteArray}}{{/vendorExtensions.isByteArrayArray}}{{/isFile}}
               }{{/formParams}}
               else -> {}
             }
           } {{#formParams}}{{#required}}
 
-          if ({{#isArray}}state.{{paramName}}All.isEmpty(){{/isArray}}{{^isArray}}state.{{paramName}} == null{{/isArray}}) {
+          if ({{#isArray}}{{#isFile}}state.{{paramName}}All.isEmpty(){{/isFile}}{{^isFile}}{{#vendorExtensions.isByteArrayArray}}state.{{paramName}}.isEmpty(){{/vendorExtensions.isByteArrayArray}}{{^vendorExtensions.isByteArrayArray}}state.{{paramName}} == null{{/vendorExtensions.isByteArrayArray}}{{/isFile}}{{/isArray}}{{^isArray}}state.{{paramName}} == null{{/isArray}}) {
             throw ru.tinkoff.kora.http.server.common.HttpServerResponseException.of(400, "Form key '{{baseName}}' is required")
           }{{/required}}{{/formParams}}
 

--- a/openapi/openapi-generator/src/test/resources/example/petstoreV3_form.yaml
+++ b/openapi/openapi-generator/src/test/resources/example/petstoreV3_form.yaml
@@ -97,6 +97,28 @@ paths:
         '200':
           description: Updated
 
+  /form-multipart-form-data-with-byte:
+    patch:
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - payload
+              properties:
+                payload:
+                  type: string
+                  format: byte
+                payloads:
+                  type: array
+                  items:
+                    type: string
+                    format: byte
+      responses:
+        '200':
+          description: Updated
+
   /form-image:
     patch:
       requestBody:

--- a/settings.gradle
+++ b/settings.gradle
@@ -43,7 +43,6 @@ include(
     'symbol-processors',
     'grpc:grpc-server',
     'grpc:grpc-client',
-    'grpc:grpc-common',
     'grpc:grpc-client-annotation-processor',
     'grpc:grpc-client-symbol-processor',
     'database:database-annotation-processor',


### PR DESCRIPTION
Decode multipart format: byte parts from Base64 on server and encode byte arrays to Base64 on client.