### PR TITLE
Fixed(test-junit5,json): propagate meta-annotation tags through @TestComponent injection (Backport of #674)

### DIFF
--- a/json/json-common/src/main/java/io/koraframework/json/common/annotation/Json.java
+++ b/json/json-common/src/main/java/io/koraframework/json/common/annotation/Json.java
@@ -13,6 +13,6 @@ import java.lang.annotation.Target;
  * <b>English</b>: Annotation specifies that for the type is represented in JSON format. If specified for a type, a JSON reader and writer will be created for that type and embedded in the dependency container.
  */
 @Tag(Json.class)
-@Target({ElementType.TYPE, ElementType.PARAMETER, ElementType.METHOD, ElementType.TYPE_USE})
+@Target({ElementType.TYPE, ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD, ElementType.TYPE_USE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Json { }

--- a/test/test-junit5/src/main/java/io/koraframework/test/extension/junit5/KoraJUnit5Extension.java
+++ b/test/test-junit5/src/main/java/io/koraframework/test/extension/junit5/KoraJUnit5Extension.java
@@ -766,11 +766,20 @@ final class KoraJUnit5Extension implements BeforeAllCallback, BeforeEachCallback
 
     @Nullable
     private static Class<?> parseTag(AnnotatedElement object) {
-        return Arrays.stream(object.getDeclaredAnnotations())
-            .filter(a -> a.annotationType().equals(Tag.class))
-            .map(a -> ((Tag) a).value())
-            .findFirst()
-            .orElse(null);
+        final Annotation[] annotations = object.getDeclaredAnnotations();
+        for (Annotation annotation : annotations) {
+            if (annotation.annotationType().equals(Tag.class)) {
+                return ((Tag) annotation).value();
+            }
+        }
+
+        for (Annotation annotation : annotations) {
+            final Tag metaTag = annotation.annotationType().getAnnotation(Tag.class);
+            if (metaTag != null) {
+                return metaTag.value();
+            }
+        }
+        return null;
     }
 
     private static Object getComponentFromGraph(TestGraphContext graph, GraphCandidate candidate) {


### PR DESCRIPTION
Fixed(test-junit5,json): propagate meta-annotation tags through @TestComponent injection.

Backport of #674 (branch 1.0, commit 0a9dfd0f29b312d19376e78ea2ed8d96a28ef4b3)

An annotation that is itself meta-annotated with `@Tag` (such as `@Json`, which carries `@Tag(Json.class)`) was dropped by `KoraJUnit5Extension`'s tag resolution, which only matched a literal `@Tag`. A `@TestComponent` field, constructor parameter, or method parameter annotated `@Json` failed injection with "no tags" instead of resolving the `Json` tag.

- Fixed(test-junit5): `KoraJUnit5Extension.parseTag` now falls back to a meta-annotation's own `@Tag` when no literal `@Tag` is present.
- Fixed(json): `@Json` now targets `ElementType.FIELD` in addition to its existing targets, so it can be placed directly on a `@TestComponent` field.

Master's KSP-side tag resolution (`TagUtils.parseTagValue`, used by `@KoraSubmodule` and HTTP route generation) was already meta-annotation aware; only the JUnit5 test-injection path and `@Json`'s target list were missing this from the original 1.0 fix.