### PR TITLE
Fixed(logging): handle non-native `@Mdc` parameter types and `\${}` value expressions in KSP (Backport of #692)

### DIFF
--- a/logging/logging-annotation-processor/src/main/java/io/koraframework/logging/annotation/processor/aop/MdcAspect.java
+++ b/logging/logging-annotation-processor/src/main/java/io/koraframework/logging/annotation/processor/aop/MdcAspect.java
@@ -9,7 +9,10 @@ import io.koraframework.aop.annotation.processor.KoraAspect;
 
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeMirror;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -21,6 +24,24 @@ import static io.koraframework.logging.annotation.processor.aop.MdcAspectClassNa
 public class MdcAspect implements KoraAspect {
 
     private static final String MDC_CONTEXT_VAR_NAME = "__mdcContext";
+
+    private static final Set<String> NATIVE_MDC_TYPES = Set.of(
+        String.class.getCanonicalName(),
+        Integer.class.getCanonicalName(),
+        Long.class.getCanonicalName(),
+        Boolean.class.getCanonicalName(),
+        mdcWriter.canonicalName()
+    );
+
+    private static boolean isNativeMdcType(TypeMirror type) {
+        return switch (type.getKind()) {
+            // primitives autobox to their wrappers, which have dedicated MDC.put overloads
+            case INT, LONG, BOOLEAN -> true;
+            case DECLARED -> ((DeclaredType) type).asElement() instanceof TypeElement typeElement
+                && NATIVE_MDC_TYPES.contains(typeElement.getQualifiedName().toString());
+            default -> false;
+        };
+    }
 
     @Override
     public Set<ClassName> getSupportedAnnotationClassNames() {
@@ -110,12 +131,16 @@ public class MdcAspect implements KoraAspect {
 
             final Boolean global = parseAnnotationValueWithoutDefault(firstAnnotation, "global");
 
-            fillMdcBuilder.addStatement(
-                "$T.put($S, $N)",
-                mdc,
-                key,
-                parameterName
-            );
+            final TypeMirror parameterType = parameter.asType();
+            if (isNativeMdcType(parameterType)) {
+                fillMdcBuilder.addStatement("$T.put($S, $N)", mdc, key, parameterName);
+            } else if (parameterType.getKind().isPrimitive()) {
+                fillMdcBuilder.addStatement("$T.put($S, $T.valueOf($N))", mdc, key, String.class, parameterName);
+            } else {
+                fillMdcBuilder.beginControlFlow("if ($N != null)", parameterName)
+                    .addStatement("$T.put($S, $N.toString())", mdc, key, parameterName)
+                    .endControlFlow();
+            }
 
             if (global == null || !global) {
                 keys.add(key);

--- a/logging/logging-annotation-processor/src/main/java/io/koraframework/logging/annotation/processor/aop/MdcAspectClassNames.java
+++ b/logging/logging-annotation-processor/src/main/java/io/koraframework/logging/annotation/processor/aop/MdcAspectClassNames.java
@@ -6,4 +6,5 @@ public class MdcAspectClassNames {
     public static final ClassName mdcAnnotation = ClassName.get("io.koraframework.logging.common.annotation", "Mdc");
     public static final ClassName mdcContainerAnnotation = ClassName.get("io.koraframework.logging.common.annotation", "Mdc", "MdcContainer");
     public static final ClassName mdc = ClassName.get("io.koraframework.logging.common", "MDC");
+    public static final ClassName mdcWriter = ClassName.get("io.koraframework.logging.common.arg", "StructuredArgumentWriter");
 }

--- a/logging/logging-annotation-processor/src/test/java/io/koraframework/logging/aspect/mdc/MdcAspectTest.java
+++ b/logging/logging-annotation-processor/src/test/java/io/koraframework/logging/aspect/mdc/MdcAspectTest.java
@@ -176,6 +176,118 @@ class MdcAspectTest extends AbstractMdcAspectTest {
         );
     }
 
+    @Test
+    void testMdcNonNativeParameterNonNull() throws Exception {
+        var aopProxy = compile(
+            List.of(new AopAnnotationProcessor()),
+            """
+                public class TestMdc {
+
+                  private final MDCContextHolder mdcContextHolder;
+
+                  public TestMdc(MDCContextHolder mdcContextHolder) {
+                      this.mdcContextHolder = mdcContextHolder;
+                  }
+
+                  public Integer test(@Mdc(key = "subscriptionId") java.util.UUID subscriptionId) {
+                      mdcContextHolder.set(MDC.get().values());
+                      return null;
+                  }
+                }
+                """
+        );
+
+        aopProxy.assertSuccess();
+
+        final UUID subscriptionId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        var generatedClass = aopProxy.loadClass("$TestMdc__AopProxy");
+        var constructor = generatedClass.getConstructors()[0];
+        final TestObject testObject = new TestObject(generatedClass, constructor.newInstance(CONTEXT_HOLDER));
+
+        ScopedValue.where(MDC.VALUE, new MDC()).call(() -> {
+            testObject.invoke("test", subscriptionId);
+
+            final Map<String, String> context = extractMdcContextFromHolder();
+            assertEquals(Map.of("subscriptionId", "\"" + subscriptionId + "\""), context);
+            assertEquals(emptyMap(), currentMdcContext());
+            return null;
+        });
+    }
+
+    @Test
+    void testMdcNonNativeParameterNull() throws Exception {
+        var aopProxy = compile(
+            List.of(new AopAnnotationProcessor()),
+            """
+                public class TestMdc {
+
+                  private final MDCContextHolder mdcContextHolder;
+
+                  public TestMdc(MDCContextHolder mdcContextHolder) {
+                      this.mdcContextHolder = mdcContextHolder;
+                  }
+
+                  public Integer test(@Mdc(key = "subscriptionId") java.util.UUID subscriptionId) {
+                      mdcContextHolder.set(MDC.get().values());
+                      return null;
+                  }
+                }
+                """
+        );
+
+        aopProxy.assertSuccess();
+
+        var generatedClass = aopProxy.loadClass("$TestMdc__AopProxy");
+        var constructor = generatedClass.getConstructors()[0];
+        final TestObject testObject = new TestObject(generatedClass, constructor.newInstance(CONTEXT_HOLDER));
+
+        ScopedValue.where(MDC.VALUE, new MDC()).call(() -> {
+            testObject.invoke("test", (Object) null);
+
+            final Map<String, String> context = extractMdcContextFromHolder();
+            assertEquals(emptyMap(), context);
+            assertEquals(emptyMap(), currentMdcContext());
+            return null;
+        });
+    }
+
+    @Test
+    void testMdcNonNativePrimitiveParameter() throws Exception {
+        var aopProxy = compile(
+            List.of(new AopAnnotationProcessor()),
+            """
+                public class TestMdc {
+
+                  private final MDCContextHolder mdcContextHolder;
+
+                  public TestMdc(MDCContextHolder mdcContextHolder) {
+                      this.mdcContextHolder = mdcContextHolder;
+                  }
+
+                  public Integer test(@Mdc(key = "amount") double amount) {
+                      mdcContextHolder.set(MDC.get().values());
+                      return null;
+                  }
+                }
+                """
+        );
+
+        aopProxy.assertSuccess();
+
+        var generatedClass = aopProxy.loadClass("$TestMdc__AopProxy");
+        var constructor = generatedClass.getConstructors()[0];
+        final TestObject testObject = new TestObject(generatedClass, constructor.newInstance(CONTEXT_HOLDER));
+
+        ScopedValue.where(MDC.VALUE, new MDC()).call(() -> {
+            testObject.invoke("test", 1.5d);
+
+            final Map<String, String> context = extractMdcContextFromHolder();
+            assertEquals(Map.of("amount", "\"1.5\""), context);
+            assertEquals(emptyMap(), currentMdcContext());
+            return null;
+        });
+    }
+
     private static void invokeMethod(CompileResult aopProxy) throws Exception {
         aopProxy.assertSuccess();
 

--- a/logging/logging-symbol-processor/src/main/kotlin/io/koraframework/logging/symbol/processor/aop/MdcKoraAspect.kt
+++ b/logging/logging-symbol-processor/src/main/kotlin/io/koraframework/logging/symbol/processor/aop/MdcKoraAspect.kt
@@ -2,6 +2,7 @@ package io.koraframework.logging.symbol.processor.aop
 
 import com.google.devtools.ksp.symbol.KSAnnotation
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSValueParameter
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
@@ -24,8 +25,18 @@ class MdcKoraAspect : KoraAspect {
     companion object {
         const val MDC_CONTEXT_VAL_NAME = "__mdcContext"
         val mdc = ClassName("io.koraframework.logging.common", "MDC")
+        val mdcWriter = ClassName("io.koraframework.logging.common.arg", "StructuredArgumentWriter")
         val mdcAnnotation = ClassName("io.koraframework.logging.common.annotation", "Mdc")
         val mdcContainerAnnotation = mdcAnnotation.nestedClass("MdcContainer")
+
+        // Parameter types that have a dedicated MDC.put overload and keep their JSON type
+        private val NATIVE_MDC_TYPES = setOf(
+            String::class.qualifiedName!!,
+            Int::class.qualifiedName!!,
+            Long::class.qualifiedName!!,
+            Boolean::class.qualifiedName!!,
+            mdcWriter.canonicalName,
+        )
     }
 
     override fun getSupportedAnnotationTypes(): Set<String> = setOf(mdcAnnotation.canonicalName, mdcContainerAnnotation.canonicalName)
@@ -98,12 +109,11 @@ class MdcKoraAspect : KoraAspect {
             } else if (!globalIsSupported) {
                 throw ProcessingErrorException("@Mdc annotation with 'global' attribute is not supported for this function", annotation.annotationType)
             }
-            fillMdcBuilder.addStatement(
-                "%T.put(%S, %S)",
-                mdc,
-                key,
-                value
-            )
+            if (value.startsWith("\${") && value.endsWith("}")) {
+                fillMdcBuilder.addStatement("%T.put(%S, %L)", mdc, key, value.substring(2, value.length - 1))
+            } else {
+                fillMdcBuilder.addStatement("%T.put(%S, %S)", mdc, key, value)
+            }
         }
         return keys
     }
@@ -126,12 +136,16 @@ class MdcKoraAspect : KoraAspect {
 
             val global = annotation.findValue("global") ?: false
 
-            fillMdcBuilder.addStatement(
-                "%T.put(%S, %N)",
-                mdc,
-                key,
-                parameterName
-            )
+            val type = parameter.type.resolve()
+            when {
+                isNativeMdcType(type) -> fillMdcBuilder.addStatement("%T.put(%S, %N)", mdc, key, parameterName)
+                type.isMarkedNullable -> fillMdcBuilder
+                    .beginControlFlow("if (%N != null)", parameterName)
+                    .addStatement("%T.put(%S, %N.toString())", mdc, key, parameterName)
+                    .endControlFlow()
+
+                else -> fillMdcBuilder.addStatement("%T.put(%S, %N.toString())", mdc, key, parameterName)
+            }
 
             if (!global) {
                 keys.add(key)
@@ -143,6 +157,9 @@ class MdcKoraAspect : KoraAspect {
 
         return keys
     }
+
+    private fun isNativeMdcType(type: KSType): Boolean =
+        type.declaration.qualifiedName?.asString() in NATIVE_MDC_TYPES
 
     private fun clearMdc(keys: Set<String>, b: CodeBlock.Builder) = keys.forEach {
         b.beginControlFlow("if (__%L != null)", it)

--- a/logging/logging-symbol-processor/src/test/kotlin/io/koraframework/logging/symbol/processor/aop/mdc/MdcKoraAspectTest.kt
+++ b/logging/logging-symbol-processor/src/test/kotlin/io/koraframework/logging/symbol/processor/aop/mdc/MdcKoraAspectTest.kt
@@ -133,6 +133,146 @@ class MdcKoraAspectTest : AbstractMdcAspectTest() {
         }
     }
 
+    @Test
+    fun testMdcNonNativeParameterNonNull() {
+        val aopProxy = compile0(
+            listOf(AopSymbolProcessorProvider()),
+            """
+            import java.util.UUID
+
+            open class TestMdc(
+                private val mdcContextHolder: MDCContextHolder
+            ) {
+                open fun test(@Mdc(key = "subscriptionId") subscriptionId: UUID): Int? {
+                    mdcContextHolder.set(MDC.get().values())
+                    return null
+                }
+            }
+        """.trimIndent()
+        )
+
+        aopProxy.assertSuccess()
+
+        val subscriptionId = UUID.fromString("00000000-0000-0000-0000-000000000001")
+        val generatedClass = loadClass("\$TestMdc__AopProxy")
+        val constructor = generatedClass.constructors.first()
+        val testObject = TestObject(generatedClass.kotlin, constructor.newInstance(contextHolder))
+
+        withMdc {
+            testObject.invoke<Int?>("test", subscriptionId)
+
+            val context = contextHolder.get()
+                ?.mapValues { it.value.writeToString() }
+
+            assertEquals(mapOf("subscriptionId" to "\"$subscriptionId\""), context)
+            assertEquals(emptyMap<String, String>(), currentContext())
+        }
+    }
+
+    @Test
+    fun testMdcNonNativeNullableParameterNull() {
+        val aopProxy = compile0(
+            listOf(AopSymbolProcessorProvider()),
+            """
+            import java.util.UUID
+
+            open class TestMdc(
+                private val mdcContextHolder: MDCContextHolder
+            ) {
+                open fun test(@Mdc(key = "subscriptionId") subscriptionId: UUID?): Int? {
+                    mdcContextHolder.set(MDC.get().values())
+                    return null
+                }
+            }
+        """.trimIndent()
+        )
+
+        aopProxy.assertSuccess()
+
+        val generatedClass = loadClass("\$TestMdc__AopProxy")
+        val constructor = generatedClass.constructors.first()
+        val testObject = TestObject(generatedClass.kotlin, constructor.newInstance(contextHolder))
+
+        withMdc {
+            testObject.invoke<Int?>("test", null)
+
+            val context = contextHolder.get()
+                ?.mapValues { it.value.writeToString() }
+
+            assertEquals(emptyMap<String, String>(), context)
+            assertEquals(emptyMap<String, String>(), currentContext())
+        }
+    }
+
+    @Test
+    fun testMdcNonNativePrimitiveParameter() {
+        val aopProxy = compile0(
+            listOf(AopSymbolProcessorProvider()),
+            """
+            open class TestMdc(
+                private val mdcContextHolder: MDCContextHolder
+            ) {
+                open fun test(@Mdc(key = "amount") amount: Double): Int? {
+                    mdcContextHolder.set(MDC.get().values())
+                    return null
+                }
+            }
+        """.trimIndent()
+        )
+
+        aopProxy.assertSuccess()
+
+        val generatedClass = loadClass("\$TestMdc__AopProxy")
+        val constructor = generatedClass.constructors.first()
+        val testObject = TestObject(generatedClass.kotlin, constructor.newInstance(contextHolder))
+
+        withMdc {
+            testObject.invoke<Int?>("test", 1.5)
+
+            val context = contextHolder.get()
+                ?.mapValues { it.value.writeToString() }
+
+            assertEquals(mapOf("amount" to "\"1.5\""), context)
+            assertEquals(emptyMap<String, String>(), currentContext())
+        }
+    }
+
+    @Test
+    fun testMdcMethodLevelGeneratedValue() {
+        // single literal dollar; used to emit a non-interpolated `${...}` into the compiled source
+        val dollar = "$"
+        val aopProxy = compile0(
+            listOf(AopSymbolProcessorProvider()),
+            """
+            open class TestMdc(
+                private val mdcContextHolder: MDCContextHolder
+            ) {
+                @Mdc(key = "k", value = "\${dollar}{1 + 1}")
+                open fun test(s: String): Int? {
+                    mdcContextHolder.set(MDC.get().values())
+                    return null
+                }
+            }
+        """.trimIndent()
+        )
+
+        aopProxy.assertSuccess()
+
+        val generatedClass = loadClass("\$TestMdc__AopProxy")
+        val constructor = generatedClass.constructors.first()
+        val testObject = TestObject(generatedClass.kotlin, constructor.newInstance(contextHolder))
+
+        withMdc {
+            testObject.invoke<Int?>("test", "x")
+
+            val context = contextHolder.get()
+                ?.mapValues { it.value.writeToString() }
+
+            assertEquals(mapOf("k" to "2"), context)
+            assertEquals(emptyMap<String, String>(), currentContext())
+        }
+    }
+
     private fun invokeMethod(aopProxy: TestUtils.ProcessingResult) {
         aopProxy.assertSuccess()
 


### PR DESCRIPTION
Fixed(logging): handle non-native `@Mdc` parameter types and `\${}` value expressions in KSP.

Backport of #692 (branch 1.0, commit a6c84161aa51f222ad58f3176039bf508ac1fd52)

`@Mdc` on a parameter whose type has no `MDC.put` overload (UUID, enum, or any other object) generated a non-compiling `MDC.put(key, param)` call in both the Java annotation processor and the KSP processor. Non-native parameter types now go through `param.toString()`, with a null check for nullable/reference types; native types (String, Int/Integer, Long, Boolean, StructuredArgumentWriter) are unchanged.

- Fixed(logging): the KSP aspect now also evaluates method-level `@Mdc(value = "\${expr}")` as a runtime expression instead of emitting it as a string literal, matching the Java annotation processor's existing behavior and the documented semantics.

This mirrors the fix already applied on the 1.0 branch.