### PR TITLE
Fixed(kafka): complete the producer `Deferred` result on send callback. (Backport of #594)

### DIFF
--- a/kafka/kafka-symbol-processor/src/main/kotlin/io/koraframework/kafka/symbol/processor/producer/KafkaPublisherGenerator.kt
+++ b/kafka/kafka-symbol-processor/src/main/kotlin/io/koraframework/kafka/symbol/processor/producer/KafkaPublisherGenerator.kt
@@ -330,7 +330,7 @@ class KafkaPublisherGenerator(val env: SymbolProcessorEnvironment, val resolver:
                 if (publishData.callback != null) {
                     addStatement("%N.onCompletion(_meta, _ex)", publishData.callback.name?.asString().toString())
                 }
-                if (publishMethod.isFuture() || publishMethod.isCompletionStage() || publishMethod.isSuspend()) {
+                if (publishMethod.isFuture() || publishMethod.isCompletionStage() || publishMethod.isSuspend() || publishMethod.isDeferred()) {
                     controlFlow("if (_ex != null)") {
                         addStatement("_future.completeExceptionally(_ex)")
                         nextControlFlow("else") {


### PR DESCRIPTION
Fixed(kafka): complete the producer `Deferred` result on send callback.

Backport of #594 (branch 1.0, commit 3539c4015b121b3dfd0694a8c8c561ccd6d7f2a4)

The generated Kafka publisher's send-callback completion guard checked `isFuture() || isCompletionStage() || isSuspend()` but not `isDeferred()`, while the return-value branch below it does return `_future.asDeferred()`. A publisher method declared to return `Deferred<RecordMetadata>` therefore produced a `Deferred` that was never completed or failed, hanging forever on await.

This mirrors the fix already applied on the 1.0 branch.