### PR TITLE
Fixed(openapi-generator): apply the `nameMapping` option in `KoraCodegen.toVarName` (Backport of #600)

### DIFF
--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/KoraCodegen.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/KoraCodegen.java
@@ -375,6 +375,10 @@ public class KoraCodegen extends DefaultCodegen {
 
     @Override
     public String toVarName(String name) {
+        if (nameMapping.containsKey(name)) {
+            name = nameMapping.get(name);
+        }
+
         // sanitize name
         name = sanitizeName(name, "\\W-[\\$]"); // FIXME: a parameter should not be assigned. Also declare the methods parameters as 'final'.
 


### PR DESCRIPTION
Fixed(openapi-generator): apply the `nameMapping` option in `KoraCodegen.toVarName`.

Backport of #600 (branch 1.0, commit 612f3fc3bfa8485cd0c6b0060fdbd77723616fc0)

`KoraCodegen.toVarName` overrides `DefaultCodegen.toVarName` without consulting `nameMapping`, so user-supplied property renames configured via the generator's `nameMapping` option were silently dropped for every model field and parameter.

This mirrors the fix already applied on the 1.0 branch. The Java/Kotlin reserved-word list split from the same original PR is already present on master via a later, independent change.