### PR TITLE
Fixed(cache-redis): propagate exceptions thrown by the `computeIfAbsent` mapping function (Backport of #624)

### DIFF
--- a/cache/cache-redis-common/src/main/java/io/koraframework/cache/redis/AbstractRedisCache.java
+++ b/cache/cache-redis-common/src/main/java/io/koraframework/cache/redis/AbstractRedisCache.java
@@ -294,29 +294,38 @@ public abstract class AbstractRedisCache<K, V> implements RedisCache<K, V> {
                         observation.observeError(e);
                     }
 
-                    V value = mappingFunction.apply(key);
+                    final V value;
+                    try {
+                        value = mappingFunction.apply(key);
+                    } catch (Exception e) {
+                        observation.observeError(e);
+                        throw e;
+                    }
+
                     if (value == null) {
                         return null;
                     }
 
                     try {
-                        final byte[] keyAsBytes = mapKey(key);
-                        final byte[] valueAsBytes = valueMapper.write(value);
-                        if (expireAfterWriteMillis == null) {
-                            redisClient.set(keyAsBytes, valueAsBytes);
-                        } else {
-                            redisClient.psetex(keyAsBytes, valueAsBytes, expireAfterWriteMillis);
+                        try {
+                            final byte[] keyAsBytes = mapKey(key);
+                            final byte[] valueAsBytes = valueMapper.write(value);
+                            if (expireAfterWriteMillis == null) {
+                                redisClient.set(keyAsBytes, valueAsBytes);
+                            } else {
+                                redisClient.psetex(keyAsBytes, valueAsBytes, expireAfterWriteMillis);
+                            }
+                        } catch (Exception e) {
+                            observation.observeError(e);
                         }
+                        return value;
+                    } catch (CompletionException e) {
+                        observation.observeError(e.getCause());
+                        return value;
                     } catch (Exception e) {
                         observation.observeError(e);
+                        return value;
                     }
-                    return value;
-                } catch (CompletionException e) {
-                    observation.observeError(e.getCause());
-                    return null;
-                } catch (Exception e) {
-                    observation.observeError(e);
-                    return null;
                 } finally {
                     observation.end();
                 }
@@ -369,37 +378,44 @@ public abstract class AbstractRedisCache<K, V> implements RedisCache<K, V> {
                     var missingKeys = keys.stream()
                         .filter(k -> !fromCache.containsKey(k))
                         .collect(Collectors.toSet());
-                    var values = mappingFunction.apply(missingKeys);
-                    if (values == null) {
-                        values = Collections.emptyMap();
+
+                    final Map<K, V> values;
+                    try {
+                        var mapped = mappingFunction.apply(missingKeys);
+                        values = (mapped == null) ? Collections.emptyMap() : mapped;
+                    } catch (Exception e) {
+                        observation.observeError(e);
+                        throw e;
                     }
 
-                    if (!values.isEmpty()) {
-                        try {
-                            var keyAndValuesAsBytes = new HashMap<byte[], byte[]>();
-                            values.forEach((k, v) -> {
-                                final byte[] keyAsBytes = mapKey(k);
-                                final byte[] valueAsBytes = valueMapper.write(v);
-                                keyAndValuesAsBytes.put(keyAsBytes, valueAsBytes);
-                            });
+                    try {
+                        if (!values.isEmpty()) {
+                            try {
+                                var keyAndValuesAsBytes = new HashMap<byte[], byte[]>();
+                                values.forEach((k, v) -> {
+                                    final byte[] keyAsBytes = mapKey(k);
+                                    final byte[] valueAsBytes = valueMapper.write(v);
+                                    keyAndValuesAsBytes.put(keyAsBytes, valueAsBytes);
+                                });
 
-                            if (expireAfterWriteMillis == null) {
-                                redisClient.mset(keyAndValuesAsBytes);
-                            } else {
-                                redisClient.psetex(keyAndValuesAsBytes, expireAfterWriteMillis);
+                                if (expireAfterWriteMillis == null) {
+                                    redisClient.mset(keyAndValuesAsBytes);
+                                } else {
+                                    redisClient.psetex(keyAndValuesAsBytes, expireAfterWriteMillis);
+                                }
+                            } catch (Exception e) {
+                                observation.observeError(e);
                             }
-                        } catch (Exception e) {
-                            observation.observeError(e);
                         }
+                        fromCache.putAll(values);
+                        return fromCache;
+                    } catch (CompletionException e) {
+                        observation.observeError(e.getCause());
+                        return fromCache;
+                    } catch (Exception e) {
+                        observation.observeError(e);
+                        return fromCache;
                     }
-                    fromCache.putAll(values);
-                    return fromCache;
-                } catch (CompletionException e) {
-                    observation.observeError(e.getCause());
-                    return fromCache;
-                } catch (Exception e) {
-                    observation.observeError(e);
-                    return fromCache;
                 } finally {
                     observation.end();
                 }


### PR DESCRIPTION
Fixed(cache-redis): propagate exceptions thrown by the `computeIfAbsent` mapping function.

Backport of #624 residual (branch 1.0, commit 91bce5d64c415d31585cab26d648b3ad27edf8e1)

`AbstractRedisCache.computeIfAbsent` (both the single-key and the collection-key overload) called the user-supplied mapping function from inside the same try block that catches `CompletionException`/`Exception` around Redis I/O and swallows them into a fallback return value. A mapping function that threw was therefore silently swallowed: the single-key overload returned `null` and the collection overload returned a partial `fromCache` map, instead of the exception propagating to the caller.

The mapping function call is now wrapped in its own try/catch that records the error via `observation.observeError` and rethrows, separate from the Redis read/write try blocks (which continue to degrade gracefully on cache-backend failures) and separate from the outer `CompletionException`/`Exception` handling (which now only wraps the write-back-and-return path).

This completes the fix that was already partially applied on master from 1.0's original commit — the null-key and empty-key-set handling from that commit landed, but this specific exception-propagation change did not.