### PR TITLE
Added(openapi-generator): option to disable the generated server validation interceptor (Backport of #646)

### DIFF
--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/CodegenParams.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/CodegenParams.java
@@ -13,6 +13,7 @@ import java.util.regex.Pattern;
 public class CodegenParams {
     public static final String CODEGEN_MODE = "mode";
     public static final String ENABLE_VALIDATION = "enableServerValidation";
+    public static final String ENABLE_VALIDATION_INTERCEPTOR = "enableServerValidationInterceptor";
     public static final String DISCRIMINATOR_CASE_SENSITIVE = "discriminatorCaseSensitive";
     public static final String PRIMARY_AUTH = "primaryAuth";
     public static final String CLIENT_CONFIG = "clientConfig";
@@ -34,6 +35,7 @@ public class CodegenParams {
     
     public CodegenMode codegenMode = CodegenMode.JAVA_CLIENT;
     public boolean enableValidation = false;
+    public boolean enableValidationInterceptor = true;
     public boolean authAsMethodArgument = false;
     public @Nullable String primaryAuth = null;
     public @Nullable String clientConfig = null;
@@ -63,6 +65,7 @@ public class CodegenParams {
         cliOptions.add(CliOption.newString(EXTENSIONS, "Json containing generator extensions for annotations and interceptors"));
         cliOptions.add(CliOption.newString(SERVER_CONFIG_PREFIX, "Generated server controller config prefix for extension annotation substitution"));
         cliOptions.add(CliOption.newBoolean(ENABLE_VALIDATION, "Generate validation related annotation on models and controllers"));
+        cliOptions.add(CliOption.newBoolean(ENABLE_VALIDATION_INTERCEPTOR, "Generate `@InterceptWith(ValidationHttpServerInterceptor.class)` on controllers when validation is enabled, disable when validation errors are mapped manually"));
         cliOptions.add(CliOption.newBoolean(REQUEST_DELEGATE_PARAMS, "Generate HttpServerRequest parameter in delegate methods"));
         cliOptions.add(CliOption.newBoolean(AUTH_AS_METHOD_ARGUMENT, "HTTP client authorization as method argument"));
         cliOptions.add(CliOption.newBoolean(FILTER_WITH_MODELS, "If enabled then when openapiNormalizer FILTER option is specified, will try to filter not only operations, but all unused models as well"));
@@ -107,6 +110,9 @@ public class CodegenParams {
         }
         if (additionalProperties.containsKey(ENABLE_VALIDATION) && params.codegenMode.isServer()) {
             params.enableValidation = Boolean.parseBoolean(additionalProperties.get(ENABLE_VALIDATION).toString());
+        }
+        if (additionalProperties.containsKey(ENABLE_VALIDATION_INTERCEPTOR) && params.codegenMode.isServer()) {
+            params.enableValidationInterceptor = Boolean.parseBoolean(additionalProperties.get(ENABLE_VALIDATION_INTERCEPTOR).toString());
         }
         if (additionalProperties.containsKey(REQUEST_DELEGATE_PARAMS) && params.codegenMode.isServer()) {
             params.requestInDelegateParams = Boolean.parseBoolean(additionalProperties.get(REQUEST_DELEGATE_PARAMS).toString());

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ServerApiGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ServerApiGenerator.java
@@ -66,7 +66,9 @@ public class ServerApiGenerator extends AbstractJavaGenerator<OperationsMap> {
             b.addAnnotation(auth);
         }
         if (params.enableValidation) {
-            b.addAnnotation(AnnotationSpec.builder(Classes.interceptWith).addMember("value", "$T.class", Classes.validationHttpServerInterceptor).build());
+            if (params.enableValidationInterceptor) {
+                b.addAnnotation(AnnotationSpec.builder(Classes.interceptWith).addMember("value", "$T.class", Classes.validationHttpServerInterceptor).build());
+            }
             b.addAnnotation(AnnotationSpec.builder(Classes.validate).build());
         }
         this.buildInterceptors(ctx, operation, Classes.httpServerInterceptor).forEach(b::addAnnotation);

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ServerApiGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ServerApiGenerator.kt
@@ -56,7 +56,9 @@ class ServerApiGenerator() : AbstractKotlinGenerator<OperationsMap>() {
             b.addAnnotation(auth)
         }
         if (params.enableValidation) {
-            b.addAnnotation(AnnotationSpec.builder(Classes.interceptWith.asKt()).addMember("value = %T::class", Classes.validationHttpServerInterceptor.asKt()).build())
+            if (params.enableValidationInterceptor) {
+                b.addAnnotation(AnnotationSpec.builder(Classes.interceptWith.asKt()).addMember("value = %T::class", Classes.validationHttpServerInterceptor.asKt()).build())
+            }
             b.addAnnotation(AnnotationSpec.builder(Classes.validate.asKt()).build())
         }
         this.buildInterceptors(ctx, operation, Classes.httpServerInterceptor.asKt()).forEach(b::addAnnotation)


### PR DESCRIPTION
Added(openapi-generator): option to disable the generated server validation interceptor.

Backport of #646 (branch 1.0, commit e6597640a153a99ac57e590b5a7a368bf94c8515)

Enabling `enableServerValidation` always additionally forced `@InterceptWith(ValidationHttpServerInterceptor.class)` onto every generated controller, with no way to opt out for users who map validation errors themselves. A new `enableServerValidationInterceptor` CLI option (default `true`, preserving current behavior) now independently controls whether the interceptor annotation is emitted, while `@Valid` continues to be generated whenever validation is enabled.

This mirrors the fix already applied on the 1.0 branch, ported to the generator's `CodegenParams`/`javagen`/`kotlingen` classes that replaced the mustache-template-based server API generation used at the time of the original commit.