### PR TITLE
Documented(config): add Javadoc to configuration interfaces from documentation (Backport of #744)

### DIFF
--- a/cache/cache-caffeine/src/main/java/io/koraframework/cache/caffeine/CaffeineCacheConfig.java
+++ b/cache/cache-caffeine/src/main/java/io/koraframework/cache/caffeine/CaffeineCacheConfig.java
@@ -14,12 +14,21 @@ public interface CaffeineCacheConfig {
         return true;
     }
 
+    /**
+     * @return Time after which a value is removed from the cache, counted from the moment the value was written.
+     */
     @Nullable
     Duration expireAfterWrite();
 
+    /**
+     * @return Time after which a value is removed from the cache, counted from the moment the value was read.
+     */
     @Nullable
     Duration expireAfterAccess();
 
+    /**
+     * @return Maximum cache size, upon reaching it or slightly earlier the least relevant values are evicted.
+     */
     default Long maximumSize() {
         return 100_000L;
     }

--- a/cache/cache-redis-common/src/main/java/io/koraframework/cache/redis/RedisCacheConfig.java
+++ b/cache/cache-redis-common/src/main/java/io/koraframework/cache/redis/RedisCacheConfig.java
@@ -21,6 +21,9 @@ public interface RedisCacheConfig {
      */
     String keyPrefix();
 
+    /**
+     * @return Value expiration time applied on write.
+     */
     @Nullable
     Duration expireAfterWrite();
 

--- a/database/database-cassandra/src/main/java/io/koraframework/database/cassandra/CassandraConfig.java
+++ b/database/database-cassandra/src/main/java/io/koraframework/database/cassandra/CassandraConfig.java
@@ -28,19 +28,34 @@ public interface CassandraConfig {
     @Nullable
     Map<String, Profile> profiles();
 
+    /**
+     * @return Basic driver settings such as node addresses, datacenter, keyspace and request parameters.
+     */
     Basic basic();
 
     Advanced advanced();
 
+    /**
+     * @return Credentials used for authentication in Cassandra.
+     */
     @Nullable
     CassandraCredentials auth();
 
+    /**
+     * @return Kora telemetry settings for executed queries.
+     */
     DatabaseTelemetryConfig telemetry();
 
     @ConfigMapper
     interface CassandraCredentials {
+        /**
+         * @return Username for authentication in Cassandra.
+         */
         String login();
 
+        /**
+         * @return Password for authentication in Cassandra.
+         */
         String password();
     }
 
@@ -48,6 +63,9 @@ public interface CassandraConfig {
     interface Profile {
         @ConfigMapper
         interface ProfileBasic extends Basic {
+            /**
+             * @return Cassandra node addresses, which can not be overridden per profile and are always taken from the root configuration.
+             */
             @Override
             @Nullable
             default List<String> contactPoints() {
@@ -55,31 +73,58 @@ public interface CassandraConfig {
             }
         }
 
+        /**
+         * @return Basic driver settings overridden by this profile.
+         */
         ProfileBasic basic();
 
+        /**
+         * @return Advanced driver settings overridden by this profile.
+         */
         @Nullable
         Advanced advanced();
     }
 
     @ConfigMapper
     interface Basic {
+        /**
+         * @return Regular request execution settings such as timeout, consistency level and page size.
+         */
         @Nullable
         BasicRequestConfig request();
 
+        /**
+         * @return Driver session name used in logs, metrics and diagnostics.
+         */
         @Nullable
         String sessionName();
 
+        /**
+         * @return Cassandra node addresses in host:port format.
+         */
         List<String> contactPoints();
 
+        /**
+         * @return Local datacenter for the load balancing policy.
+         */
         @Nullable
         String dc();
 
+        /**
+         * @return Keyspace that is set for the session after connection.
+         */
         @Nullable
         String sessionKeyspace();
 
+        /**
+         * @return Basic load balancing policy settings.
+         */
         @Nullable
         LoadBalancingPolicyConfig loadBalancingPolicy();
 
+        /**
+         * @return Settings for connecting to DataStax Astra or cloud Cassandra.
+         */
         @Nullable
         CloudConfig cloud();
 
@@ -91,24 +136,39 @@ public interface CassandraConfig {
             @Nullable
             String consistency();
 
+            /**
+             * @return Result page size, meaning the maximum number of rows requested in one network round trip.
+             */
             @Nullable
             Integer pageSize();
 
+            /**
+             * @return Serial consistency level for lightweight transactions (LWT), either SERIAL or LOCAL_SERIAL.
+             */
             @Nullable
             String serialConsistency();
 
+            /**
+             * @return Default request idempotence that defines whether retries and speculative execution can be applied safely.
+             */
             @Nullable
             Boolean defaultIdempotence();
         }
 
         @ConfigMapper
         interface LoadBalancingPolicyConfig {
+            /**
+             * @return Enables slow replica avoidance in the default load balancing policy.
+             */
             @Nullable
             Boolean slowReplicaAvoidance();
         }
 
         @ConfigMapper
         interface CloudConfig {
+            /**
+             * @return Path or URL to the Secure Connect Bundle for connecting to DataStax Astra or cloud Cassandra.
+             */
             @Nullable
             String secureConnectBundle();
         }
@@ -116,78 +176,147 @@ public interface CassandraConfig {
 
     @ConfigMapper
     interface Advanced {
+        /**
+         * @return Driver session leak detection settings.
+         */
         @Nullable
         SessionLeakConfig sessionLeak();
 
+        /**
+         * @return Node connection and connection pool settings.
+         */
         @Nullable
         ConnectionConfig connection();
 
+        /**
+         * @return Allows initialization retry when none of the contact points answer during startup.
+         */
         @Nullable
         Boolean reconnectOnInit();
 
+        /**
+         * @return Reconnection policy delay settings.
+         */
         @Nullable
         ReconnectionPolicyConfig reconnectionPolicy();
 
+        /**
+         * @return Advanced load balancing policy settings such as remote datacenter failover.
+         */
         @Nullable
         AdvancedLoadBalancingPolicyConfig loadBalancingPolicy();
 
+        /**
+         * @return SSL/TLS settings for connections to Cassandra.
+         */
         @Nullable
         SslEngineFactoryConfig sslEngineFactory();
 
+        /**
+         * @return Query timestamp generator settings.
+         */
         @Nullable
         TimestampGeneratorConfig timestampGenerator();
 
+        /**
+         * @return Cassandra binary protocol settings.
+         */
         @Nullable
         ProtocolConfig protocol();
 
+        /**
+         * @return Advanced request execution settings such as query tracing and warning logging.
+         */
         @Nullable
         AdvancedRequestConfig request();
 
+        /**
+         * @return Driver metrics settings.
+         */
         MetricsConfig metrics();
 
+        /**
+         * @return TCP socket settings for connections to Cassandra.
+         */
         @Nullable
         SocketConfig socket();
 
+        /**
+         * @return Heartbeat settings for idle connections.
+         */
         @Nullable
         HeartBeatConfig heartbeat();
 
+        /**
+         * @return Schema and cluster topology metadata settings.
+         */
         @Nullable
         MetadataConfig metadata();
 
+        /**
+         * @return Service control connection settings.
+         */
         @Nullable
         ControlConnectionConfig controlConnection();
 
+        /**
+         * @return Prepared statement preparation and caching settings.
+         */
         @Nullable
         PreparedStatementsConfig preparedStatements();
 
+        /**
+         * @return Netty thread group and timer settings of the driver.
+         */
         @Nullable
         NettyConfig netty();
 
+        /**
+         * @return Message coalescing settings applied before sending.
+         */
         @Nullable
         CoalescerConfig coalescer();
 
+        /**
+         * @return Allows the driver to resolve contact points through DNS during startup.
+         */
         @Nullable
         Boolean resolveContactPoints();
 
+        /**
+         * @return Driver request throttler settings.
+         */
         @Nullable
         ThrottlerConfig throttler();
 
         @ConfigMapper
         interface SessionLeakConfig {
+            /**
+             * @return Driver session leak warning threshold.
+             */
             @Nullable
             Integer threshold();
         }
 
         @ConfigMapper
         interface AdvancedLoadBalancingPolicyConfig {
+            /**
+             * @return Failover settings for remote datacenter nodes.
+             */
             @Nullable
             DcFailover dcFailover();
 
             @ConfigMapper
             interface DcFailover {
+                /**
+                 * @return Maximum number of remote datacenter nodes that can be used for failover.
+                 */
                 @Nullable
                 Integer maxNodesPerRemoveDc();
 
+                /**
+                 * @return Allows failover to a remote datacenter for local consistency levels.
+                 */
                 @Nullable
                 Boolean allowForLocalConsistencyLevels();
             }
@@ -195,32 +324,59 @@ public interface CassandraConfig {
 
         @ConfigMapper
         interface ConnectionConfig {
+            /**
+             * @return Timeout for opening a network connection to a node.
+             */
             @Nullable
             Duration connectTimeout();
 
+            /**
+             * @return Timeout for requests that the driver executes while initializing a connection.
+             */
             @Nullable
             Duration initQueryTimeout();
 
+            /**
+             * @return Timeout for setting the keyspace on a connection.
+             */
             @Nullable
             Duration setKeyspaceTimeout();
 
+            /**
+             * @return Maximum number of simultaneous requests per connection.
+             */
             @Nullable
             Integer maxRequestsPerConnection();
 
+            /**
+             * @return Maximum number of requests whose response is no longer awaited but may still complete inside the driver.
+             */
             @Nullable
             Integer maxOrphanRequests();
 
+            /**
+             * @return Logs a warning when connection initialization fails for an individual node.
+             */
             @Nullable
             Boolean warnOnInitError();
 
+            /**
+             * @return Connection pool size settings.
+             */
             @Nullable
             PoolConfig pool();
 
             @ConfigMapper
             interface PoolConfig {
+                /**
+                 * @return Connection pool size for local datacenter nodes.
+                 */
                 @Nullable
                 Integer localSize();
 
+                /**
+                 * @return Connection pool size for remote nodes.
+                 */
                 @Nullable
                 Integer remoteSize();
             }
@@ -228,47 +384,83 @@ public interface CassandraConfig {
 
         @ConfigMapper
         interface ReconnectionPolicyConfig {
+            /**
+             * @return Initial delay of the reconnection policy.
+             */
             @Nullable
             Duration baseDelay();
 
+            /**
+             * @return Maximum delay of the reconnection policy.
+             */
             @Nullable
             Duration maxDelay();
         }
 
         @ConfigMapper
         interface SslEngineFactoryConfig {
+            /**
+             * @return Allowed cipher suites for SSL/TLS.
+             */
             @Nullable
             List<String> cipherSuites();
 
+            /**
+             * @return Checks that the node hostname matches the SSL/TLS certificate.
+             */
             @Nullable
             Boolean hostnameValidation();
 
+            /**
+             * @return Path to the client keystore.
+             */
             @Nullable
             String keystorePath();
 
+            /**
+             * @return Client keystore password.
+             */
             @Nullable
             String keystorePassword();
 
+            /**
+             * @return Path to the truststore.
+             */
             @Nullable
             String truststorePath();
 
+            /**
+             * @return Truststore password.
+             */
             @Nullable
             String truststorePassword();
         }
 
         @ConfigMapper
         interface TimestampGeneratorConfig {
+            /**
+             * @return Forces Java system clock usage for query timestamp generation.
+             */
             @Nullable
             Boolean forceJavaClock();
 
+            /**
+             * @return Timestamp drift warning settings.
+             */
             @Nullable
             DriftWarningConfig driftWarning();
 
             @ConfigMapper
             interface DriftWarningConfig {
+                /**
+                 * @return Warning threshold for timestamp drift into the future.
+                 */
                 @Nullable
                 Duration threshold();
 
+                /**
+                 * @return Minimum interval between timestamp drift warnings.
+                 */
                 @Nullable
                 Duration interval();
             }
@@ -276,35 +468,59 @@ public interface CassandraConfig {
 
         @ConfigMapper
         interface ProtocolConfig {
+            /**
+             * @return Cassandra binary protocol version, for example V4.
+             */
             @Nullable
             String version();
 
+            /**
+             * @return Protocol compression algorithm, for example lz4 or snappy.
+             */
             @Nullable
             String compression();
 
+            /**
+             * @return Maximum protocol frame size in bytes.
+             */
             @Nullable
             Long maxFrameLength();
         }
 
         @ConfigMapper
         interface AdvancedRequestConfig {
+            /**
+             * @return Logs a warning when a query explicitly changes the keyspace.
+             */
             @Nullable
             Boolean warnIfSetKeyspace();
 
+            /**
+             * @return Settings for fetching query tracing information.
+             */
             @Nullable
             TraceConfig trace();
 
+            /**
+             * @return Logs warnings returned by Cassandra along with a query response.
+             */
             @Nullable
             Boolean logWarnings();
 
             @ConfigMapper
             interface TraceConfig {
+                /**
+                 * @return Number of attempts to fetch query tracing information from Cassandra.
+                 */
                 @Nullable
                 Integer attempts();
 
                 @Nullable
                 Duration interval();
 
+                /**
+                 * @return Consistency level for queries to tracing tables.
+                 */
                 @Nullable
                 String consistency();
             }
@@ -313,14 +529,26 @@ public interface CassandraConfig {
         @ConfigMapper
         interface MetricsConfig {
 
+            /**
+             * @return Driver metric identifier generator settings.
+             */
             IdGenerator idGenerator();
 
+            /**
+             * @return Node level driver metrics settings.
+             */
             @Nullable
             NodeConfig node();
 
+            /**
+             * @return Session level driver metrics settings.
+             */
             @Nullable
             SessionConfig session();
 
+            /**
+             * @return Publishes percentile histograms for driver metrics.
+             */
             default boolean publishPercentileHistogram() {
                 return false;
             }
@@ -328,10 +556,16 @@ public interface CassandraConfig {
             @ConfigMapper
             interface IdGenerator {
 
+                /**
+                 * @return Driver metric identifier generator name.
+                 */
                 default String name() {
                     return "TaggingMetricIdGenerator";
                 }
 
+                /**
+                 * @return Driver metric name prefix.
+                 */
                 @Nullable
                 String prefix();
             }
@@ -354,6 +588,9 @@ public interface CassandraConfig {
                     );
                 }
 
+                /**
+                 * @return Histogram settings of the node level cqlMessages metric.
+                 */
                 Config cqlMessages();
             }
 
@@ -374,28 +611,49 @@ public interface CassandraConfig {
                     );
                 }
 
+                /**
+                 * @return Histogram settings of the session level cqlRequests metric.
+                 */
                 Config cqlRequests();
 
+                /**
+                 * @return Histogram settings of the session level throttlingDelay metric.
+                 */
                 Config throttlingDelay();
             }
 
             @ConfigMapper
             interface Config {
 
+                /**
+                 * @return Lowest expected latency of the metric histogram.
+                 */
                 default Duration lowestLatency() {
                     return Duration.ofMillis(1);
                 }
 
+                /**
+                 * @return Highest expected latency of the metric histogram.
+                 */
                 default Duration highestLatency() {
                     return Duration.ofSeconds(90);
                 }
 
+                /**
+                 * @return Number of significant digits of the metric histogram.
+                 */
                 @Nullable
                 Integer significantDigits();
 
+                /**
+                 * @return Snapshot refresh interval of the metric histogram.
+                 */
                 @Nullable
                 Duration refreshInterval();
 
+                /**
+                 * @return SLO boundaries of the metric.
+                 */
                 default Duration[] slo() {
                     return TelemetryConfig.MetricsConfig.DEFAULT_SLO;
                 }
@@ -404,21 +662,39 @@ public interface CassandraConfig {
 
         @ConfigMapper
         interface SocketConfig {
+            /**
+             * @return Enables TCP_NODELAY, which disables the Nagle algorithm.
+             */
             @Nullable
             Boolean tcpNoDelay();
 
+            /**
+             * @return Enables SO_KEEPALIVE for TCP sockets.
+             */
             @Nullable
             Boolean keepAlive();
 
+            /**
+             * @return Enables SO_REUSEADDR for TCP sockets.
+             */
             @Nullable
             Boolean reuseAddress();
 
+            /**
+             * @return SO_LINGER value for TCP sockets.
+             */
             @Nullable
             Integer lingerInterval();
 
+            /**
+             * @return TCP socket receive buffer size in bytes.
+             */
             @Nullable
             Integer receiveBufferSize();
 
+            /**
+             * @return TCP socket send buffer size in bytes.
+             */
             @Nullable
             Integer sendBufferSize();
         }
@@ -434,12 +710,21 @@ public interface CassandraConfig {
 
         @ConfigMapper
         interface MetadataConfig {
+            /**
+             * @return Schema metadata loading and refresh settings.
+             */
             @Nullable
             SchemaConfig schema();
 
+            /**
+             * @return Coalescing settings for cluster topology change events.
+             */
             @Nullable
             TopologyConfig topologyEventDebouncer();
 
+            /**
+             * @return Enables the token map used for routing requests by data owners.
+             */
             @Nullable
             Boolean tokenMapEnabled();
 
@@ -448,15 +733,27 @@ public interface CassandraConfig {
                 @Nullable
                 Boolean enabled();
 
+                /**
+                 * @return Timeout for schema metadata queries.
+                 */
                 @Nullable
                 Duration requestTimeout();
 
+                /**
+                 * @return Page size for schema metadata queries.
+                 */
                 @Nullable
                 Integer requestPageSize();
 
+                /**
+                 * @return Keyspace names whose schema metadata is refreshed by the driver.
+                 */
                 @Nullable
                 List<String> refreshedKeyspaces();
 
+                /**
+                 * @return Coalescing settings for schema refresh events.
+                 */
                 @Nullable
                 DebouncerConfig debouncer();
 
@@ -485,6 +782,9 @@ public interface CassandraConfig {
             @Nullable
             Duration timeout();
 
+            /**
+             * @return Schema agreement check settings between nodes.
+             */
             @Nullable
             SchemaAgreementConfig schemaAgreement();
 
@@ -496,6 +796,9 @@ public interface CassandraConfig {
                 @Nullable
                 Duration timeout();
 
+                /**
+                 * @return Logs a warning if schema agreement is not reached in time.
+                 */
                 @Nullable
                 Boolean warnOnFailure();
             }
@@ -503,12 +806,21 @@ public interface CassandraConfig {
 
         @ConfigMapper
         interface PreparedStatementsConfig {
+            /**
+             * @return Prepares a statement on all nodes after it has been prepared successfully on one node.
+             */
             @Nullable
             Boolean prepareOnAllNodes();
 
+            /**
+             * @return Statement re-preparation settings for a node that became available again.
+             */
             @Nullable
             ReprepareConfig reprepareOnUp();
 
+            /**
+             * @return Prepared statement cache settings.
+             */
             @Nullable
             PreparedCacheConfig preparedCache();
 
@@ -517,12 +829,21 @@ public interface CassandraConfig {
                 @Nullable
                 Boolean enabled();
 
+                /**
+                 * @return Checks the system.prepared_statements system table before re-preparing a statement.
+                 */
                 @Nullable
                 Boolean checkSystemTable();
 
+                /**
+                 * @return Maximum number of statements to re-prepare, where 0 means no driver side limit.
+                 */
                 @Nullable
                 Integer maxStatements();
 
+                /**
+                 * @return Maximum number of parallel re-prepare requests.
+                 */
                 @Nullable
                 Integer maxParallelism();
 
@@ -532,6 +853,9 @@ public interface CassandraConfig {
 
             @ConfigMapper
             interface PreparedCacheConfig {
+                /**
+                 * @return Stores prepared statement cache values through weak references.
+                 */
                 @Nullable
                 Boolean weakValues();
             }
@@ -539,15 +863,27 @@ public interface CassandraConfig {
 
         @ConfigMapper
         interface NettyConfig {
+            /**
+             * @return Netty thread group settings for network I/O.
+             */
             @Nullable
             IoGroupConfig ioGroup();
 
+            /**
+             * @return Netty thread group settings for driver administrative tasks.
+             */
             @Nullable
             AdminGroupConfig adminGroup();
 
+            /**
+             * @return Netty timer settings for delayed driver tasks.
+             */
             @Nullable
             TimerConfig timer();
 
+            /**
+             * @return Makes Netty threads daemon threads.
+             */
             @Nullable
             Boolean daemon();
 
@@ -571,21 +907,36 @@ public interface CassandraConfig {
 
             @ConfigMapper
             interface ShutdownConfig {
+                /**
+                 * @return Quiet period for graceful thread group shutdown.
+                 */
                 @Nullable
                 Integer quietPeriod();
 
+                /**
+                 * @return Maximum wait time for thread group shutdown.
+                 */
                 @Nullable
                 Integer timeout();
 
+                /**
+                 * @return Time unit of the thread group shutdown parameters.
+                 */
                 @Nullable
                 String unit();
             }
 
             @ConfigMapper
             interface TimerConfig {
+                /**
+                 * @return Duration of one Netty timer tick for delayed driver tasks.
+                 */
                 @Nullable
                 Duration tickDuration();
 
+                /**
+                 * @return Number of ticks in the Netty timer wheel.
+                 */
                 @Nullable
                 Integer ticksPerWheel();
             }
@@ -593,24 +944,42 @@ public interface CassandraConfig {
 
         @ConfigMapper
         interface CoalescerConfig {
+            /**
+             * @return Rescheduling interval for message coalescing before sending.
+             */
             @Nullable
             Duration rescheduleInterval();
         }
 
         @ConfigMapper
         interface ThrottlerConfig {
+            /**
+             * @return Driver request throttler class.
+             */
             @Nullable
             String throttlerClass();
 
+            /**
+             * @return Maximum number of concurrent requests for the throttler.
+             */
             @Nullable
             Integer maxConcurrentRequests();
 
+            /**
+             * @return Maximum number of requests per second for the throttler.
+             */
             @Nullable
             Integer maxRequestsPerSecond();
 
+            /**
+             * @return Maximum throttler request queue size.
+             */
             @Nullable
             Integer maxQueueSize();
 
+            /**
+             * @return Interval at which the throttler releases requests from the queue.
+             */
             @Nullable
             Duration drainInterval();
         }

--- a/database/database-flyway/src/main/java/io/koraframework/database/flyway/FlywayConfig.java
+++ b/database/database-flyway/src/main/java/io/koraframework/database/flyway/FlywayConfig.java
@@ -8,6 +8,9 @@ import java.util.Map;
 @ConfigMapper
 public interface FlywayConfig {
 
+    /**
+     * @return Whether to execute migrations during JdbcDatabase initialization.
+     */
     default boolean enabled() {
         return true;
     }
@@ -16,22 +19,37 @@ public interface FlywayConfig {
         return Mode.MIGRATE;
     }
 
+    /**
+     * @return Paths to directories with migration scripts.
+     */
     default List<String> locations() {
         return List.of("db/migration");
     }
 
+    /**
+     * @return Whether to execute migrations inside a transaction when supported by the database and the SQL operations themselves.
+     */
     default boolean executeInTransaction() {
         return true;
     }
 
+    /**
+     * @return Whether to validate checksums of already applied migrations before executing new ones.
+     */
     default boolean validateOnMigrate() {
         return true;
     }
 
+    /**
+     * @return Whether to allow mixing transactional and non-transactional SQL operations in one migration, executing the whole migration without a transaction.
+     */
     default boolean mixed() {
         return false;
     }
 
+    /**
+     * @return Additional Flyway key-value properties for settings that have no separate Kora configuration option.
+     */
     default Map<String, String> configurationProperties() {
         return Map.of();
     }

--- a/database/database-jdbc/src/main/java/io/koraframework/database/jdbc/JdbcDatabaseConfig.java
+++ b/database/database-jdbc/src/main/java/io/koraframework/database/jdbc/JdbcDatabaseConfig.java
@@ -19,56 +19,104 @@ import java.util.Properties;
 @ConfigMapper
 public interface JdbcDatabaseConfig {
 
+    /**
+     * @return Username for the database connection.
+     */
     String username();
 
+    /**
+     * @return User password for the database connection.
+     */
     String password();
 
+    /**
+     * @return JDBC URL for connecting to the database.
+     */
     String jdbcUrl();
 
+    /**
+     * @return Hikari connection pool name.
+     */
     String poolName();
 
+    /**
+     * @return Database schema for the connection.
+     */
     @Nullable
     String schema();
 
+    /**
+     * @return Maximum time to wait for a connection from the Hikari pool.
+     */
     default Duration connectionTimeout() {
         return Duration.ofSeconds(10);
     }
 
+    /**
+     * @return Maximum time for Hikari connection validation.
+     */
     default Duration validationTimeout() {
         return Duration.ofSeconds(5);
     }
 
+    /**
+     * @return Maximum idle time for a Hikari connection.
+     */
     default Duration idleTimeout() {
         return Duration.ofMinutes(10);
     }
 
+    /**
+     * @return Maximum lifetime of a Hikari connection.
+     */
     default Duration maxLifetime() {
         return Duration.ofMinutes(15);
     }
 
+    /**
+     * @return Time after which a busy connection is considered a possible leak.
+     */
     default Duration leakDetectionThreshold() {
         return Duration.ofSeconds(0);
     }
 
+    /**
+     * @return Maximum Hikari connection pool size.
+     */
     default int maxPoolSize() {
         return 10;
     }
 
+    /**
+     * @return Minimum number of idle ready connections in the Hikari pool.
+     */
     default int minIdle() {
         return 0;
     }
 
+    /**
+     * @return Maximum time to wait for connection initialization at service startup.
+     */
     @Nullable
     Duration initializationFailTimeout();
 
+    /**
+     * @return Whether to enable the readiness probe for the database connection.
+     */
     default boolean readinessProbe() {
         return false;
     }
 
+    /**
+     * @return Additional JDBC connection properties passed to Hikari dataSourceProperties.
+     */
     default Properties dsProperties() {
         return new Properties();
     }
 
+    /**
+     * @return Telemetry configuration for logging, metrics and tracing of database queries.
+     */
     DatabaseTelemetryConfig telemetry();
 
     static HikariConfig toHikariConfig(JdbcDatabaseConfig config, @Nullable Configurer<HikariConfig> configurer) {

--- a/database/database-liquibase/src/main/java/io/koraframework/database/liquibase/LiquibaseConfig.java
+++ b/database/database-liquibase/src/main/java/io/koraframework/database/liquibase/LiquibaseConfig.java
@@ -6,6 +6,9 @@ import io.koraframework.config.common.annotation.ConfigMapper;
 @ConfigMapper
 public interface LiquibaseConfig {
 
+    /**
+     * @return Path to the main changelog file with migration definitions.
+     */
     default String changelog() {
         return "db/changelog/db.changelog-master.xml";
     }

--- a/experimental/camunda-engine-bpmn/src/main/java/io/koraframework/camunda/engine/bpmn/CamundaEngineBpmnConfig.java
+++ b/experimental/camunda-engine-bpmn/src/main/java/io/koraframework/camunda/engine/bpmn/CamundaEngineBpmnConfig.java
@@ -10,25 +10,46 @@ import java.util.List;
 @ConfigMapper
 public interface CamundaEngineBpmnConfig {
 
+    /**
+     * @return Parallel engine initialization configuration.
+     */
     ParallelInitConfig parallelInitialization();
 
+    /**
+     * @return JobExecutor configuration.
+     */
     JobExecutorConfig jobExecutor();
 
+    /**
+     * @return Automatic BPMN / FORM / DMN resource deployment configuration.
+     */
     @Nullable
     DeploymentConfig deployment();
 
+    /**
+     * @return Camunda administrator user configuration.
+     */
     @Nullable
     AdminConfig admin();
 
+    /**
+     * @return Telemetry configuration of the module.
+     */
     CamundaEngineTelemetryConfig telemetry();
 
     @ConfigMapper
     interface ParallelInitConfig {
 
+        /**
+         * @return Whether parallel engine initialization is enabled.
+         */
         default boolean enabled() {
             return true;
         }
 
+        /**
+         * @return Whether incomplete engine statements are validated during parallel initialization.
+         */
         default boolean validateIncompleteStatements() {
             return true;
         }
@@ -37,16 +58,31 @@ public interface CamundaEngineBpmnConfig {
     @ConfigMapper
     interface AdminConfig {
 
+        /**
+         * @return Camunda administrator identifier.
+         */
         String id();
 
+        /**
+         * @return Camunda administrator password.
+         */
         String password();
 
+        /**
+         * @return Camunda administrator first name, uppercase identifier is used when not specified.
+         */
         @Nullable
         String firstname();
 
+        /**
+         * @return Camunda administrator last name, uppercase identifier is used when not specified.
+         */
         @Nullable
         String lastname();
 
+        /**
+         * @return Camunda administrator email address.
+         */
         @Nullable
         String email();
     }
@@ -54,25 +90,43 @@ public interface CamundaEngineBpmnConfig {
     @ConfigMapper
     interface FilterConfig {
 
+        /**
+         * @return Name of the Camunda filter to create.
+         */
         String create();
     }
 
     @ConfigMapper
     interface DeploymentConfig {
 
+        /**
+         * @return Tenant identifier the deployment is bound to.
+         */
         @Nullable
         String tenantId();
 
+        /**
+         * @return Resource deployment name.
+         */
         default String name() {
             return "KoraEngineAutoDeployment";
         }
 
+        /**
+         * @return Whether only changed resources are deployed through Camunda duplicate filtering.
+         */
         default boolean deployChangedOnly() {
             return true;
         }
 
+        /**
+         * @return Paths where BPMN / FORM / DMN resources are searched for, only the classpath: prefix is supported.
+         */
         List<String> resources();
 
+        /**
+         * @return Delay before deploying resources to the engine.
+         */
         @Nullable
         Duration delay();
     }
@@ -80,22 +134,37 @@ public interface CamundaEngineBpmnConfig {
     @ConfigMapper
     interface JobExecutorConfig {
 
+        /**
+         * @return Minimum number of permanently alive threads in the JobExecutor.
+         */
         default Integer corePoolSize() {
             return 5;
         }
 
+        /**
+         * @return Maximum number of threads in the JobExecutor.
+         */
         default Integer maxPoolSize() {
             return 25;
         }
 
+        /**
+         * @return JobExecutor task queue size before new tasks are rejected.
+         */
         default Integer queueSize() {
             return 25;
         }
 
+        /**
+         * @return Maximum number of jobs acquired by the JobExecutor in one request.
+         */
         default Integer maxJobsPerAcquisition() {
             return Runtime.getRuntime().availableProcessors() * 2;
         }
 
+        /**
+         * @return Whether virtual threads are used as the JobExecutor base, making pool and queue size settings unused.
+         */
         default boolean virtualThreadsEnabled() {
             return false;
         }

--- a/experimental/camunda-rest-undertow/src/main/java/io/koraframework/camunda/rest/CamundaRestConfig.java
+++ b/experimental/camunda-rest-undertow/src/main/java/io/koraframework/camunda/rest/CamundaRestConfig.java
@@ -15,22 +15,40 @@ public interface CamundaRestConfig {
         return false;
     }
 
+    /**
+     * @return Path prefix of the Camunda 7 REST API.
+     */
     default String path() {
         return "/engine-rest";
     }
 
+    /**
+     * @return Port of the separate Undertow HTTP server serving the REST API.
+     */
     default Integer port() {
         return 8081;
     }
 
+    /**
+     * @return Maximum time to wait for the HTTP server graceful shutdown.
+     */
     default Duration shutdownWait() {
         return Duration.ofSeconds(30);
     }
 
+    /**
+     * @return OpenAPI, Swagger UI and RapiDoc serving configuration.
+     */
     CamundaOpenApiConfig openapi();
 
+    /**
+     * @return Telemetry configuration of the module.
+     */
     CamundaRestTelemetryConfig telemetry();
 
+    /**
+     * @return CORS filter configuration.
+     */
     CamundaCorsConfig cors();
 
     @ConfigMapper
@@ -52,6 +70,9 @@ public interface CamundaRestConfig {
             return CacheMode.GZIP;
         }
 
+        /**
+         * @return Swagger UI serving configuration.
+         */
         SwaggerUIConfig swaggerui();
 
         ScalarConfig scalar();
@@ -118,25 +139,43 @@ public interface CamundaRestConfig {
             return false;
         }
 
+        /**
+         * @return Whether the path template is logged instead of the full path, when not specified the full path is used only at TRACE level.
+         */
         @Nullable
         String allowOrigin();
 
+        /**
+         * @return Allowed headers for CORS requests.
+         */
         default List<String> allowHeaders() {
             return List.of("*");
         }
 
+        /**
+         * @return Allowed HTTP methods for CORS requests.
+         */
         default List<String> allowMethods() {
             return List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD");
         }
 
+        /**
+         * @return Whether credentials are allowed in CORS requests.
+         */
         default Boolean allowCredentials() {
             return true;
         }
 
+        /**
+         * @return Headers exposed to the client in a CORS response.
+         */
         default List<String> exposeHeaders() {
             return List.of("*");
         }
 
+        /**
+         * @return Maximum caching time for CORS preflight requests.
+         */
         default Duration maxAge() {
             return Duration.ofHours(1);
         }

--- a/experimental/camunda-zeebe-worker/src/main/java/io/koraframework/camunda/zeebe/worker/ZeebeClientConfig.java
+++ b/experimental/camunda-zeebe-worker/src/main/java/io/koraframework/camunda/zeebe/worker/ZeebeClientConfig.java
@@ -13,25 +13,43 @@ import java.util.List;
 @ConfigMapper
 public interface ZeebeClientConfig {
 
+    /**
+     * @return Maximum number of threads for job workers.
+     */
     default int executionThreads() {
         return Math.max(Runtime.getRuntime().availableProcessors() * 2, 2);
     }
 
+    /**
+     * @return Time without read activity before sending a KeepAlive check.
+     */
     default Duration keepAlive() {
         return Duration.ofSeconds(45);
     }
 
+    /**
+     * @return File path to the connection certificate, when not specified the system certificate is used.
+     */
     @Nullable
     String certificatePath();
 
+    /**
+     * @return Maximum time to wait for the topology availability check on client startup.
+     */
     @Nullable
     Duration initializationFailTimeout();
 
     @Nullable
+    /**
+     * @return gRPC connection configuration.
+     */
     GrpcConfig grpc();
 
     RestConfig rest();
 
+    /**
+     * @return Resource deployment configuration.
+     */
     DeploymentConfig deployment();
 
     ZeebeWorkerTelemetryConfig telemetry();
@@ -39,6 +57,9 @@ public interface ZeebeClientConfig {
     @ConfigMapper
     interface RestConfig {
 
+        /**
+         * @return URL for connecting to the Zeebe REST address.
+         */
         String url();
     }
 
@@ -47,14 +68,23 @@ public interface ZeebeClientConfig {
 
         String url();
 
+        /**
+         * @return How long a message sent through gRPC is kept on the broker.
+         */
         default Duration ttl() {
             return Duration.ofHours(1);
         }
 
+        /**
+         * @return Maximum inbound message size for gRPC.
+         */
         default Size maxMessageSize() {
             return Size.of(4, Size.Type.MiB);
         }
 
+        /**
+         * @return Retry policy configuration of the gRPC connection.
+         */
         GrpcRetryConfig retryPolicy();
 
         GrpcClientTelemetryConfig telemetry();
@@ -63,22 +93,37 @@ public interface ZeebeClientConfig {
     @ConfigMapper
     interface GrpcRetryConfig {
 
+        /**
+         * @return Whether the retry policy for the gRPC connection is enabled.
+         */
         default boolean enabled() {
             return true;
         }
 
+        /**
+         * @return Number of retry attempts.
+         */
         default int attempts() {
             return 5;
         }
 
+        /**
+         * @return Initial delay between attempts.
+         */
         default Duration delay() {
             return Duration.ofMillis(100);
         }
 
+        /**
+         * @return Maximum delay between attempts.
+         */
         default Duration delayMax() {
             return Duration.ofSeconds(5);
         }
 
+        /**
+         * @return Delay multiplier between attempts.
+         */
         default Double step() {
             return 3.0;
         }
@@ -87,10 +132,16 @@ public interface ZeebeClientConfig {
     @ConfigMapper
     interface DeploymentConfig {
 
+        /**
+         * @return Maximum time to wait for resource upload.
+         */
         default Duration timeout() {
             return Duration.ofSeconds(45);
         }
 
+        /**
+         * @return Paths where resources uploaded to the orchestrator after startup are searched for, only the classpath: prefix is supported.
+         */
         default List<String> resources() {
             return Collections.emptyList();
         }

--- a/experimental/camunda-zeebe-worker/src/main/java/io/koraframework/camunda/zeebe/worker/ZeebeWorkerConfig.java
+++ b/experimental/camunda-zeebe-worker/src/main/java/io/koraframework/camunda/zeebe/worker/ZeebeWorkerConfig.java
@@ -14,6 +14,9 @@ public interface ZeebeWorkerConfig {
 
     String DEFAULT = "default";
 
+    /**
+     * @return Job worker settings by worker type, where the default section is applied to all workers.
+     */
     default Map<String, JobConfig> job() {
         return Map.of();
     }
@@ -21,34 +24,64 @@ public interface ZeebeWorkerConfig {
     @ConfigMapper
     interface JobConfig {
 
+        /**
+         * @return Name the worker is registered under on the broker.
+         */
         default String name() {
             return "default";
         }
 
+        /**
+         * @return Retry backoff configuration of the worker.
+         */
         @Nullable
         BackoffConfig backoff();
 
+        /**
+         * @return Tenant identifiers for which the worker can receive jobs.
+         */
         @Nullable
         List<String> tenantIds();
 
+        /**
+         * @return Maximum time for one job execution by the worker.
+         */
         @Nullable
         Duration timeout();
 
+        /**
+         * @return Maximum number of jobs activated simultaneously for this worker, used to align job fetching speed with processing speed.
+         */
         @Nullable
         Integer maxJobsActive();
 
+        /**
+         * @return Request timeout used for polling a new job by the worker.
+         */
         @Nullable
         Duration requestTimeout();
 
+        /**
+         * @return Maximum interval between polling new jobs.
+         */
         @Nullable
         Duration pollInterval();
 
+        /**
+         * @return Whether the worker is enabled.
+         */
         @Nullable
         Boolean enabled();
 
+        /**
+         * @return Whether streaming is used together with polling for job activation.
+         */
         @Nullable
         Boolean streamEnabled();
 
+        /**
+         * @return Maximum stream lifetime when streaming is enabled.
+         */
         @Nullable
         Duration streamTimeout();
     }
@@ -56,15 +89,27 @@ public interface ZeebeWorkerConfig {
     @ConfigMapper
     interface BackoffConfig {
 
+        /**
+         * @return Maximum retry delay, which can be exceeded due to jitter.
+         */
         @Nullable
         Duration maxDelay();
 
+        /**
+         * @return Minimum retry delay, which the actual delay can fall below due to jitter.
+         */
         @Nullable
         Duration minDelay();
 
+        /**
+         * @return Factor the previous delay is multiplied by.
+         */
         @Nullable
         Double factor();
 
+        /**
+         * @return Jitter factor randomly changing the next delay within its +/- range.
+         */
         @Nullable
         Double jitter();
     }

--- a/grpc/grpc-client/src/main/java/io/koraframework/grpc/client/GrpcClientConfig.java
+++ b/grpc/grpc-client/src/main/java/io/koraframework/grpc/client/GrpcClientConfig.java
@@ -12,22 +12,43 @@ import java.time.Duration;
 @ConfigMapper
 public interface GrpcClientConfig {
 
+    /**
+     * @return Server URL where requests will be sent.
+     */
     String url();
 
+    /**
+     * @return Maximum request execution time, applied as a call deadline if the call does not already have its own.
+     */
     @Nullable
     Duration timeout();
 
+    /**
+     * @return Telemetry configuration for logging, metrics and tracing of client calls.
+     */
     GrpcClientTelemetryConfig telemetry();
 
+    /**
+     * @return Standard gRPC service configuration passed to ManagedChannelBuilder.defaultServiceConfig.
+     */
     @Nullable
     DefaultServiceConfig defaultServiceConfig();
 
+    /**
+     * @return Interval between gRPC PING frames.
+     */
     @Nullable
     Duration keepAliveTime();
 
+    /**
+     * @return Timeout for acknowledging a PING frame, after which the connection is closed.
+     */
     @Nullable
     Duration keepAliveTimeout();
 
+    /**
+     * @return Load balancing policy for ManagedChannelBuilder.
+     */
     @Nullable
     String loadBalancingPolicy();
 

--- a/grpc/grpc-server/src/main/java/io/koraframework/grpc/server/GrpcServerConfig.java
+++ b/grpc/grpc-server/src/main/java/io/koraframework/grpc/server/GrpcServerConfig.java
@@ -10,33 +10,60 @@ import java.time.Duration;
 @ConfigMapper
 public interface GrpcServerConfig {
 
+    /**
+     * @return gRPC server port.
+     */
     default int port() {
         return 8090;
     }
 
+    /**
+     * @return Enables the gRPC Server Reflection service.
+     */
     default boolean reflectionEnabled() {
         return false;
     }
 
+    /**
+     * @return Maximum size of an incoming message.
+     */
     default Size maxMessageSize() {
         return Size.of(4, Size.Type.MiB);
     }
 
+    /**
+     * @return Time to wait for in-flight calls to complete before shutting down the server during graceful shutdown.
+     */
     default Duration shutdownWait() {
         return Duration.ofSeconds(30);
     }
 
+    /**
+     * @return Telemetry configuration for logging, metrics and tracing of server calls.
+     */
     GrpcServerTelemetryConfig telemetry();
 
+    /**
+     * @return Maximum connection age after which the connection is gracefully terminated, with a random jitter of +/-10%.
+     */
     @Nullable
     Duration maxConnectionAge();
 
+    /**
+     * @return Additional time for graceful connection termination after the maximum connection age is reached.
+     */
     @Nullable
     Duration maxConnectionAgeGrace();
 
+    /**
+     * @return Interval between PING frames.
+     */
     @Nullable
     Duration keepAliveTime();
 
+    /**
+     * @return Timeout for acknowledging a PING frame, after which the connection is closed.
+     */
     @Nullable
     Duration keepAliveTimeout();
 }

--- a/http/http-client-common/src/main/java/io/koraframework/http/client/common/HttpClientConfig.java
+++ b/http/http-client-common/src/main/java/io/koraframework/http/client/common/HttpClientConfig.java
@@ -10,17 +10,29 @@ import java.util.List;
 @ConfigMapper
 public interface HttpClientConfig {
 
+    /**
+     * @return Maximum time to establish a connection.
+     */
     default Duration connectTimeout() {
         return Duration.ofSeconds(5);
     }
 
+    /**
+     * @return Maximum time to read a response.
+     */
     default Duration readTimeout() {
         return Duration.ofMinutes(2);
     }
 
+    /**
+     * @return Proxy settings used for outgoing requests.
+     */
     @Nullable
     HttpClientProxyConfig proxy();
 
+    /**
+     * @return Whether to use https_proxy / HTTPS_PROXY / http_proxy / HTTP_PROXY and no_proxy / NO_PROXY environment variables for proxy configuration.
+     */
     default boolean useEnvProxy() {
         return false;
     }
@@ -28,16 +40,31 @@ public interface HttpClientConfig {
     @ConfigMapper
     interface HttpClientProxyConfig {
 
+        /**
+         * @return Proxy host.
+         */
         String host();
 
+        /**
+         * @return Proxy port.
+         */
         int port();
 
+        /**
+         * @return Hosts to exclude from proxying.
+         */
         @Nullable
         List<String> nonProxyHosts();
 
+        /**
+         * @return Proxy user.
+         */
         @Nullable
         String user();
 
+        /**
+         * @return Proxy password.
+         */
         @Nullable
         String password();
 

--- a/http/http-client-common/src/main/java/io/koraframework/http/client/common/declarative/DeclarativeHttpClientConfig.java
+++ b/http/http-client-common/src/main/java/io/koraframework/http/client/common/declarative/DeclarativeHttpClientConfig.java
@@ -10,10 +10,19 @@ import java.time.Duration;
 
 public interface DeclarativeHttpClientConfig {
 
+    /**
+     * @return Base service URL where requests will be sent.
+     */
     String url();
 
+    /**
+     * @return Telemetry configuration for logging, metrics and tracing of client requests.
+     */
     HttpClientTelemetryConfig telemetry();
 
+    /**
+     * @return Maximum request time that may include DNS resolution, connection, request body write, server processing and response body read.
+     */
     @Nullable
     Duration requestTimeout();
 

--- a/http/http-client-common/src/main/java/io/koraframework/http/client/common/declarative/HttpClientOperationConfig.java
+++ b/http/http-client-common/src/main/java/io/koraframework/http/client/common/declarative/HttpClientOperationConfig.java
@@ -11,9 +11,15 @@ import java.util.Set;
 @ConfigMapper
 public interface HttpClientOperationConfig {
 
+    /**
+     * @return Maximum request time that may include DNS resolution, connection, request body write, server processing and response body read.
+     */
     @Nullable
     Duration requestTimeout();
 
+    /**
+     * @return Telemetry settings that override the client telemetry settings for this operation.
+     */
     OperationTelemetryConfig telemetry();
 
     @ConfigMapper

--- a/http/http-client-jdk/src/main/java/io/koraframework/http/client/jdk/JdkHttpClientConfig.java
+++ b/http/http-client-jdk/src/main/java/io/koraframework/http/client/jdk/JdkHttpClientConfig.java
@@ -7,10 +7,16 @@ import java.net.http.HttpClient;
 @ConfigMapper
 public interface JdkHttpClientConfig {
 
+    /**
+     * @return Whether to follow HTTP redirects.
+     */
     default boolean followRedirects() {
         return true;
     }
 
+    /**
+     * @return Which HTTP protocol version to use.
+     */
     default HttpClient.Version httpVersion() {
         return HttpClient.Version.HTTP_1_1;
     }

--- a/http/http-client-ok/src/main/java/io/koraframework/http/client/ok/OkHttpClientConfig.java
+++ b/http/http-client-ok/src/main/java/io/koraframework/http/client/ok/OkHttpClientConfig.java
@@ -5,14 +5,23 @@ import io.koraframework.config.common.annotation.ConfigMapper;
 @ConfigMapper
 public interface OkHttpClientConfig {
 
+    /**
+     * @return Whether to follow HTTP redirects.
+     */
     default boolean followRedirects() {
         return true;
     }
 
+    /**
+     * @return Whether to retry a request after a connection failure, this can affect the maximum connection establishment time.
+     */
     default boolean retryOnConnectionFailure() {
         return true;
     }
 
+    /**
+     * @return Maximum HTTP protocol version to use.
+     */
     default HttpVersion httpVersion() {
         return HttpVersion.HTTP_1_1;
     }

--- a/http/http-server-common/src/main/java/io/koraframework/http/server/common/HttpServerConfig.java
+++ b/http/http-server-common/src/main/java/io/koraframework/http/server/common/HttpServerConfig.java
@@ -13,18 +13,30 @@ public interface HttpServerConfig {
         return 8080;
     }
 
+    /**
+     * @return Whether to ignore a trailing slash in the path, so that /my/path and /my/path/ are treated as the same route.
+     */
     default boolean ignoreTrailingSlash() {
         return false;
     }
 
+    /**
+     * @return Maximum time to wait for reading data from a socket or connection, zero disables the timeout.
+     */
     default Duration socketReadTimeout() {
         return Duration.ZERO;
     }
 
+    /**
+     * @return Maximum time to wait for writing data to a socket or connection, zero disables the timeout.
+     */
     default Duration socketWriteTimeout() {
         return Duration.ZERO;
     }
 
+    /**
+     * @return Whether to enable TCP keep-alive for a socket or connection.
+     */
     default boolean socketKeepAliveEnabled() {
         return false;
     }
@@ -37,13 +49,22 @@ public interface HttpServerConfig {
         return true;
     }
 
+    /**
+     * @return Time to wait for request processing before server shutdown during graceful shutdown.
+     */
     default Duration shutdownWait() {
         return Duration.ofSeconds(30);
     }
 
+    /**
+     * @return Maximum allowed size of an incoming request body.
+     */
     default Size maxRequestBodySize() {
         return Size.of(256, Size.Type.MiB);
     }
 
+    /**
+     * @return Telemetry configuration for logging, metrics and tracing of incoming requests.
+     */
     HttpServerTelemetryConfig telemetry();
 }

--- a/http/soap-client/src/main/java/io/koraframework/soap/client/common/SoapServiceConfig.java
+++ b/http/soap-client/src/main/java/io/koraframework/soap/client/common/SoapServiceConfig.java
@@ -8,11 +8,20 @@ import java.time.Duration;
 @ConfigMapper
 public interface SoapServiceConfig {
 
+    /**
+     * @return Service URL where requests will be sent.
+     */
     String url();
 
+    /**
+     * @return Maximum request execution time.
+     */
     default Duration timeout() {
         return Duration.ofSeconds(60);
     }
 
+    /**
+     * @return Telemetry configuration of the SOAP client such as logging, metrics and tracing.
+     */
     SoapClientTelemetryConfig telemetry();
 }

--- a/jms/src/main/java/io/koraframework/jms/JmsListenerContainerConfig.java
+++ b/jms/src/main/java/io/koraframework/jms/JmsListenerContainerConfig.java
@@ -5,9 +5,18 @@ import io.koraframework.jms.telemetry.JmsConsumerTelemetryConfig;
 
 @ConfigMapper
 public interface JmsListenerContainerConfig {
+    /**
+     * @return Name of the JMS queue the listener consumes messages from.
+     */
     String queueName();
 
+    /**
+     * @return Number of consumer threads listening to the queue, zero disables the listener.
+     */
     int threads();
 
+    /**
+     * @return Telemetry configuration for logging, metrics and tracing of consumed messages.
+     */
     JmsConsumerTelemetryConfig telemetry();
 }

--- a/kafka/kafka/src/main/java/io/koraframework/kafka/common/consumer/KafkaListenerConfig.java
+++ b/kafka/kafka/src/main/java/io/koraframework/kafka/common/consumer/KafkaListenerConfig.java
@@ -14,41 +14,74 @@ import java.util.regex.Pattern;
 @ConfigMapper
 public interface KafkaListenerConfig {
 
+    /**
+     * @return Official Kafka Consumer properties.
+     */
     Properties driverProperties();
 
+    /**
+     * @return List of topics the Consumer subscribes to, either topics or topicsPattern must be specified.
+     */
     @Nullable
     List<String> topics();
 
+    /**
+     * @return Topic pattern the Consumer subscribes to, either topics or topicsPattern must be specified.
+     */
     @Nullable
     Pattern topicsPattern();
 
+    /**
+     * @return List of partitions used only for consumer name construction when group.id, topics and topicsPattern are not specified.
+     */
     @Nullable
     List<String> partitions();
 
+    /**
+     * @return Initial read position for the assign strategy when group.id is not specified: earliest, latest or a Duration to shift back from the latest offset.
+     */
     default Either<Duration, Offset> offset() {
         return Either.right(Offset.latest);
     }
 
+    /**
+     * @return Maximum time to wait for messages from a topic within one poll() call.
+     */
     default Duration pollTimeout() {
         return Duration.ofSeconds(5);
     }
 
+    /**
+     * @return Initial delay before consumer restart after an unexpected processing error, growing up to 60s on repeated errors.
+     */
     default Duration backoffTimeout() {
         return Duration.ofSeconds(15);
     }
 
+    /**
+     * @return Number of threads the consumer starts on, 0 means the consumer is not started.
+     */
     default int threads() {
         return 1;
     }
 
+    /**
+     * @return Partition list refresh period for the assign strategy.
+     */
     default Duration partitionRefreshInterval() {
         return Duration.ofMinutes(1);
     }
 
+    /**
+     * @return Time to wait for record processing to complete before stopping the consumer during graceful shutdown.
+     */
     default Duration shutdownWait() {
         return Duration.ofSeconds(30);
     }
 
+    /**
+     * @return Whether to call the listener with an empty ConsumerRecords batch when the signature accepts ConsumerRecords.
+     */
     default boolean allowEmptyRecords() {
         return false;
     }
@@ -56,6 +89,9 @@ public interface KafkaListenerConfig {
     @Nullable
     Duration initializationFailTimeout();
 
+    /**
+     * @return Telemetry configuration of the consumer: logging, metrics and tracing.
+     */
     KafkaConsumerTelemetryConfig telemetry();
 
     enum Offset {

--- a/kafka/kafka/src/main/java/io/koraframework/kafka/common/producer/KafkaPublisherConfig.java
+++ b/kafka/kafka/src/main/java/io/koraframework/kafka/common/producer/KafkaPublisherConfig.java
@@ -10,21 +10,36 @@ import java.util.Properties;
 @ConfigMapper
 public interface KafkaPublisherConfig {
 
+    /**
+     * @return Official Kafka Producer properties.
+     */
     Properties driverProperties();
 
+    /**
+     * @return Telemetry configuration of the producer: logging, metrics and tracing.
+     */
     KafkaPublisherTelemetryConfig telemetry();
 
     @ConfigMapper
     interface TransactionConfig {
 
+        /**
+         * @return Transaction identifier prefix to which a random UUID is appended.
+         */
         default String idPrefix() {
             return "kora-app-";
         }
 
+        /**
+         * @return Maximum size of the transactional Producer pool.
+         */
         default int maxPoolSize() {
             return 10;
         }
 
+        /**
+         * @return Maximum time to wait for a free Producer from the pool.
+         */
         default Duration maxWaitTime() {
             return Duration.ofSeconds(10);
         }
@@ -33,8 +48,14 @@ public interface KafkaPublisherConfig {
     @ConfigMapper
     interface TopicConfig {
 
+        /**
+         * @return Topic where the method sends data.
+         */
         String topic();
 
+        /**
+         * @return Topic partition where the method sends data, standard Kafka partitioning is used when not specified.
+         */
         @Nullable
         Integer partition();
     }

--- a/netty-common/src/main/java/io/koraframework/netty/common/NettyTransportConfig.java
+++ b/netty-common/src/main/java/io/koraframework/netty/common/NettyTransportConfig.java
@@ -20,6 +20,9 @@ public interface NettyTransportConfig {
     @Nullable
     EventLoopType transport();
 
+    /**
+     * @return Number of worker event loop threads that process connections and network I/O, server boss event loop is not affected.
+     */
     default int threads() {
         return NettyRuntime.availableProcessors() * 2;
     }

--- a/openapi/openapi-management/src/main/java/io/koraframework/openapi/management/OpenApiManagementConfig.java
+++ b/openapi/openapi-management/src/main/java/io/koraframework/openapi/management/OpenApiManagementConfig.java
@@ -22,6 +22,9 @@ public interface OpenApiManagementConfig {
         return CacheMode.GZIP;
     }
 
+    /**
+     * @return Swagger UI page configuration.
+     */
     SwaggerUIConfig swaggerui();
 
     ScalarConfig scalar();

--- a/scheduling/scheduling-quartz/src/main/java/io/koraframework/scheduling/quartz/SchedulingQuartzConfig.java
+++ b/scheduling/scheduling-quartz/src/main/java/io/koraframework/scheduling/quartz/SchedulingQuartzConfig.java
@@ -5,6 +5,9 @@ import io.koraframework.config.common.annotation.ConfigMapper;
 @ConfigMapper
 public interface SchedulingQuartzConfig {
 
+    /**
+     * @return Whether to wait for tasks to complete before scheduler shutdown during graceful shutdown.
+     */
     default boolean waitForJobComplete() {
         return true;
     }

--- a/telemetry/opentelemetry-tracing-exporter-grpc/src/main/java/io/koraframework/opentelemetry/tracing/exporter/grpc/OpentelemetryGrpcExporterConfig.java
+++ b/telemetry/opentelemetry-tracing-exporter-grpc/src/main/java/io/koraframework/opentelemetry/tracing/exporter/grpc/OpentelemetryGrpcExporterConfig.java
@@ -9,37 +9,67 @@ import java.time.Duration;
 public interface OpentelemetryGrpcExporterConfig {
 
     @Nullable
+        /**
+         * @return OpenTelemetry Collector endpoint where traces are exported over OTLP/gRPC.
+         */
     String endpoint();
 
+        /**
+         * @return Maximum time to wait while the exporter sends data.
+         */
     default Duration exportTimeout() {
         return Duration.ofSeconds(3);
     }
 
+        /**
+         * @return Maximum time to wait for one accumulated batch of spans to be exported.
+         */
     default Duration batchExportTimeout() {
         return Duration.ofSeconds(30);
     }
 
+        /**
+         * @return Timeout for establishing a connection to the exporter.
+         */
     @Nullable
     Duration connectTimeout();
 
+        /**
+         * @return Data compression used during export, gzip or none.
+         */
     default String compression() {
         return "gzip";
     }
 
+        /**
+         * @return Retry policy applied to failed export attempts.
+         */
     RetryPolicy retryPolicy();
 
+        /**
+         * @return Delay between sending accumulated spans to the collector.
+         */
     default Duration scheduleDelay() {
         return Duration.ofSeconds(2);
     }
 
+        /**
+         * @return Maximum number of spans in one export batch.
+         */
     default int maxExportBatchSize() {
         return 512;
     }
 
+        /**
+         * @return Maximum queue size for spans waiting to be sent.
+         */
     default int maxQueueSize() {
         return 2048;
     }
 
+        /**
+         * @return Whether to export spans that were not selected by the Sampler.
+         */
     default boolean exportUnsampledSpans() {
         return false;
     }
@@ -47,18 +77,30 @@ public interface OpentelemetryGrpcExporterConfig {
     @ConfigMapper
     interface RetryPolicy {
 
+        /**
+         * @return Maximum number of retry attempts.
+         */
         default int maxAttempts() {
             return 5;
         }
 
+        /**
+         * @return Initial delay before a retry attempt.
+         */
         default Duration initialBackoff() {
             return Duration.ofSeconds(1);
         }
 
+        /**
+         * @return Maximum delay before a retry attempt.
+         */
         default Duration maxBackoff() {
             return Duration.ofSeconds(5);
         }
 
+        /**
+         * @return Delay multiplier between retry attempts.
+         */
         default double backoffMultiplier() {
             return 1.5d;
         }

--- a/telemetry/opentelemetry-tracing-exporter-http/src/main/java/io/koraframework/opentelemetry/tracing/exporter/http/OpentelemetryHttpExporterConfig.java
+++ b/telemetry/opentelemetry-tracing-exporter-http/src/main/java/io/koraframework/opentelemetry/tracing/exporter/http/OpentelemetryHttpExporterConfig.java
@@ -10,37 +10,67 @@ import java.time.Duration;
 public interface OpentelemetryHttpExporterConfig {
 
     @Nullable
+        /**
+         * @return OpenTelemetry Collector endpoint where traces are exported over OTLP/HTTP.
+         */
     String endpoint();
 
+        /**
+         * @return Maximum time to wait while the exporter sends data.
+         */
     default Duration exportTimeout() {
         return Duration.ofSeconds(3);
     }
 
+        /**
+         * @return Maximum time to wait for one accumulated batch of spans to be exported.
+         */
     default Duration batchExportTimeout() {
         return Duration.ofSeconds(30);
     }
 
+        /**
+         * @return Timeout for establishing a connection to the exporter.
+         */
     @Nullable
     Duration connectTimeout();
 
+        /**
+         * @return Data compression used during export, gzip or none.
+         */
     default String compression() {
         return "gzip";
     }
 
+        /**
+         * @return Retry policy applied to failed export attempts.
+         */
     RetryPolicy retryPolicy();
 
+        /**
+         * @return Delay between sending accumulated spans to the collector.
+         */
     default Duration scheduleDelay() {
         return Duration.ofSeconds(2);
     }
 
+        /**
+         * @return Maximum number of spans in one export batch.
+         */
     default int maxExportBatchSize() {
         return 512;
     }
 
+        /**
+         * @return Maximum queue size for spans waiting to be sent.
+         */
     default int maxQueueSize() {
         return 2048;
     }
 
+        /**
+         * @return Whether to export spans that were not selected by the Sampler.
+         */
     default boolean exportUnsampledSpans() {
         return false;
     }
@@ -48,18 +78,30 @@ public interface OpentelemetryHttpExporterConfig {
     @ConfigMapper
     interface RetryPolicy {
 
+        /**
+         * @return Maximum number of retry attempts.
+         */
         default int maxAttempts() {
             return 5;
         }
 
+        /**
+         * @return Initial delay before a retry attempt.
+         */
         default Duration initialBackoff() {
             return Duration.ofSeconds(1);
         }
 
+        /**
+         * @return Maximum delay before a retry attempt.
+         */
         default Duration maxBackoff() {
             return Duration.ofSeconds(5);
         }
 
+        /**
+         * @return Delay multiplier between retry attempts.
+         */
         default double backoffMultiplier() {
             return 1.5d;
         }

--- a/telemetry/telemetry-common/src/main/java/io/koraframework/telemetry/common/TelemetryConfig.java
+++ b/telemetry/telemetry-common/src/main/java/io/koraframework/telemetry/common/TelemetryConfig.java
@@ -8,10 +8,19 @@ import java.util.Map;
 @ConfigMapper
 public interface TelemetryConfig {
 
+    /**
+     * @return Logging telemetry configuration.
+     */
     LoggingConfig logging();
 
+    /**
+     * @return Tracing telemetry configuration.
+     */
     TracingConfig tracing();
 
+    /**
+     * @return Metrics telemetry configuration.
+     */
     MetricsConfig metrics();
 
     @ConfigMapper
@@ -29,6 +38,9 @@ public interface TelemetryConfig {
             return true;
         }
 
+        /**
+         * @return Attributes added to every span created by the module.
+         */
         default Map<String, String> attributes() {
             return Map.of();
         }
@@ -62,6 +74,9 @@ public interface TelemetryConfig {
             return DEFAULT_SLO;
         }
 
+        /**
+         * @return Extra common tags added to every metric reported by the module.
+         */
         default Map<String, String> tags() {
             return Map.of();
         }


### PR DESCRIPTION
Documented(config): add Javadoc to configuration interfaces from documentation.

Backport of #744 (branch 1.0, commit 3480a285d15671a9875967d5b1543a33cc33d7b2)

Adds one-line `@return` descriptions to configuration getters, based on the official documentation, so configuration options are visible directly in the IDE. Documentation only: no code, ordering, formatting, or import changes.

This ports the subset of the 1.0 branch's javadoc coverage that still matches master's configuration interfaces one-for-one. Several config classes touched by the original commit (r2dbc, vertx, http-client-async, micrometer per-version tag providers, HttpClientLoggerConfig, HttpServerLoggerConfig, UndertowHttpServerConfig, OpentelemetryResourceConfig, ScheduledExecutorServiceConfig) no longer exist on master after the 2.0 module removals/rework, so their javadoc was left out. A handful of individual getters in the ported files (mostly in the heavily-restructured resilient, http-server, and openapi-management configs) did not have a matching declaration in master's version of the interface and were left undocumented rather than guessed at.