### PR TITLE
Fixed(cache): change `@Cache` annotation retention from CLASS to RUNTIME (Backport of #722)

### DIFF
--- a/cache/cache-common/src/main/java/io/koraframework/cache/annotation/Cache.java
+++ b/cache/cache-common/src/main/java/io/koraframework/cache/annotation/Cache.java
@@ -6,7 +6,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Target({ElementType.TYPE})
-@Retention(RetentionPolicy.CLASS)
+@Retention(RetentionPolicy.RUNTIME)
 public @interface Cache {
 
     /**


### PR DESCRIPTION
Fixed(cache): change `@Cache` annotation retention from CLASS to RUNTIME (Backport of #722)

Backport of #722 (branch 1.0, commit ef42269f2e68f9104feb7c85675ff6074dc51867)

`@Cache` was declared with `@Retention(RetentionPolicy.CLASS)`, making it invisible to runtime reflection. Consumers relying on runtime annotation lookup could not detect `@Cache`-annotated types.

This mirrors the fix already applied on the 1.0 branch and does not change compile-time processing behavior.