### PR TITLE
Fixed(openapi-generator): support array-of-file multipart client form params (Backport of #651)

### DIFF
--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/AbstractJavaGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/AbstractJavaGenerator.java
@@ -26,7 +26,7 @@ public abstract class AbstractJavaGenerator<C> extends AbstractGenerator<C, Java
         var b = MethodSpec.constructorBuilder();
         for (var formParam : operation.formParams) {
             var type = formParam.isFile
-                ? Classes.formPart
+                ? (formParam.isArray ? ParameterizedTypeName.get(ClassName.get(List.class), Classes.formPart) : Classes.formPart)
                 : asType(ctx, operation, formParam);
             if (!formParam.required) {
                 type = type.box().annotated(AnnotationSpec.builder(Classes.nullable).build());

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientRequestMapperGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientRequestMapperGenerator.java
@@ -81,7 +81,11 @@ public class ClientRequestMapperGenerator extends AbstractJavaGenerator<Operatio
             for (var formParam : operation.formParams) {
                 apply.beginControlFlow("if (value.$N() != null)", formParam.paramName);
                 if (formParam.isFile) {
-                    apply.addStatement("l.add(value.$N())", formParam.paramName);
+                    if (formParam.isArray) {
+                        apply.addStatement("l.addAll(value.$N())", formParam.paramName);
+                    } else {
+                        apply.addStatement("l.add(value.$N())", formParam.paramName);
+                    }
                 } else if (requiresMapper(formParam)) {
                     apply.addStatement("l.add($T.data($S, $N.convert(value.$N())))", Classes.formMultipart, formParam.baseName, formParam.paramName + "Converter", formParam.paramName);
                 } else {

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ServerRequestMapperGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ServerRequestMapperGenerator.java
@@ -97,6 +97,10 @@ public class ServerRequestMapperGenerator extends AbstractJavaGenerator<Operatio
     private CodeBlock mapMultipart(OperationsMap ctx, CodegenOperation op, ClassName formParamClass) {
         var b = CodeBlock.builder();
         for (var formParam : op.formParams) {
+            if (formParam.isFile && formParam.isArray) {
+                b.addStatement("var $N = new $T<$T>()", formParam.paramName, ClassName.get(java.util.ArrayList.class), Classes.formPart);
+                continue;
+            }
             var type = asType(formParam);
             if (formParam.isFile) {
                 type = Classes.formPart;
@@ -108,7 +112,9 @@ public class ServerRequestMapperGenerator extends AbstractJavaGenerator<Operatio
         for (var formParam : op.formParams) {
             b.beginControlFlow("case $S -> ", formParam.baseName);
             var type = asType(formParam);
-            if (formParam.isFile) {
+            if (formParam.isFile && formParam.isArray) {
+                b.addStatement("$N.add(_part)", formParam.paramName);
+            } else if (formParam.isFile) {
                 b.addStatement("$N = _part", formParam.paramName);
             } else if (type.equals(ClassName.get(String.class))) {
                 b.addStatement("$N = new $T(_part.content(), $T.UTF_8)", formParam.paramName, String.class, StandardCharsets.class);
@@ -122,7 +128,11 @@ public class ServerRequestMapperGenerator extends AbstractJavaGenerator<Operatio
         b.endControlFlow();
         for (var formParam : op.formParams) {
             if (formParam.required) {
-                b.beginControlFlow("if ($N == null)", formParam.paramName);
+                if (formParam.isFile && formParam.isArray) {
+                    b.beginControlFlow("if ($N.isEmpty())", formParam.paramName);
+                } else {
+                    b.beginControlFlow("if ($N == null)", formParam.paramName);
+                }
                 b.addStatement("throw $T.of(400, $S)", Classes.httpServerResponseException, "Form key '%s' is required".formatted(formParam.baseName));
                 b.endControlFlow();
             }

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/AbstractKotlinGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/AbstractKotlinGenerator.kt
@@ -71,7 +71,7 @@ abstract class AbstractKotlinGenerator<C : Any> : AbstractGenerator<C, FileSpec>
         val b = FunSpec.constructorBuilder()
         for (formParam in operation.formParams) {
             var type = if (formParam.isFile)
-                Classes.formPart.asKt()
+                (if (formParam.isArray) LIST.parameterizedBy(Classes.formPart.asKt()) else Classes.formPart.asKt())
             else
                 asType(ctx, operation, formParam).asKt()
             if (!formParam.required) {

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ClientRequestMapperGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ClientRequestMapperGenerator.kt
@@ -83,7 +83,11 @@ class ClientRequestMapperGenerator : AbstractKotlinGenerator<OperationsMap>() {
                     apply.beginControlFlow("value.%N?.let", formParam.paramName)
                 }
                 if (formParam.isFile) {
-                    apply.addStatement("l.add(it)")
+                    if (formParam.isArray) {
+                        apply.addStatement("l.addAll(it)")
+                    } else {
+                        apply.addStatement("l.add(it)")
+                    }
                 } else if (requiresMapper(formParam)) {
                     apply.addStatement("l.add(%T.data(%S, %N.convert(it)))", Classes.formMultipart.asKt(), formParam.baseName, formParam.paramName + "Converter")
                 } else {

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ServerRequestMappersGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ServerRequestMappersGenerator.kt
@@ -92,6 +92,10 @@ class ServerRequestMappersGenerator : AbstractKotlinGenerator<OperationsMap>() {
     private fun mapMultipart(ctx: OperationsMap, op: CodegenOperation, formParamClass: ClassName): CodeBlock {
         val b = CodeBlock.builder()
         for (formParam in op.formParams) {
+            if (formParam.isFile && formParam.isArray) {
+                b.addStatement("val %N = mutableListOf<%T>()", formParam.paramName, Classes.formPart.asKt())
+                continue
+            }
             var type = asType(formParam).asKt()
             if (formParam.isFile) {
                 type = Classes.formPart.asKt()
@@ -103,7 +107,9 @@ class ServerRequestMappersGenerator : AbstractKotlinGenerator<OperationsMap>() {
         for (formParam in op.formParams) {
             b.beginControlFlow("%S -> ", formParam.baseName)
             val type = asType(formParam).asKt()
-            if (formParam.isFile) {
+            if (formParam.isFile && formParam.isArray) {
+                b.addStatement("%N.add(_part)", formParam.paramName)
+            } else if (formParam.isFile) {
                 b.addStatement("%N = _part", formParam.paramName)
             } else if (type == String::class.asClassName()) {
                 b.addStatement("%N = %T(_part.content(), %T.UTF_8)", formParam.paramName, String::class.asClassName(), StandardCharsets::class.asClassName())
@@ -117,7 +123,11 @@ class ServerRequestMappersGenerator : AbstractKotlinGenerator<OperationsMap>() {
         b.endControlFlow()
         for (formParam in op.formParams) {
             if (formParam.required) {
-                b.beginControlFlow("if (%N == null)", formParam.paramName)
+                if (formParam.isFile && formParam.isArray) {
+                    b.beginControlFlow("if (%N.isEmpty())", formParam.paramName)
+                } else {
+                    b.beginControlFlow("if (%N == null)", formParam.paramName)
+                }
                 b.addStatement("throw %T.of(400, %S)", Classes.httpServerResponseException.asKt(), "Form key '${formParam.baseName}' is required")
                 b.endControlFlow()
             }


### PR DESCRIPTION
Fixed(openapi-generator): support array-of-file multipart client form params (Backport of #651)

Backport of #651 (branch 1.0, commit 20813b8326934dd3554d80b1c4333ce4713e3e6e)

For a multipart client operation with an array-of-file form parameter, the generated `FormParam` record held a single `FormPart` and the request mapper only ever sent the last supplied part, silently dropping the rest. File form params now generate a `List<FormPart>` type when the underlying schema is an array, and the client request mapper appends all of them via `addAll` instead of overwriting with a single `add`.

This mirrors the fix already applied on the 1.0 branch, ported to the JavaPoet/KotlinPoet-based `javagen`/`kotlingen` generators that replaced the mustache-template-based client generation used at the time of the original commit.