### PR TITLE
Fixed(openapi-generator): Base64-encode/decode multipart `byte`-format form fields (Backport of #763)

### DIFF
--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientRequestMapperGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientRequestMapperGenerator.java
@@ -7,6 +7,7 @@ import org.openapitools.codegen.model.OperationsMap;
 
 import javax.lang.model.element.Modifier;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Objects;
 
 import static io.koraframework.openapi.generator.KoraCodegen.isContentJson;
@@ -86,6 +87,12 @@ public class ClientRequestMapperGenerator extends AbstractJavaGenerator<Operatio
                     } else {
                         apply.addStatement("l.add(value.$N())", formParam.paramName);
                     }
+                } else if (isByteArrayArrayType(formParam)) {
+                    apply.beginControlFlow("for (var item : value.$N())", formParam.paramName)
+                        .addStatement("l.add($T.data($S, $T.getEncoder().encodeToString(item)))", Classes.formMultipart, formParam.baseName, ClassName.get(Base64.class))
+                        .endControlFlow();
+                } else if (isByteArrayType(formParam)) {
+                    apply.addStatement("l.add($T.data($S, $T.getEncoder().encodeToString(value.$N())))", Classes.formMultipart, formParam.baseName, ClassName.get(Base64.class), formParam.paramName);
                 } else if (requiresMapper(formParam)) {
                     apply.addStatement("l.add($T.data($S, $N.convert(value.$N())))", Classes.formMultipart, formParam.baseName, formParam.paramName + "Converter", formParam.paramName);
                 } else {
@@ -99,6 +106,17 @@ public class ClientRequestMapperGenerator extends AbstractJavaGenerator<Operatio
         }
 
         return b.addMethod(constructor.build()).addMethod(apply.build()).build();
+    }
+
+    private boolean isByteArrayType(CodegenParameter p) {
+        return "byte[]".equals(p.dataType) || "ByteArray".equals(p.dataType);
+    }
+
+    private boolean isByteArrayArrayType(CodegenParameter p) {
+        return Boolean.TRUE.equals(p.isArray)
+            && ("byte[]".equals(p.baseType)
+                || "ByteArray".equals(p.baseType)
+                || (p.dataType != null && (p.dataType.contains("byte[]") || p.dataType.contains("ByteArray"))));
     }
 
     private boolean requiresMapper(CodegenParameter p) {

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ServerRequestMapperGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ServerRequestMapperGenerator.java
@@ -2,12 +2,14 @@ package io.koraframework.openapi.generator.javagen;
 
 import com.palantir.javapoet.*;
 import org.openapitools.codegen.CodegenOperation;
+import org.openapitools.codegen.CodegenParameter;
 import org.openapitools.codegen.model.OperationsMap;
 import io.koraframework.openapi.generator.KoraCodegen;
 
 import javax.lang.model.element.Modifier;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.List;
 
 public class ServerRequestMapperGenerator extends AbstractJavaGenerator<OperationsMap> {
@@ -49,7 +51,8 @@ public class ServerRequestMapperGenerator extends AbstractJavaGenerator<Operatio
 
         for (var formParam : op.formParams) {
             var paramType = asType(formParam);
-            if (paramType.equals(ParameterizedTypeName.get(List.class, String.class)) || paramType.equals(ClassName.get(String.class))) {
+            if (paramType.equals(ParameterizedTypeName.get(List.class, String.class)) || paramType.equals(ClassName.get(String.class))
+                || isByteArrayType(formParam) || isByteArrayArrayType(formParam)) {
                 continue;
             }
             var mapperType = ParameterizedTypeName.get(Classes.stringParameterReader, formParam.isArray ? ((ParameterizedTypeName) paramType).typeArguments().getFirst().box() : paramType.box());
@@ -84,6 +87,17 @@ public class ServerRequestMapperGenerator extends AbstractJavaGenerator<Operatio
         return b.build();
     }
 
+    private boolean isByteArrayType(CodegenParameter p) {
+        return "byte[]".equals(p.dataType) || "ByteArray".equals(p.dataType);
+    }
+
+    private boolean isByteArrayArrayType(CodegenParameter p) {
+        return Boolean.TRUE.equals(p.isArray)
+            && ("byte[]".equals(p.baseType)
+                || "ByteArray".equals(p.baseType)
+                || (p.dataType != null && (p.dataType.contains("byte[]") || p.dataType.contains("ByteArray"))));
+    }
+
     private static String missingFormContentTypeError(CodegenOperation operation) {
         return """
             Invalid OpenAPI operation `%s`: unsupported server form request body.
@@ -99,6 +113,9 @@ public class ServerRequestMapperGenerator extends AbstractJavaGenerator<Operatio
         for (var formParam : op.formParams) {
             if (formParam.isFile && formParam.isArray) {
                 b.addStatement("var $N = new $T<$T>()", formParam.paramName, ClassName.get(java.util.ArrayList.class), Classes.formPart);
+                continue;
+            } else if (isByteArrayArrayType(formParam)) {
+                b.addStatement("var $N = new $T<byte[]>()", formParam.paramName, ClassName.get(java.util.ArrayList.class));
                 continue;
             }
             var type = asType(formParam);
@@ -116,6 +133,10 @@ public class ServerRequestMapperGenerator extends AbstractJavaGenerator<Operatio
                 b.addStatement("$N.add(_part)", formParam.paramName);
             } else if (formParam.isFile) {
                 b.addStatement("$N = _part", formParam.paramName);
+            } else if (isByteArrayArrayType(formParam)) {
+                b.addStatement("$N.add($T.getDecoder().decode(_part.content()))", formParam.paramName, ClassName.get(Base64.class));
+            } else if (isByteArrayType(formParam)) {
+                b.addStatement("$N = $T.getDecoder().decode(_part.content())", formParam.paramName, ClassName.get(Base64.class));
             } else if (type.equals(ClassName.get(String.class))) {
                 b.addStatement("$N = new $T(_part.content(), $T.UTF_8)", formParam.paramName, String.class, StandardCharsets.class);
             } else {
@@ -129,6 +150,8 @@ public class ServerRequestMapperGenerator extends AbstractJavaGenerator<Operatio
         for (var formParam : op.formParams) {
             if (formParam.required) {
                 if (formParam.isFile && formParam.isArray) {
+                    b.beginControlFlow("if ($N.isEmpty())", formParam.paramName);
+                } else if (isByteArrayArrayType(formParam)) {
                     b.beginControlFlow("if ($N.isEmpty())", formParam.paramName);
                 } else {
                     b.beginControlFlow("if ($N == null)", formParam.paramName);

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ClientRequestMapperGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ClientRequestMapperGenerator.kt
@@ -12,6 +12,7 @@ class ClientRequestMapperGenerator : AbstractKotlinGenerator<OperationsMap>() {
 
     companion object {
         val urlEncodedWriter = ClassName("io.koraframework.http.client.common.request.form", "FormUrlEncodedWriter")
+        val base64 = ClassName("java.util", "Base64")
     }
 
     override fun generate(ctx: OperationsMap): FileSpec {
@@ -88,6 +89,12 @@ class ClientRequestMapperGenerator : AbstractKotlinGenerator<OperationsMap>() {
                     } else {
                         apply.addStatement("l.add(it)")
                     }
+                } else if (isByteArrayArrayType(formParam)) {
+                    apply.beginControlFlow("for (item in it)")
+                        .addStatement("l.add(%T.data(%S, %T.getEncoder().encodeToString(item)))", Classes.formMultipart.asKt(), formParam.baseName, base64)
+                        .endControlFlow()
+                } else if (isByteArrayType(formParam)) {
+                    apply.addStatement("l.add(%T.data(%S, %T.getEncoder().encodeToString(it)))", Classes.formMultipart.asKt(), formParam.baseName, base64)
                 } else if (requiresMapper(formParam)) {
                     apply.addStatement("l.add(%T.data(%S, %N.convert(it)))", Classes.formMultipart.asKt(), formParam.baseName, formParam.paramName + "Converter")
                 } else {
@@ -104,6 +111,13 @@ class ClientRequestMapperGenerator : AbstractKotlinGenerator<OperationsMap>() {
         b.primaryConstructor(constructor.build())
         return b.build()
     }
+
+    private fun isByteArrayType(p: CodegenParameter): Boolean =
+        p.dataType == "byte[]" || p.dataType == "ByteArray"
+
+    private fun isByteArrayArrayType(p: CodegenParameter): Boolean =
+        p.isArray == true && (p.baseType == "byte[]" || p.baseType == "ByteArray"
+            || p.dataType?.contains("byte[]") == true || p.dataType?.contains("ByteArray") == true)
 
     private fun requiresMapper(p: CodegenParameter): Boolean {
         if (isContentJson(p)) {

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ServerRequestMappersGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ServerRequestMappersGenerator.kt
@@ -3,6 +3,7 @@ package io.koraframework.openapi.generator.kotlingen
 import com.squareup.kotlinpoet.*
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import org.openapitools.codegen.CodegenOperation
+import org.openapitools.codegen.CodegenParameter
 import org.openapitools.codegen.model.OperationsMap
 import io.koraframework.openapi.generator.KoraCodegen
 import java.nio.charset.StandardCharsets
@@ -13,7 +14,15 @@ class ServerRequestMappersGenerator : AbstractKotlinGenerator<OperationsMap>() {
     companion object {
         val multipartReader = ClassName("io.koraframework.http.server.common.request.form", "MultipartReaderUtils")
         val formUrlMapper = ClassName("io.koraframework.http.server.common.request.mapper", "FormUrlEncodedServerRequestMapper")
+        val base64 = ClassName("java.util", "Base64")
     }
+
+    private fun isByteArrayType(p: CodegenParameter): Boolean =
+        p.dataType == "byte[]" || p.dataType == "ByteArray"
+
+    private fun isByteArrayArrayType(p: CodegenParameter): Boolean =
+        p.isArray == true && (p.baseType == "byte[]" || p.baseType == "ByteArray"
+            || p.dataType?.contains("byte[]") == true || p.dataType?.contains("ByteArray") == true)
 
     override fun generate(ctx: OperationsMap): FileSpec {
         val b = TypeSpec.interfaceBuilder(ctx.get("classname").toString() + "ServerRequestMappers")
@@ -47,7 +56,8 @@ class ServerRequestMappersGenerator : AbstractKotlinGenerator<OperationsMap>() {
 
         for (formParam in op.formParams) {
             val paramType = asType(formParam).asKt()
-            if (paramType == List::class.asClassName().parameterizedBy(String::class.asClassName()) || paramType == String::class.asClassName()) {
+            if (paramType == List::class.asClassName().parameterizedBy(String::class.asClassName()) || paramType == String::class.asClassName()
+                || isByteArrayType(formParam) || isByteArrayArrayType(formParam)) {
                 continue
             }
             val mapperType = Classes.stringParameterReader.asKt().parameterizedBy(if (formParam.isArray) (paramType as ParameterizedTypeName).typeArguments.single() else paramType)
@@ -95,6 +105,9 @@ class ServerRequestMappersGenerator : AbstractKotlinGenerator<OperationsMap>() {
             if (formParam.isFile && formParam.isArray) {
                 b.addStatement("val %N = mutableListOf<%T>()", formParam.paramName, Classes.formPart.asKt())
                 continue
+            } else if (isByteArrayArrayType(formParam)) {
+                b.addStatement("val %N = mutableListOf<ByteArray>()", formParam.paramName)
+                continue
             }
             var type = asType(formParam).asKt()
             if (formParam.isFile) {
@@ -111,6 +124,10 @@ class ServerRequestMappersGenerator : AbstractKotlinGenerator<OperationsMap>() {
                 b.addStatement("%N.add(_part)", formParam.paramName)
             } else if (formParam.isFile) {
                 b.addStatement("%N = _part", formParam.paramName)
+            } else if (isByteArrayArrayType(formParam)) {
+                b.addStatement("%N.add(%T.getDecoder().decode(_part.content()))", formParam.paramName, base64)
+            } else if (isByteArrayType(formParam)) {
+                b.addStatement("%N = %T.getDecoder().decode(_part.content())", formParam.paramName, base64)
             } else if (type == String::class.asClassName()) {
                 b.addStatement("%N = %T(_part.content(), %T.UTF_8)", formParam.paramName, String::class.asClassName(), StandardCharsets::class.asClassName())
             } else {
@@ -124,6 +141,8 @@ class ServerRequestMappersGenerator : AbstractKotlinGenerator<OperationsMap>() {
         for (formParam in op.formParams) {
             if (formParam.required) {
                 if (formParam.isFile && formParam.isArray) {
+                    b.beginControlFlow("if (%N.isEmpty())", formParam.paramName)
+                } else if (isByteArrayArrayType(formParam)) {
                     b.beginControlFlow("if (%N.isEmpty())", formParam.paramName)
                 } else {
                     b.beginControlFlow("if (%N == null)", formParam.paramName)


### PR DESCRIPTION
Fixed(openapi-generator): Base64-encode/decode multipart `byte`-format form fields (Backport of #763)

Backport of #763 (branch 1.0, commit c93cb7759b2f517c4fa00965dfba68e5756330b9)

An OpenAPI `type: string, format: byte` multipart form field (Java `byte[]` / Kotlin `ByteArray`) was serialized client-side with `Objects.toString(value)` (producing an array's `Object.toString()`, e.g. `[B@1a2b3c`) and read back server-side as a raw UTF-8 string, instead of the Base64 encoding OpenAPI's `byte` format requires.

Byte-typed (and array-of-byte-typed) multipart form fields are now detected via their generated Java/Kotlin type and Base64-encoded on the client request mapper and Base64-decoded on the server request mapper, bypassing the generic string-parameter converter machinery for that field entirely.

This mirrors the fix already applied on the 1.0 branch, ported to the JavaPoet/KotlinPoet-based `javagen`/`kotlingen` generators that replaced the mustache-template-based generation used at the time of the original commit.