### PR TITLE
Added(database-jdbc): Kotlin lambda extensions for JdbcExecutor (Backport of #698)

### DIFF
--- a/database/database-jdbc/build.gradle
+++ b/database/database-jdbc/build.gradle
@@ -1,3 +1,5 @@
+apply from: "${project.rootDir}/gradle/kotlin-plugin.gradle"
+
 dependencies {
     annotationProcessor project(":config:config-annotation-processor")
 

--- a/database/database-jdbc/src/main/kotlin/io/koraframework/database/jdbc/JdbcExecutorExtension.kt
+++ b/database/database-jdbc/src/main/kotlin/io/koraframework/database/jdbc/JdbcExecutorExtension.kt
@@ -1,0 +1,27 @@
+package io.koraframework.database.jdbc
+
+import java.sql.Connection
+
+/**
+ * <b>Русский</b>: Выполняет операцию на JDBC-соединении в ручном режиме. Kotlin-обёртка над
+ * перегруженными методами [JdbcExecutor.withConnection], которая снимает неоднозначность
+ * вывода перегрузок (overload resolution ambiguity) при передаче лямбды из Kotlin.
+ * <hr>
+ * <b>English</b>: Runs an operation on a JDBC connection in manual mode. A Kotlin wrapper over the
+ * overloaded [JdbcExecutor.withConnection] methods that removes the overload-resolution ambiguity
+ * when a lambda is passed from Kotlin.
+ */
+inline fun <T> JdbcExecutor.withConnectionKt(crossinline callback: (Connection) -> T): T =
+    withConnection(JdbcExecutor.SqlFunction<Connection, T> { callback(it) })
+
+/**
+ * <b>Русский</b>: Выполняет операцию на JDBC-соединении в рамках транзакции. Kotlin-обёртка над
+ * перегруженными методами [JdbcExecutor.inTx], которая снимает неоднозначность вывода
+ * перегрузок (overload resolution ambiguity) при передаче лямбды из Kotlin.
+ * <hr>
+ * <b>English</b>: Runs an operation on a JDBC connection within a transaction. A Kotlin wrapper over
+ * the overloaded [JdbcExecutor.inTx] methods that removes the overload-resolution ambiguity
+ * when a lambda is passed from Kotlin.
+ */
+inline fun <T> JdbcExecutor.inTxKt(crossinline callback: (ConnectionContext) -> T): T =
+    inTx(JdbcExecutor.SqlFunction<ConnectionContext, T> { callback(it) })


### PR DESCRIPTION
Added(database-jdbc): Kotlin lambda extensions for JdbcExecutor (Backport of #698)

Backport of #698 (branch 1.0, commit 0cce1033e6c00f43a69499a09dc257042555e47f)

`JdbcExecutor.withConnection`/`inTx` are each overloaded across `SqlFunction`, `SqlSupplier`, `SqlConsumer`, and `SqlRunnable` functional interfaces. Calling them with a Kotlin trailing lambda is ambiguous for the compiler, since more than one overload's SAM shape matches. Two inline extension functions, `withConnectionKt` and `inTxKt`, pin the call to the `SqlFunction` overload so a plain Kotlin lambda resolves unambiguously.

Enables the Kotlin plugin on `database-jdbc`, which previously had no Kotlin sources.

This ports the intent of the 1.0 branch's `JdbcConnectionFactory` extensions to 2.0's renamed `JdbcExecutor`/`ConnectionContext` API. `inTxKt`'s callback receives `ConnectionContext` (as `inTx` itself does in 2.0) rather than `Connection`. The 1.0 commit's coroutine-suspending variants (`withConnectionSuspend`, `inTxSuspend`) are intentionally not ported: JDBC-repository coroutine support was removed in 2.0 and has no replacement to build a suspending extension against.