### PR TITLE
Fixed(http-client): avoid NPE in telemetry tags/logs for undefined host, scheme, or authority (Backport of #754)

### DIFF
--- a/http/http-client-common/src/main/java/io/koraframework/http/client/common/telemetry/impl/DefaultHttpClientLoggerFactory.java
+++ b/http/http-client-common/src/main/java/io/koraframework/http/client/common/telemetry/impl/DefaultHttpClientLoggerFactory.java
@@ -87,7 +87,9 @@ public class DefaultHttpClientLoggerFactory {
                 : null;
             var arg = (StructuredArgumentWriter) gen -> {
                 gen.writeStartObject();
-                gen.writeStringProperty("authority", rq.uri().getAuthority());
+                if (rq.uri().getAuthority() != null) {
+                    gen.writeStringProperty("authority", rq.uri().getAuthority());
+                }
                 gen.writeStringProperty("operation", operation);
                 if (finalQuery != null && !finalQuery.isEmpty()) {
                     gen.writeStringProperty("queryParams", MaskingUtils.toMaskedString(maskedQueryParams, context.config().logging().mask(), finalQuery));
@@ -139,7 +141,9 @@ public class DefaultHttpClientLoggerFactory {
 
             var arg = (StructuredArgumentWriter) gen -> {
                 gen.writeStartObject();
-                gen.writeStringProperty("authority", rq.uri().getAuthority());
+                if (rq.uri().getAuthority() != null) {
+                    gen.writeStringProperty("authority", rq.uri().getAuthority());
+                }
                 gen.writeStringProperty("operation", operation);
                 gen.writeStringProperty("resultCode", HttpResultCode.fromStatusCode(rs.code()).string());
                 gen.writeNumberProperty("processingTime", processingTookNanos / 1_000_000);
@@ -168,7 +172,9 @@ public class DefaultHttpClientLoggerFactory {
             var exceptionTypeString = exception.getClass().getCanonicalName();
             var arg = (StructuredArgumentWriter) gen -> {
                 gen.writeStartObject();
-                gen.writeStringProperty("authority", rq.uri().getAuthority());
+                if (rq.uri().getAuthority() != null) {
+                    gen.writeStringProperty("authority", rq.uri().getAuthority());
+                }
                 gen.writeStringProperty("operation", operation);
                 gen.writeStringProperty("resultCode", HttpResultCode.CONNECTION_ERROR.string());
                 gen.writeNumberProperty("processingTime", processingTime / 1_000_000);

--- a/http/http-client-common/src/main/java/io/koraframework/http/client/common/telemetry/impl/DefaultHttpClientMetricsFactory.java
+++ b/http/http-client-common/src/main/java/io/koraframework/http/client/common/telemetry/impl/DefaultHttpClientMetricsFactory.java
@@ -28,8 +28,8 @@ public class DefaultHttpClientMetricsFactory {
 
         public record DurationKey(int statusCode,
                                   String method,
-                                  String host,
-                                  String scheme,
+                                  @Nullable String host,
+                                  @Nullable String scheme,
                                   String target,
                                   @Nullable Class<? extends Throwable> errorType,
                                   @Nullable Tags extraTags) {
@@ -88,8 +88,12 @@ public class DefaultHttpClientMetricsFactory {
 
             staticTags.add(Tag.of(HttpAttributes.HTTP_REQUEST_METHOD.getKey(), request.method()));
             staticTags.add(Tag.of(HttpAttributes.HTTP_RESPONSE_STATUS_CODE.getKey(), statusCodeStr));
-            staticTags.add(Tag.of(ServerAttributes.SERVER_ADDRESS.getKey(), request.uri().getHost()));
-            staticTags.add(Tag.of(UrlAttributes.URL_SCHEME.getKey(), request.uri().getScheme()));
+            if (request.uri().getHost() != null) {
+                staticTags.add(Tag.of(ServerAttributes.SERVER_ADDRESS.getKey(), request.uri().getHost()));
+            }
+            if (request.uri().getScheme() != null) {
+                staticTags.add(Tag.of(UrlAttributes.URL_SCHEME.getKey(), request.uri().getScheme()));
+            }
             staticTags.add(Tag.of(HttpAttributes.HTTP_ROUTE.getKey(), request.uriTemplate()));
             staticTags.add(Tag.of(ErrorAttributes.ERROR_TYPE.getKey(), errorType));
             staticTags.add(Tag.of(DefaultHttpClientTelemetry.SYSTEM_CONFIG_PATH, this.context.clientConfigPath()));


### PR DESCRIPTION
Fixed(http-client): avoid NPE in telemetry tags/logs for undefined host, scheme, or authority (Backport of #754)

Backport of #754 (branch 1.0, commit 1344c66e1a0f34c9702d74627cf20e9936fb8a09)

`URI.getHost()`, `URI.getScheme()`, and `URI.getAuthority()` return `null` for relative or opaque request URIs. `DefaultHttpClientMetricsFactory` passed the host/scheme values straight into `Tag.of(key, value)`, which throws NPE on a null value, and `DefaultHttpClientLoggerFactory` wrote the authority unconditionally via `writeStringProperty`.

- Fixed(http-client): `DurationKey.host`/`scheme` are now `@Nullable`, and the corresponding metric tags are only added when non-null.
- Fixed(http-client): the `authority` log property (request start, response, and error logging) is now only written when non-null.

This mirrors the fix already applied on the 1.0 branch; the specific telemetry types touched by the original commit (`Opentelemetry120/123` tag providers) no longer exist after 2.0's telemetry rework, so the fix is applied to their equivalent `Default*Factory` classes.