### PR TITLE
Fixed(http): stop forcing span status OK for successful HTTP requests (Backport of #578)

### DIFF
--- a/http/http-client-common/src/main/java/io/koraframework/http/client/common/telemetry/impl/DefaultHttpClientObservation.java
+++ b/http/http-client-common/src/main/java/io/koraframework/http/client/common/telemetry/impl/DefaultHttpClientObservation.java
@@ -187,8 +187,6 @@ public class DefaultHttpClientObservation implements HttpClientObservation {
         var resultCode = Objects.requireNonNullElse(this.resultCode, HttpResultCode.SERVER_ERROR);
         if (statusCode >= 400 || resultCode == HttpResultCode.CONNECTION_ERROR || exception != null) {
             span.setStatus(StatusCode.ERROR);
-        } else {
-            span.setStatus(StatusCode.OK);
         }
         if (response != null && response.body() != null) {
             var contentType = response.body().contentType();

--- a/http/http-server-common/src/main/java/io/koraframework/http/server/common/telemetry/impl/DefaultHttpServerObservation.java
+++ b/http/http-server-common/src/main/java/io/koraframework/http/server/common/telemetry/impl/DefaultHttpServerObservation.java
@@ -210,8 +210,6 @@ public class DefaultHttpServerObservation implements HttpServerObservation {
 
             if (statusCode >= 500 || resultCode == HttpResultCode.CONNECTION_ERROR || exception != null) {
                 span.setStatus(StatusCode.ERROR);
-            } else {
-                span.setStatus(StatusCode.OK);
             }
 
             if (statusCode != 0) {


### PR DESCRIPTION
Fixed(http): stop forcing span status OK for successful HTTP requests (Backport of #578)

Backport of #578 (branch 1.0, commit 1231608ef98e64e0c909b3bda3cf02eb2473a7e6)

Per the OpenTelemetry HTTP semantic conventions, span status must be left unset for successful responses and only set to ERROR on failure - explicitly setting OK is a spec deviation. Both `DefaultHttpServerObservation.closeSpan` and `DefaultHttpClientObservation.completeSpan` set `StatusCode.OK` in the non-error branch; that branch is removed, leaving status unset on success while the existing ERROR conditions (5xx / connection error / exception on the server side, 4xx+ / connection error / exception on the client side) are unchanged.

This mirrors the corresponding half of the fix already applied on the 1.0 branch.