### PR TITLE
Fixed(database-cassandra): apply `advanced.coalescer.rescheduleInterval` to the driver (Backport of #745)

### DIFF
--- a/database/database-cassandra/src/main/java/io/koraframework/database/cassandra/util/CassandraSessionBuilderUtils.java
+++ b/database/database-cassandra/src/main/java/io/koraframework/database/cassandra/util/CassandraSessionBuilderUtils.java
@@ -132,6 +132,10 @@ public final class CassandraSessionBuilderUtils {
             applyNettyConfig(builder, config.netty());
         }
 
+        if (config.coalescer() != null && config.coalescer().rescheduleInterval() != null) {
+            builder.withDuration(COALESCER_INTERVAL, config.coalescer().rescheduleInterval());
+        }
+
         if (config.throttler() != null) {
             var throttler = config.throttler();
             if (throttler.throttlerClass() != null) builder.withString(REQUEST_THROTTLER_CLASS, throttler.throttlerClass());


### PR DESCRIPTION
Fixed(database-cassandra): apply `advanced.coalescer.rescheduleInterval` to the driver (Backport of #745)

Backport of #745 (branch 1.0, commit c60c3b20f2eb0a2918d39a09547fbb303ac22240)

The `coalescer.rescheduleInterval` config value was parsed into `CassandraConfig.Advanced.CoalescerConfig` but never applied to the DataStax driver's `ProgrammaticDriverConfigLoaderBuilder`, so the setting had no effect at runtime.

This mirrors the fix already applied on the 1.0 branch.