### PR TITLE
Fixed(openapi-generator): support array-of-file multipart server form params (Backport of #649)

### DIFF
--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ServerRequestMapperGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ServerRequestMapperGenerator.java
@@ -8,6 +8,7 @@ import io.koraframework.openapi.generator.KoraCodegen;
 import javax.lang.model.element.Modifier;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 
 public class ServerRequestMapperGenerator extends AbstractJavaGenerator<OperationsMap> {


### PR DESCRIPTION
Fixed(openapi-generator): support array-of-file multipart server form params (Backport of #649)

Backport of #649 (branch 1.0, commit 23b8646283e8ddd67bd79c5f85f575c99eedec0d)

For a multipart server operation with an array-of-file form parameter, the generated request mapper switch-assigned each incoming part with the same field name to a single variable, so repeated parts overwrote each other and only the last one reached the controller; the required-field check also compared against `null` instead of checking for an empty collection. File form params now accumulate into a `List<FormPart>` (matching the record type from #651) and the required check uses `isEmpty()`.

This mirrors the fix already applied on the 1.0 branch, ported to the JavaPoet/KotlinPoet-based `javagen`/`kotlingen` generators that replaced the mustache-template-based server generation used at the time of the original commit.