### PR TITLE
Added(cache-redis): `RedisCache#putExpireAfterWrite` contracts for manual TTL regulation (Backport of #682)

### DIFF
--- a/cache/cache-redis-common/src/main/java/io/koraframework/cache/redis/AbstractRedisCache.java
+++ b/cache/cache-redis-common/src/main/java/io/koraframework/cache/redis/AbstractRedisCache.java
@@ -14,6 +14,7 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.helpers.NOPLogger;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.CompletionException;
 import java.util.function.Function;
@@ -157,6 +158,16 @@ public abstract class AbstractRedisCache<K, V> implements RedisCache<K, V> {
 
     @Override
     public V put(K key, V value) {
+        return putExpireAfterWrite(key, value, expireAfterWriteMillis);
+    }
+
+    @Override
+    public V putExpireAfterWrite(K key, V value, Duration expireAfterWrite) {
+        Objects.requireNonNull(expireAfterWrite, "RedisCache#putExpireAfterWrite received nullable expireAfterWrite argument");
+        return putExpireAfterWrite(key, value, expireAfterWrite.toMillis());
+    }
+
+    private V putExpireAfterWrite(K key, V value, @Nullable Long expireAfterWriteMillis) {
         if (key == null || value == null) {
             return null;
         }
@@ -194,6 +205,16 @@ public abstract class AbstractRedisCache<K, V> implements RedisCache<K, V> {
 
     @Override
     public Map<K, V> put(Map<K, V> keyAndValues) {
+        return putExpireAfterWrite(keyAndValues, expireAfterWriteMillis);
+    }
+
+    @Override
+    public Map<K, V> putExpireAfterWrite(Map<K, V> keyAndValues, Duration expireAfterWrite) {
+        Objects.requireNonNull(expireAfterWrite, "RedisCache#putExpireAfterWrite received nullable expireAfterWrite argument");
+        return putExpireAfterWrite(keyAndValues, expireAfterWrite.toMillis());
+    }
+
+    private Map<K, V> putExpireAfterWrite(Map<K, V> keyAndValues, @Nullable Long expireAfterWriteMillis) {
         if (keyAndValues == null || keyAndValues.isEmpty()) {
             return Collections.emptyMap();
         }

--- a/cache/cache-redis-common/src/main/java/io/koraframework/cache/redis/RedisCache.java
+++ b/cache/cache-redis-common/src/main/java/io/koraframework/cache/redis/RedisCache.java
@@ -2,6 +2,12 @@ package io.koraframework.cache.redis;
 
 import io.koraframework.cache.Cache;
 
+import java.time.Duration;
+import java.util.Map;
+
 public interface RedisCache<K, V> extends Cache<K, V> {
 
+    V putExpireAfterWrite(K key, V value, Duration expireAfterWrite);
+
+    Map<K, V> putExpireAfterWrite(Map<K, V> keyAndValues, Duration expireAfterWrite);
 }


### PR DESCRIPTION
Added(cache-redis): `RedisCache#putExpireAfterWrite` contracts for manual TTL regulation (Backport of #682)

Backport of #682 (branch 1.0, commit eea616159b394c80430878458afe3623a9bb3410)

`RedisCache` only supported the config-level `expireAfterWrite` for every `put`, with no way to override the TTL for a specific entry. `put`/`put(Map)` now delegate to a private millis-taking helper also used by two new public `putExpireAfterWrite` overloads that accept an explicit `Duration`.

This ports only the synchronous contracts from the original 1.0 commit; `putAsyncExpireAfterWrite` is not applicable since the asynchronous cache API (`AsyncCache`) was removed from `RedisCache` in 2.0.