### PR TITLE
Added(json): custom JSON value for arbitrary types via @JsonReader factory / @JsonWriter method (Backport of #701)

### DIFF
--- a/json/json-annotation-processor/src/main/java/io/koraframework/json/annotation/processor/JsonAnnotationProcessor.java
+++ b/json/json-annotation-processor/src/main/java/io/koraframework/json/annotation/processor/JsonAnnotationProcessor.java
@@ -61,10 +61,24 @@ public class JsonAnnotationProcessor extends AbstractKoraProcessor {
         }
         var jsonWriterElements = annotatedElements.getOrDefault(JsonTypes.jsonWriterAnnotation, List.of());
         LogUtils.logAnnotatedElementsFull(log, Level.DEBUG, "Generating JsonWriters for", jsonWriterElements);
+        var processedWriterTypes = new java.util.HashSet<String>();
         for (var annotated : jsonWriterElements) {
             var element = annotated.element();
+            if (element.getKind() == ElementKind.METHOD) {
+                var enclosing = element.getEnclosingElement();
+                if (!enclosing.getKind().isClass()) {
+                    messager.printMessage(Diagnostic.Kind.ERROR,
+                        "@JsonWriter on a method is supported only for a method of a class or enum, got enclosing " + enclosing.getKind(),
+                        annotated.element());
+                    continue;
+                }
+                element = enclosing;
+            }
+            if (AnnotationUtils.isAnnotationPresent(element, JsonTypes.json)) {
+                continue;
+            }
             if (element.getKind().isClass() || element.getKind().isInterface() && element.getModifiers().contains(Modifier.SEALED)) {
-                if (AnnotationUtils.findAnnotation(element, JsonTypes.json) == null) {
+                if (processedWriterTypes.add(((TypeElement) element).getQualifiedName().toString())) {
                     try {
                         this.processor.generateWriter((TypeElement) element);
                     } catch (ProcessingErrorException ex) {
@@ -72,24 +86,36 @@ public class JsonAnnotationProcessor extends AbstractKoraProcessor {
                     }
                 }
             } else {
-                messager.printMessage(Diagnostic.Kind.ERROR, "Only classes and interfaces can be annotated with @JsonWriter, got " + annotated.element().getKind(), annotated.element());
+                messager.printMessage(Diagnostic.Kind.ERROR, "Only classes, interfaces and enum methods can be annotated with @JsonWriter, got " + element.getKind(), annotated.element());
             }
         }
         var jsonReaderElements = annotatedElements.getOrDefault(JsonTypes.jsonReaderAnnotation, List.of());
         LogUtils.logAnnotatedElementsFull(log, Level.DEBUG, "Generating JsonReaders for", jsonReaderElements);
+        var processedReaderTypes = new java.util.HashSet<String>();
         for (var annotated : jsonReaderElements) {
             var element = annotated.element();
             if (element.getKind() == ElementKind.CONSTRUCTOR) {
                 element = element.getEnclosingElement();
+            } else if (element.getKind() == ElementKind.METHOD) {
+                var enclosing = element.getEnclosingElement();
+                if (!enclosing.getKind().isClass()) {
+                    messager.printMessage(Diagnostic.Kind.ERROR,
+                        "@JsonReader on a method is supported only for a static factory method of a class or enum, got enclosing " + enclosing.getKind(),
+                        annotated.element());
+                    continue;
+                }
+                element = enclosing;
             }
             if (AnnotationUtils.isAnnotationPresent(element, JsonTypes.json)) {
                 continue;
             }
             if (element.getKind().isClass() || element.getKind().isInterface() && element.getModifiers().contains(Modifier.SEALED)) {
-                try {
-                    this.processor.generateReader((TypeElement) element);
-                } catch (ProcessingErrorException ex) {
-                    ex.printError(this.processingEnv);
+                if (processedReaderTypes.add(((TypeElement) element).getQualifiedName().toString())) {
+                    try {
+                        this.processor.generateReader((TypeElement) element);
+                    } catch (ProcessingErrorException ex) {
+                        ex.printError(this.processingEnv);
+                    }
                 }
             } else {
                 messager.printMessage(Diagnostic.Kind.ERROR, "Only classes and sealed interfaces can be annotated with @JsonReader, got " + element.getKind(), annotated.element());

--- a/json/json-annotation-processor/src/main/java/io/koraframework/json/annotation/processor/JsonProcessor.java
+++ b/json/json-annotation-processor/src/main/java/io/koraframework/json/annotation/processor/JsonProcessor.java
@@ -4,10 +4,12 @@ import com.palantir.javapoet.JavaFile;
 import io.koraframework.annotation.processor.common.CommonUtils;
 import io.koraframework.annotation.processor.common.ComparableTypeMirror;
 import io.koraframework.annotation.processor.common.SealedTypeUtils;
+import io.koraframework.json.annotation.processor.reader.DelegatingReaderGenerator;
 import io.koraframework.json.annotation.processor.reader.EnumReaderGenerator;
 import io.koraframework.json.annotation.processor.reader.JsonReaderGenerator;
 import io.koraframework.json.annotation.processor.reader.ReaderTypeMetaParser;
 import io.koraframework.json.annotation.processor.reader.SealedInterfaceReaderGenerator;
+import io.koraframework.json.annotation.processor.writer.DelegatingWriterGenerator;
 import io.koraframework.json.annotation.processor.writer.EnumWriterGenerator;
 import io.koraframework.json.annotation.processor.writer.JsonWriterGenerator;
 import io.koraframework.json.annotation.processor.writer.SealedInterfaceWriterGenerator;
@@ -34,6 +36,8 @@ public class JsonProcessor {
     private final SealedInterfaceWriterGenerator sealedWriterGenerator;
     private final EnumReaderGenerator enumReaderGenerator;
     private final EnumWriterGenerator enumWriterGenerator;
+    private final DelegatingReaderGenerator delegatingReaderGenerator;
+    private final DelegatingWriterGenerator delegatingWriterGenerator;
 
     public JsonProcessor(ProcessingEnvironment processingEnv) {
         this.processingEnv = processingEnv;
@@ -48,6 +52,8 @@ public class JsonProcessor {
         this.sealedWriterGenerator = new SealedInterfaceWriterGenerator(this.processingEnv);
         this.enumReaderGenerator = new EnumReaderGenerator();
         this.enumWriterGenerator = new EnumWriterGenerator();
+        this.delegatingReaderGenerator = new DelegatingReaderGenerator();
+        this.delegatingWriterGenerator = new DelegatingWriterGenerator();
     }
 
     public void generateReader(TypeElement jsonElement) {
@@ -64,6 +70,11 @@ public class JsonProcessor {
         }
         if (jsonElement.getModifiers().contains(Modifier.SEALED)) {
             this.generateSealedRootReader(jsonElement);
+            return;
+        }
+        if (this.delegatingReaderGenerator.detectReaderFactory(jsonElement) != null) {
+            var readerType = this.delegatingReaderGenerator.generate(jsonElement);
+            CommonUtils.safeWriteTo(this.processingEnv, JavaFile.builder(packageElement, readerType).build());
             return;
         }
         this.generateDtoReader(jsonElement, jsonElementType);
@@ -115,6 +126,11 @@ public class JsonProcessor {
         }
         if (jsonElement.getModifiers().contains(Modifier.SEALED)) {
             this.generateSealedWriter(jsonElement);
+            return;
+        }
+        if (this.delegatingWriterGenerator.detectWriterMethod(jsonElement) != null) {
+            var delegatingWriterType = this.delegatingWriterGenerator.generate(jsonElement);
+            CommonUtils.safeWriteTo(this.processingEnv, JavaFile.builder(packageElement, delegatingWriterType).build());
             return;
         }
         this.tryGenerateWriter(jsonElement, jsonElement.asType());

--- a/json/json-annotation-processor/src/main/java/io/koraframework/json/annotation/processor/reader/DelegatingReaderGenerator.java
+++ b/json/json-annotation-processor/src/main/java/io/koraframework/json/annotation/processor/reader/DelegatingReaderGenerator.java
@@ -1,0 +1,101 @@
+package io.koraframework.json.annotation.processor.reader;
+
+import com.palantir.javapoet.*;
+import io.koraframework.annotation.processor.common.AnnotationUtils;
+import io.koraframework.annotation.processor.common.CommonClassNames;
+import io.koraframework.annotation.processor.common.CommonUtils;
+import io.koraframework.annotation.processor.common.ProcessingErrorException;
+import io.koraframework.json.annotation.processor.JsonTypes;
+import io.koraframework.json.annotation.processor.JsonUtils;
+import org.jspecify.annotations.Nullable;
+
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeElement;
+
+/**
+ * Generates a delegating {@code JsonReader} for a non-enum type that declares a
+ * {@code @JsonReader}-annotated {@code public static} factory method {@code (V) -> T}. The JSON value is read as
+ * {@code V} and passed to the factory (Jackson {@code @JsonCreator(mode = DELEGATING)} semantics).
+ */
+public class DelegatingReaderGenerator {
+
+    public record DelegatingRead(TypeName valueType, String methodName, boolean valueNullable) {}
+
+    public TypeSpec generate(TypeElement typeElement) {
+        var typeName = ClassName.get(typeElement);
+        var factory = this.detectReaderFactory(typeElement);
+        if (factory == null) {
+            throw new ProcessingErrorException("No @JsonReader factory method found on " + typeName, typeElement);
+        }
+        var valueReaderType = ParameterizedTypeName.get(JsonTypes.jsonReader, factory.valueType().box());
+
+        var readBuilder = MethodSpec.methodBuilder("read")
+            .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+            .addParameter(JsonTypes.jsonParser, "__parser")
+            .returns(typeName.withoutAnnotations().annotated(CommonClassNames.nullableAnnotation))
+            .addAnnotation(Override.class);
+        if (factory.valueNullable()) {
+            readBuilder.addStatement("return $T.$N(this.valueReader.read(__parser))", typeName, factory.methodName());
+        } else {
+            readBuilder.addStatement("var value = this.valueReader.read(__parser)")
+                .addStatement("return value == null ? null : $T.$N(value)", typeName, factory.methodName());
+        }
+        var read = readBuilder.build();
+
+        return TypeSpec.classBuilder(JsonUtils.jsonReaderName(typeElement))
+            .addAnnotation(AnnotationUtils.generated(DelegatingReaderGenerator.class))
+            .addSuperinterface(ParameterizedTypeName.get(JsonTypes.jsonReader, typeName))
+            .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+            .addOriginatingElement(typeElement)
+            .addField(valueReaderType, "valueReader", Modifier.PRIVATE, Modifier.FINAL)
+            .addMethod(MethodSpec.constructorBuilder()
+                .addModifiers(Modifier.PUBLIC)
+                .addParameter(valueReaderType, "valueReader")
+                .addStatement("this.valueReader = valueReader")
+                .build())
+            .addMethod(read)
+            .build();
+    }
+
+    @Nullable
+    public DelegatingRead detectReaderFactory(TypeElement typeElement) {
+        var factories = typeElement.getEnclosedElements().stream()
+            .filter(e -> e.getKind() == ElementKind.METHOD)
+            .map(ExecutableElement.class::cast)
+            .filter(e -> AnnotationUtils.isAnnotationPresent(e, JsonTypes.jsonReaderAnnotation))
+            .toList();
+        if (factories.isEmpty()) {
+            return null;
+        }
+        if (factories.size() > 1) {
+            throw new ProcessingErrorException(
+                "Type " + typeElement.getSimpleName() + " has multiple @JsonReader factory methods, only one is allowed",
+                factories.get(1));
+        }
+        var factory = factories.get(0);
+        if (!factory.getModifiers().contains(Modifier.PUBLIC) || !factory.getModifiers().contains(Modifier.STATIC)) {
+            throw new ProcessingErrorException("@JsonReader factory method must be public static", factory);
+        }
+        if (factory.getParameters().size() != 1) {
+            throw new ProcessingErrorException(
+                "@JsonReader factory method must have exactly one parameter, got " + factory.getParameters().size(),
+                factory);
+        }
+        var typeName = ClassName.get(typeElement);
+        if (!TypeName.get(factory.getReturnType()).equals(typeName)) {
+            throw new ProcessingErrorException("@JsonReader factory method must return " + typeName, factory);
+        }
+        var hasReaderConstructor = CommonUtils.findConstructors(typeElement, m -> !m.contains(Modifier.PRIVATE)).stream()
+            .anyMatch(c -> AnnotationUtils.isAnnotationPresent(c, JsonTypes.jsonReaderAnnotation)
+                || AnnotationUtils.isAnnotationPresent(c, JsonTypes.json));
+        if (hasReaderConstructor) {
+            throw new ProcessingErrorException(
+                "Type " + typeName + " has both a @JsonReader factory method and a @JsonReader/@Json constructor — only one is allowed",
+                factory);
+        }
+        var valueNullable = CommonUtils.isNullable(factory.getParameters().get(0));
+        return new DelegatingRead(TypeName.get(factory.getParameters().get(0).asType()), factory.getSimpleName().toString(), valueNullable);
+    }
+}

--- a/json/json-annotation-processor/src/main/java/io/koraframework/json/annotation/processor/writer/DelegatingWriterGenerator.java
+++ b/json/json-annotation-processor/src/main/java/io/koraframework/json/annotation/processor/writer/DelegatingWriterGenerator.java
@@ -1,0 +1,107 @@
+package io.koraframework.json.annotation.processor.writer;
+
+import com.palantir.javapoet.*;
+import io.koraframework.annotation.processor.common.AnnotationUtils;
+import io.koraframework.annotation.processor.common.CommonClassNames;
+import io.koraframework.annotation.processor.common.ProcessingErrorException;
+import io.koraframework.json.annotation.processor.JsonTypes;
+import io.koraframework.json.annotation.processor.JsonUtils;
+import org.jspecify.annotations.Nullable;
+
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeKind;
+
+/**
+ * Generates a delegating {@code JsonWriter} for a non-enum type that declares a
+ * {@code @JsonWriter}-annotated method producing the single JSON value the type is serialized as
+ * (Jackson {@code @JsonValue} semantics). The method is either an instance method {@code () -> V} or a static
+ * method {@code (T) -> V}.
+ */
+public class DelegatingWriterGenerator {
+
+    public record DelegatingWrite(TypeName valueType, String accessor, boolean isStatic) {}
+
+    public TypeSpec generate(TypeElement typeElement) {
+        var typeName = ClassName.get(typeElement);
+        var value = this.detectWriterMethod(typeElement);
+        if (value == null) {
+            throw new ProcessingErrorException("No @JsonWriter method found on " + typeName, typeElement);
+        }
+        var valueWriterType = ParameterizedTypeName.get(JsonTypes.jsonWriter, value.valueType().box());
+
+        CodeBlock extracted = value.isStatic()
+            ? CodeBlock.of("$T.$N(_object)", typeName, value.accessor())
+            : CodeBlock.of("_object.$N()", value.accessor());
+        var write = MethodSpec.methodBuilder("write")
+            .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+            .addParameter(JsonTypes.jsonGenerator, "_gen")
+            .addParameter(ParameterSpec.builder(typeName.withoutAnnotations().annotated(CommonClassNames.nullableAnnotation), "_object").build())
+            .addAnnotation(Override.class)
+            .beginControlFlow("if (_object == null)")
+            .addStatement("_gen.writeNull()")
+            .addStatement("return")
+            .endControlFlow()
+            .addStatement("this.valueWriter.write(_gen, $L)", extracted)
+            .build();
+
+        return TypeSpec.classBuilder(JsonUtils.jsonWriterName(typeElement))
+            .addAnnotation(AnnotationUtils.generated(DelegatingWriterGenerator.class))
+            .addSuperinterface(ParameterizedTypeName.get(JsonTypes.jsonWriter, typeName))
+            .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+            .addOriginatingElement(typeElement)
+            .addField(valueWriterType, "valueWriter", Modifier.PRIVATE, Modifier.FINAL)
+            .addMethod(MethodSpec.constructorBuilder()
+                .addModifiers(Modifier.PUBLIC)
+                .addParameter(valueWriterType, "valueWriter")
+                .addStatement("this.valueWriter = valueWriter")
+                .build())
+            .addMethod(write)
+            .build();
+    }
+
+    @Nullable
+    public DelegatingWrite detectWriterMethod(TypeElement typeElement) {
+        var methods = typeElement.getEnclosedElements().stream()
+            .filter(e -> e.getKind() == ElementKind.METHOD)
+            .map(ExecutableElement.class::cast)
+            .filter(e -> AnnotationUtils.isAnnotationPresent(e, JsonTypes.jsonWriterAnnotation))
+            .toList();
+        if (methods.isEmpty()) {
+            return null;
+        }
+        if (methods.size() > 1) {
+            throw new ProcessingErrorException(
+                "Type " + typeElement.getSimpleName() + " has multiple @JsonWriter methods, only one is allowed",
+                methods.get(1));
+        }
+        var method = methods.get(0);
+        if (!method.getModifiers().contains(Modifier.PUBLIC)) {
+            throw new ProcessingErrorException("@JsonWriter method must be public", method);
+        }
+        if (method.getReturnType().getKind() == TypeKind.VOID) {
+            throw new ProcessingErrorException("@JsonWriter method must return a value", method);
+        }
+        var typeName = ClassName.get(typeElement);
+        boolean isStatic = method.getModifiers().contains(Modifier.STATIC);
+        if (isStatic) {
+            if (method.getParameters().size() != 1) {
+                throw new ProcessingErrorException(
+                    "@JsonWriter static method must have exactly one parameter (the value type), got " + method.getParameters().size(),
+                    method);
+            }
+            if (!TypeName.get(method.getParameters().get(0).asType()).equals(typeName)) {
+                throw new ProcessingErrorException("@JsonWriter static method parameter must be of type " + typeName, method);
+            }
+        } else {
+            if (!method.getParameters().isEmpty()) {
+                throw new ProcessingErrorException(
+                    "@JsonWriter instance method must have no parameters, got " + method.getParameters().size(),
+                    method);
+            }
+        }
+        return new DelegatingWrite(TypeName.get(method.getReturnType()), method.getSimpleName().toString(), isStatic);
+    }
+}

--- a/json/json-annotation-processor/src/test/java/io/koraframework/json/annotation/processor/DelegatingValueTest.java
+++ b/json/json-annotation-processor/src/test/java/io/koraframework/json/annotation/processor/DelegatingValueTest.java
@@ -1,0 +1,75 @@
+package io.koraframework.json.annotation.processor;
+
+import org.junit.jupiter.api.Test;
+import io.koraframework.json.common.JsonReader;
+import io.koraframework.json.common.JsonWriter;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.JsonParser;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DelegatingValueTest extends AbstractJsonAnnotationProcessorTest {
+    JsonReader<Long> longReader = JsonParser::getLongValue;
+    JsonWriter<Long> longWriter = JsonGenerator::writeNumber;
+    JsonReader<String> stringReader = JsonParser::getValueAsString;
+    JsonWriter<String> stringWriter = JsonGenerator::writeString;
+
+    private Object newObject(String name, Class<?> argType, Object arg) throws Exception {
+        return compileResult.loadClass(name).getDeclaredConstructor(argType).newInstance(arg);
+    }
+
+    @Test
+    public void testDelegatingInstanceWriterAndFactoryReader() throws Exception {
+        compile("""
+            public record UserId(long id) {
+              @JsonReader public static UserId of(long v) { return new UserId(v); }
+              @JsonWriter public long id() { return id; }
+            }
+            """);
+        compileResult.assertSuccess();
+        var mapper = mapper("UserId", List.of(longReader), List.of(longWriter));
+        mapper.verify(newObject("UserId", long.class, 42L), "42");
+    }
+
+    @Test
+    public void testDelegatingStaticWriter() throws Exception {
+        compile("""
+            public record UserId(long id) {
+              @JsonReader public static UserId of(long v) { return new UserId(v); }
+              @JsonWriter public static long toJson(UserId u) { return u.id(); }
+            }
+            """);
+        compileResult.assertSuccess();
+        var mapper = mapper("UserId", List.of(longReader), List.of(longWriter));
+        mapper.verify(newObject("UserId", long.class, 7L), "7");
+    }
+
+    @Test
+    public void testDelegatingStringValue() throws Exception {
+        compile("""
+            public record Sku(String code) {
+              @JsonReader public static Sku parse(String v) { return new Sku(v); }
+              @JsonWriter public String code() { return code; }
+            }
+            """);
+        compileResult.assertSuccess();
+        var mapper = mapper("Sku", List.of(stringReader), List.of(stringWriter));
+        mapper.verify(newObject("Sku", String.class, "ABC"), "\"ABC\"");
+    }
+
+    @Test
+    public void testDelegatingWriterNullHandling() throws Exception {
+        compile("""
+            public record Sku(String code) {
+              @JsonReader public static Sku parse(String v) { return new Sku(v); }
+              @JsonWriter public String code() { return code; }
+            }
+            """);
+        compileResult.assertSuccess();
+        var w = writer("Sku", stringWriter);
+        assertThat(w.toByteArray(null)).asString(StandardCharsets.UTF_8).isEqualTo("null");
+    }
+}

--- a/json/json-symbol-processor/src/main/kotlin/io/koraframework/json/ksp/JsonProcessor.kt
+++ b/json/json-symbol-processor/src/main/kotlin/io/koraframework/json/ksp/JsonProcessor.kt
@@ -8,10 +8,12 @@ import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.Modifier
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.ksp.writeTo
+import io.koraframework.json.ksp.reader.DelegatingJsonReaderGenerator
 import io.koraframework.json.ksp.reader.EnumJsonReaderGenerator
 import io.koraframework.json.ksp.reader.JsonReaderGenerator
 import io.koraframework.json.ksp.reader.ReaderTypeMetaParser
 import io.koraframework.json.ksp.reader.SealedInterfaceReaderGenerator
+import io.koraframework.json.ksp.writer.DelegatingJsonWriterGenerator
 import io.koraframework.json.ksp.writer.EnumJsonWriterGenerator
 import io.koraframework.json.ksp.writer.JsonWriterGenerator
 import io.koraframework.json.ksp.writer.SealedInterfaceWriterGenerator
@@ -31,6 +33,8 @@ class JsonProcessor(
     private val sealedWriterGenerator = SealedInterfaceWriterGenerator()
     private val enumJsonReaderGenerator = EnumJsonReaderGenerator()
     private val enumJsonWriterGenerator = EnumJsonWriterGenerator()
+    private val delegatingReaderGenerator = DelegatingJsonReaderGenerator()
+    private val delegatingWriterGenerator = DelegatingJsonWriterGenerator()
 
     fun generateReader(jsonClassDeclaration: KSClassDeclaration) {
         val packageElement = jsonClassPackage(jsonClassDeclaration)
@@ -42,6 +46,7 @@ class JsonProcessor(
         val readerType = when {
             isSealed(jsonClassDeclaration) -> sealedReaderGenerator.generateSealedReader(jsonClassDeclaration)
             jsonClassDeclaration.modifiers.contains(Modifier.ENUM) -> enumJsonReaderGenerator.generateEnumReader(jsonClassDeclaration)
+            delegatingReaderGenerator.detectReaderFactory(jsonClassDeclaration) != null -> delegatingReaderGenerator.generate(jsonClassDeclaration)
             else -> {
                 val meta = readerTypeMetaParser.parse(jsonClassDeclaration)
                 readerGenerator.generate(meta)
@@ -65,6 +70,7 @@ class JsonProcessor(
         val writerType = when {
             isSealed(declaration) -> sealedWriterGenerator.generateSealedWriter(declaration)
             declaration.modifiers.contains(Modifier.ENUM) -> enumJsonWriterGenerator.generateEnumWriter(declaration)
+            delegatingWriterGenerator.detectWriterMethod(declaration) != null -> delegatingWriterGenerator.generate(declaration)
             else -> {
                 val meta = writerTypeMetaParser.parse(declaration)
                 writerGenerator.generate(meta)

--- a/json/json-symbol-processor/src/main/kotlin/io/koraframework/json/ksp/JsonSymbolProcessor.kt
+++ b/json/json-symbol-processor/src/main/kotlin/io/koraframework/json/ksp/JsonSymbolProcessor.kt
@@ -66,6 +66,27 @@ class JsonSymbolProcessor(
                             if (processedReaders.add(clazz.qualifiedName!!.asString())) {
                                 jsonProcessor.generateReader(clazz)
                             }
+                        } else if (it.isAnnotationPresent(JsonTypes.jsonReaderAnnotation)) {
+                            val enclosing = enclosingType(it)
+                            if (enclosing == null) {
+                                kspLogger.error(
+                                    "@JsonReader on a method is supported only for a static factory method of a class or enum (in Kotlin: declared in the companion object)",
+                                    it
+                                )
+                            } else if (processedReaders.add(enclosing.qualifiedName!!.asString())) {
+                                jsonProcessor.generateReader(enclosing)
+                            }
+                        }
+                        if (it.isAnnotationPresent(JsonTypes.jsonWriterAnnotation)) {
+                            val enclosing = enclosingType(it)
+                            if (enclosing == null) {
+                                kspLogger.error(
+                                    "@JsonWriter on a method is supported only for a method of a class or enum",
+                                    it
+                                )
+                            } else if (processedWriters.add(enclosing.qualifiedName!!.asString())) {
+                                jsonProcessor.generateWriter(enclosing)
+                            }
                         }
                     }
                 }
@@ -74,6 +95,11 @@ class JsonSymbolProcessor(
             }
         }
         return symbolsToDelay
+    }
+
+    private fun enclosingType(function: KSFunctionDeclaration): KSClassDeclaration? {
+        val parent = function.parentDeclaration as? KSClassDeclaration ?: return null
+        return if (parent.isCompanionObject) parent.parentDeclaration as? KSClassDeclaration else parent
     }
 }
 

--- a/json/json-symbol-processor/src/main/kotlin/io/koraframework/json/ksp/reader/DelegatingJsonReaderGenerator.kt
+++ b/json/json-symbol-processor/src/main/kotlin/io/koraframework/json/ksp/reader/DelegatingJsonReaderGenerator.kt
@@ -1,0 +1,125 @@
+package io.koraframework.json.ksp.reader
+
+import com.google.devtools.ksp.getConstructors
+import com.google.devtools.ksp.isConstructor
+import com.google.devtools.ksp.isPublic
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.squareup.kotlinpoet.*
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.ksp.toClassName
+import com.squareup.kotlinpoet.ksp.toTypeName
+import io.koraframework.json.ksp.JsonTypes
+import io.koraframework.json.ksp.jsonReaderName
+import io.koraframework.ksp.common.AnnotationUtils.isAnnotationPresent
+import io.koraframework.ksp.common.KspCommonUtils.addOriginatingKSFile
+import io.koraframework.ksp.common.KspCommonUtils.generated
+import io.koraframework.ksp.common.KspCommonUtils.toTypeName
+import io.koraframework.ksp.common.exception.ProcessingErrorException
+
+/**
+ * Generates a delegating [io.koraframework.json.common.JsonReader] for a non-enum type that declares a
+ * `@JsonReader`-annotated static factory method `(V) -> T` (Kotlin: in the companion object). The JSON
+ * value is read as `V` and passed to the factory (Jackson `@JsonCreator(mode = DELEGATING)` semantics).
+ */
+class DelegatingJsonReaderGenerator {
+    data class ReaderFactory(val methodName: String, val valueType: TypeName, val valueNullable: Boolean)
+
+    fun generate(declaration: KSClassDeclaration): TypeSpec {
+        val className = declaration.toClassName()
+        val typeName = declaration.toTypeName()
+        val factory = detectReaderFactory(declaration)
+            ?: throw ProcessingErrorException("No @JsonReader factory method found on ${declaration.simpleName.asString()}", declaration)
+        val valueReaderType = JsonTypes.jsonReader.parameterizedBy(factory.valueType)
+
+        val readFun = FunSpec.builder("read")
+            .addModifiers(KModifier.OVERRIDE)
+            .addParameter("parser", JsonTypes.jsonParser)
+            .returns(typeName.copy(nullable = true))
+            .apply {
+                if (factory.valueNullable) {
+                    addStatement("return %T.%N(valueReader.read(parser))", className, factory.methodName)
+                } else {
+                    addStatement("val value = valueReader.read(parser) ?: return null")
+                    addStatement("return %T.%N(value)", className, factory.methodName)
+                }
+            }
+            .build()
+
+        return TypeSpec.classBuilder(declaration.jsonReaderName())
+            .generated(DelegatingJsonReaderGenerator::class)
+            .addSuperinterface(JsonTypes.jsonReader.parameterizedBy(typeName))
+            .primaryConstructor(
+                FunSpec.constructorBuilder()
+                    .addParameter("valueReader", valueReaderType)
+                    .build()
+            )
+            .addProperty(
+                PropertySpec.builder("valueReader", valueReaderType, KModifier.PRIVATE)
+                    .initializer("valueReader")
+                    .build()
+            )
+            .addFunction(readFun)
+            .addOriginatingKSFile(declaration)
+            .build()
+    }
+
+    fun detectReaderFactory(declaration: KSClassDeclaration): ReaderFactory? {
+        val companion = declaration.declarations
+            .filterIsInstance<KSClassDeclaration>()
+            .firstOrNull { it.isCompanionObject }
+        val companionFactories = companion
+            ?.getAllFunctions()
+            ?.filter { it.isAnnotationPresent(JsonTypes.jsonReaderAnnotation) }
+            ?.toList()
+            .orEmpty()
+        val bodyFactories = declaration.getAllFunctions()
+            .filter { !it.isConstructor() }
+            .filter { it.isAnnotationPresent(JsonTypes.jsonReaderAnnotation) }
+            .toList()
+        val factories = companionFactories + bodyFactories
+        if (factories.isEmpty()) {
+            return null
+        }
+        if (factories.size > 1) {
+            throw ProcessingErrorException(
+                "Type ${declaration.simpleName.asString()} has multiple @JsonReader factory methods, only one is allowed",
+                factories[1]
+            )
+        }
+        val factory = factories[0]
+        if (factory !in companionFactories) {
+            throw ProcessingErrorException(
+                "@JsonReader factory method must be static (declared in the companion object)",
+                factory
+            )
+        }
+        if (!factory.isPublic()) {
+            throw ProcessingErrorException("@JsonReader factory method must be public", factory)
+        }
+        if (factory.parameters.size != 1) {
+            throw ProcessingErrorException(
+                "@JsonReader factory method must have exactly one parameter, got ${factory.parameters.size}",
+                factory
+            )
+        }
+        val returnDeclaration = factory.returnType?.resolve()?.declaration
+        if (returnDeclaration != declaration) {
+            throw ProcessingErrorException(
+                "@JsonReader factory method must return ${declaration.simpleName.asString()}",
+                factory
+            )
+        }
+        val hasReaderConstructor = declaration.getConstructors().any {
+            it.isAnnotationPresent(JsonTypes.jsonReaderAnnotation) || it.isAnnotationPresent(JsonTypes.json)
+        }
+        if (hasReaderConstructor) {
+            throw ProcessingErrorException(
+                "Type ${declaration.simpleName.asString()} has both a @JsonReader factory method and a @JsonReader/@Json constructor — only one is allowed",
+                factory
+            )
+        }
+        val valueType = factory.parameters[0].type.toTypeName()
+        val valueNullable = factory.parameters[0].type.resolve().isMarkedNullable
+        return ReaderFactory(factory.simpleName.asString(), valueType, valueNullable)
+    }
+}

--- a/json/json-symbol-processor/src/main/kotlin/io/koraframework/json/ksp/writer/DelegatingJsonWriterGenerator.kt
+++ b/json/json-symbol-processor/src/main/kotlin/io/koraframework/json/ksp/writer/DelegatingJsonWriterGenerator.kt
@@ -1,0 +1,127 @@
+package io.koraframework.json.ksp.writer
+
+import com.google.devtools.ksp.isPublic
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.squareup.kotlinpoet.*
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.ksp.toClassName
+import com.squareup.kotlinpoet.ksp.toTypeName
+import io.koraframework.json.ksp.JsonTypes
+import io.koraframework.json.ksp.jsonWriterName
+import io.koraframework.ksp.common.AnnotationUtils.isAnnotationPresent
+import io.koraframework.ksp.common.KspCommonUtils.addOriginatingKSFile
+import io.koraframework.ksp.common.KspCommonUtils.generated
+import io.koraframework.ksp.common.KspCommonUtils.toTypeName
+import io.koraframework.ksp.common.exception.ProcessingErrorException
+
+/**
+ * Generates a delegating [io.koraframework.json.common.JsonWriter] for a non-enum type that declares a
+ * `@JsonWriter`-annotated method producing the single JSON value the type is serialized as
+ * (Jackson `@JsonValue` semantics). The method is either an instance method `() -> V` or a static
+ * method (Kotlin: companion object) `(T) -> V`.
+ */
+class DelegatingJsonWriterGenerator {
+    data class WriterValue(val valueType: TypeName, val accessor: String, val isStatic: Boolean)
+
+    fun generate(declaration: KSClassDeclaration): TypeSpec {
+        val className = declaration.toClassName()
+        val typeName = declaration.toTypeName()
+        val value = detectWriterMethod(declaration)
+            ?: throw ProcessingErrorException("No @JsonWriter method found on ${declaration.simpleName.asString()}", declaration)
+        val valueWriterType = JsonTypes.jsonWriter.parameterizedBy(value.valueType)
+
+        val extracted = if (value.isStatic) {
+            CodeBlock.of("%T.%N(_object)", className, value.accessor)
+        } else {
+            CodeBlock.of("_object.%N()", value.accessor)
+        }
+        val body = CodeBlock.builder()
+            .beginControlFlow("if (_object == null)")
+            .addStatement("_gen.writeNull()")
+            .addStatement("return")
+            .endControlFlow()
+            .addStatement("this.valueWriter.write(_gen, %L)", extracted)
+            .build()
+
+        return TypeSpec.classBuilder(declaration.jsonWriterName())
+            .generated(DelegatingJsonWriterGenerator::class)
+            .addSuperinterface(JsonTypes.jsonWriter.parameterizedBy(typeName))
+            .primaryConstructor(
+                FunSpec.constructorBuilder()
+                    .addParameter("valueWriter", valueWriterType)
+                    .build()
+            )
+            .addProperty(
+                PropertySpec.builder("valueWriter", valueWriterType, KModifier.PRIVATE)
+                    .initializer("valueWriter")
+                    .build()
+            )
+            .addFunction(
+                FunSpec.builder("write")
+                    .addModifiers(KModifier.PUBLIC, KModifier.OVERRIDE)
+                    .addParameter("_gen", JsonTypes.jsonGenerator)
+                    .addParameter("_object", typeName.copy(nullable = true))
+                    .addCode(body)
+                    .build()
+            )
+            .addOriginatingKSFile(declaration)
+            .build()
+    }
+
+    fun detectWriterMethod(declaration: KSClassDeclaration): WriterValue? {
+        val companion = declaration.declarations
+            .filterIsInstance<KSClassDeclaration>()
+            .firstOrNull { it.isCompanionObject }
+        val companionMethods = companion
+            ?.getAllFunctions()
+            ?.filter { it.isAnnotationPresent(JsonTypes.jsonWriterAnnotation) }
+            ?.toList()
+            .orEmpty()
+        val bodyMethods = declaration.getAllFunctions()
+            .filter { it.isAnnotationPresent(JsonTypes.jsonWriterAnnotation) }
+            .toList()
+        val methods = companionMethods + bodyMethods
+        if (methods.isEmpty()) {
+            return null
+        }
+        if (methods.size > 1) {
+            throw ProcessingErrorException(
+                "Type ${declaration.simpleName.asString()} has multiple @JsonWriter methods, only one is allowed",
+                methods[1]
+            )
+        }
+        val method = methods[0]
+        if (!method.isPublic()) {
+            throw ProcessingErrorException("@JsonWriter method must be public", method)
+        }
+        val returnDeclaration = method.returnType?.resolve()?.declaration
+        if (returnDeclaration == null || returnDeclaration.qualifiedName?.asString() == "kotlin.Unit") {
+            throw ProcessingErrorException("@JsonWriter method must return a value", method)
+        }
+        val valueType = method.returnType!!.toTypeName()
+        val isStatic = method in companionMethods
+        if (isStatic) {
+            if (method.parameters.size != 1) {
+                throw ProcessingErrorException(
+                    "@JsonWriter static method must have exactly one parameter (the value type), got ${method.parameters.size}",
+                    method
+                )
+            }
+            val paramDeclaration = method.parameters[0].type.resolve().declaration
+            if (paramDeclaration != declaration) {
+                throw ProcessingErrorException(
+                    "@JsonWriter static method parameter must be of type ${declaration.simpleName.asString()}",
+                    method
+                )
+            }
+        } else {
+            if (method.parameters.isNotEmpty()) {
+                throw ProcessingErrorException(
+                    "@JsonWriter instance method must have no parameters, got ${method.parameters.size}",
+                    method
+                )
+            }
+        }
+        return WriterValue(valueType, method.simpleName.asString(), isStatic)
+    }
+}

--- a/json/json-symbol-processor/src/test/kotlin/io/koraframework/json/ksp/DelegatingValueTest.kt
+++ b/json/json-symbol-processor/src/test/kotlin/io/koraframework/json/ksp/DelegatingValueTest.kt
@@ -1,0 +1,70 @@
+package io.koraframework.json.ksp
+
+import io.koraframework.json.common.JsonReader
+import io.koraframework.json.common.JsonWriter
+import org.junit.jupiter.api.Test
+import tools.jackson.core.JsonGenerator
+import tools.jackson.core.JsonParser
+
+class DelegatingValueTest : AbstractJsonSymbolProcessorTest() {
+    private val stringReader = JsonReader<String> { p: JsonParser -> p.valueAsString }
+    private val stringWriter = JsonWriter<String> { g: JsonGenerator, v: String? -> g.writeString(v) }
+    private val longReader = JsonReader<Long> { p: JsonParser -> p.longValue }
+    private val longWriter = JsonWriter<Long> { g: JsonGenerator, v: Long? -> g.writeNumber(v!!) }
+
+    private fun newObject(name: String, argType: Class<*>, arg: Any?): Any =
+        compileResult.assertSuccess().classLoader.loadClass("${testPackage()}.$name").getDeclaredConstructor(argType).newInstance(arg)
+
+    @Test
+    fun testDelegatingInstanceWriterAndFactoryReader() {
+        compile(
+            """
+            class UserId(val id: Long) {
+              @JsonWriter fun toJson(): Long = id
+              companion object { @JsonReader fun of(v: Long): UserId = UserId(v) }
+              override fun equals(other: Any?) = other is UserId && other.id == id
+              override fun hashCode() = id.hashCode()
+            }
+            """.trimIndent()
+        )
+        compileResult.assertSuccess()
+        val mapper = mapper("UserId", listOf(longReader), listOf(longWriter))
+        mapper.assert(newObject("UserId", Long::class.javaPrimitiveType!!, 42L), "42")
+    }
+
+    @Test
+    fun testDelegatingStaticWriter() {
+        compile(
+            """
+            class UserId(val id: Long) {
+              companion object {
+                @JsonReader fun of(v: Long): UserId = UserId(v)
+                @JsonWriter fun toJson(u: UserId): Long = u.id
+              }
+              override fun equals(other: Any?) = other is UserId && other.id == id
+              override fun hashCode() = id.hashCode()
+            }
+            """.trimIndent()
+        )
+        compileResult.assertSuccess()
+        val mapper = mapper("UserId", listOf(longReader), listOf(longWriter))
+        mapper.assert(newObject("UserId", Long::class.javaPrimitiveType!!, 7L), "7")
+    }
+
+    @Test
+    fun testDelegatingStringValue() {
+        compile(
+            """
+            class Sku(val code: String) {
+              @JsonWriter fun toJson(): String = code
+              companion object { @JsonReader fun parse(v: String): Sku = Sku(v) }
+              override fun equals(other: Any?) = other is Sku && other.code == code
+              override fun hashCode() = code.hashCode()
+            }
+            """.trimIndent()
+        )
+        compileResult.assertSuccess()
+        val mapper = mapper("Sku", listOf(stringReader), listOf(stringWriter))
+        mapper.assert(newObject("Sku", String::class.java, "ABC"), "\"ABC\"")
+    }
+}


### PR DESCRIPTION
Added(json): custom JSON value for arbitrary types via @JsonReader factory / @JsonWriter method (Backport of #701)

Backport of #701 (branch 1.0, commit f18225e50b573c46154b3996e6e38ee104b871e2)

A non-enum type can now declare a public static @JsonReader factory method (V) -> T and a @JsonWriter method producing the single JSON value the type serializes as (Jackson @JsonCreator(mode = DELEGATING) / @JsonValue semantics), instead of the default field-by-field JSON mapping. The @JsonWriter method may be an instance method () -> V or a static method (T) -> V. Both the Java annotation processor and the KSP processor generate a delegating JsonReader/JsonWriter that reads/writes the raw value type and converts through the factory/accessor method.

This is a best-effort re-design against master's current JSON generator architecture rather than a verified line-for-line port, since master's generators (package `io.koraframework.json.*`, Jackson 3's `tools.jackson.core` types, no checked `IOException` on `JsonReader.read`/ `JsonWriter.write`) have diverged non-trivially from the 1.0 codebase this commit was written against. Compiled and tested (Java AP: 4 new tests + full existing suite; KSP: 3 new tests + full existing suite, no regressions), but review carefully before merging — this was not diffed against the original 1.0 commit's own test suite line-by-line, and the enum-specific `@JsonReader` factory support from the original commit (master's enum reader/writer already use a different, independently-added `@Json`-annotated-accessor customization mechanism) was intentionally not ported to avoid conflicting with that existing mechanism.