### PR TITLE
Added(konvert): Kotlin/KSP-native Konvert mapper integration (Backport of #703)

### DIFF
--- a/core/symbol-processors/build.gradle
+++ b/core/symbol-processors/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     api project(':cache:cache-symbol-processor')
     api project(':validation:validation-symbol-processor')
     api project(':mapstruct:mapstruct-ksp-extension')
+    api project(':konvert:konvert-ksp-extension')
     api project(':logging:logging-symbol-processor')
     api project(':grpc:grpc-client-symbol-processor')
     api project(':experimental:s3-client-symbol-processor')

--- a/gradle/ci-tests.gradle
+++ b/gradle/ci-tests.gradle
@@ -103,6 +103,7 @@ addDependencies(tasksCodegenJava, "mapstruct:mapstruct-java-extension")
 addDependenciesByPattern(tasksCodegenKotlin, "symbol-processor")
 addDependenciesByPattern(tasksCodegenKotlin, "ksp")
 addDependencies(tasksCodegenKotlin, "mapstruct:mapstruct-ksp-extension")
+addDependencies(tasksCodegenKotlin, "konvert:konvert-ksp-extension")
 
 rootProject.allprojects.forEach {
     if (it.name != rootProject.name && it.name != "kora-bom" && it.childProjects.isEmpty()) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ kotlin-stdlib = "2.4.10" # Visit https://kotlinlang.org/docs/releases.html#relea
 ksp = "2.3.11"
 kotlinpoet = "2.3.0"
 mapstruct = "1.6.3"
+konvert = "3.2.3"
 
 # Observability
 micrometer = "1.17.0"
@@ -263,6 +264,8 @@ zeebe-client = { module = "io.camunda:camunda-client-java", version.ref = "zeebe
 
 mapstruct = { module = "org.mapstruct:mapstruct", version.ref = "mapstruct" }
 mapstruct-processor = { module = "org.mapstruct:mapstruct-processor", version.ref = "mapstruct" }
+
+konvert-api = { module = "io.mcarle:konvert-api", version.ref = "konvert" }
 
 ["bundles"]
 netty = [

--- a/konvert/konvert-ksp-extension/build.gradle
+++ b/konvert/konvert-ksp-extension/build.gradle
@@ -1,0 +1,12 @@
+apply from: "${project.rootDir}/gradle/in-test-generated.gradle"
+apply from: "${project.rootDir}/gradle/kotlin-plugin.gradle"
+
+dependencies {
+    implementation project(":core:kora-app-symbol-processor")
+
+    testImplementation libs.konvert.api
+
+    testImplementation project(":core:kora-app-symbol-processor")
+    testImplementation project(":core:symbol-processor-common")
+    testImplementation testFixtures(project(":core:symbol-processor-common"))
+}

--- a/konvert/konvert-ksp-extension/src/main/kotlin/io/koraframework/konvert/ksp/extension/KonvertKoraExtension.kt
+++ b/konvert/konvert-ksp-extension/src/main/kotlin/io/koraframework/konvert/ksp/extension/KonvertKoraExtension.kt
@@ -1,0 +1,71 @@
+package io.koraframework.konvert.ksp.extension
+
+import com.google.devtools.ksp.getClassDeclarationByName
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.ClassKind
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSDeclaration
+import com.google.devtools.ksp.symbol.KSType
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.CodeBlock
+import io.koraframework.kora.app.ksp.extension.ExtensionResult
+import io.koraframework.kora.app.ksp.extension.KoraExtension
+import io.koraframework.ksp.common.AnnotationUtils.findAnnotation
+import io.koraframework.ksp.common.TagUtils.parseTag
+
+object KonvertKoraExtension : KoraExtension {
+
+    val konverterAnnotation = ClassName("io.mcarle.konvert.api", "Konverter")
+    private const val implementationSuffix = "Impl"
+
+    override fun getDependencyGenerator(resolver: Resolver, type: KSType, tag: String?): (() -> ExtensionResult)? {
+        val declaration = type.declaration
+        if (declaration !is KSClassDeclaration) {
+            return null
+        }
+        if (declaration.classKind != ClassKind.INTERFACE) {
+            return null
+        }
+        val annotation = declaration.findAnnotation(konverterAnnotation)
+        if (annotation == null) {
+            return null
+        }
+        if (declaration.parseTag() != tag) {
+            return null
+        }
+        val packageName = declaration.packageName.asString()
+        val expectedName = getKonverterImplName(declaration)
+        val implClassName = ClassName(packageName, expectedName)
+        return {
+            val implementation = resolver.getClassDeclarationByName("$packageName.$expectedName")
+            if (implementation == null) {
+                throw io.koraframework.ksp.common.exception.ProcessingErrorException(
+                    """
+                    Generated Konvert implementation was not found:
+                      expected type: $packageName.$expectedName
+
+                    Fix:
+                      - Ensure the Konvert KSP processor is enabled and generating `Impl` objects.
+                      - Compile again after fixing earlier processing errors.
+                    """.trimIndent(),
+                    declaration
+                )
+            } else {
+                ExtensionResult.CodeBlockResult(
+                    declaration,
+                    { CodeBlock.of("%T", implClassName) },
+                    type,
+                    tag,
+                    emptyList(),
+                    emptyList()
+                )
+            }
+        }
+    }
+
+    private fun getKonverterImplName(declaration: KSDeclaration): String {
+        // Konvert always generates a top-level `object <SimpleName>Impl` in the same package,
+        // even for a nested @Konverter interface (the enclosing type name is dropped).
+        return declaration.simpleName.asString() + implementationSuffix
+    }
+}

--- a/konvert/konvert-ksp-extension/src/main/kotlin/io/koraframework/konvert/ksp/extension/KonvertKoraExtensionFactory.kt
+++ b/konvert/konvert-ksp-extension/src/main/kotlin/io/koraframework/konvert/ksp/extension/KonvertKoraExtensionFactory.kt
@@ -1,0 +1,16 @@
+package io.koraframework.konvert.ksp.extension
+
+import com.google.devtools.ksp.getClassDeclarationByName
+import com.google.devtools.ksp.processing.CodeGenerator
+import com.google.devtools.ksp.processing.KSPLogger
+import com.google.devtools.ksp.processing.Resolver
+import io.koraframework.kora.app.ksp.extension.ExtensionFactory
+import io.koraframework.kora.app.ksp.extension.KoraExtension
+
+class KonvertKoraExtensionFactory : ExtensionFactory {
+
+    override fun create(resolver: Resolver, kspLogger: KSPLogger, codeGenerator: CodeGenerator): KoraExtension? {
+        return resolver.getClassDeclarationByName(KonvertKoraExtension.konverterAnnotation.canonicalName)
+            ?.let { KonvertKoraExtension }
+    }
+}

--- a/konvert/konvert-ksp-extension/src/main/resources/META-INF/services/io.koraframework.kora.app.ksp.extension.ExtensionFactory
+++ b/konvert/konvert-ksp-extension/src/main/resources/META-INF/services/io.koraframework.kora.app.ksp.extension.ExtensionFactory
@@ -1,0 +1,1 @@
+io.koraframework.konvert.ksp.extension.KonvertKoraExtensionFactory

--- a/konvert/konvert-ksp-extension/src/test/kotlin/io/koraframework/konvert/ksp/extension/CarMapperImpl.kt
+++ b/konvert/konvert-ksp-extension/src/test/kotlin/io/koraframework/konvert/ksp/extension/CarMapperImpl.kt
@@ -1,0 +1,7 @@
+package io.koraframework.konvert.ksp.extension
+
+object CarMapperImpl : CarMapper {
+    override fun carToCarDto(car: Car): CarDto {
+        return CarDto(car.make, car.numberOfSeats)
+    }
+}

--- a/konvert/konvert-ksp-extension/src/test/kotlin/io/koraframework/konvert/ksp/extension/Examples.kt
+++ b/konvert/konvert-ksp-extension/src/test/kotlin/io/koraframework/konvert/ksp/extension/Examples.kt
@@ -1,0 +1,12 @@
+package io.koraframework.konvert.ksp.extension
+
+import io.mcarle.konvert.api.Konverter
+
+data class Car(val make: String, val numberOfSeats: Int)
+
+data class CarDto(val make: String, val seatCount: Int)
+
+@Konverter
+interface CarMapper {
+    fun carToCarDto(car: Car): CarDto
+}

--- a/konvert/konvert-ksp-extension/src/test/kotlin/io/koraframework/konvert/ksp/extension/KonvertKoraExtensionTest.kt
+++ b/konvert/konvert-ksp-extension/src/test/kotlin/io/koraframework/konvert/ksp/extension/KonvertKoraExtensionTest.kt
@@ -1,0 +1,72 @@
+package io.koraframework.konvert.ksp.extension
+
+import org.assertj.core.api.Assertions.assertThat
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+import io.koraframework.kora.app.ksp.KoraAppProcessorProvider
+import io.koraframework.ksp.common.AbstractSymbolProcessorTest
+import io.koraframework.ksp.common.GraphUtil
+import io.koraframework.ksp.common.GraphUtil.toGraph
+import java.util.*
+
+class KonvertKoraExtensionTest : AbstractSymbolProcessorTest() {
+
+    override fun commonImports(): String {
+        return super.commonImports() + """
+            import io.mcarle.konvert.api.Konverter
+            import io.koraframework.konvert.ksp.extension.*
+
+            """.trimIndent()
+    }
+
+    private fun compile(@Language("kotlin") vararg sources: String): GraphUtil.GraphContainer {
+        val patchedSources = Arrays.copyOf(sources, sources.size + 1)
+
+        @Language("kotlin")
+        val main = """
+            @KoraApp
+            interface TestApp {
+                @Root
+                fun root(carMapper: CarMapper): String {
+                    return ""
+                }
+            }
+            """.trimIndent()
+
+        patchedSources[sources.size] = main
+        super.compile0(listOf(KoraAppProcessorProvider()), *patchedSources)
+        compileResult.assertSuccess()
+        return loadClass("TestAppGraph").toGraph()
+    }
+
+    /**
+     * @see CarMapper
+     */
+    @Test
+    fun testDocumentationExample() {
+        val graph = compile()
+        assertThat(graph.draw.size()).isEqualTo(2)
+    }
+
+    @Test
+    fun plainInterfaceWithoutKonverterIsNotProvided() {
+        super.compile0(
+            listOf(KoraAppProcessorProvider()),
+            """
+            interface NotAMapper {
+                fun map(value: String): String
+            }
+            """.trimIndent(),
+            """
+            @KoraApp
+            interface TestApp {
+                @Root
+                fun root(mapper: NotAMapper): String {
+                    return ""
+                }
+            }
+            """.trimIndent()
+        )
+        compileResult.assertFailure()
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -99,6 +99,7 @@ include(
     'redis:redis-lettuce',
     'mapstruct:mapstruct-java-extension',
     'mapstruct:mapstruct-ksp-extension',
+    'konvert:konvert-ksp-extension',
     'experimental:s3-client-annotation-processor',
     'experimental:s3-client-symbol-processor',
     'experimental:s3-client-kora',


### PR DESCRIPTION
Added(konvert): Kotlin/KSP-native Konvert mapper integration (Backport of #703)

Backport of #703 (branch 1.0, commit fa9cc5e5af0b5690e91daea9a7e7636192ab196b)

Adds a new konvert:konvert-ksp-extension module: a KoraExtension that registers types annotated `@io.mcarle.konvert.api.Konverter` (a third-party KSP-native interface-mapper generator, https://github.com/mcarleXX/konvert) as injectable Kora DI components, resolving the generated top-level `<InterfaceName>Impl` singleton object as the component instance, honoring the interface's `@Tag` if present.

This is a best-effort re-design against master's current KoraExtension API rather than a verified line-for-line port. It adapts 1.0's multi-tag `Set<String>-based` extension contract to master's current single-tag `String?-based` one, and follows the sibling mapstruct:mapstruct-ksp-extension module (added independently after the 1.0 fork) as the structural template for build.gradle, module wiring (settings.gradle, core/symbol-processors, gradle/ci-tests.gradle), and dependency-catalog conventions. Unlike Mapstruct's generated implementation, which is a regular class, Konvert generates a Kotlin `object` singleton, so the extension emits a direct type reference (`ExtensionResult.CodeBlockResult`) rather than reusing the constructor-invocation-based `KoraExtension.generatedByProcessorWithName` helper that the Mapstruct extension relies on.

Compiled and tested (2 new tests: a documented @Konverter interface wires into the DI graph; a plain `non-@Konverter` interface fails compilation as expected), but review carefully before merging — the test exercises the extension's DI-wiring logic against a hand-written fixture standing in for `Konvert's` generated output (mirroring the existing `Mapstruct` extension test's approach) rather than running the real `io.mcarle:konvert` KSP processor, since its exact `SymbolProcessorProvider` entry point was not independently verified against the published artifact.