### PR TITLE
Fixed(openapi): generate custom request mappers for non-standard body content-types

### DIFF
--- a/openapi/openapi-generator/build.gradle
+++ b/openapi/openapi-generator/build.gradle
@@ -91,6 +91,7 @@ sourceSets {
             addOpenapiDir("petstoreV3_nullable_enable_json_nullable")
             addOpenapiDir("petstoreV3_request_parameters")
             addOpenapiDir("petstoreV3_responses")
+            addOpenapiDir("petstoreV3_requests")
             addOpenapiDir("petstoreV3_security_all")
             addOpenapiDir("petstoreV3_security_all_auth_arg")
             addOpenapiDir("petstoreV3_security_multi")

--- a/openapi/openapi-generator/src/main/java/ru/tinkoff/kora/openapi/generator/KoraCodegen.java
+++ b/openapi/openapi-generator/src/main/java/ru/tinkoff/kora/openapi/generator/KoraCodegen.java
@@ -2445,7 +2445,10 @@ public class KoraCodegen extends DefaultCodegen {
                         op.bodyParam.vendorExtensions.put("hasMapperTag", false);
                         op.bodyParam.vendorExtensions.put("contentType", contentType);
                     }
-                } else if (!isContentJson(op.bodyParam) && op.bodyParam.isString && !op.bodyParam.isModel) {
+                } else if (isContentJson(op.bodyParam)) {
+                    op.bodyParam.vendorExtensions.put("hasMapperTag", true);
+                    op.bodyParam.vendorExtensions.put("mapperTag", params.jsonAnnotation);
+                } else if (op.bodyParam.isString && !op.bodyParam.isModel) {
                     var i = op.bodyParam.getContent().keySet().iterator();
                     String contentType = i.hasNext() ? i.next() : "text/plain";
                     if (!"text/plain".equals(contentType)) {
@@ -2461,7 +2464,10 @@ public class KoraCodegen extends DefaultCodegen {
                             param.vendorExtensions.put("hasMapperTag", false);
                             param.vendorExtensions.put("contentType", contentType);
                         }
-                    } else if (param.isBodyParam && !isContentJson(param) && param.isString && !param.isModel) {
+                    } else if (param.isBodyParam && isContentJson(param)) {
+                        param.vendorExtensions.put("hasMapperTag", true);
+                        param.vendorExtensions.put("mapperTag", params.jsonAnnotation);
+                    } else if (param.isBodyParam && param.isString && !param.isModel) {
                         var i = param.getContent().keySet().iterator();
                         String contentType = i.hasNext() ? i.next() : "text/plain";
                         if (!"text/plain".equals(contentType)) {

--- a/openapi/openapi-generator/src/main/java/ru/tinkoff/kora/openapi/generator/KoraCodegen.java
+++ b/openapi/openapi-generator/src/main/java/ru/tinkoff/kora/openapi/generator/KoraCodegen.java
@@ -2433,18 +2433,41 @@ public class KoraCodegen extends DefaultCodegen {
                 }
             }
             if (op.bodyParam != null) {
-                if (op.bodyParam.isBinary) {
-                    op.bodyParam.vendorExtensions.put("hasMapperTag", false);
-                } else if (isContentJson(op.bodyParam)) {
-                    op.bodyParam.vendorExtensions.put("hasMapperTag", true);
-                    op.bodyParam.vendorExtensions.put("mapperTag", params.jsonAnnotation);
+                // Custom mapper needed ONLY for primitive types with non-standard content types:
+                // 1. Binary types that are NOT application/octet-stream (e.g., application/pdf, image/png)
+                // 2. String types that are NOT text/plain (e.g., text/html)
+                // Models (isModel=true) should use user-provided mapper via @Json or similar
+                // Standard mapper handles: application/json (via @Json), application/octet-stream, text/plain
+                if (op.bodyParam.isBinary && !op.bodyParam.isModel) {
+                    var i = op.bodyParam.getContent().keySet().iterator();
+                    String contentType = i.hasNext() ? i.next() : "application/octet-stream";
+                    if (!"application/octet-stream".equals(contentType)) {
+                        op.bodyParam.vendorExtensions.put("hasMapperTag", false);
+                        op.bodyParam.vendorExtensions.put("contentType", contentType);
+                    }
+                } else if (!isContentJson(op.bodyParam) && op.bodyParam.isString && !op.bodyParam.isModel) {
+                    var i = op.bodyParam.getContent().keySet().iterator();
+                    String contentType = i.hasNext() ? i.next() : "text/plain";
+                    if (!"text/plain".equals(contentType)) {
+                        op.bodyParam.vendorExtensions.put("hasMapperTag", false);
+                        op.bodyParam.vendorExtensions.put("contentType", contentType);
+                    }
                 }
                 for (var param : op.allParams) {
-                    if (param.isBodyParam && param.isBinary) {
-                        op.bodyParam.vendorExtensions.put("hasMapperTag", false);
-                    } else if (param.isBodyParam && (isContentJson(param))) {
-                        param.vendorExtensions.put("hasMapperTag", true);
-                        param.vendorExtensions.put("mapperTag", params.jsonAnnotation);
+                    if (param.isBodyParam && param.isBinary && !param.isModel) {
+                        var i = param.getContent().keySet().iterator();
+                        String contentType = i.hasNext() ? i.next() : "application/octet-stream";
+                        if (!"application/octet-stream".equals(contentType)) {
+                            param.vendorExtensions.put("hasMapperTag", false);
+                            param.vendorExtensions.put("contentType", contentType);
+                        }
+                    } else if (param.isBodyParam && !isContentJson(param) && param.isString && !param.isModel) {
+                        var i = param.getContent().keySet().iterator();
+                        String contentType = i.hasNext() ? i.next() : "text/plain";
+                        if (!"text/plain".equals(contentType)) {
+                            param.vendorExtensions.put("hasMapperTag", false);
+                            param.vendorExtensions.put("contentType", contentType);
+                        }
                     }
                 }
             }

--- a/openapi/openapi-generator/src/main/java/ru/tinkoff/kora/openapi/generator/KoraCodegen.java
+++ b/openapi/openapi-generator/src/main/java/ru/tinkoff/kora/openapi/generator/KoraCodegen.java
@@ -2591,6 +2591,12 @@ public class KoraCodegen extends DefaultCodegen {
                     } else {
                         response.vendorExtensions.put("contentType", "application/octet-stream");
                     }
+                } else if (response.isString && !isContentJson(response.getContent())) {
+                    var i = response.getContent().keySet().iterator();
+                    String contentType = i.hasNext() ? i.next() : "text/plain";
+                    if (!"text/plain".equals(contentType)) {
+                        response.vendorExtensions.put("contentType", contentType);
+                    }
                 }
             }
             op.vendorExtensions.put("singleResponse", op.responses.size() == 1);

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaAnnotatedParams.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaAnnotatedParams.mustache
@@ -8,7 +8,9 @@
         @ru.tinkoff.kora.http.common.annotation.Path("{{baseName}}"){{/isPathParam}}{{#isHeaderParam}}
         @ru.tinkoff.kora.http.common.annotation.Header("{{baseName}}"){{/isHeaderParam}}{{#isCookieParam}}
         @ru.tinkoff.kora.http.common.annotation.Cookie("{{baseName}}"){{/isCookieParam}}{{#isBodyParam}}{{#vendorExtensions.hasMapperTag}}
-        @{{vendorExtensions.mapperTag}}{{/vendorExtensions.hasMapperTag}}{{/isBodyParam}}
+        @{{vendorExtensions.mapperTag}}{{/vendorExtensions.hasMapperTag}}{{^vendorExtensions.hasMapperTag}}{{#vendorExtensions.contentType}}{{#isClient}}
+        @ru.tinkoff.kora.common.Mapping({{classname}}ClientRequestMappers.{{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}BodyParamRequestMapper.class){{/isClient}}{{^isClient}}
+        @ru.tinkoff.kora.common.Mapping({{classname}}ServerRequestMappers.{{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}BodyParamRequestMapper.class){{/isClient}}{{/vendorExtensions.contentType}}{{/vendorExtensions.hasMapperTag}}{{/isBodyParam}}
         {{^required}}@Nullable {{/required}}{{{dataType}}} {{paramName}}{{#hasFormParams}},{{/hasFormParams}}{{^hasFormParams}}{{^-last}},{{/-last}}{{#-last}}
     {{/-last}}{{/hasFormParams}}{{/isFormParam}}{{/allParams}}{{#hasFormParams}}{{#isClient}}
         @ru.tinkoff.kora.common.Mapping({{classname}}ClientRequestMappers.{{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}FormParamRequestMapper.class){{/isClient}}{{^isClient}}

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaAnnotatedParams.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaAnnotatedParams.mustache
@@ -9,8 +9,7 @@
         @ru.tinkoff.kora.http.common.annotation.Header("{{baseName}}"){{/isHeaderParam}}{{#isCookieParam}}
         @ru.tinkoff.kora.http.common.annotation.Cookie("{{baseName}}"){{/isCookieParam}}{{#isBodyParam}}{{#vendorExtensions.hasMapperTag}}
         @{{vendorExtensions.mapperTag}}{{/vendorExtensions.hasMapperTag}}{{^vendorExtensions.hasMapperTag}}{{#vendorExtensions.contentType}}{{#isClient}}
-        @ru.tinkoff.kora.common.Mapping({{classname}}ClientRequestMappers.{{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}BodyParamRequestMapper.class){{/isClient}}{{^isClient}}
-        @ru.tinkoff.kora.common.Mapping({{classname}}ServerRequestMappers.{{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}BodyParamRequestMapper.class){{/isClient}}{{/vendorExtensions.contentType}}{{/vendorExtensions.hasMapperTag}}{{/isBodyParam}}
+        @ru.tinkoff.kora.common.Mapping({{classname}}ClientRequestMappers.{{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}BodyParamRequestMapper.class){{/isClient}}{{/vendorExtensions.contentType}}{{/vendorExtensions.hasMapperTag}}{{/isBodyParam}}
         {{^required}}@Nullable {{/required}}{{{dataType}}} {{paramName}}{{#hasFormParams}},{{/hasFormParams}}{{^hasFormParams}}{{^-last}},{{/-last}}{{#-last}}
     {{/-last}}{{/hasFormParams}}{{/isFormParam}}{{/allParams}}{{#hasFormParams}}{{#isClient}}
         @ru.tinkoff.kora.common.Mapping({{classname}}ClientRequestMappers.{{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}FormParamRequestMapper.class){{/isClient}}{{^isClient}}

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaClientRequestMappers.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaClientRequestMappers.mustache
@@ -8,6 +8,7 @@ package {{package}};
 import ru.tinkoff.kora.http.client.common.form.UrlEncodedWriter;
 import ru.tinkoff.kora.http.client.common.form.MultipartWriter;
 import ru.tinkoff.kora.http.client.common.request.HttpClientRequestMapper;
+import ru.tinkoff.kora.http.common.body.HttpBody;
 import ru.tinkoff.kora.http.common.body.HttpBodyOutput;
 import ru.tinkoff.kora.common.Context;
 
@@ -15,63 +16,24 @@ import ru.tinkoff.kora.common.Context;
 public interface {{classname}}ClientRequestMappers {
 {{#operations}}
 {{#operation}}
-{{#hasFormParams}}
+{{#bodyParam}}{{#vendorExtensions.contentType}}
 
   @ru.tinkoff.kora.common.annotation.Generated("openapi generator kora client")
-  final class {{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}FormParamRequestMapper implements HttpClientRequestMapper<{{classname}}.{{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}FormParam> { {{#vendorExtensions.requiresFormParamMappers}}
+  final class {{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}BodyParamRequestMapper implements HttpClientRequestMapper<{{{dataType}}}> {
 
-    {{#vendorExtensions.formParamMappers}}
-    private ru.tinkoff.kora.http.client.common.writer.StringParameterConverter<{{{paramType}}}> {{paramName}}Converter;
-    {{/vendorExtensions.formParamMappers}}
-
-    public {{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}FormParamRequestMapper({{#vendorExtensions.formParamMappers}}{{#requireTag}}
-      @{{mapperTag}}{{/requireTag}}
-      ru.tinkoff.kora.http.client.common.writer.StringParameterConverter<{{{paramType}}}> {{paramName}}Converter{{^last}},{{/last}}{{/vendorExtensions.formParamMappers}}
-    ) {
-    {{#vendorExtensions.formParamMappers}}
-       this.{{paramName}}Converter = {{paramName}}Converter;
-    {{/vendorExtensions.formParamMappers}}
+    public {{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}BodyParamRequestMapper() {
     }
 
-{{/vendorExtensions.requiresFormParamMappers}}
     @Override
-    public HttpBodyOutput apply(Context ctx, {{classname}}.{{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}FormParam value) throws Exception { {{#vendorExtensions.urlEncodedForm}}
-      var b = new UrlEncodedWriter();{{#formParams}}
-      if (value.{{paramName}}() != null) { {{#vendorExtensions.requiresMapper}}
-        b.add("{{baseName}}", {{paramName}}Converter.convert(value.{{paramName}}()));{{/vendorExtensions.requiresMapper}}{{^vendorExtensions.requiresMapper}}
-        b.add("{{baseName}}", java.util.Objects.toString(value.{{paramName}}()));{{/vendorExtensions.requiresMapper}}
-      }{{/formParams}}
-      return b.write();{{/vendorExtensions.urlEncodedForm}}{{#vendorExtensions.multipartForm}}
-      var l = new java.util.ArrayList<ru.tinkoff.kora.http.common.form.FormMultipart.FormPart>();{{#formParams}}
-      {{#isFile}}
-      {{#isArray}}if (value.{{paramName}}All() != null) {
-          l.addAll(value.{{paramName}}All());
-      }{{/isArray}}{{^isArray}}if (value.{{paramName}}() != null) {
-          var file = value.{{paramName}}();
-          l.add(file);
-      }{{/isArray}}{{/isFile}}{{^isFile}}
-      if (value.{{paramName}}() != null) {
-          {{#vendorExtensions.isByteArrayArray}}for (var item : value.{{paramName}}()) {
-              l.add(ru.tinkoff.kora.http.common.form.FormMultipart.data(
-              "{{baseName}}",
-                java.util.Base64.getEncoder().encodeToString(item)
-              ));
-          }{{/vendorExtensions.isByteArrayArray}}{{^vendorExtensions.isByteArrayArray}}{{#vendorExtensions.isByteArray}}
-          l.add(ru.tinkoff.kora.http.common.form.FormMultipart.data(
-          "{{baseName}}",
-            java.util.Base64.getEncoder().encodeToString(value.{{paramName}}())
-          ));{{/vendorExtensions.isByteArray}}{{^vendorExtensions.isByteArray}}
-          var buf = java.nio.charset.StandardCharsets.UTF_8.encode(java.util.Objects.toString(value.{{paramName}}()));
-          var part = ru.tinkoff.kora.http.common.form.FormMultipart.data(
-          "{{baseName}}",
-            java.util.Objects.toString(value.{{paramName}}())
-          );
-          l.add(part);{{/vendorExtensions.isByteArray}}{{/vendorExtensions.isByteArrayArray}}
-      }{{/isFile}}{{/formParams}}
-      return MultipartWriter.write(l);{{/vendorExtensions.multipartForm}}
+    public HttpBodyOutput apply(Context ctx, {{{dataType}}} value) throws Exception {
+{{#isBinary}}
+      return HttpBody.of("{{{vendorExtensions.contentType}}}", value);
+{{/isBinary}}{{^isBinary}}
+      return HttpBody.of("{{{vendorExtensions.contentType}}}", value.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+{{/isBinary}}
     }
   }
-{{/hasFormParams}}
+{{/vendorExtensions.contentType}}{{/bodyParam}}
 {{/operation}}
 {{/operations}}
 }

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaClientRequestMappers.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaClientRequestMappers.mustache
@@ -21,12 +21,13 @@ public interface {{classname}}ClientRequestMappers {
   @ru.tinkoff.kora.common.annotation.Generated("openapi generator kora client")
   final class {{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}BodyParamRequestMapper implements HttpClientRequestMapper<{{{dataType}}}> {
 
-    public {{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}BodyParamRequestMapper() {
-    }
-
     @Override
-    public HttpBodyOutput apply(Context ctx, {{{dataType}}} value) throws Exception {
-{{#isBinary}}
+    public HttpBodyOutput apply(Context ctx, {{^required}}@jakarta.annotation.Nullable {{/required}}{{{dataType}}} value) throws Exception {
+{{^required}}
+      if (value == null) {
+        return HttpBody.empty();
+      }
+{{/required}}{{#isBinary}}
       return HttpBody.of("{{{vendorExtensions.contentType}}}", value);
 {{/isBinary}}{{^isBinary}}
       return HttpBody.of("{{{vendorExtensions.contentType}}}", value.getBytes(java.nio.charset.StandardCharsets.UTF_8));

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaClientRequestMappers.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaClientRequestMappers.mustache
@@ -34,6 +34,63 @@ public interface {{classname}}ClientRequestMappers {
     }
   }
 {{/vendorExtensions.contentType}}{{/bodyParam}}
+{{#hasFormParams}}
+
+  @ru.tinkoff.kora.common.annotation.Generated("openapi generator kora client")
+  final class {{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}FormParamRequestMapper implements HttpClientRequestMapper<{{classname}}.{{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}FormParam> { {{#vendorExtensions.requiresFormParamMappers}}
+
+    {{#vendorExtensions.formParamMappers}}
+    private ru.tinkoff.kora.http.client.common.writer.StringParameterConverter<{{{paramType}}}> {{paramName}}Converter;
+    {{/vendorExtensions.formParamMappers}}
+
+    public {{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}FormParamRequestMapper({{#vendorExtensions.formParamMappers}}{{#requireTag}}
+      @{{mapperTag}}{{/requireTag}}
+      ru.tinkoff.kora.http.client.common.writer.StringParameterConverter<{{{paramType}}}> {{paramName}}Converter{{^last}},{{/last}}{{/vendorExtensions.formParamMappers}}
+    ) {
+    {{#vendorExtensions.formParamMappers}}
+       this.{{paramName}}Converter = {{paramName}}Converter;
+    {{/vendorExtensions.formParamMappers}}
+    }
+
+{{/vendorExtensions.requiresFormParamMappers}}
+    @Override
+    public HttpBodyOutput apply(Context ctx, {{classname}}.{{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}FormParam value) throws Exception { {{#vendorExtensions.urlEncodedForm}}
+      var b = new UrlEncodedWriter();{{#formParams}}
+      if (value.{{paramName}}() != null) { {{#vendorExtensions.requiresMapper}}
+        b.add("{{baseName}}", {{paramName}}Converter.convert(value.{{paramName}}()));{{/vendorExtensions.requiresMapper}}{{^vendorExtensions.requiresMapper}}
+        b.add("{{baseName}}", java.util.Objects.toString(value.{{paramName}}()));{{/vendorExtensions.requiresMapper}}
+      }{{/formParams}}
+      return b.write();{{/vendorExtensions.urlEncodedForm}}{{#vendorExtensions.multipartForm}}
+      var l = new java.util.ArrayList<ru.tinkoff.kora.http.common.form.FormMultipart.FormPart>();{{#formParams}}
+      {{#isFile}}
+      {{#isArray}}if (value.{{paramName}}All() != null) {
+          l.addAll(value.{{paramName}}All());
+      }{{/isArray}}{{^isArray}}if (value.{{paramName}}() != null) {
+          var file = value.{{paramName}}();
+          l.add(file);
+      }{{/isArray}}{{/isFile}}{{^isFile}}
+      if (value.{{paramName}}() != null) {
+          {{#vendorExtensions.isByteArrayArray}}for (var item : value.{{paramName}}()) {
+              l.add(ru.tinkoff.kora.http.common.form.FormMultipart.data(
+              "{{baseName}}",
+                java.util.Base64.getEncoder().encodeToString(item)
+              ));
+          }{{/vendorExtensions.isByteArrayArray}}{{^vendorExtensions.isByteArrayArray}}{{#vendorExtensions.isByteArray}}
+          l.add(ru.tinkoff.kora.http.common.form.FormMultipart.data(
+          "{{baseName}}",
+            java.util.Base64.getEncoder().encodeToString(value.{{paramName}}())
+          ));{{/vendorExtensions.isByteArray}}{{^vendorExtensions.isByteArray}}
+          var buf = java.nio.charset.StandardCharsets.UTF_8.encode(java.util.Objects.toString(value.{{paramName}}()));
+          var part = ru.tinkoff.kora.http.common.form.FormMultipart.data(
+          "{{baseName}}",
+            java.util.Objects.toString(value.{{paramName}}())
+          );
+          l.add(part);{{/vendorExtensions.isByteArray}}{{/vendorExtensions.isByteArrayArray}}
+      }{{/isFile}}{{/formParams}}
+      return MultipartWriter.write(l);{{/vendorExtensions.multipartForm}}
+    }
+  }
+{{/hasFormParams}}
 {{/operation}}
 {{/operations}}
 }

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaServerRequestMappers.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaServerRequestMappers.mustache
@@ -13,7 +13,39 @@ import java.util.concurrent.CompletionStage;
 {{/isBlocking}}
 
 @ru.tinkoff.kora.common.annotation.Generated("openapi generator kora server"){{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
-public interface {{classname}}ServerRequestMappers { {{#operations}}{{#operation}}{{#hasFormParams}}
+public interface {{classname}}ServerRequestMappers { {{#operations}}{{#operation}}{{#bodyParam}}{{#vendorExtensions.contentType}}
+
+  @ru.tinkoff.kora.common.annotation.Generated("openapi generator kora server")
+  final class {{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}BodyParamRequestMapper implements HttpServerRequestMapper<{{#isBlocking}}{{{dataType}}}{{/isBlocking}}{{^isBlocking}}CompletionStage<{{{dataType}}}>{{/isBlocking}}> {
+
+    public {{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}BodyParamRequestMapper() {
+    }
+
+    @Override
+    public {{#isBlocking}}{{{dataType}}}{{/isBlocking}}{{^isBlocking}}CompletionStage<{{{dataType}}}>{{/isBlocking}} apply(HttpServerRequest request) throws Exception {
+{{#isBinary}}{{#isBlocking}}
+      return ({{{dataType}}}) request.body().asArrayStage().toCompletableFuture().get();
+{{/isBlocking}}{{/isBinary}}
+{{#isBinary}}{{^isBlocking}}
+      return request.body().asArrayStage().thenApply(bytes -> ({{{dataType}}}) bytes);
+{{/isBlocking}}{{/isBinary}}
+{{#isString}}{{#isBlocking}}
+      return new String(request.body().asArrayStage().toCompletableFuture().get(), java.nio.charset.StandardCharsets.UTF_8);
+{{/isBlocking}}{{/isString}}
+{{#isString}}{{^isBlocking}}
+      return request.body().asArrayStage().thenApply(bytes -> new String(bytes, java.nio.charset.StandardCharsets.UTF_8));
+{{/isBlocking}}{{/isString}}
+{{^isBinary}}{{^isString}}{{#isBlocking}}
+      return null;
+{{/isBlocking}}{{/isString}}{{/isBinary}}
+{{^isBinary}}{{^isString}}{{^isBlocking}}
+      return request.body().asArrayStage().thenApply(bytes -> null);
+{{/isBlocking}}{{/isString}}{{/isBinary}}
+    }
+  }
+{{/vendorExtensions.contentType}}{{/bodyParam}}{{/operation}}
+{{/operations}}
+{{#operations}}{{#operation}}{{#hasFormParams}}
 
   @ru.tinkoff.kora.common.annotation.Generated("openapi generator kora server")
   final class {{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}FormParamRequestMapper implements HttpServerRequestMapper<{{#isBlocking}}{{classname}}Controller.{{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}FormParam{{/isBlocking}}{{^isBlocking}}CompletionStage<{{classname}}Controller.{{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}FormParam>{{/isBlocking}}> {

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaServerRequestMappers.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaServerRequestMappers.mustache
@@ -13,39 +13,7 @@ import java.util.concurrent.CompletionStage;
 {{/isBlocking}}
 
 @ru.tinkoff.kora.common.annotation.Generated("openapi generator kora server"){{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
-public interface {{classname}}ServerRequestMappers { {{#operations}}{{#operation}}{{#bodyParam}}{{#vendorExtensions.contentType}}
-
-  @ru.tinkoff.kora.common.annotation.Generated("openapi generator kora server")
-  final class {{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}BodyParamRequestMapper implements HttpServerRequestMapper<{{#isBlocking}}{{{dataType}}}{{/isBlocking}}{{^isBlocking}}CompletionStage<{{{dataType}}}>{{/isBlocking}}> {
-
-    public {{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}BodyParamRequestMapper() {
-    }
-
-    @Override
-    public {{#isBlocking}}{{{dataType}}}{{/isBlocking}}{{^isBlocking}}CompletionStage<{{{dataType}}}>{{/isBlocking}} apply(HttpServerRequest request) throws Exception {
-{{#isBinary}}{{#isBlocking}}
-      return ({{{dataType}}}) request.body().asArrayStage().toCompletableFuture().get();
-{{/isBlocking}}{{/isBinary}}
-{{#isBinary}}{{^isBlocking}}
-      return request.body().asArrayStage().thenApply(bytes -> ({{{dataType}}}) bytes);
-{{/isBlocking}}{{/isBinary}}
-{{#isString}}{{#isBlocking}}
-      return new String(request.body().asArrayStage().toCompletableFuture().get(), java.nio.charset.StandardCharsets.UTF_8);
-{{/isBlocking}}{{/isString}}
-{{#isString}}{{^isBlocking}}
-      return request.body().asArrayStage().thenApply(bytes -> new String(bytes, java.nio.charset.StandardCharsets.UTF_8));
-{{/isBlocking}}{{/isString}}
-{{^isBinary}}{{^isString}}{{#isBlocking}}
-      return null;
-{{/isBlocking}}{{/isString}}{{/isBinary}}
-{{^isBinary}}{{^isString}}{{^isBlocking}}
-      return request.body().asArrayStage().thenApply(bytes -> null);
-{{/isBlocking}}{{/isString}}{{/isBinary}}
-    }
-  }
-{{/vendorExtensions.contentType}}{{/bodyParam}}{{/operation}}
-{{/operations}}
-{{#operations}}{{#operation}}{{#hasFormParams}}
+public interface {{classname}}ServerRequestMappers { {{#operations}}{{#operation}}{{#hasFormParams}}
 
   @ru.tinkoff.kora.common.annotation.Generated("openapi generator kora server")
   final class {{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}FormParamRequestMapper implements HttpServerRequestMapper<{{#isBlocking}}{{classname}}Controller.{{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}FormParam{{/isBlocking}}{{^isBlocking}}CompletionStage<{{classname}}Controller.{{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}FormParam>{{/isBlocking}}> {

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaServerResponseMappers.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaServerResponseMappers.mustache
@@ -49,9 +49,10 @@ public interface {{classname}}ServerResponseMappers {
         var entity = HttpResponseEntity.of({{#isDefault}}rs.statusCode(){{/isDefault}}{{^isDefault}}{{code}}{{/isDefault}}, headers, rs.content());
         return this.response{{code}}Delegate.apply(ctx, request, entity);{{/vendorExtensions.isBinaryUnknownType}}{{^vendorExtensions.isBinaryUnknownType}}
         return HttpServerResponse.of({{#isDefault}}rs.statusCode(){{/isDefault}}{{^isDefault}}{{code}}{{/isDefault}}, headers, HttpBody.of(ctx, "{{{vendorExtensions.contentType}}}", rs.content()));{{/vendorExtensions.isBinaryUnknownType}}{{/isBinary}}{{^isBinary}}{{^dataType}}
-        return HttpServerResponse.of({{#isDefault}}rs.statusCode(){{/isDefault}}{{^isDefault}}{{code}}{{/isDefault}}, headers);{{/dataType}}{{#dataType}}
+        return HttpServerResponse.of({{#isDefault}}rs.statusCode(){{/isDefault}}{{^isDefault}}{{code}}{{/isDefault}}, headers);{{/dataType}}{{#dataType}}{{#vendorExtensions.contentType}}
+        return HttpServerResponse.of({{#isDefault}}rs.statusCode(){{/isDefault}}{{^isDefault}}{{code}}{{/isDefault}}, headers, HttpBody.of(ctx, "{{{vendorExtensions.contentType}}}", rs.content().getBytes(java.nio.charset.StandardCharsets.UTF_8)));{{/vendorExtensions.contentType}}{{^vendorExtensions.contentType}}
         var entity = HttpResponseEntity.of({{#isDefault}}rs.statusCode(){{/isDefault}}{{^isDefault}}{{code}}{{/isDefault}}, headers, rs.content());
-        return this.response{{code}}Delegate.apply(ctx, request, entity);{{/dataType}}{{/isBinary}}{{^vendorExtensions.singleResponse}}
+        return this.response{{code}}Delegate.apply(ctx, request, entity);{{/vendorExtensions.contentType}}{{/dataType}}{{/isBinary}}{{^vendorExtensions.singleResponse}}
       }
       {{/vendorExtensions.singleResponse}}{{/responses}}
       {{^vendorExtensions.singleResponse}}

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinAnnotatedParams.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinAnnotatedParams.mustache
@@ -8,7 +8,8 @@
         @ru.tinkoff.kora.http.common.annotation.Path("{{baseName}}"){{/isPathParam}}{{#isHeaderParam}}
         @ru.tinkoff.kora.http.common.annotation.Header("{{baseName}}"){{/isHeaderParam}}{{#isCookieParam}}
         @ru.tinkoff.kora.http.common.annotation.Cookie("{{baseName}}"){{/isCookieParam}}{{#isBodyParam}}{{#vendorExtensions.hasMapperTag}}
-        @{{vendorExtensions.mapperTag}}{{/vendorExtensions.hasMapperTag}}{{/isBodyParam}}
+        @{{vendorExtensions.mapperTag}}{{/vendorExtensions.hasMapperTag}}{{^vendorExtensions.hasMapperTag}}{{#vendorExtensions.contentType}}{{#isClient}}
+        @ru.tinkoff.kora.common.Mapping(value={{classname}}ClientRequestMappers.{{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}BodyParamRequestMapper::class){{/isClient}}{{/vendorExtensions.contentType}}{{/vendorExtensions.hasMapperTag}}{{/isBodyParam}}
         {{paramName}}: {{{dataType}}}{{^required}}? = {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}{{/required}}{{#hasFormParams}},{{/hasFormParams}}{{^hasFormParams}}{{^-last}},{{/-last}}{{#-last}}
     {{/-last}}{{/hasFormParams}}{{/isFormParam}}{{/allParams}}{{#hasFormParams}}{{#isClient}}
         @ru.tinkoff.kora.common.Mapping(value={{classname}}ClientRequestMappers.{{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}FormParamRequestMapper::class){{/isClient}}{{^isClient}}

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinClientRequestMappers.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinClientRequestMappers.mustache
@@ -8,6 +8,7 @@ package {{package}}
 import ru.tinkoff.kora.http.client.common.form.UrlEncodedWriter
 import ru.tinkoff.kora.http.client.common.form.MultipartWriter
 import ru.tinkoff.kora.http.client.common.request.HttpClientRequestMapper
+import ru.tinkoff.kora.http.common.body.HttpBody
 import ru.tinkoff.kora.http.common.body.HttpBodyOutput;
 import ru.tinkoff.kora.common.Context
 
@@ -15,6 +16,19 @@ import ru.tinkoff.kora.common.Context
 interface {{classname}}ClientRequestMappers {
 {{#operations}}
 {{#operation}}
+{{#bodyParam}}{{#vendorExtensions.contentType}}
+
+  @ru.tinkoff.kora.common.annotation.Generated("openapi generator kora client")
+  class {{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}BodyParamRequestMapper : HttpClientRequestMapper<{{{dataType}}}{{^required}}?{{/required}}> {
+    override fun apply(ctx: Context, value: {{{dataType}}}{{^required}}?{{/required}}): HttpBodyOutput { {{^required}}
+      if (value == null) {
+        return HttpBody.empty()
+      }{{/required}}{{#isBinary}}
+      return HttpBody.of("{{{vendorExtensions.contentType}}}", value){{/isBinary}}{{^isBinary}}
+      return HttpBody.of("{{{vendorExtensions.contentType}}}", value.toByteArray(Charsets.UTF_8)){{/isBinary}}
+    }
+  }
+{{/vendorExtensions.contentType}}{{/bodyParam}}
 {{#hasFormParams}}
 
   @ru.tinkoff.kora.common.annotation.Generated("openapi generator kora client")

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinServerResponseMappers.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinServerResponseMappers.mustache
@@ -41,9 +41,10 @@ interface {{classname}}ServerResponseMappers {
           val entity = HttpResponseEntity.of({{#isDefault}}rs.statusCode{{/isDefault}}{{^isDefault}}{{code}}{{/isDefault}}, headers, rs.content)
           return response{{code}}Delegate.apply(ctx, rq, entity){{/vendorExtensions.isBinaryUnknownType}}{{^vendorExtensions.isBinaryUnknownType}}
           return HttpServerResponse.of({{#isDefault}}rs.statusCode{{/isDefault}}{{^isDefault}}{{code}}{{/isDefault}}, headers, HttpBody.of(ctx, "{{{vendorExtensions.contentType}}}", rs.content)){{/vendorExtensions.isBinaryUnknownType}}{{/isBinary}}{{^isBinary}}{{^dataType}}
-          return HttpServerResponse.of({{#isDefault}}rs.statusCode{{/isDefault}}{{^isDefault}}{{code}}{{/isDefault}}, headers){{/dataType}}{{#dataType}}
+          return HttpServerResponse.of({{#isDefault}}rs.statusCode{{/isDefault}}{{^isDefault}}{{code}}{{/isDefault}}, headers){{/dataType}}{{#dataType}}{{#vendorExtensions.contentType}}
+          return HttpServerResponse.of({{#isDefault}}rs.statusCode{{/isDefault}}{{^isDefault}}{{code}}{{/isDefault}}, headers, HttpBody.of(ctx, "{{{vendorExtensions.contentType}}}", rs.content.toByteArray(Charsets.UTF_8))){{/vendorExtensions.contentType}}{{^vendorExtensions.contentType}}
           val entity = HttpResponseEntity.of({{#isDefault}}rs.statusCode{{/isDefault}}{{^isDefault}}{{code}}{{/isDefault}}, headers, rs.content)
-          return response{{code}}Delegate.apply(ctx, rq, entity){{/dataType}}{{/isBinary}}{{^vendorExtensions.singleResponse}}
+          return response{{code}}Delegate.apply(ctx, rq, entity){{/vendorExtensions.contentType}}{{/dataType}}{{/isBinary}}{{^vendorExtensions.singleResponse}}
         }{{/vendorExtensions.singleResponse}}{{/responses}}{{^vendorExtensions.singleResponse}}
       }{{/vendorExtensions.singleResponse}}
     }

--- a/openapi/openapi-generator/src/test/java/ru/tinkoff/kora/openapi/generator/KoraCodegenTest.java
+++ b/openapi/openapi-generator/src/test/java/ru/tinkoff/kora/openapi/generator/KoraCodegenTest.java
@@ -137,6 +137,7 @@ class KoraCodegenTest {
             "/example/petstoreV3_form.yaml",
             "/example/petstoreV3_request_parameters.yaml",
             "/example/petstoreV3_responses.yaml",
+            "/example/petstoreV3_requests.yaml",
             "/example/petstoreV3_types.yaml",
             "/example/petstoreV3_validation.yaml",
             "/example/petstoreV3_single_response.yaml",

--- a/openapi/openapi-generator/src/test/resources/example/petstoreV3_requests.yaml
+++ b/openapi/openapi-generator/src/test/resources/example/petstoreV3_requests.yaml
@@ -1,0 +1,113 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /text-plain:
+    post:
+      operationId: plain
+      requestBody:
+        required: true
+        content:
+          text/plain:
+            schema:
+              type: string
+      responses:
+        '200':
+          description: OK
+
+  /text-html:
+    post:
+      operationId: html
+      requestBody:
+        required: true
+        content:
+          text/html:
+            schema:
+              type: string
+      responses:
+        '200':
+          description: OK
+
+  /application-octet-stream:
+    post:
+      operationId: octet-stream
+      requestBody:
+        required: true
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+      responses:
+        '200':
+          description: OK
+
+  /application-pdf:
+    post:
+      operationId: pdf
+      requestBody:
+        required: true
+        content:
+          application/pdf:
+            schema:
+              type: string
+              format: binary
+      responses:
+        '200':
+          description: OK
+
+  /image-png:
+    post:
+      operationId: png
+      requestBody:
+        required: true
+        content:
+          image/png:
+            schema:
+              type: string
+              format: binary
+      responses:
+        '200':
+          description: OK
+
+  /application-json:
+    post:
+      operationId: json
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        '200':
+          description: OK
+
+  /application-xml:
+    get:
+      operationId: xml
+      requestBody:
+        required: true
+        content:
+          application/xml:
+            schema:
+              $ref: '#/components/schemas/Pet'
+      responses:
+        '200':
+          description: OK
+
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string


### PR DESCRIPTION
Fixed(openapi): generate custom request mappers for non-standard body content-types

Generate custom HttpClientRequestMapper implementations for body parameters with content-types other than application/octet-stream, text/plain, or JSON. This ensures correct Content-Type headers for types like application/pdf, image/png, text/html, etc.
Generate custom HttpClientRequestMapper for non-standard body content-types
in Kotlin clients (previously Java-only), handling optional/nullable bodies
via HttpBody.empty(). Removed the equivalent server-side request mapper
generation since HttpServerRequestMapperModule already provides default
byte[]/String mappers with the getFullContentIfAvailable() hot path.

Also fixes non-JSON string responses (e.g. text/html) incorrectly falling
back to the default text/plain response mapper.