### PR TITLE
fix(http-client): tag JSON response entity mapper with @Json

### DIFF
--- a/http/http-client-annotation-processor/src/test/java/io/koraframework/http/client/annotation/processor/HttpClientExtensionTest.java
+++ b/http/http-client-annotation-processor/src/test/java/io/koraframework/http/client/annotation/processor/HttpClientExtensionTest.java
@@ -79,6 +79,27 @@ public class HttpClientExtensionTest extends AbstractAnnotationProcessorTest {
         compileResult.assertSuccess();
     }
 
+    /**
+     * Untagged {@code HttpClientResponseMapper<HttpResponseEntity<T>>} must resolve to the plain
+     * response entity mapper even when a {@code JsonReader<T>} is in the graph: the JSON flavour is
+     * reachable only under the {@code @Json} tag. Without that tag on the JSON factory both default
+     * template factories match and the graph fails with "Multiple components match dependency".
+     */
+    @Test
+    public void testExtensionResponseEntityWhenJsonReaderIsPresent() {
+        compile(List.of(new KoraAppProcessor()), """
+            @KoraApp
+            public interface App extends io.koraframework.http.client.common.response.HttpClientResponseMapperModule {
+                @Root
+                default String root(HttpClientResponseMapper<HttpResponseEntity<String>> mapper) { return ""; }
+
+                default JsonReader<String> reader() { return parser -> ""; }
+            }
+            """);
+
+        compileResult.assertSuccess();
+    }
+
     @Test
     public void testExtensionJsonEither() {
         compile(List.of(new KoraAppProcessor()), """

--- a/http/http-client-common/src/main/java/io/koraframework/http/client/common/response/HttpClientResponseMapperModule.java
+++ b/http/http-client-common/src/main/java/io/koraframework/http/client/common/response/HttpClientResponseMapperModule.java
@@ -51,6 +51,7 @@ public interface HttpClientResponseMapperModule {
         return response -> HttpResponseEntity.of(response.code(), response.headers(), mapper.apply(response));
     }
 
+    @Json
     @DefaultComponent
     default <T> HttpClientResponseMapper<HttpResponseEntity<T>> httpClientResponseJsonEntityResponseMapper(JsonReader<T> reader) {
         var delegate = new JsonHttpClientResponseMapper<>(reader);


### PR DESCRIPTION
## What

`HttpClientResponseMapperModule` tags every JSON factory with `@Json` except
`httpClientResponseJsonEntityResponseMapper(JsonReader<T>)`. Without the tag two
`@DefaultComponent` template factories produce the same untagged
`HttpClientResponseMapper<HttpResponseEntity<T>>`, and the graph cannot choose:

```
error: Multiple components match dependency:
    HttpClientResponseMapper<HttpResponseEntity<String>> (no tags)
  Candidates:
    - factory HttpClientResponseMapperModule#httpClientResponseEntityResponseMapper(...)
    - factory HttpClientResponseMapperModule#httpClientResponseJsonEntityResponseMapper(...)
```

Any HTTP client method returning `HttpResponseEntity<T>` fails to compile in an application that
has a `JsonReader<T>` — that is, in practically any service with JSON.

Added the missing `@Json`.

## Tests

`HttpClientExtensionTest#testExtensionResponseEntityWhenJsonReaderIsPresent`. Fails without the fix
with `Multiple components match dependency`. The existing `testExtensionWithoutTag` did not catch it:
its graph has no `JsonReader`.

## Compatibility

Code that relied on implicit JSON mapping of `HttpResponseEntity<T>` without `@Json` now has to say
`@Json` explicitly. Nothing breaks in practice: such code did not compile before.
