### PR TITLE
fix(kafka): detect Exception listener parameter by type element, not by printed type

### DIFF
--- a/kafka/kafka-annotation-processor/src/main/java/io/koraframework/kafka/annotation/processor/utils/KafkaUtils.java
+++ b/kafka/kafka-annotation-processor/src/main/java/io/koraframework/kafka/annotation/processor/utils/KafkaUtils.java
@@ -90,7 +90,13 @@ public final class KafkaUtils {
     }
 
     public static boolean isAnyException(TypeMirror tm) {
-        return tm.toString().equals("java.lang.Throwable") || tm.toString().equals("java.lang.Exception");
+        if (!(tm instanceof DeclaredType dt)) {
+            return false;
+        }
+
+        // toString() would carry type-use annotations, e.g. "java.lang.@Nullable Exception"
+        var qualifiedName = ((TypeElement) dt.asElement()).getQualifiedName().toString();
+        return qualifiedName.equals("java.lang.Throwable") || qualifiedName.equals("java.lang.Exception");
     }
 
     public static boolean isConsumer(TypeMirror tm) {

--- a/kafka/kafka-annotation-processor/src/test/java/io/koraframework/kafka/annotation/processor/consumer/KafkaListenerRecordTest.java
+++ b/kafka/kafka-annotation-processor/src/test/java/io/koraframework/kafka/annotation/processor/consumer/KafkaListenerRecordTest.java
@@ -207,6 +207,32 @@ public class KafkaListenerRecordTest extends AbstractKafkaListenerAnnotationProc
         );
     }
 
+    /**
+     * JSpecify annotations are type-use, so an annotated parameter renders as
+     * {@code java.lang.@Nullable Exception}. Parameter kind detection must look at the type element
+     * rather than at the printed type, otherwise such a listener is rejected with
+     * "Kafka record listener method has unsupported parameter".
+     */
+    @Test
+    public void testProcessRecordAndParseExceptionWithTypeUseAnnotation() {
+        var handler = compile("""
+            public class KafkaListenerClass {
+                @KafkaListener("test.config.path")
+                public void process(@org.jspecify.annotations.Nullable ConsumerRecord<String, String> event,
+                                    @org.jspecify.annotations.Nullable Exception exception) {
+                }
+            }
+            """)
+            .handler(String.class, String.class);
+
+        handler.handle(record("test", "test-value"), i -> i
+            .assertNoException(1)
+            .assertRecord(0)
+            .hasKey("test")
+            .hasValue("test-value")
+        );
+    }
+
     @Test
     public void testProcessRecordAndParseThrowable() {
         var handler = compile("""


### PR DESCRIPTION
## What

`KafkaUtils.isAnyException` compared `tm.toString()` against `"java.lang.Exception"`. JSpecify
annotations are type-use, so `toString()` prints them inside the type name:

```
error: Kafka record listener method has unsupported parameter:
    java.lang.@org.jspecify.annotations.Nullable Exception
```

The parameter is then classified as `ConsumerParameter.Unknown` and rejected. The same listener
without `@Nullable` compiles.

This was the only string-based check in `KafkaUtils` — `isConsumer`, `isHeaders`,
`isKeyDeserializationException` and `isValueDeserializationException` all resolve the element and
are therefore annotation-proof. `isAnyException` now does the same.

Since JSpecify is the standard way to express nullability in 2.0, this hits ordinary application code.

## Tests

`KafkaListenerRecordTest#testProcessRecordAndParseExceptionWithTypeUseAnnotation`. Fails without the
fix with the original error.

## Compatibility

Strictly widening: signatures that used to be rejected are now accepted; listeners without
annotations are unaffected.
