### PR TITLE
fix(openapi-generator): make generated client request mappers public too

### DIFF
--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientApiGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientApiGenerator.java
@@ -20,6 +20,7 @@ public class ClientApiGenerator extends AbstractJavaGenerator<OperationsMap> {
     @Override
     public JavaFile generate(OperationsMap ctx) {
         var b = TypeSpec.interfaceBuilder((String) ctx.get("classname"))
+            .addModifiers(Modifier.PUBLIC)
             .addAnnotation(generated())
             .addAnnotation(buildHttpClientAnnotation(ctx));
         for (var operation : ctx.getOperations().getOperation()) {

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientRequestMapperGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientRequestMapperGenerator.java
@@ -19,6 +19,7 @@ public class ClientRequestMapperGenerator extends AbstractJavaGenerator<Operatio
     public JavaFile generate(OperationsMap ctx) {
         var className = ClassName.get(apiPackage, ctx.get("classname") + "ClientRequestMappers");
         var b = TypeSpec.interfaceBuilder(className)
+            .addModifiers(Modifier.PUBLIC)
             .addAnnotation(generated());
         for (var operation : ctx.getOperations().getOperation()) {
             if (!operation.getHasFormParams()) {

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientJavaOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientJavaOpenapiTest.java
@@ -46,6 +46,37 @@ public class HttpClientJavaOpenapiTest extends BaseJavaOpenapiTest {
         assertFalse(content.contains("httpClient.petstoreV3."));
     }
 
+    /**
+     * The generated client interface is meant to be injected into application code, which almost
+     * always lives in another package, so it has to be public. Without an explicit modifier
+     * JavaPoet emits a package-private interface and any usage fails with
+     * "PetApi is not public in ...; cannot be accessed from outside package".
+     */
+    @Test
+    void clientApiInterfaceIsPublic() throws Exception {
+        var files = generate(
+            "petstoreV3_public_api",
+            "java-client",
+            getClass().getResource("/example/petstoreV3.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+        );
+
+        var content = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().endsWith("Api.java"))
+            .filter(path -> {
+                try {
+                    return Files.readString(path).contains("@HttpClient");
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            })
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(content.contains("public interface "), content);
+    }
+
     @Test
     void clientConfigPrefixAppendsLowerCamelClientName() throws Exception {
         var files = generate(


### PR DESCRIPTION
## What

Interfaces generated in `java-client` mode came out package-private, so an application could not use
them:

```
error: PetApi is not public in io.koraframework.example.openapi.petV2.api;
       cannot be accessed from outside package
```

The generated API interface is now public.

## Tests

Generator test asserting the modifier on the generated interface. Fails without the fix.
