### PR TITLE
fix(camunda-zeebe-worker): stop marking job worker annotations as AOP annotations

### DIFF
--- a/experimental/camunda-zeebe-worker-annotation-processor/build.gradle
+++ b/experimental/camunda-zeebe-worker-annotation-processor/build.gradle
@@ -5,6 +5,7 @@ dependencies {
     implementation libs.javapoet
 
     testImplementation testFixtures(project(":core:annotation-processor-common"))
+    testImplementation project(":aop:aop-annotation-processor")
     testImplementation project(":internal:test-logging")
     testImplementation project(":experimental:camunda-zeebe-worker")
 }

--- a/experimental/camunda-zeebe-worker-annotation-processor/src/test/java/io/koraframework/camunda/zeebe/worker/annotation/processor/ZeebeWorkerTests.java
+++ b/experimental/camunda-zeebe-worker-annotation-processor/src/test/java/io/koraframework/camunda/zeebe/worker/annotation/processor/ZeebeWorkerTests.java
@@ -2,7 +2,9 @@ package io.koraframework.camunda.zeebe.worker.annotation.processor;
 
 import org.junit.jupiter.api.Test;
 import io.koraframework.annotation.processor.common.AbstractAnnotationProcessorTest;
+import io.koraframework.aop.annotation.processor.AopAnnotationProcessor;
 import io.koraframework.camunda.zeebe.worker.KoraJobWorker;
+import io.koraframework.kora.app.annotation.processor.KoraAppProcessor;
 
 import java.util.Arrays;
 import java.util.List;
@@ -16,6 +18,7 @@ public class ZeebeWorkerTests extends AbstractAnnotationProcessorTest {
         return super.commonImports() + """
             import io.koraframework.camunda.zeebe.worker.annotation.*;
             import io.koraframework.camunda.zeebe.worker.*;
+            import io.koraframework.application.graph.All;
             """;
     }
 
@@ -128,5 +131,37 @@ public class ZeebeWorkerTests extends AbstractAnnotationProcessorTest {
         assertThat(Arrays.stream(clazz.getMethods()).anyMatch(m -> m.getName().equals("fetchVariables"))).isTrue();
         assertThat(Arrays.stream(clazz.getMethods()).anyMatch(m -> m.getName().equals("type"))).isTrue();
         assertThat(Arrays.stream(clazz.getMethods()).anyMatch(m -> m.getName().equals("handle"))).isTrue();
+    }
+
+    @Test
+    public void workerWithPublicMethodIsResolvedInGraph() {
+        this.compile(List.of(new KoraAppProcessor(), new AopAnnotationProcessor(), new ZeebeWorkerAnnotationProcessor()), """
+            @KoraApp
+            public interface ExampleApplication {
+
+                @Root
+                default Object root(All<KoraJobWorker> workers) {
+                    return workers;
+                }
+
+                default ZeebeWorkerConfig zeebeWorkerConfig() {
+                    return null;
+                }
+
+                default io.koraframework.json.common.JsonReader<String> stringJsonReader() {
+                    return null;
+                }
+            }
+            """, """
+            @Component
+            public final class Handler {
+                @JobWorker("worker")
+                public void handle(@JobVariable String var1) {
+                    // do something
+                }
+            }
+            """);
+
+        this.compileResult.assertSuccess();
     }
 }

--- a/experimental/camunda-zeebe-worker/src/main/java/io/koraframework/camunda/zeebe/worker/annotation/JobVariable.java
+++ b/experimental/camunda-zeebe-worker/src/main/java/io/koraframework/camunda/zeebe/worker/annotation/JobVariable.java
@@ -1,7 +1,5 @@
 package io.koraframework.camunda.zeebe.worker.annotation;
 
-import io.koraframework.common.annotation.AopAnnotation;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -9,7 +7,6 @@ import java.lang.annotation.Target;
 
 @Target({ElementType.METHOD, ElementType.PARAMETER})
 @Retention(RetentionPolicy.RUNTIME)
-@AopAnnotation
 public @interface JobVariable {
 
     String value() default "";

--- a/experimental/camunda-zeebe-worker/src/main/java/io/koraframework/camunda/zeebe/worker/annotation/JobVariables.java
+++ b/experimental/camunda-zeebe-worker/src/main/java/io/koraframework/camunda/zeebe/worker/annotation/JobVariables.java
@@ -1,7 +1,5 @@
 package io.koraframework.camunda.zeebe.worker.annotation;
 
-import io.koraframework.common.annotation.AopAnnotation;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -9,7 +7,6 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
-@AopAnnotation
 public @interface JobVariables {
 
 }

--- a/experimental/camunda-zeebe-worker/src/main/java/io/koraframework/camunda/zeebe/worker/annotation/JobWorker.java
+++ b/experimental/camunda-zeebe-worker/src/main/java/io/koraframework/camunda/zeebe/worker/annotation/JobWorker.java
@@ -1,7 +1,5 @@
 package io.koraframework.camunda.zeebe.worker.annotation;
 
-import io.koraframework.common.annotation.AopAnnotation;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -9,7 +7,6 @@ import java.lang.annotation.Target;
 
 @Target({ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
-@AopAnnotation
 public @interface JobWorker {
 
     /**


### PR DESCRIPTION
## What

A `@Component` class with a `public` method annotated `@JobWorker` silently disappeared from the
dependency graph. The generated `$X_handle_KoraJobWorker` requires `X`, and the compiler reports that
no such component exists:

```
error: No component found for dependency:
  public $Step1JobWorker_handle_KoraJobWorker(Step1JobWorker handler, ZeebeWorkerConfig config, ...)
```

The worker annotations were registered as AOP annotations, so the AOP processor took ownership of the
class and the original component was never registered. They are not aspects and are no longer treated
as such.

## Tests

`ZeebeWorkerTests` covering a `@Component` worker with a public handler method. Fails without the fix.
