### PR TITLE
fix(camunda-zeebe-worker): raise a BPMN error for JobWorkerException again

### DIFF
--- a/experimental/camunda-zeebe-worker-annotation-processor/src/main/java/io/koraframework/camunda/zeebe/worker/annotation/processor/ZeebeWorkerAnnotationProcessor.java
+++ b/experimental/camunda-zeebe-worker-annotation-processor/src/main/java/io/koraframework/camunda/zeebe/worker/annotation/processor/ZeebeWorkerAnnotationProcessor.java
@@ -163,8 +163,14 @@ public final class ZeebeWorkerAnnotationProcessor extends AbstractKoraProcessor 
             codeBuilder.endControlFlow();
         }
 
+        // JobWorkerException is the contract for raising a BPMN error, not for failing the job:
+        // ZeebeWorkerObservation#observeFinalCommandStep recognizes the throw error command as `failedByUser`
         codeBuilder.nextControlFlow("catch ($T e)", CLASS_WORKER_EXCEPTION);
-        codeBuilder.addStatement("throw e");
+        codeBuilder.addStatement("var _error = client.newThrowErrorCommand(job).errorCode(e.getCode()).errorMessage(e.getMessage())");
+        codeBuilder.beginControlFlow("if (e.getVariables() != null)");
+        codeBuilder.addStatement("_error.variables(e.getVariables())");
+        codeBuilder.endControlFlow();
+        codeBuilder.addStatement("return _error");
 
 //        if (variables.stream().anyMatch(v -> v.isVars || v.isVar)) {
 //            codeBuilder.nextControlFlow("catch ($T e)", IOException.class);

--- a/experimental/camunda-zeebe-worker-annotation-processor/src/test/java/io/koraframework/camunda/zeebe/worker/annotation/processor/ZeebeWorkerTests.java
+++ b/experimental/camunda-zeebe-worker-annotation-processor/src/test/java/io/koraframework/camunda/zeebe/worker/annotation/processor/ZeebeWorkerTests.java
@@ -1,6 +1,10 @@
 package io.koraframework.camunda.zeebe.worker.annotation.processor;
 
+import io.camunda.client.api.command.ThrowErrorCommandStep1;
+import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.client.api.worker.JobClient;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import io.koraframework.annotation.processor.common.AbstractAnnotationProcessorTest;
 import io.koraframework.aop.annotation.processor.AopAnnotationProcessor;
 import io.koraframework.camunda.zeebe.worker.KoraJobWorker;
@@ -18,6 +22,7 @@ public class ZeebeWorkerTests extends AbstractAnnotationProcessorTest {
         return super.commonImports() + """
             import io.koraframework.camunda.zeebe.worker.annotation.*;
             import io.koraframework.camunda.zeebe.worker.*;
+            import io.koraframework.camunda.zeebe.worker.exception.*;
             import io.koraframework.application.graph.All;
             """;
     }
@@ -163,5 +168,34 @@ public class ZeebeWorkerTests extends AbstractAnnotationProcessorTest {
             """);
 
         this.compileResult.assertSuccess();
+    }
+
+    @Test
+    public void workerJobWorkerExceptionIsTurnedIntoBpmnError() {
+        this.compile(List.of(new ZeebeWorkerAnnotationProcessor()), """
+            @Component
+            public final class Handler {
+                @JobWorker("worker")
+                void handle() {
+                    throw new JobWorkerException("DOESNT_WORK");
+                }
+            }
+            """);
+
+        this.compileResult.assertSuccess();
+
+        var worker = (KoraJobWorker) newObject("$Handler_handle_KoraJobWorker", newObject("Handler"));
+
+        var errorStep2 = Mockito.mock(ThrowErrorCommandStep1.ThrowErrorCommandStep2.class);
+        Mockito.when(errorStep2.errorMessage(Mockito.anyString())).thenReturn(errorStep2);
+        var errorStep1 = Mockito.mock(ThrowErrorCommandStep1.class);
+        Mockito.when(errorStep1.errorCode("DOESNT_WORK")).thenReturn(errorStep2);
+        var job = Mockito.mock(ActivatedJob.class);
+        var client = Mockito.mock(JobClient.class);
+        Mockito.when(client.newThrowErrorCommand(job)).thenReturn(errorStep1);
+
+        var command = worker.handle(client, job);
+
+        assertThat(command).isSameAs(errorStep2);
     }
 }


### PR DESCRIPTION
## What

`JobWorkerException` was rethrown instead of being turned into
`client.newThrowErrorCommand(...)`. The job fails and is retried, and the BPMN error boundary event
never fires — the process cannot handle a business error the way the documentation describes.

Only `JobWorkerException` is mapped to a BPMN error; every other exception is still wrapped in
`JobWorkerException("UNEXPECTED", e)`.

## Tests

`ZeebeWorkerTests#workerJobWorkerExceptionIsTurnedIntoBpmnError`. Without the fix the exception
escapes `handle()`.
