### PR TITLE
fix(kora-app-symbol-processor): stop template resolution from dying on message rendering

### DIFF
--- a/core/kora-app-symbol-processor/src/main/kotlin/io/koraframework/kora/app/ksp/exception/UnresolvedDependencyException.kt
+++ b/core/kora-app-symbol-processor/src/main/kotlin/io/koraframework/kora/app/ksp/exception/UnresolvedDependencyException.kt
@@ -5,7 +5,9 @@ import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSDeclaration
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.google.devtools.ksp.symbol.KSValueParameter
+import com.squareup.kotlinpoet.ksp.TypeParameterResolver
 import com.squareup.kotlinpoet.ksp.toTypeName
+import com.squareup.kotlinpoet.ksp.toTypeParameterResolver
 import io.koraframework.kora.app.ksp.DependencyModuleHintProvider
 import io.koraframework.kora.app.ksp.GraphBuilder
 import io.koraframework.kora.app.ksp.component.DependencyClaim
@@ -43,12 +45,15 @@ class UnresolvedDependencyException(
             }
             msg.append("\n\nNote:\n  Kotlin nullable and non-nullable types are different dependency keys.")
 
+            val declaringPair = declaringPair(declaration)
+            val typeParameterResolver = typeParameterResolver(declaringPair.first, declaringPair.second)
+
             val requestedMsg = getRequestedMessage(declaration)
             msg.append("\n\nRequired at:\n  ").append(requestedMsg)
             val source = dependencyClaim.source
             if (source is KSValueParameter) {
                 msg.append("\n  parameter: ")
-                    .append(source.type.toTypeName())
+                    .append(source.type.toTypeName(typeParameterResolver))
                     .append(" ")
                     .append(source.name?.asString() ?: "<unnamed>")
             }
@@ -86,6 +91,25 @@ class UnresolvedDependencyException(
 
 
         private fun getRequestedMessage(declaration: ComponentDeclaration): String {
+            val (module, factoryMethod) = declaringPair(declaration)
+
+            val typeParameterResolver = typeParameterResolver(module, factoryMethod)
+            return if (module != null && factoryMethod != null && factoryMethod.isConstructor()) {
+                "${module.qualifiedName!!.asString()}#${factoryMethod}(${
+                    factoryMethod.parameters.joinToString(", ") {
+                        it.type.toTypeName(typeParameterResolver).toString()
+                    }
+                })"
+            } else {
+                "${module!!.qualifiedName!!.asString()}#${factoryMethod!!.qualifiedName!!.asString()}(${
+                    factoryMethod.parameters.joinToString(", ") {
+                        it.type.toTypeName(typeParameterResolver).toString()
+                    }
+                })"
+            }
+        }
+
+        private fun declaringPair(declaration: ComponentDeclaration): Pair<KSDeclaration?, KSFunctionDeclaration?> {
             var element: KSDeclaration? = declaration.source
             var factoryMethod: KSFunctionDeclaration? = null
             var module: KSDeclaration? = null
@@ -100,20 +124,18 @@ class UnresolvedDependencyException(
                 }
                 element = element.parentDeclaration
             } while (element != null)
+            return module to factoryMethod
+        }
 
-            return if (module != null && factoryMethod != null && factoryMethod.isConstructor()) {
-                "${module.qualifiedName!!.asString()}#${factoryMethod}(${
-                    factoryMethod.parameters.joinToString(", ") {
-                        it.type.toTypeName().toString()
-                    }
-                })"
-            } else {
-                "${module!!.qualifiedName!!.asString()}#${factoryMethod!!.qualifiedName!!.asString()}(${
-                    factoryMethod.parameters.joinToString(", ") {
-                        it.type.toTypeName().toString()
-                    }
-                })"
-            }
+        /**
+         * A template factory method — and the module that declares it — introduce type parameters that its
+         * own parameter types refer to. Rendering such a type with [TypeParameterResolver.EMPTY] throws
+         * `NoSuchElementException`, replacing the dependency diagnostic with a KSP crash.
+         */
+        private fun typeParameterResolver(module: KSDeclaration?, factoryMethod: KSFunctionDeclaration?): TypeParameterResolver {
+            val moduleResolver = (module as? KSClassDeclaration)?.typeParameters?.toTypeParameterResolver()
+                ?: TypeParameterResolver.EMPTY
+            return factoryMethod?.typeParameters?.toTypeParameterResolver(moduleResolver) ?: moduleResolver
         }
 
         private fun getDependencyTreeSimpleMessage(
@@ -186,37 +208,6 @@ class UnresolvedDependencyException(
             }
 
             return msg.toString()
-        }
-    }
-
-    private fun getRequestedMessage(declaration: ComponentDeclaration): String {
-        var element: KSDeclaration? = declaration.source
-        var factoryMethod: KSFunctionDeclaration? = null
-        var module: KSDeclaration? = null
-        do {
-            if (element is KSFunctionDeclaration) {
-                factoryMethod = element
-            } else if (element is KSClassDeclaration) {
-                module = element
-                break
-            } else if (element == null) {
-                continue
-            }
-            element = element.parentDeclaration
-        } while (element != null)
-
-        return if (module != null && factoryMethod != null && factoryMethod.isConstructor()) {
-            "Dependency requested at: ${module.qualifiedName!!.asString()}#${factoryMethod}(${
-                factoryMethod.parameters.joinToString(", ") {
-                    it.type.toTypeName().toString()
-                }
-            })"
-        } else {
-            "Dependency requested at: ${module!!.qualifiedName!!.asString()}#${factoryMethod!!.qualifiedName!!.asString()}(${
-                factoryMethod.parameters.joinToString(", ") {
-                    it.type.toTypeName().toString()
-                }
-            })"
         }
     }
 

--- a/core/kora-app-symbol-processor/src/test/kotlin/io/koraframework/kora/app/ksp/DependencyTest.kt
+++ b/core/kora-app-symbol-processor/src/test/kotlin/io/koraframework/kora/app/ksp/DependencyTest.kt
@@ -1,5 +1,6 @@
 package io.koraframework.kora.app.ksp
 
+import io.koraframework.ksp.common.CompilationErrorException
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
@@ -197,13 +198,39 @@ open class DependencyTest : AbstractKoraAppProcessorTest() {
             interface ExampleApplication {
                 @Root
                 fun root1(node: Node<String>): Any { return ""; }
-            
+
                 fun component(): String { return ""; }
             }
             """
         );
         Assertions.assertThat(draw.nodes).hasSize(2);
         draw.init();
+    }
+
+    @Test
+    fun testUnresolvedDependencyOfTemplateFactoryIsReportedAsDiagnostic() {
+        Assertions.assertThatThrownBy {
+            compile(
+                """
+                @KoraApp
+                interface ExampleApplication {
+                    class Holder<T>(val value: T)
+                    class Wrapper<T>(val value: T)
+
+                    fun <T> wrapper(holder: Holder<T>): Wrapper<T> { return Wrapper(holder.value); }
+
+                    @Root
+                    fun root(wrapper: Wrapper<String>): Any { return ""; }
+                }
+                """
+            )
+        }
+            .isInstanceOf(CompilationErrorException::class.java)
+            .hasMessageContaining("No component found for dependency")
+            .hasMessageContaining("parameter: ")
+
+        val messages = compileResult.assertFailure().messages.joinToString("\n")
+        Assertions.assertThat(messages).doesNotContain("NoSuchElementException")
     }
 
 }


### PR DESCRIPTION
## What

`UnresolvedDependencyException` builds its whole diagnostic in the constructor and renders the
factory method's declared parameter types with `toTypeName()` and an empty `TypeParameterResolver`.
For a template factory the parameters reference the method's own type parameters, and KotlinPoet
throws:

```
java.lang.NoSuchElementException: No TypeParameter found for index T
```

This is not only lost diagnostics. `GraphBuilder` throws this exception as ordinary control flow while
trying template candidates, so building the message for a discarded fork killed KSP — an application
with a perfectly resolvable graph failed to compile.

Both `toTypeName()` call sites now receive a resolver built from the module and the factory method.

## Tests

Reproduction with a generic factory whose graph resolves; fails without the fix with the
`NoSuchElementException` above.
