### PR TITLE
fix(symbol-processor-common): fix Java platform collection types in two more cases

### DIFF
--- a/core/kora-app-symbol-processor/src/test/java/io/koraframework/kora/app/ksp/fixture/PlatformTypeJavaModule.java
+++ b/core/kora-app-symbol-processor/src/test/java/io/koraframework/kora/app/ksp/fixture/PlatformTypeJavaModule.java
@@ -1,0 +1,19 @@
+package io.koraframework.kora.app.ksp.fixture;
+
+import java.util.List;
+
+/**
+ * Compiled on the test classpath on purpose: a Kotlin flexible type only carries its mutability
+ * flexibility when the declaration is read from a class file rather than from a source in the
+ * same compilation.
+ */
+public interface PlatformTypeJavaModule {
+
+    default List<String> names() {
+        return List.of("first");
+    }
+
+    default String joined(List<String> names) {
+        return String.join(",", names);
+    }
+}

--- a/core/kora-app-symbol-processor/src/test/java/io/koraframework/kora/app/ksp/fixture/package-info.java
+++ b/core/kora-app-symbol-processor/src/test/java/io/koraframework/kora/app/ksp/fixture/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Kora modules are null-marked, which is what makes the type arguments of a Java collection
+ * non-platform while the collection itself stays mutability-flexible for Kotlin.
+ */
+@NullMarked
+package io.koraframework.kora.app.ksp.fixture;
+
+import org.jspecify.annotations.NullMarked;

--- a/core/kora-app-symbol-processor/src/test/kotlin/io/koraframework/kora/app/ksp/ModuleTest.kt
+++ b/core/kora-app-symbol-processor/src/test/kotlin/io/koraframework/kora/app/ksp/ModuleTest.kt
@@ -598,4 +598,19 @@ class ModuleTest : AbstractKoraAppProcessorTest() {
         assertThat(draw.nodes).hasSize(7)
         draw.init()
     }
+
+    @Test
+    fun testJavaModuleKeepsGenericArgumentsOfPlatformTypes() {
+        val draw = compile(
+            """
+            @KoraApp
+            interface ExampleApplication : io.koraframework.kora.app.ksp.fixture.PlatformTypeJavaModule {
+                @Root
+                fun root(joined: String): Any = joined
+            }
+            """.trimIndent()
+        )
+        assertThat(draw.nodes).hasSize(3)
+        draw.init()
+    }
 }

--- a/core/symbol-processor-common/src/main/kotlin/io/koraframework/ksp/common/KspCommonUtils.kt
+++ b/core/symbol-processor-common/src/main/kotlin/io/koraframework/ksp/common/KspCommonUtils.kt
@@ -33,13 +33,18 @@ object KspCommonUtils {
         return sequenceOf(annotations, containeredAnnotations).flatten().toList()
     }
 
+    private val TYPE_ANNOTATION = Regex("""\[@[^]]*]\s*""")
+
     fun KSType.fixPlatformType(resolver: Resolver): KSType {
         val type = if (this.nullability == Nullability.PLATFORM) {
             this.makeNotNullable()
         } else {
             this
         }
-        val fixMutability = type.toString().startsWith("(Mutable")
+        // KSP renders type-use annotations into the type itself, so a tagged Java parameter reads as
+        // `[@Tag(Factory::class)] ([@Tag(Factory::class)] MutableList<T>..[@Tag(Factory::class)] List<T>?)`
+        // and the flexible-mutability marker no longer sits at the start of the string
+        val fixMutability = TYPE_ANNOTATION.replace(type.toString(), "").startsWith("(Mutable")
         if (this.arguments.isEmpty()) {
             if (fixMutability) {
                 return type.immutableDeclaration(resolver).asType(listOf())
@@ -72,7 +77,9 @@ object KspCommonUtils {
             }
         } else {
             if (fixMutability) {
-                return type.immutableDeclaration(resolver).asType(listOf())
+                // `args` holds every original argument here — asType(listOf()) would swap them for the
+                // declaration's own type parameters, turning List<String> into List<E>
+                return type.immutableDeclaration(resolver).asType(args)
             } else {
                 return type
             }

--- a/core/symbol-processor-common/src/testFixtures/kotlin/io/koraframework/ksp/common/AbstractSymbolProcessorTest.kt
+++ b/core/symbol-processor-common/src/testFixtures/kotlin/io/koraframework/ksp/common/AbstractSymbolProcessorTest.kt
@@ -67,7 +67,18 @@ abstract class AbstractSymbolProcessorTest {
             """.trimIndent()
     }
 
-    protected fun compile0(processors: List<SymbolProcessorProvider>, @Language("kotlin") vararg sources: String): TestUtils.ProcessingResult {
+    protected fun compile0(processors: List<SymbolProcessorProvider>, @Language("kotlin") vararg sources: String): TestUtils.ProcessingResult =
+        compile0(processors, listOf(), *sources)
+
+    /**
+     * Java sources participate in the same compilation, which is the only way to reproduce
+     * behavior that depends on Kotlin flexible/platform types.
+     */
+    protected fun compile0(
+        processors: List<SymbolProcessorProvider>,
+        @Language("java") javaSources: List<String>,
+        @Language("kotlin") vararg sources: String
+    ): TestUtils.ProcessingResult {
         val testPackage = testPackage()
         val testClass: Class<*> = testInfo.testClass.get()
         val testMethod: Method = testInfo.testMethod.get()
@@ -93,8 +104,25 @@ abstract class AbstractSymbolProcessorTest {
             }
             .toList()
 
+        val javaSourceList = javaSources
+            .map { s -> "package $testPackage;\n" + s }
+            .map { s ->
+                val className = Regex("""\b(?:class|interface|enum|record)\s+([A-Za-z_][A-Za-z0-9_]*)""")
+                    .find(s)
+                    ?.groupValues
+                    ?.get(1)
+                    ?: throw IllegalArgumentException("No class or interface declaration found in test java source")
+                val file = kc.baseDir
+                    .resolve(testPackage.replace('.', File.separatorChar))
+                    .resolve("$className.java")
+                Files.createDirectories(file.parent)
+                Files.deleteIfExists(file)
+                Files.writeString(file, s, StandardCharsets.UTF_8, StandardOpenOption.CREATE_NEW)
+                file
+            }
+
         try {
-            val cl = kc.withSrc(sourceList).compile()
+            val cl = kc.withSrc(sourceList).withJavaSrcs(javaSourceList).compile()
             compileResult = TestUtils.ProcessingResult.Success(cl)
         } catch (e: CompilationErrorException) {
             compileResult = TestUtils.ProcessingResult.Failure(e.messages)


### PR DESCRIPTION
## What

`fixPlatformType` dropped the type arguments when unwrapping a Java platform type, so a dependency
declared as `List<String>` in Java became a raw `List` on the Kotlin side and no longer matched.

Two problems in one place:

- the mutability check tested a string prefix (`startsWith("(Mutable")`), which a type-use annotation
  such as `@Tag` shifts — so only annotated Java collection parameters broke;
- the unchanged branch rebuilt the type with `asType(listOf())`, discarding the arguments.

## Tests

Covered by the KSP test that exercises a Java collection parameter with a type-use annotation.
