### PR TITLE
fix(camunda-zeebe-worker): raise a BPMN error for JobWorkerException in the KSP worker too

### DIFF
--- a/experimental/camunda-zeebe-worker-symbol-processor/build.gradle
+++ b/experimental/camunda-zeebe-worker-symbol-processor/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     testImplementation testFixtures(project(":core:symbol-processor-common"))
     testImplementation(libs.kotlin.stdlib.lib)
     testImplementation project(":experimental:camunda-zeebe-worker")
+    testImplementation libs.mockito.core
 }
 
 apply from: "${project.rootDir}/gradle/in-test-generated.gradle"

--- a/experimental/camunda-zeebe-worker-symbol-processor/src/main/kotlin/io/koraframework/camunda/zeebe/worker/symbol/processor/ZeebeWorkerSymbolProcessor.kt
+++ b/experimental/camunda-zeebe-worker-symbol-processor/src/main/kotlin/io/koraframework/camunda/zeebe/worker/symbol/processor/ZeebeWorkerSymbolProcessor.kt
@@ -191,9 +191,15 @@ class ZeebeWorkerSymbolProcessor(
             codeBuilder.addStatement("throw %T(%S, e)", CLASS_WORKER_EXCEPTION, "SERIALIZATION")
         }
 
+        // JobWorkerException is the contract for raising a BPMN error, not for failing the job:
+        // ZeebeWorkerObservation#observeFinalCommandStep recognizes the throw error command as `failedByUser`
         codeBuilder.nextControlFlow("catch (e: %T)", CLASS_WORKER_EXCEPTION)
-        codeBuilder.addStatement("throw e")
-        codeBuilder.nextControlFlow("catch (e: Exception)", CLASS_WORKER_EXCEPTION)
+        codeBuilder.addStatement("val _error = client.newThrowErrorCommand(job).errorCode(e.code).errorMessage(e.message)")
+        codeBuilder.beginControlFlow("if (e.variables != null)")
+        codeBuilder.addStatement("_error.variables(e.variables)")
+        codeBuilder.endControlFlow()
+        codeBuilder.addStatement("return _error")
+        codeBuilder.nextControlFlow("catch (e: Exception)")
         codeBuilder.addStatement("throw %T(%S, e)", CLASS_WORKER_EXCEPTION, "UNEXPECTED")
         codeBuilder.endControlFlow()
 

--- a/experimental/camunda-zeebe-worker-symbol-processor/src/test/kotlin/io/koraframework/camunda/zeebe/worker/symbol/processor/ZeebeWorkerTests.kt
+++ b/experimental/camunda-zeebe-worker-symbol-processor/src/test/kotlin/io/koraframework/camunda/zeebe/worker/symbol/processor/ZeebeWorkerTests.kt
@@ -1,7 +1,11 @@
 package io.koraframework.camunda.zeebe.worker.symbol.processor
 
+import io.camunda.client.api.command.ThrowErrorCommandStep1
+import io.camunda.client.api.response.ActivatedJob
+import io.camunda.client.api.worker.JobClient
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.mockito.Mockito
 import io.koraframework.camunda.zeebe.worker.KoraJobWorker
 import io.koraframework.ksp.common.AbstractSymbolProcessorTest
 import java.lang.reflect.Method
@@ -13,6 +17,7 @@ class ZeebeWorkerTests : AbstractSymbolProcessorTest() {
         return super.commonImports() + """
             import io.koraframework.camunda.zeebe.worker.annotation.*
             import io.koraframework.camunda.zeebe.worker.*
+            import io.koraframework.camunda.zeebe.worker.exception.*
         """.trimIndent()
     }
 
@@ -142,5 +147,37 @@ class ZeebeWorkerTests : AbstractSymbolProcessorTest() {
         assertThat(Arrays.stream(clazz.methods).anyMatch { m: Method -> m.name == "fetchVariables" }).isTrue()
         assertThat(Arrays.stream(clazz.methods).anyMatch { m: Method -> m.name == "type" }).isTrue()
         assertThat(Arrays.stream(clazz.methods).anyMatch { m: Method -> m.name == "handle" }).isTrue()
+    }
+
+    @Test
+    fun workerJobWorkerExceptionIsTurnedIntoBpmnError() {
+        compile0(listOf(ZeebeWorkerSymbolProcessorProvider()),
+            """
+            @Component
+            class Handler {
+
+                @JobWorker("worker")
+                fun handle() {
+                    throw JobWorkerException("DOESNT_WORK")
+                }
+            }
+            """.trimIndent()
+        )
+
+        compileResult.assertSuccess()
+
+        val worker = new("\$Handler_handle_KoraJobWorker", new("Handler")) as KoraJobWorker
+
+        val errorStep2 = Mockito.mock(ThrowErrorCommandStep1.ThrowErrorCommandStep2::class.java)
+        Mockito.`when`(errorStep2.errorMessage(Mockito.anyString())).thenReturn(errorStep2)
+        val errorStep1 = Mockito.mock(ThrowErrorCommandStep1::class.java)
+        Mockito.`when`(errorStep1.errorCode("DOESNT_WORK")).thenReturn(errorStep2)
+        val job = Mockito.mock(ActivatedJob::class.java)
+        val client = Mockito.mock(JobClient::class.java)
+        Mockito.`when`(client.newThrowErrorCommand(job)).thenReturn(errorStep1)
+
+        val command = worker.handle(client, job)
+
+        assertThat(command).isSameAs(errorStep2)
     }
 }


### PR DESCRIPTION
## What

The Kotlin worker generator has the same defect fixed for the Java processor: `JobWorkerException`
is rethrown instead of `client.newThrowErrorCommand(...)`, so the job fails and retries and the BPMN
error boundary event never fires. An identical Kotlin application behaves differently from a Java one.

Symmetrical to the Java fix: only `JobWorkerException` is mapped to a BPMN error, everything else is
still wrapped in `JobWorkerException("UNEXPECTED", e)`.

## Tests

`ZeebeWorkerTests#workerJobWorkerExceptionIsTurnedIntoBpmnError`; without the fix the exception
escapes `handle()`. The module gained a `mockito-core` test dependency.
