### PR TITLE
fix(kafka-symbol-processor): report an unresolvable listener parameter instead of dying

### DIFF
--- a/kafka/kafka-symbol-processor/src/main/kotlin/io/koraframework/kafka/symbol/processor/KafkaUtils.kt
+++ b/kafka/kafka-symbol-processor/src/main/kotlin/io/koraframework/kafka/symbol/processor/KafkaUtils.kt
@@ -46,19 +46,25 @@ object KafkaUtils {
     fun KSFunctionDeclaration.handlerFunName() = moduleName("Handler").replaceFirstChar { it.lowercaseChar() }
     fun KSFunctionDeclaration.configFunName() = moduleName("Config").replaceFirstChar { it.lowercaseChar() }
 
-    fun KSType.isConsumerRecord() = declaration.let { it is KSClassDeclaration && it.toClassName() == consumerRecord }
+    // A parameter type that is not resolvable in the current round has no qualified name, and
+    // toClassName() fails its own precondition on it ("Required value was null"), taking KSP down
+    // before the listener can be deferred. Comparing the qualified name keeps the check total.
+    private fun KSType.isClass(className: ClassName) =
+        declaration.let { it is KSClassDeclaration && it.qualifiedName?.asString() == className.canonicalName }
 
-    fun KSType.isConsumerRecords() = declaration.let { it is KSClassDeclaration && it.toClassName() == consumerRecords }
+    fun KSType.isConsumerRecord() = isClass(consumerRecord)
 
-    fun KSType.isKeyDeserializationException() = declaration.let { it is KSClassDeclaration && it.toClassName() == recordKeyDeserializationException }
+    fun KSType.isConsumerRecords() = isClass(consumerRecords)
 
-    fun KSType.isValueDeserializationException() = declaration.let { it is KSClassDeclaration && it.toClassName() == recordValueDeserializationException }
+    fun KSType.isKeyDeserializationException() = isClass(recordKeyDeserializationException)
+
+    fun KSType.isValueDeserializationException() = isClass(recordValueDeserializationException)
 
     fun KSType.isAnyException() = toTypeName().copy(false).let {
         it is ClassName && (it == THROWABLE || it.toString() == "kotlin.Exception" || it.toString() == "java.lang.Exception" || it.toString() == "java.lang.Throwable")
     }
 
-    fun KSType.isConsumer() = declaration.let { it is KSClassDeclaration && it.toClassName() == consumer }
+    fun KSType.isConsumer() = isClass(consumer)
 }
 
 

--- a/kafka/kafka-symbol-processor/src/main/kotlin/io/koraframework/kafka/symbol/processor/consumer/ConsumerParameter.kt
+++ b/kafka/kafka-symbol-processor/src/main/kotlin/io/koraframework/kafka/symbol/processor/consumer/ConsumerParameter.kt
@@ -1,6 +1,7 @@
 package io.koraframework.kafka.symbol.processor.consumer
 
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import io.koraframework.ksp.common.exception.ProcessingErrorException
 import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSValueParameter
 import io.koraframework.kafka.symbol.processor.KafkaUtils.isAnyException
@@ -32,6 +33,22 @@ sealed interface ConsumerParameter {
     companion object {
         fun parseParameters(function: KSFunctionDeclaration) = function.parameters.map {
             val type = it.type.resolve()
+            if (type.isError) {
+                // KotlinPoet refuses to render an error type, and every check below renders one, so
+                // an unresolvable parameter used to take KSP down instead of naming the parameter
+                throw ProcessingErrorException(
+                    """
+                    Kafka listener parameter type cannot be resolved:
+                      parameter: ${it.name?.asString()}
+                      type: ${it.type}
+
+                    Fix:
+                      - Check imports and module dependencies.
+                      - Compile without Kora symbol processors to expose earlier Kotlin errors if KSP hides them.
+                    """.trimIndent(),
+                    it
+                )
+            }
             when {
                 type.isConsumerRecord() -> Record(it, type.arguments[0].type?.resolve(), type.arguments[1].type?.resolve())
                 type.isConsumerRecords() -> Records(it, type.arguments[0].type?.resolve(), type.arguments[1].type?.resolve())

--- a/kafka/kafka-symbol-processor/src/test/kotlin/io/koraframework/kafka/symbol/processor/consumer/KafkaListenerUnresolvedParameterTest.kt
+++ b/kafka/kafka-symbol-processor/src/test/kotlin/io/koraframework/kafka/symbol/processor/consumer/KafkaListenerUnresolvedParameterTest.kt
@@ -1,0 +1,33 @@
+package io.koraframework.kafka.symbol.processor.consumer
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import io.koraframework.ksp.common.AbstractSymbolProcessorTest
+
+class KafkaListenerUnresolvedParameterTest : AbstractSymbolProcessorTest() {
+
+    override fun commonImports(): String {
+        return super.commonImports() + """
+            import io.koraframework.kafka.common.annotation.KafkaListener;
+            """.trimIndent()
+    }
+
+    @Test
+    fun listenerWithUnresolvedParameterTypeIsReportedAsDiagnostic() {
+        val result = compile0(
+            listOf(KafkaListenerSymbolProcessorProvider()),
+            """
+            @Component
+            class KafkaListenerClass {
+                @KafkaListener("test.config.path")
+                fun process(context: SomeTypeThatDoesNotExist) {
+                }
+            }
+            """.trimIndent()
+        ).assertFailure()
+
+        val messages = result.messages.joinToString("\n")
+        assertThat(messages).doesNotContain("Required value was null")
+        assertThat(messages).contains("SomeTypeThatDoesNotExist")
+    }
+}


### PR DESCRIPTION
## What

The Kotlin counterpart of the `isAnyException` fix. `KafkaUtils` identified listener parameter types
by comparing the *printed* type. When a type does not resolve — a typo in an import, a not-yet
generated class, an error in another file — the printed form is `<ERROR TYPE>`, matches nothing, and
the processor died with an internal exception instead of a diagnostic. The user saw a KSP stack trace
rather than "cannot resolve the parameter type".

- added `KSType.isClass(ClassName)` comparing qualified names instead of strings;
- `parseParameters` now raises `ProcessingErrorException` for `type.isError`, pointing at the parameter.

## Tests

Regression test with a listener whose parameter type cannot be resolved: internal exception without
the fix, a proper message with it.

## Compatibility

Diagnostics only; correct code compiles as before.
