### PR TITLE
fix(kafka): publish a record when no MDC scope is bound

### DIFF
--- a/kafka/kafka/src/main/java/io/koraframework/kafka/common/producer/telemetry/impl/DefaultKafkaPublisherRecordObservation.java
+++ b/kafka/kafka/src/main/java/io/koraframework/kafka/common/producer/telemetry/impl/DefaultKafkaPublisherRecordObservation.java
@@ -49,8 +49,10 @@ public class DefaultKafkaPublisherRecordObservation implements KafkaPublisherRec
         this.metrics = metrics;
         this.topic = topic;
         this.span = span;
-        // A record can be published outside any request scope — from a scheduled job, at startup or
-        // in a test — and there the MDC ScopedValue is simply unbound, which is not an error.
+        // A record can be published where no MDC scope is bound at all — during graph initialization,
+        // from a shutdown hook, from a thread the application started itself or from a test — and an
+        // unbound ScopedValue is normal there, not an error. Request handlers, kafka consumers and
+        // scheduled jobs do bind one, so those keep forking the caller's MDC as before.
         this.mdc = MDC.VALUE.isBound() ? MDC.get().fork() : new MDC();
     }
 

--- a/kafka/kafka/src/main/java/io/koraframework/kafka/common/producer/telemetry/impl/DefaultKafkaPublisherRecordObservation.java
+++ b/kafka/kafka/src/main/java/io/koraframework/kafka/common/producer/telemetry/impl/DefaultKafkaPublisherRecordObservation.java
@@ -49,7 +49,9 @@ public class DefaultKafkaPublisherRecordObservation implements KafkaPublisherRec
         this.metrics = metrics;
         this.topic = topic;
         this.span = span;
-        this.mdc = MDC.get().fork();
+        // A record can be published outside any request scope — from a scheduled job, at startup or
+        // in a test — and there the MDC ScopedValue is simply unbound, which is not an error.
+        this.mdc = MDC.VALUE.isBound() ? MDC.get().fork() : new MDC();
     }
 
     @Override

--- a/kafka/kafka/src/test/java/io/koraframework/kafka/common/producer/telemetry/impl/DefaultKafkaPublisherRecordObservationTest.java
+++ b/kafka/kafka/src/test/java/io/koraframework/kafka/common/producer/telemetry/impl/DefaultKafkaPublisherRecordObservationTest.java
@@ -1,0 +1,26 @@
+package io.koraframework.kafka.common.producer.telemetry.impl;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import org.junit.jupiter.api.Test;
+import io.koraframework.logging.common.MDC;
+
+class DefaultKafkaPublisherRecordObservationTest {
+
+    @Test
+    void observationIsCreatedOutsideAnyMdcScope() {
+        // publishing from a scheduled job, at startup or in a test happens with MDC.VALUE unbound
+        assertThatCode(() -> new DefaultKafkaPublisherRecordObservation(null, null, null, "topic", null))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void observationForksTheBoundMdc() {
+        var mdc = new MDC();
+        mdc.put0("key", "value");
+
+        ScopedValue.where(MDC.VALUE, mdc).run(() ->
+                assertThatCode(() -> new DefaultKafkaPublisherRecordObservation(null, null, null, "topic", null))
+                        .doesNotThrowAnyException());
+    }
+}

--- a/kafka/kafka/src/test/java/io/koraframework/kafka/common/producer/telemetry/impl/DefaultKafkaPublisherRecordObservationTest.java
+++ b/kafka/kafka/src/test/java/io/koraframework/kafka/common/producer/telemetry/impl/DefaultKafkaPublisherRecordObservationTest.java
@@ -9,7 +9,7 @@ class DefaultKafkaPublisherRecordObservationTest {
 
     @Test
     void observationIsCreatedOutsideAnyMdcScope() {
-        // publishing from a scheduled job, at startup or in a test happens with MDC.VALUE unbound
+        // during graph initialization, in a shutdown hook or in a test MDC.VALUE is simply unbound
         assertThatCode(() -> new DefaultKafkaPublisherRecordObservation(null, null, null, "topic", null))
                 .doesNotThrowAnyException();
     }


### PR DESCRIPTION
## What

`DefaultKafkaPublisherRecordObservation` called `MDC.get().fork()` unconditionally. In the 2.0
synchronous model `MDC.VALUE` is a scoped value, and outside an established scope it is not bound —
publishing from `main`, from a scheduler or from a test threw.

```java
this.mdc = MDC.VALUE.isBound() ? MDC.get().fork() : new MDC();
```

Same thing the rest of the code does when no scope is present: an empty context instead of an
exception.

## Tests

Publishing with no MDC scope established; fails on `MDC.get()` without the fix.

## Compatibility

Widening: what used to throw now works.
