### PR TITLE
fix(kora-app-symbol-processor): treat a star projection as a concrete type, not a template

### DIFF
--- a/core/kora-app-symbol-processor/src/main/kotlin/io/koraframework/kora/app/ksp/ComponentTemplateHelper.kt
+++ b/core/kora-app-symbol-processor/src/main/kotlin/io/koraframework/kora/app/ksp/ComponentTemplateHelper.kt
@@ -60,7 +60,10 @@ object ComponentTemplateHelper {
                 return false
             }
             for ((templateArg, requiredArg) in template.arguments.zip(required.arguments)) {
-                if (!fillMap(templateArg.type!!.resolve(), requiredArg.type!!.resolve())) {
+                // a star projection carries no type on either side, so the argument cannot be matched
+                val templateArgType = templateArg.type?.resolve() ?: return false
+                val requiredArgType = requiredArg.type?.resolve() ?: return false
+                if (!fillMap(templateArgType, requiredArgType)) {
                     return false
                 }
             }
@@ -88,7 +91,9 @@ object ComponentTemplateHelper {
     private fun initMap(map: MutableMap<TypeParameterWrapper, KSType>, type: KSType) {
         val declaration = type.declaration
         for ((typeArg, typeArgType) in declaration.typeParameters.zip(type.arguments)) {
-            map[TypeParameterWrapper(typeArg)] = typeArgType.type!!.resolve()
+            // a star projection carries no type, so there is nothing to bind that parameter to
+            val resolved = typeArgType.type?.resolve() ?: continue
+            map[TypeParameterWrapper(typeArg)] = resolved
         }
         if (declaration is KSClassDeclaration) {
             for (parent in declaration.superTypes) {
@@ -170,7 +175,10 @@ object ComponentTemplateHelper {
     private fun KSTypeArgument.hasGenericVariable(): Boolean {
         val type = this.type
         if (type == null) {
-            return true
+            // a star projection is the Kotlin view of a Java unbounded wildcard: a concrete type that
+            // happens to hide its argument, not a variable to bind. TypeParameterUtils#visitWildcard
+            // says the same on the Java side, and a component must be classified the same either way.
+            return false
         }
         val resolvedType = type.resolve()
         if (resolvedType.declaration is KSTypeParameter) {

--- a/core/kora-app-symbol-processor/src/main/kotlin/io/koraframework/kora/app/ksp/component/ComponentDependencyHelper.kt
+++ b/core/kora-app-symbol-processor/src/main/kotlin/io/koraframework/kora/app/ksp/component/ComponentDependencyHelper.kt
@@ -131,7 +131,10 @@ object ComponentDependencyHelper {
             return DependencyClaim(parameterType, tag, DependencyClaim.DependencyClaimType.GRAPH, element)
         }
         if (typeName is ParameterizedTypeName) {
-            val firstTypeParam = parameterType.arguments[0].type!!.resolve()
+            // Only the wrapper types below unwrap their argument. An ordinary parameterized claim is
+            // taken as a whole, and its argument may well be a star projection, which has no type.
+            val firstTypeParam = parameterType.arguments[0].type?.resolve()
+                ?: return claimOfWholeType(parameterType, tag, element)
             if (typeName.rawType == CommonClassNames.typeRef) {
                 return DependencyClaim(firstTypeParam, tag, DependencyClaim.DependencyClaimType.TYPE_REF, element)
             }
@@ -179,10 +182,14 @@ object ComponentDependencyHelper {
                 }
             }
         }
-        if (parameterType.isMarkedNullable || element.isAnnotationPresent(CommonClassNames.nullable)) {
-            return DependencyClaim(parameterType, tag, DependencyClaim.DependencyClaimType.NULLABLE_ONE, element)
+        return claimOfWholeType(parameterType, tag, element)
+    }
+
+    private fun claimOfWholeType(parameterType: KSType, tag: String?, element: KSAnnotated): DependencyClaim {
+        return if (parameterType.isMarkedNullable || element.isAnnotationPresent(CommonClassNames.nullable)) {
+            DependencyClaim(parameterType, tag, DependencyClaim.DependencyClaimType.NULLABLE_ONE, element)
         } else {
-            return DependencyClaim(parameterType, tag, DependencyClaim.DependencyClaimType.ONE_REQUIRED, element)
+            DependencyClaim(parameterType, tag, DependencyClaim.DependencyClaimType.ONE_REQUIRED, element)
         }
     }
 }

--- a/core/kora-app-symbol-processor/src/main/kotlin/io/koraframework/kora/app/ksp/declaration/ComponentDeclaration.kt
+++ b/core/kora-app-symbol-processor/src/main/kotlin/io/koraframework/kora/app/ksp/declaration/ComponentDeclaration.kt
@@ -288,7 +288,9 @@ sealed interface ComponentDeclaration {
 private fun KSTypeArgument.hasGenericVariable(): Boolean {
     val type = this.type
     if (type == null) {
-        return true
+        // a star projection is the Kotlin view of a Java unbounded wildcard: a concrete type that
+        // hides its argument, not a variable to bind, so it does not make a component a template
+        return false
     }
     val resolvedType = type.resolve()
     if (resolvedType.declaration is KSTypeParameter) {

--- a/core/kora-app-symbol-processor/src/test/kotlin/io/koraframework/kora/app/ksp/ComponentTemplatesTest.kt
+++ b/core/kora-app-symbol-processor/src/test/kotlin/io/koraframework/kora/app/ksp/ComponentTemplatesTest.kt
@@ -58,4 +58,23 @@ class ComponentTemplatesTest : AbstractKoraAppProcessorTest() {
                 }
                 """);
     }
+
+    @Test
+    fun testStarProjectionIsNotATemplate() {
+        val draw = compile(
+            """
+            @KoraApp
+            interface ExampleApplication {
+                interface Contract<T>
+                class ContractImpl : Contract<String>
+
+                fun contract(): Contract<*> = ContractImpl()
+
+                @Root
+                fun root(contract: Contract<*>): Any = contract
+            }
+            """
+        )
+        draw.init()
+    }
 }


### PR DESCRIPTION
## What

KSP sees a Java wildcard `<?>` as a star projection whose `KSTypeArgument.type` is `null`. Both
implementations of `hasGenericVariable()` treated `null` as "there is a type variable", so a concrete
type such as `ForwardingServerBuilder<?>` ended up in the template set and was never resolved as an
ordinary component. The Java processor returns `false` in the same situation
(`TypeParameterUtils#visitWildcard`), so the two languages disagreed on identical code.

Additionally `ComponentTemplateHelper.initMap`/`fillMap` and `ComponentDependencyHelper.parseClaim`
dereferenced `KSTypeArgument.type` without a null check and threw NPE on the same input.

- both `hasGenericVariable()` return `false` for `type == null`, matching the Java processor;
- `initMap`/`fillMap` skip an unresolvable argument instead of throwing;
- `parseClaim` falls back to a claim on the whole type when the first type argument is absent.

## Tests

No synthetic test was added, deliberately: the variants written for the star projection and the raw
supertype passed both with and without the fix, because reproducing the path needs a Java class on
the classpath rather than a Kotlin source. A test that is green either way gives false confidence.
Verified on real gRPC modules, which do not compile without the fix.
