### PR TITLE
fix(openapi-generator): generate the Kotlin basic auth config as a data class

### DIFF
--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ClientSecuritySchemaGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ClientSecuritySchemaGenerator.kt
@@ -241,6 +241,9 @@ class ClientSecuritySchemaGenerator : AbstractKotlinGenerator<Map<String, Any>>(
     private fun basicAuthConfig(authMethod: CodegenSecurity): TypeSpec {
         val nullableString = String::class.asClassName().copy(true)
         return TypeSpec.classBuilder(authMethod.name + "Config")
+            // @ConfigSource accepts an interface or a data class only, and the enclosing Config is
+            // already generated as a data class
+            .addModifiers(KModifier.DATA)
             .addAnnotation(generated())
             .addProperty(PropertySpec.builder("username", nullableString).initializer("username").build())
             .addProperty(PropertySpec.builder("password", nullableString).initializer("password").build())

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ClientSecuritySchemaGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ClientSecuritySchemaGenerator.kt
@@ -241,8 +241,6 @@ class ClientSecuritySchemaGenerator : AbstractKotlinGenerator<Map<String, Any>>(
     private fun basicAuthConfig(authMethod: CodegenSecurity): TypeSpec {
         val nullableString = String::class.asClassName().copy(true)
         return TypeSpec.classBuilder(authMethod.name + "Config")
-            // @ConfigSource accepts an interface or a data class only, and the enclosing Config is
-            // already generated as a data class
             .addModifiers(KModifier.DATA)
             .addAnnotation(generated())
             .addProperty(PropertySpec.builder("username", nullableString).initializer("username").build())

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientKotlinOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientKotlinOpenapiTest.java
@@ -295,4 +295,23 @@ public class HttpClientKotlinOpenapiTest extends BaseKotlinOpenapiTest {
         assertTrue(responseMapperContent.contains("@DefaultComponent"));
         assertTrue(responseMapperContent.contains("public open class StoreInventory200ApiResponseMapper"));
     }
+
+    @Test
+    void basicAuthConfigIsGeneratedAsDataClass() throws Exception {
+        var files = generate(
+            "petstoreV3_security_basic_data_class",
+            "kotlin-client",
+            getClass().getResource("/example/petstoreV3_security_basic.yaml").toExternalForm(),
+            new SwaggerParams.Options());
+
+        var content = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("ApiSecurity.kt"))
+            .findFirst()
+            .orElseThrow());
+
+        // @ConfigSource is rejected by the config processor on a plain class
+        assertTrue(content.contains("@ConfigSource"), content);
+        assertTrue(content.contains("public data class basicAuthConfig"), content);
+    }
 }


### PR DESCRIPTION
## What

`ClientSecuritySchemaGenerator.basicAuthConfig` generated a plain `class`, while `@ConfigSource` in
Kotlin requires a `data class` — the config processor needs the `componentN` functions. A Kotlin
client with basic authentication did not compile; the Java counterpart did, because it generates a
`record`.

## Tests

Generator test on a specification with `basicAuth`: the generated config is declared as a `data class`.
Fails without the fix.
