### PR TITLE
fix(openapi-generator): stop requesting a converter for a multipart file part

### DIFF
--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ServerRequestMapperGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ServerRequestMapperGenerator.java
@@ -48,11 +48,17 @@ public class ServerRequestMapperGenerator extends AbstractJavaGenerator<Operatio
         var urlEncodedForm = op.consumes != null && op.consumes.stream()
             .map(m -> m.get("mediaType"))
             .anyMatch("application/x-www-form-urlencoded"::equalsIgnoreCase);
+        // url-encoded wins when an operation declares both, same as the apply() body below
+        var multipartBody = multipartForm && !urlEncodedForm;
 
         for (var formParam : op.formParams) {
             var paramType = asType(formParam);
             if (paramType.equals(ParameterizedTypeName.get(List.class, String.class)) || paramType.equals(ClassName.get(String.class))
                 || isByteArrayType(formParam) || isByteArrayArrayType(formParam)) {
+                continue;
+            }
+            if (multipartBody && formParam.isFile) {
+                // mapMultipart passes a binary part through as FormPart, so it never calls a converter
                 continue;
             }
             var mapperType = ParameterizedTypeName.get(Classes.stringParameterReader, formParam.isArray ? ((ParameterizedTypeName) paramType).typeArguments().getFirst().box() : paramType.box());

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ServerRequestMappersGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ServerRequestMappersGenerator.kt
@@ -53,11 +53,17 @@ class ServerRequestMappersGenerator : AbstractKotlinGenerator<OperationsMap>() {
         val urlEncodedForm = op.consumes != null && op.consumes.stream()
             .map({ m -> m["mediaType"] })
             .anyMatch { anotherString: String? -> "application/x-www-form-urlencoded".equals(anotherString, ignoreCase = true) }
+        // url-encoded wins when an operation declares both, same as the apply() body below
+        val multipartBody = multipartForm && !urlEncodedForm
 
         for (formParam in op.formParams) {
             val paramType = asType(formParam).asKt()
             if (paramType == List::class.asClassName().parameterizedBy(String::class.asClassName()) || paramType == String::class.asClassName()
                 || isByteArrayType(formParam) || isByteArrayArrayType(formParam)) {
+                continue
+            }
+            if (multipartBody && formParam.isFile) {
+                // mapMultipart passes a binary part through as FormPart, so it never calls a converter
                 continue
             }
             val mapperType = Classes.stringParameterReader.asKt().parameterizedBy(if (formParam.isArray) (paramType as ParameterizedTypeName).typeArguments.single() else paramType)

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpServerJavaOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpServerJavaOpenapiTest.java
@@ -30,7 +30,7 @@ public class HttpServerJavaOpenapiTest extends BaseJavaOpenapiTest {
         assertFalse(singleFile.contains("HttpServerParameterReader"));
 
         var fileArray = nestedClass(content, "FormMultipartFormDataWithArrayPatchFormParamRequestMapper");
-        assertTrue(fileArray.contains("filename = _part"));
+        assertTrue(fileArray.contains("filename.add(_part)"));
         assertFalse(fileArray.contains("HttpServerParameterReader"));
 
         // a url-encoded form still converts every non-string parameter

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpServerJavaOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpServerJavaOpenapiTest.java
@@ -11,6 +11,42 @@ import static org.junit.jupiter.api.Assertions.*;
 public class HttpServerJavaOpenapiTest extends BaseJavaOpenapiTest {
 
     @Test
+    void multipartFileFormParamDoesNotAskForAConverterItNeverUses() throws Exception {
+        var files = generate(
+            "petstoreV3_form_multipart",
+            "java-server",
+            getClass().getResource("/example/petstoreV3_form.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+        );
+
+        var content = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("DefaultApiServerRequestMappers.java"))
+            .findFirst()
+            .orElseThrow());
+
+        var singleFile = nestedClass(content, "FormMultipartFormDataWithObjectPatchFormParamRequestMapper");
+        assertTrue(singleFile.contains("file = _part"));
+        assertFalse(singleFile.contains("HttpServerParameterReader"));
+
+        var fileArray = nestedClass(content, "FormMultipartFormDataWithArrayPatchFormParamRequestMapper");
+        assertTrue(fileArray.contains("filename = _part"));
+        assertFalse(fileArray.contains("HttpServerParameterReader"));
+
+        // a url-encoded form still converts every non-string parameter
+        var urlEncoded = nestedClass(content, "FormUrlencodedObjectPatchFormParamRequestMapper");
+        assertTrue(urlEncoded.contains("HttpServerParameterReader<Boolean> providedConverter"));
+    }
+
+    private static String nestedClass(String content, String name) {
+        var start = content.indexOf("class " + name);
+        assertTrue(start > 0, () -> name + " was not generated");
+        var end = content.indexOf("class ", start + 1);
+        return end < 0 ? content.substring(start) : content.substring(start, end);
+    }
+
+
+    @Test
     void numericRangeUsesTheSchemaMaximumAsUpperBound() throws Exception {
         var files = generate(
             "petstoreV3_validation_range",

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpServerKotlinOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpServerKotlinOpenapiTest.java
@@ -31,7 +31,7 @@ public class HttpServerKotlinOpenapiTest extends BaseKotlinOpenapiTest {
         assertFalse(singleFile.contains("HttpServerParameterReader"));
 
         var fileArray = nestedClass(content, "FormMultipartFormDataWithArrayPatchFormParamRequestMapper");
-        assertTrue(fileArray.contains("= _part"));
+        assertTrue(fileArray.contains(".add(_part)"));
         assertFalse(fileArray.contains("HttpServerParameterReader"));
 
         // a url-encoded form still converts every non-string parameter

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpServerKotlinOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpServerKotlinOpenapiTest.java
@@ -9,6 +9,43 @@ import java.nio.file.Files;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class HttpServerKotlinOpenapiTest extends BaseKotlinOpenapiTest {
+
+    @Test
+    void multipartFileFormParamDoesNotAskForAConverterItNeverUses() throws Exception {
+        var files = generate(
+            "petstoreV3_form_multipart",
+            "kotlin-server",
+            getClass().getResource("/example/petstoreV3_form.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+        );
+
+        var content = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("DefaultApiServerRequestMappers.kt"))
+            .findFirst()
+            .orElseThrow());
+
+        // KotlinPoet may escape the parameter name, so the assertion only looks at the assigned part
+        var singleFile = nestedClass(content, "FormMultipartFormDataWithObjectPatchFormParamRequestMapper");
+        assertTrue(singleFile.contains("= _part"));
+        assertFalse(singleFile.contains("HttpServerParameterReader"));
+
+        var fileArray = nestedClass(content, "FormMultipartFormDataWithArrayPatchFormParamRequestMapper");
+        assertTrue(fileArray.contains("= _part"));
+        assertFalse(fileArray.contains("HttpServerParameterReader"));
+
+        // a url-encoded form still converts every non-string parameter
+        var urlEncoded = nestedClass(content, "FormUrlencodedObjectPatchFormParamRequestMapper");
+        assertTrue(urlEncoded.contains("providedConverter: HttpServerParameterReader<Boolean>"));
+    }
+
+    private static String nestedClass(String content, String name) {
+        var start = content.indexOf("class " + name);
+        assertTrue(start > 0, () -> name + " was not generated");
+        var end = content.indexOf("class ", start + 1);
+        return end < 0 ? content.substring(start) : content.substring(start, end);
+    }
+
     @ParameterizedTest
     @MethodSource("generateParams")
     void test(SwaggerParams params) throws Exception {


### PR DESCRIPTION
## What

For a `multipart/form-data` operation with a `type: string, format: binary` property, both server
generators declared an `HttpServerParameterReader<byte[]>` constructor parameter that the generated
`apply()` never calls — `mapMultipart` hands the binary part through as a `FormMultipart.FormPart`.
No such component exists in the framework, and none should: the reader converts a `String`. The whole
application graph failed to build over a dependency the mapper does not use.

The skip is tied to the same decision the `apply()` body makes rather than to `multipartForm` alone:
an operation declaring both `multipart/form-data` and `application/x-www-form-urlencoded` takes the
url-encoded branch, and that one does call the converter.

The case was already present in the generator fixtures (`petstoreV3_form.yaml`,
`/form-multipart-form-data-with-object` and `/form-multipart-form-data-with-array`). The existing
tests missed it because they only compile the generated code — and it compiles. Only building a
`@KoraApp` graph surfaces it.

## Tests

New tests for both languages assert on the generated source: neither multipart mapper declares an
`HttpServerParameterReader`, both still assign the raw part, and the url-encoded mapper keeps its
converters. Both fail without the fix.

## Compatibility

The generated constructor signature changes, but only for a case that did not build at all before.
