### PR TITLE
fix(database-annotation-processor): support CompletableFuture from a Cassandra repository

### DIFF
--- a/database/database-annotation-processor/src/main/java/io/koraframework/database/annotation/processor/cassandra/CassandraRepositoryGenerator.java
+++ b/database/database-annotation-processor/src/main/java/io/koraframework/database/annotation/processor/cassandra/CassandraRepositoryGenerator.java
@@ -140,13 +140,16 @@ public class CassandraRepositoryGenerator implements RepositoryGenerator {
                         o.addStatement("_observation.end()");
                     });
                     st.add(".whenComplete((_result, _error) -> $L)", whenComplete);
-                    if (((DeclaredType) returnType).asElement().toString().equals(CompletableFuture.class.getCanonicalName())) {
-                        st.add(".toCompletableFuture()");
-                    }
                     st.add(";");
                 });
                 b.add(");\n");
             });
+            // the observe(...) wrapper yields whatever the lambda returns, and the chain inside it is a
+            // CompletionStage; converting inside the lambda would make R unresolvable against the
+            // declared CompletableFuture return type
+            if (((DeclaredType) returnType).asElement().toString().equals(CompletableFuture.class.getCanonicalName())) {
+                mb.addCode(".toCompletableFuture()");
+            }
         } else {
             if (method.getReturnType().getKind() != TypeKind.VOID) {
                 mb.addCode("return ");

--- a/database/database-annotation-processor/src/test/java/io/koraframework/database/common/annotation/processor/cassandra/AbstractCassandraRepositoryTest.java
+++ b/database/database-annotation-processor/src/test/java/io/koraframework/database/common/annotation/processor/cassandra/AbstractCassandraRepositoryTest.java
@@ -15,6 +15,7 @@ public abstract class AbstractCassandraRepositoryTest extends AbstractRepository
             import io.koraframework.database.cassandra.mapper.result.*;
             import io.koraframework.database.cassandra.mapper.parameter.*;
 
+            import java.util.concurrent.CompletableFuture;
             import java.util.concurrent.CompletionStage;
 
             import com.datastax.oss.driver.api.core.cql.*;

--- a/database/database-annotation-processor/src/test/java/io/koraframework/database/common/annotation/processor/cassandra/CassandraResultsTest.java
+++ b/database/database-annotation-processor/src/test/java/io/koraframework/database/common/annotation/processor/cassandra/CassandraResultsTest.java
@@ -92,6 +92,42 @@ public class CassandraResultsTest extends AbstractCassandraRepositoryTest {
     }
 
     @Test
+    public void testReturnCompletableFutureObject() {
+        var mapper = Mockito.mock(CassandraAsyncResultSetMapper.class);
+        var repository = compileCassandra(List.of(mapper), """
+            @Repository
+            public interface TestRepository extends CassandraRepository {
+                @Query("SELECT count(*) FROM test")
+                CompletableFuture<Integer> test();
+            }
+            """);
+
+        when(mapper.apply(any())).thenReturn(CompletableFuture.completedFuture(42));
+        var result = repository.invoke("test");
+
+        assertThat(result).isEqualTo(42);
+        verify(executor.mockSession).prepareAsync("SELECT count(*) FROM test");
+        verify(executor.mockSession).executeAsync(any(Statement.class));
+        verify(mapper).apply(executor.asyncResultSet);
+    }
+
+    @Test
+    public void testReturnCompletableFutureVoid() {
+        var repository = compileCassandra(List.of(), """
+            @Repository
+            public interface TestRepository extends CassandraRepository {
+                @Query("SELECT count(*) FROM test")
+                CompletableFuture<Void> test();
+            }
+            """);
+
+        repository.invoke("test");
+
+        verify(executor.mockSession).prepareAsync("SELECT count(*) FROM test");
+        verify(executor.mockSession).executeAsync(any(Statement.class));
+    }
+
+    @Test
     public void testReturnFutureVoid() {
         var repository = compileCassandra(List.of(), """
             @Repository


### PR DESCRIPTION
## What

A Cassandra repository method returning `CompletableFuture<T>` generated code that does not compile:

```
error: incompatible types: inference variable R has incompatible bounds
  upper bounds: CompletableFuture<Entity>,Object
```

`CompletableFuture` is explicitly handled — the generator appended `.toCompletableFuture()` — but it
appended it inside the inner `observe(...)` lambda. The outer `observe(...).call(...)` still yields
whatever `prepareAsync(...).thenCompose(...)` produces, which is a `CompletionStage`, so `R` could not
be reconciled with the declared `CompletableFuture` return type.

The conversion now happens outside the outer wrapper, where the value actually crosses into the
declared return type. `CompletionStage` returns are unchanged.

## Tests

`CassandraResultsTest` covered `CompletionStage<Integer>` and `CompletionStage<Void>` but had no
`CompletableFuture` case at all, which is why the regression went unnoticed. Both are added and both
fail without the fix with the exact error above.
