### PR TITLE
fix(openapi-generator): use the schema maximum as the Range upper bound

### DIFF
--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/AbstractJavaGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/AbstractJavaGenerator.java
@@ -159,11 +159,11 @@ public abstract class AbstractJavaGenerator<C> extends AbstractGenerator<C, Java
                 }
             }
             CodeBlock maximum;
-            if (variable.getMinimum() != null) {
-                if (!variable.getMinimum().contains(".")) {
-                    maximum = CodeBlock.of("$L.0", variable.getMinimum());
+            if (variable.getMaximum() != null) {
+                if (!variable.getMaximum().contains(".")) {
+                    maximum = CodeBlock.of("$L.0", variable.getMaximum());
                 } else {
-                    maximum = CodeBlock.of("$L", variable.getMinimum());
+                    maximum = CodeBlock.of("$L", variable.getMaximum());
                 }
             } else {
                 if (variable.getIsLong()) {

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpServerJavaOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpServerJavaOpenapiTest.java
@@ -9,6 +9,33 @@ import java.nio.file.Files;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class HttpServerJavaOpenapiTest extends BaseJavaOpenapiTest {
+
+    @Test
+    void numericRangeUsesTheSchemaMaximumAsUpperBound() throws Exception {
+        var files = generate(
+            "petstoreV3_validation_range",
+            "java-server",
+            getClass().getResource("/example/petstoreV3_validation.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+        );
+
+        var pets = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("PetsApiDelegate.java"))
+            .findFirst()
+            .orElseThrow());
+        // the schema declares minimum: 1 and maximum: 100
+        assertTrue(pets.contains("@Range(from = 1.0, to = 100.0"), pets);
+
+        var pet = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("PetApiDelegate.java"))
+            .findFirst()
+            .orElseThrow());
+        // the schema declares minimum: 1 only, so the upper bound is the type maximum
+        assertTrue(pet.contains("@Range(from = 1.0, to = %s.0".formatted(Long.MAX_VALUE)), pet);
+    }
+
     @ParameterizedTest
     @MethodSource("generateParams")
     void test(SwaggerParams params) throws Exception {


### PR DESCRIPTION
## What

`AbstractJavaGenerator.getValidation` read `variable.getMinimum()` when building the upper bound of
`@Range`, so every numeric constraint the java generator emitted had `to == from`:

```
minimum: 1,   maximum: 100  ->  @Range(from = 1.0,   to = 1.0)
minimum: 200, maximum: 599  ->  @Range(from = 200.0, to = 200.0)
```

Any value above the minimum was rejected with 400 by the generated validation. The min-only case was
wrong too: it took the minimum branch instead of falling through to the type maximum, so
`minimum: 1` on an int64 path parameter also produced `to = 1.0`.

The kotlin generator computes this correctly, so the two languages disagreed on identical
specifications — which is how this surfaced: a java client sent `size=100` against a java server built
from a spec allowing `1..100` and got `Should be in range from '1' to '1', but was greater: 100`,
while the kotlin twin passed.

## Tests

`petstoreV3_validation.yaml` already covered both shapes (`minimum`+`maximum`, and `minimum` alone);
there was simply no assertion on the emitted bound. The new test checks both and fails without the fix.
