### PR TITLE
fix(common): keep the Kora wrapper when deriving an OpenTelemetry context

### DIFF
--- a/core/common/src/main/java/io/koraframework/common/telemetry/OpentelemetryContext.java
+++ b/core/common/src/main/java/io/koraframework/common/telemetry/OpentelemetryContext.java
@@ -26,9 +26,14 @@ public class OpentelemetryContext implements Context {
         return delegate.get(key);
     }
 
+    /**
+     * The derived context has to stay a Kora one: this class carries the only {@link ScopedValue}-based
+     * implementation of {@code wrap(...)}. A bare delegate falls back to the default {@code wrap(...)},
+     * which calls {@code makeCurrent()} and therefore {@code ContextStorage.attach(...)} -- unsupported here.
+     */
     @Override
     public <V> Context with(ContextKey<V> k1, V v1) {
-        return delegate.with(k1, v1);
+        return new OpentelemetryContext(delegate.with(k1, v1));
     }
 
     @Override

--- a/core/common/src/test/java/io/koraframework/common/telemetry/OpentelemetryContextTest.java
+++ b/core/common/src/test/java/io/koraframework/common/telemetry/OpentelemetryContextTest.java
@@ -1,0 +1,51 @@
+package io.koraframework.common.telemetry;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.ContextKey;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Kora carries the OpenTelemetry context in a {@link ScopedValue}, so the imperative
+ * {@code makeCurrent()} / {@code attach()} pair cannot be implemented and throws. Everything therefore
+ * depends on {@code wrap(...)}, which only {@link OpentelemetryContext} implements -- a context that
+ * loses the wrapper falls back to the default {@code wrap(...)} and blows up.
+ */
+class OpentelemetryContextTest {
+
+    private static final ContextKey<String> KEY = ContextKey.named("kora-test");
+
+    @Test
+    void aContextDerivedWithAKeyKeepsTheKoraImplementation() {
+        var derived = Context.root().with(KEY, "value");
+
+        var seen = new AtomicReference<String>();
+        assertThatCode(() -> derived.wrap(() -> seen.set(Context.current().get(KEY))).run())
+                .doesNotThrowAnyException();
+        assertThat(seen.get()).isEqualTo("value");
+    }
+
+    /**
+     * What {@code InstrumentationUtil.suppressInstrumentation} does, spelled out because it is an internal
+     * class. The OTLP exporter runs every export through it on the BatchSpanProcessor worker thread, so
+     * before the fix this threw IllegalStateException and no span ever left the application.
+     */
+    @Test
+    void theExporterSuppressionPathDoesNotThrow() {
+        var suppress = ContextKey.<Boolean>named("suppress_instrumentation");
+        var ran = new AtomicReference<>(false);
+
+        assertThatCode(() -> Context.current().with(suppress, true).wrap(() -> ran.set(true)).run())
+                .doesNotThrowAnyException();
+        assertThat(ran.get()).isTrue();
+    }
+
+    @Test
+    void theStorageIsKoras() {
+        assertThat(Context.root()).isInstanceOf(OpentelemetryContext.class);
+    }
+}


### PR DESCRIPTION
## What

No span was ever exported by an application using the OTLP exporter. The collector received metrics
and nothing else; the application log showed, on every export attempt:

```
BatchSpanProcessor$Worker exportCurrentBatch
WARNING: Exporter threw an Exception
java.lang.IllegalStateException
  at OpentelemetryContextStorage.attach(OpentelemetryContextStorage.java:12)
  at io.opentelemetry.context.Context.makeCurrent(Context.java:232)
  at io.opentelemetry.context.Context.lambda$wrap$1(Context.java:241)
  at InstrumentationUtil.suppressInstrumentation(InstrumentationUtil.java:34)
```

Kora carries the OpenTelemetry context in a `ScopedValue`, so the imperative
`attach()`/`makeCurrent()` pair cannot be implemented and deliberately throws. Everything therefore
rests on `wrap(...)`, which only `OpentelemetryContext` implements — via `ScopedValue.where(...)`.

But `with(key, value)` returned `delegate.with(key, value)`, a plain `ArrayBasedContext`. The wrapper
was dropped the moment anyone derived a context, and the derived one fell back to `Context`'s default
`wrap(...)`, which calls `makeCurrent()`. The OTLP exporter derives exactly such a context on its
worker thread to suppress instrumentation, so every export hit the throw.

`with(...)` now re-wraps the result, as `root()` already did.

## Tests

`OpentelemetryContextTest` covers the derived-context case and spells out the exporter's suppression
path (`InstrumentationUtil` is internal, so the call is reproduced rather than invoked). Both fail
with `IllegalStateException` without the fix.
