### PR TITLE
fix(micrometer-module): bind the Prometheus registry as a MetricsScraper

### DIFF
--- a/telemetry/micrometer-module/src/main/java/io/koraframework/micrometer/module/MetricsModule.java
+++ b/telemetry/micrometer-module/src/main/java/io/koraframework/micrometer/module/MetricsModule.java
@@ -1,7 +1,9 @@
 package io.koraframework.micrometer.module;
 
 import io.koraframework.application.graph.Wrapped;
+import io.koraframework.telemetry.common.MetricsScraper;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 import io.opentelemetry.contrib.metrics.micrometer.CallbackRegistrar;
 import io.opentelemetry.contrib.metrics.micrometer.MicrometerMeterProvider;
 import org.jspecify.annotations.Nullable;
@@ -15,6 +17,22 @@ public interface MetricsModule {
     @DefaultComponent
     default Wrapped<MeterRegistry> prometheusMeterRegistry(All<PrometheusMeterRegistryInitializer> initializers) {
         return new PrometheusMeterRegistryWrapper(initializers);
+    }
+
+    /**
+     * {@code MetricsHandler} resolves the scraper by type. {@link PrometheusMeterRegistryWrapper} implements
+     * {@link MetricsScraper}, but the factory above declares {@code Wrapped<MeterRegistry>}, so the graph only
+     * ever knows it as a {@link MeterRegistry} -- without this binding every application answers the metrics
+     * endpoint with "Metric Scraper disabled".
+     */
+    @DefaultComponent
+    default MetricsScraper prometheusMetricsScraper(MeterRegistry registry) {
+        if (registry instanceof PrometheusMeterRegistry prometheus) {
+            return prometheus::scrape;
+        }
+        // a registry that is not Prometheus cannot be scraped in this format; an application replacing it
+        // provides its own MetricsScraper, which wins over this @DefaultComponent
+        return os -> {};
     }
 
     @DefaultComponent

--- a/telemetry/micrometer-module/src/main/java/io/koraframework/micrometer/module/MetricsModule.java
+++ b/telemetry/micrometer-module/src/main/java/io/koraframework/micrometer/module/MetricsModule.java
@@ -19,17 +19,12 @@ public interface MetricsModule {
         return new PrometheusMeterRegistryWrapper(initializers);
     }
 
-    /**
-     * {@code MetricsHandler} resolves the scraper by type. {@link PrometheusMeterRegistryWrapper} implements
-     * {@link MetricsScraper}, but the factory above declares {@code Wrapped<MeterRegistry>}, so the graph only
-     * ever knows it as a {@link MeterRegistry} -- without this binding every application answers the metrics
-     * endpoint with "Metric Scraper disabled".
-     */
     @DefaultComponent
     default MetricsScraper prometheusMetricsScraper(MeterRegistry registry) {
         if (registry instanceof PrometheusMeterRegistry prometheus) {
             return prometheus::scrape;
         }
+
         // a registry that is not Prometheus cannot be scraped in this format; an application replacing it
         // provides its own MetricsScraper, which wins over this @DefaultComponent
         return os -> {};

--- a/telemetry/micrometer-module/src/test/java/io/koraframework/micrometer/module/MetricsScraperBindingTest.java
+++ b/telemetry/micrometer-module/src/test/java/io/koraframework/micrometer/module/MetricsScraperBindingTest.java
@@ -1,0 +1,44 @@
+package io.koraframework.micrometer.module;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.prometheusmetrics.PrometheusConfig;
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * The metrics endpoint resolves a {@code MetricsScraper} from the graph. {@link PrometheusMeterRegistryWrapper}
+ * implements it, but the registry factory declares {@code Wrapped<MeterRegistry>}, so nothing was ever bound
+ * under that type and every application answered the endpoint with "Metric Scraper disabled".
+ */
+class MetricsScraperBindingTest {
+
+    private final MetricsModule module = new MetricsModule() {};
+
+    @Test
+    void aPrometheusRegistryIsScrapedInPrometheusFormat() throws Exception {
+        var registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+        Counter.builder("kora.test.counter").register(registry).increment();
+
+        var out = new ByteArrayOutputStream();
+        module.prometheusMetricsScraper(registry).scrape(out);
+
+        assertThat(out.toString(StandardCharsets.UTF_8)).contains("kora_test_counter");
+    }
+
+    @Test
+    void anotherRegistryIsNotScrapedButDoesNotBreakTheEndpoint() {
+        MeterRegistry registry = new SimpleMeterRegistry();
+
+        var out = new ByteArrayOutputStream();
+        assertThatCode(() -> module.prometheusMetricsScraper(registry).scrape(out)).doesNotThrowAnyException();
+        assertThat(out.size()).isZero();
+    }
+}


### PR DESCRIPTION
## What

The metrics endpoint answered `# Metric Scraper disabled` in every application. `MetricsHandler`
resolves `ValueOf<Optional<MetricsScraper>>` from the graph, and nothing in the framework ever bound
one: `PrometheusMeterRegistryWrapper` does implement `MetricsScraper`, but the factory declares
`Wrapped<MeterRegistry>`, so the graph only knows it as a `MeterRegistry`. Scraping Prometheus was
therefore impossible out of the box, regardless of configuration.

`MetricsModule` now also exposes a `MetricsScraper` over the registry. It is a `@DefaultComponent`, so
an application that replaces the registry can bind its own; a non-Prometheus registry cannot be
scraped in this format and yields an empty body rather than an error, which is what the endpoint
already did.

## Tests

`MetricsScraperBindingTest` covers the scraper's behaviour for both registry kinds. It cannot fail
against the old code the usual way — the method being tested is what was missing — so the end-to-end
evidence is stated plainly instead: a container built before the fix returns
`# Metric Scraper disabled` for `GET /metrics` with the module on the classpath, and real Prometheus
output after it.
