### PR TITLE
fix(http-server-undertow): register the XNIO provider metadata needed by native-image

### DIFF
--- a/http/http-server-undertow/src/main/resources/META-INF/native-image/io.koraframework.http.server.undertow/reflect-config.json
+++ b/http/http-server-undertow/src/main/resources/META-INF/native-image/io.koraframework.http.server.undertow/reflect-config.json
@@ -4,5 +4,23 @@
         "allDeclaredConstructors": true,
         "allDeclaredFields": true,
         "allDeclaredMethods": true
+    },
+    {
+        "name": "org.xnio._private.Messages_$logger",
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": ["org.jboss.logging.Logger"]
+            }
+        ]
+    },
+    {
+        "name": "org.xnio.nio.Log_$logger",
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": ["org.jboss.logging.Logger"]
+            }
+        ]
     }
 ]

--- a/http/http-server-undertow/src/main/resources/META-INF/native-image/io.koraframework.http.server.undertow/resource-config.json
+++ b/http/http-server-undertow/src/main/resources/META-INF/native-image/io.koraframework.http.server.undertow/resource-config.json
@@ -1,0 +1,15 @@
+{
+  "resources": {
+    "includes": [
+      {
+        "pattern": "\\QMETA-INF/services/org.xnio.XnioProvider\\E"
+      },
+      {
+        "pattern": "\\Qorg/xnio/Version.properties\\E"
+      },
+      {
+        "pattern": "\\Qorg/xnio/nio/Version.properties\\E"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## What

An Undertow application built with `native-image` fails to start with:

```
IllegalArgumentException: XNIO001001: No XNIO provider found
    at org.xnio.Xnio.doGetInstance(Xnio.java:261)
    at io.koraframework.http.server.undertow.XnioLifecycle.init(XnioLifecycle.java:65)
```

The message is misleading: the provider *is* in the image. `Xnio.getInstance` iterates
the `ServiceLoader` for `XnioProvider`, and instantiating `org.xnio.nio.NioXnioProvider`
runs `NioXnio.<clinit>` → `org.xnio.nio.Log.<clinit>`, which asks jboss-logging for a
message logger. jboss-logging loads the generated implementation `<interface>_$logger`
reflectively, that class is not registered, and the resulting `ServiceConfigurationError`
is swallowed by the `catch (Throwable)` inside `doGetInstance`. The loop then ends with
"no provider found".

Isolated with a standalone probe against the same classpath:

```
# before
resource      = resource:/0!/META-INF/services/org.xnio.XnioProvider
ServiceConfigurationError: Provider org.xnio.nio.NioXnioProvider could not be instantiated
  Caused by: IllegalArgumentException: Invalid logger interface org.xnio.nio.Log (implementation not found)

# after
provider      = org.xnio.nio.NioXnioProvider
xnio          = XNIO provider "nio" <org.xnio.nio.NioXnio@...>
```

## Tests

There is no unit test here: the defect only exists inside a native image, and the JVM
path this metadata covers already works, so any JVM test would pass with and without
the change.

Verified end to end on the `kora-java-graalvm-crud-jdbc` and `kora-java-graalvm-crud-cassandra`
examples built with GraalVM CE 25.0.4: before the change the graph fails to initialize on
`XnioLifecycle`; after it, `/system/readiness` answers `OK` in 886 ms and the CRUD endpoints
respond.
