### PR TITLE
fix(database-jdbc): register the Hikari micrometer tracker for native-image

### DIFF
--- a/database/database-jdbc/src/main/resources/META-INF/native-image/io.koraframework/database-jdbc/reflect-config.json
+++ b/database/database-jdbc/src/main/resources/META-INF/native-image/io.koraframework/database-jdbc/reflect-config.json
@@ -1,0 +1,11 @@
+[
+    {
+        "name": "com.zaxxer.hikari.metrics.micrometer.MicrometerMetricsTrackerFactory",
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": ["io.micrometer.core.instrument.MeterRegistry"]
+            }
+        ]
+    }
+]


### PR DESCRIPTION
## What

With driver metrics enabled (the default), a JDBC application built with `native-image`
fails to start:

```
RuntimeException: Failed to load class com.zaxxer.hikari.metrics.micrometer.MicrometerMetricsTrackerFactory
    at com.zaxxer.hikari.util.UtilityElf.createInstance(UtilityElf.java:155)
    at com.zaxxer.hikari.pool.HikariPool.setMetricRegistry(HikariPool.java:292)
    at io.koraframework.database.jdbc.JdbcDataSource.<init>(JdbcDataSource.java:43)
```

`JdbcDataSource` calls `HikariDataSource.setMetricRegistry(meterRegistry)`, and Hikari
resolves the micrometer tracker factory by name. Nothing references the class statically,
so it is not part of the image. The shared reachability metadata for HikariCP covers the
dropwizard path (`CodahaleHealthChecker`) but not the micrometer one.

The constructor signature matches what `UtilityElf.createInstance` looks up at runtime,
as recorded by the tracing agent on the same application.

## Tests

No unit test: on the JVM this path already works, so a test would be green with and
without the change; the failure is specific to the closed-world image.

Verified on the `kora-java-graalvm-crud-jdbc` example built with GraalVM CE 25.0.4 —
before the change the pool fails during graph initialization, after it the service starts
and serves the full CRUD cycle.
