### PR TITLE
fix(cache-caffeine): register the Caffeine node classes used without statistics

### DIFF
--- a/cache/cache-caffeine/src/main/resources/META-INF/native-image/io.koraframework/cache-caffeine/reflect-config.json
+++ b/cache/cache-caffeine/src/main/resources/META-INF/native-image/io.koraframework/cache-caffeine/reflect-config.json
@@ -1,0 +1,70 @@
+[
+    {
+        "name": "com.github.benmanes.caffeine.cache.PS",
+        "allDeclaredFields": true
+    },
+    {
+        "name": "com.github.benmanes.caffeine.cache.PSA",
+        "allDeclaredFields": true
+    },
+    {
+        "name": "com.github.benmanes.caffeine.cache.PSW",
+        "allDeclaredFields": true
+    },
+    {
+        "name": "com.github.benmanes.caffeine.cache.PSAW",
+        "allDeclaredFields": true
+    },
+    {
+        "name": "com.github.benmanes.caffeine.cache.PSMS",
+        "allDeclaredConstructors": true,
+        "allDeclaredFields": true
+    },
+    {
+        "name": "com.github.benmanes.caffeine.cache.PSAMS",
+        "allDeclaredConstructors": true,
+        "allDeclaredFields": true
+    },
+    {
+        "name": "com.github.benmanes.caffeine.cache.PSWMS",
+        "allDeclaredConstructors": true,
+        "allDeclaredFields": true
+    },
+    {
+        "name": "com.github.benmanes.caffeine.cache.PSAWMS",
+        "allDeclaredConstructors": true,
+        "allDeclaredFields": true
+    },
+    {
+        "name": "com.github.benmanes.caffeine.cache.SSMS",
+        "allDeclaredFields": true
+    },
+    {
+        "name": "com.github.benmanes.caffeine.cache.SSMSA",
+        "allDeclaredFields": true
+    },
+    {
+        "name": "com.github.benmanes.caffeine.cache.SSMSW",
+        "allDeclaredFields": true
+    },
+    {
+        "name": "com.github.benmanes.caffeine.cache.SSMSAW",
+        "allDeclaredFields": true
+    },
+    {
+        "name": "com.github.benmanes.caffeine.cache.SSSMS",
+        "allDeclaredFields": true
+    },
+    {
+        "name": "com.github.benmanes.caffeine.cache.SSSMSA",
+        "allDeclaredFields": true
+    },
+    {
+        "name": "com.github.benmanes.caffeine.cache.SSSMSW",
+        "allDeclaredFields": true
+    },
+    {
+        "name": "com.github.benmanes.caffeine.cache.SSSMSAW",
+        "allDeclaredFields": true
+    }
+]


### PR DESCRIPTION
## What

A Caffeine cache built by Kora fails on first use in a native image:

```
MissingReflectionRegistrationError: Cannot reflectively invoke constructor
'com.github.benmanes.caffeine.cache.PSMS()'
    at com.github.benmanes.caffeine.cache.NodeFactory.newFactory(NodeFactory.java:154)
    at io.koraframework.cache.caffeine.CaffeineFactory.build(CaffeineFactory.java:38)
```

Caffeine picks a generated node class per cache configuration and instantiates it
reflectively. The shared reachability metadata does register `PSMS`, but only under
`"typeReached": "SSSMS"` — the cache class built **with** `recordStats()`. `CaffeineFactory`
calls `recordStats()` only when metrics are enabled, and metrics are off by default in 2.0,
so the default configuration builds `SSMS` and the condition never becomes true.

The configurations `CaffeineFactory` can produce were enumerated on the JVM:

| expireAfterAccess | expireAfterWrite | recordStats | cache | node |
|---|---|---|---|---|
| no | no | no | `SSMS` | `PSMS` |
| no | yes | no | `SSMSW` | `PSWMS` |
| yes | no | no | `SSMSA` | `PSAMS` |
| yes | yes | no | `SSMSAW` | `PSAWMS` |
| … | … | yes | `SSSMS…` | same nodes |

This change registers those classes so the cache works regardless of whether metrics are on.

## Tests

No unit test: the JVM path works either way, so a test could not distinguish the two states.

Verified on the `kora-java-graalvm-crud-jdbc` example (Caffeine cache, metrics disabled)
built with GraalVM CE 25.0.4: before the change the first cached call aborts graph
initialization, after it the cached read path returns 200.
