### PR TITLE
fix(database-cassandra): initialize the shaded guava comparator at build time

### DIFF
--- a/database/database-cassandra/src/main/resources/META-INF/native-image/io.koraframework/database-cassandra/native-image.properties
+++ b/database/database-cassandra/src/main/resources/META-INF/native-image/io.koraframework/database-cassandra/native-image.properties
@@ -1,2 +1,3 @@
 Args=--initialize-at-build-time=com.datastax.oss.driver.internal.core.util.Dependency \
+     --initialize-at-build-time=com.datastax.oss.driver.shaded.guava.common.primitives.UnsignedBytes$LexicographicalComparatorHolder$PureJavaComparator \
      --initialize-at-run-time=io.netty


### PR DESCRIPTION
## What

Building a Cassandra application with `native-image` aborts:

```
An object of type 'com.datastax.oss.driver.shaded.guava.common.primitives.
UnsignedBytes$LexicographicalComparatorHolder$PureJavaComparator' was found in the image heap.
This type, however, is marked for initialization at image run time
```

The object is reached while netty classes are analyzed: `HashedWheelTimer$HashedWheelTimeout.<clinit>`
→ `AtomicIntegerFieldUpdater.newUpdater` → reflection metadata decoding → the comparator
`SniEndPoint` installs → `UnsignedBytes.lexicographicalComparator()`, which reads the
holder's static field.

The module already pins `com.datastax.oss.driver.internal.core.util.Dependency` to build-time
initialization; this adds the shaded comparator, which is what the builder itself suggests.

## Tests

No unit test: the failure happens in the image builder, not at runtime, so it cannot be
reproduced from a JVM test.

Verified on the `kora-java-graalvm-crud-cassandra` example with GraalVM CE 25.0.4: before
the change `nativeCompile` fails after ~13 s during analysis; after it the image builds in
~31 s (76 MiB) and the service serves the full CRUD cycle against Scylla with a Redis cache.
