### PR TITLE
fix(logging-logback): keep logging events that happen outside a scope

### DIFF
--- a/logging/logging-logback/src/main/java/io/koraframework/logging/logback/KoraAsyncAppender.java
+++ b/logging/logging-logback/src/main/java/io/koraframework/logging/logback/KoraAsyncAppender.java
@@ -27,7 +27,9 @@ public final class KoraAsyncAppender extends AsyncAppenderBase<ILoggingEvent> {
             eventObject.getNanoseconds(),
             eventObject.getSequenceNumber(),
             eventObject.getKeyValuePairs(),
-            Map.copyOf(MDC.get().values()),
+            // an event logged outside a request or message scope has no MDC bound, and reading an
+            // unbound ScopedValue would throw here and make the appender drop the event
+            MDC.VALUE.isBound() ? Map.copyOf(MDC.get().values()) : Map.of(),
             Span.current().getSpanContext()
         );
         super.append(koraLoggingEvent);


### PR DESCRIPTION
## What

`KoraAsyncAppender.append` reads the Kora MDC:

```java
Map.copyOf(MDC.get().values())
```

`MDC.get()` is `ScopedValue.get()`, which throws `NoSuchElementException: ScopedValue not bound`
when no scope is active. `UnsynchronizedAppenderBase.doAppend` catches that, so the event is
silently dropped instead of being logged.

Every event logged outside a request or message scope is affected: application startup and
shutdown, background workers, connection pools, driver logs, initialization failures. Inside a
scope (an HTTP request, a Kafka record) logging works, which is why the gap is easy to miss —
an application looks like it logs fine while everything that happens before the first request
is gone.

The dropped-event error goes to logback's status manager, and Kora's own example configuration
installs `NopStatusListener`, so nothing reaches the console either.

Reproduced on the `kora-java-graalvm-kafka` example, whose logging happens almost entirely
outside any scope:

```
# before — 591 bytes, only a stack trace written directly to stderr
$ java -jar kora-java-graalvm-kafka-all.jar | wc -c
591

# with -Dlogback.statusListenerClass=...OnConsoleStatusListener the cause becomes visible
ERROR in KoraAsyncAppender[ASYNC] - Appender [ASYNC] failed to append.
java.util.NoSuchElementException: ScopedValue not bound

# after — 16001 bytes: XNIO startup, Kafka producer/consumer configuration,
# group coordinator discovery, "Application released"
```

## Tests

No unit test. I could not build one that fails without the fix and passes with it: driving
`AsyncAppenderBase` directly from a test does not deliver events to an attached
`ListAppender` in this setup, so the test would be red in both states and prove nothing.
Rather than ship a test that does not discriminate, the evidence here is the end-to-end
reproduction above — the same application, same configuration, logging goes from 591 bytes
to 16 KB with the one-line change.
