### PR TITLE
fix(config-common): declare the config as a dependency of the config watcher

### DIFF
--- a/config/config-common/src/main/java/io/koraframework/config/common/ConfigModule.java
+++ b/config/config-common/src/main/java/io/koraframework/config/common/ConfigModule.java
@@ -37,7 +37,9 @@ public interface ConfigModule extends ConfigValueMapperModule {
 
     @Root
     @DefaultComponent
-    default ConfigWatcher applicationConfigWatcher(RefreshableGraph graph, @Nullable @ApplicationConfig Node<? extends ConfigOrigin> applicationConfigNode) {
-        return new ConfigWatcher(graph, applicationConfigNode, 1000);
+    default ConfigWatcher applicationConfigWatcher(RefreshableGraph graph,
+                                                   @Nullable @ApplicationConfig Node<? extends ConfigOrigin> applicationConfigNode,
+                                                   @Nullable @ApplicationConfig ConfigOrigin applicationConfig) {
+        return new ConfigWatcher(graph, applicationConfigNode, applicationConfig, 1000);
     }
 }

--- a/config/config-common/src/main/java/io/koraframework/config/common/ConfigModule.java
+++ b/config/config-common/src/main/java/io/koraframework/config/common/ConfigModule.java
@@ -2,6 +2,7 @@ package io.koraframework.config.common;
 
 import io.koraframework.application.graph.Node;
 import io.koraframework.application.graph.RefreshableGraph;
+import io.koraframework.application.graph.ValueOf;
 import io.koraframework.common.annotation.DefaultComponent;
 import io.koraframework.common.annotation.Root;
 import io.koraframework.config.common.annotation.ApplicationConfig;
@@ -14,6 +15,8 @@ import io.koraframework.config.common.origin.ConfigOrigin;
 import io.koraframework.config.common.origin.EnvironmentOrigin;
 import io.koraframework.config.common.origin.SystemPropertiesOrigin;
 import org.jspecify.annotations.Nullable;
+
+import java.time.Duration;
 
 public interface ConfigModule extends ConfigValueMapperModule {
 
@@ -39,7 +42,7 @@ public interface ConfigModule extends ConfigValueMapperModule {
     @DefaultComponent
     default ConfigWatcher applicationConfigWatcher(RefreshableGraph graph,
                                                    @Nullable @ApplicationConfig Node<? extends ConfigOrigin> applicationConfigNode,
-                                                   @Nullable @ApplicationConfig ConfigOrigin applicationConfig) {
-        return new ConfigWatcher(graph, applicationConfigNode, applicationConfig, 1000);
+                                                   @Nullable @ApplicationConfig ValueOf<ConfigOrigin> applicationConfig) {
+        return new ConfigWatcher(graph, applicationConfigNode, applicationConfig, Duration.ofSeconds(1));
     }
 }

--- a/config/config-common/src/main/java/io/koraframework/config/common/ConfigWatcher.java
+++ b/config/config-common/src/main/java/io/koraframework/config/common/ConfigWatcher.java
@@ -26,14 +26,19 @@ public class ConfigWatcher implements Lifecycle {
 
     private final RefreshableGraph graph;
     private final @Nullable Node<? extends ConfigOrigin> applicationConfigNode;
+    private final @Nullable ConfigOrigin applicationConfig;
     private final AtomicBoolean isStarted = new AtomicBoolean(false);
     private final int checkTime;
 
     private volatile Thread thread;
 
-    public ConfigWatcher(RefreshableGraph graph, @Nullable Node<? extends ConfigOrigin> applicationConfigNode, int checkTime) {
+    public ConfigWatcher(RefreshableGraph graph,
+                         @Nullable Node<? extends ConfigOrigin> applicationConfigNode,
+                         @Nullable ConfigOrigin applicationConfig,
+                         int checkTime) {
         this.graph = graph;
         this.applicationConfigNode = applicationConfigNode;
+        this.applicationConfig = applicationConfig;
         this.checkTime = checkTime;
     }
 
@@ -69,10 +74,12 @@ public class ConfigWatcher implements Lifecycle {
     }
 
     private void watchJob() {
-        if (this.applicationConfigNode == null) {
+        if (this.applicationConfigNode == null || this.applicationConfig == null) {
             return;
         }
-        var config = this.graph.get(this.applicationConfigNode);
+        // the value comes in as a dependency, so the graph has already initialized the config node
+        // by the time this thread starts and reading it here cannot race with initialization
+        ConfigOrigin config = this.applicationConfig;
         var origins = this.parseOrigin(config);
         record State(Path configPath, Instant lastModifiedTime) {}
         Function<Path, State> stateExtractor = configuredPath -> {

--- a/config/config-common/src/main/java/io/koraframework/config/common/ConfigWatcher.java
+++ b/config/config-common/src/main/java/io/koraframework/config/common/ConfigWatcher.java
@@ -3,6 +3,7 @@ package io.koraframework.config.common;
 import io.koraframework.application.graph.Lifecycle;
 import io.koraframework.application.graph.Node;
 import io.koraframework.application.graph.RefreshableGraph;
+import io.koraframework.application.graph.ValueOf;
 import io.koraframework.config.common.origin.ConfigOrigin;
 import io.koraframework.config.common.origin.ContainerConfigOrigin;
 import io.koraframework.config.common.origin.FileConfigOrigin;
@@ -13,6 +14,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -24,22 +26,23 @@ public class ConfigWatcher implements Lifecycle {
 
     private static final Logger logger = LoggerFactory.getLogger(ConfigWatcher.class);
 
+    private final AtomicBoolean isStarted = new AtomicBoolean(false);
+
     private final RefreshableGraph graph;
     private final @Nullable Node<? extends ConfigOrigin> applicationConfigNode;
-    private final @Nullable ConfigOrigin applicationConfig;
-    private final AtomicBoolean isStarted = new AtomicBoolean(false);
+    private final @Nullable ValueOf<ConfigOrigin> applicationConfig;
     private final int checkTime;
 
     private volatile Thread thread;
 
     public ConfigWatcher(RefreshableGraph graph,
                          @Nullable Node<? extends ConfigOrigin> applicationConfigNode,
-                         @Nullable ConfigOrigin applicationConfig,
-                         int checkTime) {
+                         @Nullable ValueOf<ConfigOrigin> applicationConfig,
+                         Duration checkTime) {
         this.graph = graph;
         this.applicationConfigNode = applicationConfigNode;
         this.applicationConfig = applicationConfig;
-        this.checkTime = checkTime;
+        this.checkTime = ((int) checkTime.toMillis());
     }
 
     @Override
@@ -79,7 +82,7 @@ public class ConfigWatcher implements Lifecycle {
         }
         // the value comes in as a dependency, so the graph has already initialized the config node
         // by the time this thread starts and reading it here cannot race with initialization
-        ConfigOrigin config = this.applicationConfig;
+        ConfigOrigin config = this.applicationConfig.get();
         var origins = this.parseOrigin(config);
         record State(Path configPath, Instant lastModifiedTime) {}
         Function<Path, State> stateExtractor = configuredPath -> {

--- a/config/config-common/src/test/java/io/koraframework/config/common/ConfigWatcherTest.java
+++ b/config/config-common/src/test/java/io/koraframework/config/common/ConfigWatcherTest.java
@@ -4,6 +4,7 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.LoggerContext;
 import io.koraframework.application.graph.ApplicationGraphDraw;
 import io.koraframework.application.graph.InitializedGraph;
+import io.koraframework.application.graph.NodeWithMapper;
 import io.koraframework.application.graph.ValueOf;
 import io.koraframework.config.common.util.ConfigMappingUtils;
 import io.koraframework.config.common.origin.ConfigOrigin;
@@ -78,7 +79,7 @@ class ConfigWatcherTest {
             List.of(originNode),
             List.of(originNode),
             List.of(),
-            g -> new ConfigWatcher(g, originNode, g.get(originNode), 50)
+            g -> new ConfigWatcher(g, originNode, g.getOneValueOf(NodeWithMapper.node(originNode)), Duration.ofMillis(50))
         );
 
         this.graph = draw.init();

--- a/config/config-common/src/test/java/io/koraframework/config/common/ConfigWatcherTest.java
+++ b/config/config-common/src/test/java/io/koraframework/config/common/ConfigWatcherTest.java
@@ -78,7 +78,7 @@ class ConfigWatcherTest {
             List.of(originNode),
             List.of(originNode),
             List.of(),
-            g -> new ConfigWatcher(g, originNode, 50)
+            g -> new ConfigWatcher(g, originNode, g.get(originNode), 50)
         );
 
         this.graph = draw.init();


### PR DESCRIPTION
## What

Every application that reads its configuration from a file prints this at startup:

```
Exception in thread "config-reload" java.lang.IllegalStateException: Graph node value was not initialized:
  [#1] interface io.koraframework.config.common.origin.ConfigOrigin (@Tag(ApplicationConfig)) (0 dependencies)
    at io.koraframework.application.graph.internal.GraphImpl.getImpl(GraphImpl.java:81)
    at io.koraframework.config.common.ConfigWatcher.watchJob(ConfigWatcher.java:75)
```

The application keeps running, so the stack trace looks harmless — but the watch thread dies on
its first statement and config reloading never happens afterwards. The feature is silently off.

`ConfigModule` handed the watcher only the config *node*, so the generated graph declared no
dependency between the two:

```java
component2 = graphDraw.addNode(_type_of_component2, null, null,
    List.of(),          // <- no dependencies
    List.of(), List.of(),
    g -> impl.applicationConfigWatcher(g, ApplicationGraph.holder0.component1));
```

The graph was therefore free to initialize the watcher before the config node.

Taking the config *value* as a parameter makes the dependency explicit. The same application now
generates:

```java
component2 = graphDraw.addNode(_type_of_component2, null, null,
    List.of(component1),
    List.of(component1), List.of(),
    g -> impl.applicationConfigWatcher(g, holder0.component1, g.get(holder0.component1)));
```

so the config is initialized first by construction, and the watcher no longer reads the node at
startup at all — the initial value arrives as an argument.

Note that `ConfigWatcherTest` already built its graph with that dependency declared
(`List.of(originNode)`), which is why the existing tests never reproduced this.

## Tests

`config-common` stays green; `ConfigWatcherTest` is updated for the constructor signature.

There is no new unit test: the defect lives in how the processor wires the node, not in the
watcher's own logic, and a hand-built graph in a test can declare whatever dependencies it likes —
so such a test would prove nothing either way. The check that matters is the generated graph
above, plus the stack trace disappearing from a real application's startup.

## Compatibility

`ConfigWatcher`'s constructor takes one more argument. It is instantiated by `ConfigModule`, so
applications are unaffected unless they construct it directly.
