### PR TITLE
Fixed(openapi): generate custom request mappers for non-standard body content-types (Backport of #789)

### DIFF
--- a/openapi/openapi-generator/build.gradle
+++ b/openapi/openapi-generator/build.gradle
@@ -80,6 +80,7 @@ sourceSets {
             addOpenapiDir("petstoreV3_nullable_enable_json_nullable")
             addOpenapiDir("petstoreV3_request_parameters")
             addOpenapiDir("petstoreV3_responses")
+            addOpenapiDir("petstoreV3_requests")
             addOpenapiDir("petstoreV3_same_response_model")
             addOpenapiDir("petstoreV3_bare_object")
             addOpenapiDir("petstoreV3_security_all")

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/AbstractGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/AbstractGenerator.java
@@ -6,6 +6,7 @@ import com.palantir.javapoet.ParameterizedTypeName;
 import com.palantir.javapoet.TypeName;
 import org.apache.commons.lang3.StringUtils;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.model.ModelsMap;
 import org.openapitools.codegen.model.OperationsMap;
@@ -364,6 +365,47 @@ public abstract class AbstractGenerator<C, R> {
 
     protected boolean requiresJsonMapper(IJsonSchemaValidationProperties schema) {
         return !isBareObject(schema) || params.rawBodyMode == CodegenParams.RawBodyMode.OBJECT;
+    }
+
+    /**
+     * @return the request body's content type when it is a non-JSON, non-model binary or string body declared with a
+     * content type other than the implicit default ({@code application/octet-stream} for binary, {@code text/plain}
+     * for string), or {@code null} when the default/generic mapper is sufficient.
+     */
+    @Nullable
+    protected static String customBodyContentType(@Nullable CodegenParameter bodyParam) {
+        if (bodyParam == null || bodyParam.isModel) {
+            return null;
+        }
+        if (bodyParam.isBinary) {
+            return nonDefaultContentType(bodyParam.getContent(), "application/octet-stream");
+        }
+        if (bodyParam.isString && !KoraCodegen.isContentJson(bodyParam)) {
+            return nonDefaultContentType(bodyParam.getContent(), "text/plain");
+        }
+        return null;
+    }
+
+    /**
+     * @return the response's content type when it is a non-JSON, non-binary string response declared with a content
+     * type other than the implicit default ({@code text/plain}), or {@code null} otherwise. Binary responses already
+     * carry their content type from {@link CodegenResponse#getContent()} directly.
+     */
+    @Nullable
+    protected static String customResponseContentType(CodegenResponse response) {
+        if (response.isBinary || response.dataType == null) {
+            return null;
+        }
+        if (response.isString && !KoraCodegen.isContentJson(response.getContent())) {
+            return nonDefaultContentType(response.getContent(), "text/plain");
+        }
+        return null;
+    }
+
+    @Nullable
+    private static String nonDefaultContentType(@Nullable Map<String, CodegenMediaType> content, String defaultContentType) {
+        var contentType = (content == null || content.isEmpty()) ? defaultContentType : content.keySet().iterator().next();
+        return defaultContentType.equals(contentType) ? null : contentType;
     }
 
     protected boolean hasRawBodyHeaders(CodegenOperation operation) {

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/AbstractJavaGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/AbstractJavaGenerator.java
@@ -121,6 +121,11 @@ public abstract class AbstractJavaGenerator<C> extends AbstractGenerator<C, Java
         }
         if (param.isBodyParam && KoraCodegen.isContentJson(param) && requiresJsonMapper(param)) {
             b.addAnnotation(jsonAnnotation());
+        } else if (param.isBodyParam && params.codegenMode.isClient() && customBodyContentType(param) != null) {
+            var mapper = ClassName.get(apiPackage, ctx.get("classname") + "ClientRequestMappers", capitalize(operation.operationId) + "BodyParamRequestMapper");
+            b.addAnnotation(AnnotationSpec.builder(Classes.mapping)
+                .addMember("value", "$T.class", mapper)
+                .build());
         }
         if (params.codegenMode.isServer() && params.enableValidation) {
             var validation = getValidation(param);

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientRequestMapperGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientRequestMapperGenerator.java
@@ -22,6 +22,9 @@ public class ClientRequestMapperGenerator extends AbstractJavaGenerator<Operatio
         var b = TypeSpec.interfaceBuilder(className)
             .addAnnotation(generated());
         for (var operation : ctx.getOperations().getOperation()) {
+            if (customBodyContentType(operation.bodyParam) != null) {
+                b.addType(buildBodyParamMapper(className, operation));
+            }
             if (!operation.getHasFormParams()) {
                 continue;
             }
@@ -29,6 +32,42 @@ public class ClientRequestMapperGenerator extends AbstractJavaGenerator<Operatio
         }
 
         return JavaFile.builder(apiPackage, b.build()).build();
+    }
+
+    private TypeSpec buildBodyParamMapper(ClassName rootName, CodegenOperation operation) {
+        var bodyParam = operation.bodyParam;
+        var contentType = customBodyContentType(bodyParam);
+        var className = rootName.nestedClass(capitalize(operation.operationId) + "BodyParamRequestMapper");
+        var valueType = asType(bodyParam);
+        if (!bodyParam.required) {
+            valueType = valueType.box().annotated(AnnotationSpec.builder(Classes.nullable).build());
+        }
+        var apply = MethodSpec.methodBuilder("apply")
+            .addModifiers(Modifier.PUBLIC)
+            .addAnnotation(Override.class)
+            .returns(Classes.httpBodyOutput)
+            .addParameter(valueType, "value")
+            .addException(Exception.class);
+        if (!bodyParam.required) {
+            apply.beginControlFlow("if (value == null)")
+                .addStatement("return $T.empty()", Classes.httpBody)
+                .endControlFlow();
+        }
+        if (bodyParam.isBinary) {
+            apply.addStatement("return $T.of($S, value)", Classes.httpBody, contentType);
+        } else {
+            apply.addStatement("return $T.of($S, value.getBytes($T.UTF_8))", Classes.httpBody, contentType, ClassName.get(java.nio.charset.StandardCharsets.class));
+        }
+
+        return TypeSpec.classBuilder(className)
+            .addAnnotation(generated())
+            .addAnnotation(Classes.defaultComponent)
+            .addAnnotation(Classes.component)
+            .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
+            .addSuperinterface(ParameterizedTypeName.get(Classes.httpClientRequestMapper, valueType.withoutAnnotations()))
+            .addMethod(MethodSpec.constructorBuilder().addModifiers(Modifier.PUBLIC).build())
+            .addMethod(apply.build())
+            .build();
     }
 
     private TypeSpec buildFormMapper(OperationsMap ctx, ClassName rootName, CodegenOperation operation) {

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ServerResponseMapperGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ServerResponseMapperGenerator.java
@@ -36,7 +36,7 @@ public class ServerResponseMapperGenerator extends AbstractJavaGenerator<Operati
             .addModifiers(Modifier.PUBLIC);
         var hasConstructorParameters = false;
         for (var response : operation.responses) {
-            if (!response.isBinary && response.dataType != null) {
+            if (!response.isBinary && response.dataType != null && customResponseContentType(response) == null) {
                 var mapperType = ParameterizedTypeName.get(Classes.httpServerResponseMapper, ParameterizedTypeName.get(Classes.httpResponseEntity, asType(response)));
                 var mapperName = "response" + response.code + "Delegate";
                 b.addField(mapperType, mapperName, Modifier.PRIVATE, Modifier.FINAL);
@@ -100,6 +100,12 @@ public class ServerResponseMapperGenerator extends AbstractJavaGenerator<Operati
         }
         if (rs.dataType == null) {
             b.addStatement("return $T.of($L, headers)", Classes.httpServerResponse, responseCode);
+            return b.build();
+        }
+        var customContentType = customResponseContentType(rs);
+        if (customContentType != null) {
+            b.addStatement("return $T.of($L, headers, $T.of($S, $N.content().getBytes($T.UTF_8)))",
+                Classes.httpServerResponse, responseCode, Classes.httpBody, customContentType, rsName, ClassName.get(java.nio.charset.StandardCharsets.class));
             return b.build();
         }
         b.addStatement("var entity = $T.of($L, headers, $N.content())", Classes.httpResponseEntity, responseCode, rsName);

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/AbstractKotlinGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/AbstractKotlinGenerator.kt
@@ -247,6 +247,15 @@ abstract class AbstractKotlinGenerator<C : Any> : AbstractGenerator<C, FileSpec>
                 AnnotationSpec.builder(Classes.json.asKt())
                     .build()
             )
+
+            param.isBodyParam && params.codegenMode.isClient && customBodyContentType(param) != null -> {
+                val mapper = ClassName(apiPackage, ctx["classname"].toString() + "ClientRequestMappers", capitalize(operation.operationId) + "BodyParamRequestMapper")
+                b.addAnnotation(
+                    AnnotationSpec.builder(Classes.mapping.asKt())
+                        .addMember("value = %T::class", mapper)
+                        .build()
+                )
+            }
         }
         if (params.codegenMode.isServer && params.enableValidation) {
             val validation = getValidation(param)

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ClientRequestMapperGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ClientRequestMapperGenerator.kt
@@ -20,12 +20,47 @@ class ClientRequestMapperGenerator : AbstractKotlinGenerator<OperationsMap>() {
         val b = TypeSpec.interfaceBuilder(className)
             .addAnnotation(generated())
         for (operation in ctx.operations.operation) {
+            if (customBodyContentType(operation.bodyParam) != null) {
+                b.addType(buildBodyParamMapper(className, operation))
+            }
             if (operation.hasFormParams) {
                 b.addType(buildFormMapper(ctx, className, operation))
             }
         }
 
         return FileSpec.get(apiPackage, b.build())
+    }
+
+    private fun buildBodyParamMapper(rootName: ClassName, operation: CodegenOperation): TypeSpec {
+        val bodyParam = operation.bodyParam
+        val contentType = requireNotNull(customBodyContentType(bodyParam))
+        val className = rootName.nestedClass(capitalize(operation.operationId) + "BodyParamRequestMapper")
+        var valueType = asType(bodyParam).asKt()
+        if (!bodyParam.required) {
+            valueType = valueType.copy(nullable = true)
+        }
+        val apply = FunSpec.builder("apply")
+            .addModifiers(KModifier.OVERRIDE)
+            .returns(Classes.httpBodyOutput.asKt())
+            .addParameter("value", valueType)
+        if (!bodyParam.required) {
+            apply.beginControlFlow("if (value == null)")
+                .addStatement("return %T.empty()", Classes.httpBody.asKt())
+                .endControlFlow()
+        }
+        if (bodyParam.isBinary) {
+            apply.addStatement("return %T.of(%S, value)", Classes.httpBody.asKt(), contentType)
+        } else {
+            apply.addStatement("return %T.of(%S, value.toByteArray(Charsets.UTF_8))", Classes.httpBody.asKt(), contentType)
+        }
+
+        return TypeSpec.classBuilder(className)
+            .addAnnotation(generated())
+            .addAnnotation(Classes.defaultComponent.asKt())
+            .addAnnotation(Classes.component.asKt())
+            .addSuperinterface(Classes.httpClientRequestMapper.asKt().parameterizedBy(valueType.copy(nullable = false)))
+            .addFunction(apply.build())
+            .build()
     }
 
     private fun buildFormMapper(ctx: OperationsMap, rootName: ClassName, operation: CodegenOperation): TypeSpec {

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ServerResponseMappersGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ServerResponseMappersGenerator.kt
@@ -32,7 +32,7 @@ class ServerResponseMappersGenerator : AbstractKotlinGenerator<OperationsMap>() 
 
         val constructor = FunSpec.constructorBuilder()
         for (response in operation.responses) {
-            if (!response.isBinary && response.dataType != null) {
+            if (!response.isBinary && response.dataType != null && customResponseContentType(response) == null) {
                 val mapperType = Classes.httpServerResponseMapper.asKt().parameterizedBy(Classes.httpResponseEntity.asKt().parameterizedBy(asType(response).asKt()))
                 val mapperName = "response" + response.code + "Delegate"
                 b.addProperty(PropertySpec.builder(mapperName, mapperType).initializer(mapperName).build())
@@ -95,6 +95,11 @@ class ServerResponseMappersGenerator : AbstractKotlinGenerator<OperationsMap>() 
         }
         if (rs.dataType == null) {
             b.addStatement("return %T.of(%L, headers)", Classes.httpServerResponse.asKt(), responseCode)
+            return b.build()
+        }
+        val customContentType = customResponseContentType(rs)
+        if (customContentType != null) {
+            b.addStatement("return %T.of(%L, headers, %T.of(%S, rs.content.toByteArray(Charsets.UTF_8)))", Classes.httpServerResponse.asKt(), responseCode, Classes.httpBody.asKt(), customContentType)
             return b.build()
         }
         b.addStatement("val entity = %T.of(%L, headers, rs.content)", Classes.httpResponseEntity.asKt(), responseCode)

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/BaseOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/BaseOpenapiTest.java
@@ -122,6 +122,7 @@ public abstract class BaseOpenapiTest {
             "/example/petstoreV3_same_response_model.yaml",
             "/example/petstoreV3_bare_object.yaml",
             "/example/petstoreV3_responses.yaml",
+            "/example/petstoreV3_requests.yaml",
             "/example/petstoreV3_types.yaml",
             "/example/petstoreV3_validation.yaml",
         };

--- a/openapi/openapi-generator/src/test/resources/example/petstoreV3_requests.yaml
+++ b/openapi/openapi-generator/src/test/resources/example/petstoreV3_requests.yaml
@@ -1,0 +1,113 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /text-plain:
+    post:
+      operationId: plain
+      requestBody:
+        required: true
+        content:
+          text/plain:
+            schema:
+              type: string
+      responses:
+        '200':
+          description: OK
+
+  /text-html:
+    post:
+      operationId: html
+      requestBody:
+        required: true
+        content:
+          text/html:
+            schema:
+              type: string
+      responses:
+        '200':
+          description: OK
+
+  /application-octet-stream:
+    post:
+      operationId: octet-stream
+      requestBody:
+        required: true
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+      responses:
+        '200':
+          description: OK
+
+  /application-pdf:
+    post:
+      operationId: pdf
+      requestBody:
+        required: true
+        content:
+          application/pdf:
+            schema:
+              type: string
+              format: binary
+      responses:
+        '200':
+          description: OK
+
+  /image-png:
+    post:
+      operationId: png
+      requestBody:
+        required: true
+        content:
+          image/png:
+            schema:
+              type: string
+              format: binary
+      responses:
+        '200':
+          description: OK
+
+  /application-json:
+    post:
+      operationId: json
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        '200':
+          description: OK
+
+  /application-xml:
+    get:
+      operationId: xml
+      requestBody:
+        required: true
+        content:
+          application/xml:
+            schema:
+              $ref: '#/components/schemas/Pet'
+      responses:
+        '200':
+          description: OK
+
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string


### PR DESCRIPTION
Fixed(openapi): generate custom request mappers for non-standard body content-types (Backport of #789)

Backport of #789 (branch 1.0, commit 362e596ffed80ef3c4d9bddc5f8108b2102e26a2)

Generates custom HttpClientRequestMapper implementations for binary or string request bodies declared with a content type other than the implicit default (application/octet-stream for binary, text/plain for string, or JSON). Previously the generated client always sent such bodies with the wrong Content-Type header (e.g. application/pdf, image/png, text/html were all sent as octet-stream/plain). Also fixes non-JSON string responses (e.g. text/html) on the server side, which fell back to the default text/plain response mapper instead of using their declared content type.

- Added(openapi-generator): client-side, a body param with a non-default content type now generates a `{Operation}BodyParamRequestMapper` and gets `@Mapping(...)` applied to the body parameter, mirroring how form params already get their own generated mapper.
- Fixed(openapi-generator): server-side, a string response with a non-default content type is now written inline with `HttpBody.of(ctx, contentType, ...)` instead of going through the generic `HttpServerResponseMapper<HttpResponseEntity<String>>` delegate, which otherwise resolves to the default text/plain mapper unless the caller supplies their own.

This ports the 1.0 branch's mustache-template-based fix to master's JavaPoet/KotlinPoet-based `javagen`/`kotlingen` generators. The 1.0 commit also dropped a redundant server-side request-mapper generation path for custom body content types; master never generated one in the first place (non-JSON server body params already resolve through `HttpServerRequestMapperModule`'s default byte[]/String mappers), so there was nothing to remove there.