### PR TITLE
[Draft] Added(http-client): `@ResponseCodeMapper` status code ranges via codeTo

### DIFF
--- a/http/http-client-annotation-processor/src/main/java/io/koraframework/http/client/annotation/processor/ClientClassGenerator.java
+++ b/http/http-client-annotation-processor/src/main/java/io/koraframework/http/client/annotation/processor/ClientClassGenerator.java
@@ -490,42 +490,48 @@ public class ClientClassGenerator {
             }
         } else {
             b.addStatement("var _code = _response.code()");
-            if (resultType.getKind() != TypeKind.VOID) {
-                b.add("return ");
-            }
-            b.add("switch (_code) {\n");
+            var returnPrefix = resultType.getKind() != TypeKind.VOID ? "return " : "";
             ResponseCodeMapperData defaultMapper = null;
+            var rangedMappers = new ArrayList<ResponseCodeMapperData>();
             for (var codeMapper : methodData.codeMappers()) {
-                if (codeMapper.code() == -1) {
+                if (codeMapper.isDefault()) {
                     defaultMapper = codeMapper;
                 } else {
-                    var responseMapperName = "" + methodData.element().getSimpleName() + codeMapper.code() + "ResponseMapper";
-                    var ref = findMapperField(builder, responseMapperName).modifiers().contains(Modifier.STATIC)
-                        ? CodeBlock.of("$T", implClassName(methodData.element))
-                        : CodeBlock.of("this");
-                    if (isMapperAssignable(methodData.element.getReturnType(), codeMapper.type, codeMapper.mapper)) {
-                        b.add("  case $L -> $L.$L.apply(_response);\n", codeMapper.code(), ref, responseMapperName);
-                    } else {
-                        b.add("  case $L -> throw $L.$L.apply(_response);\n", codeMapper.code(), ref, responseMapperName);
-                    }
+                    rangedMappers.add(codeMapper);
                 }
             }
-            if (defaultMapper == null) {
-                b.add("  default -> {\n");
-                b.add("    throw $T.fromResponse(_response);\n", httpClientResponseException);
-                b.add("  }\n");
-            } else {
-                var responseMapperName = methodData.element().getSimpleName() + "DefaultResponseMapper";
+            rangedMappers.sort(Comparator.comparingInt(ResponseCodeMapperData::specificity));
+            for (var i = 0; i < rangedMappers.size(); i++) {
+                var codeMapper = rangedMappers.get(i);
+                var condition = codeMapper.isRange()
+                    ? CodeBlock.of("_code >= $L && _code <= $L", codeMapper.code(), codeMapper.codeTo())
+                    : CodeBlock.of("_code == $L", codeMapper.code());
+                b.add(i == 0 ? "if ($L) {\n" : "} else if ($L) {\n", condition);
+                var responseMapperName = codeMapper.mapperFieldName(methodData.element().getSimpleName());
                 var ref = findMapperField(builder, responseMapperName).modifiers().contains(Modifier.STATIC)
                     ? CodeBlock.of("$T", implClassName(methodData.element))
                     : CodeBlock.of("this");
-                if (isMapperAssignable(methodData.element.getReturnType(), defaultMapper.type, defaultMapper.mapper)) {
-                    b.add("  default -> $L.$L.apply(_response);\n", ref, responseMapperName);
+                if (isMapperAssignable(methodData.element.getReturnType(), codeMapper.type(), codeMapper.mapper())) {
+                    b.add("  $L$L.$L.apply(_response);\n", returnPrefix, ref, responseMapperName);
                 } else {
-                    b.add("  default -> throw $L.$L.apply(_response);\n", ref, responseMapperName);
+                    b.add("  throw $L.$L.apply(_response);\n", ref, responseMapperName);
                 }
             }
-            b.add("};\n");
+            b.add(rangedMappers.isEmpty() ? "{\n" : "} else {\n");
+            if (defaultMapper == null) {
+                b.add("  throw $T.fromResponse(_response);\n", httpClientResponseException);
+            } else {
+                var responseMapperName = defaultMapper.mapperFieldName(methodData.element().getSimpleName());
+                var ref = findMapperField(builder, responseMapperName).modifiers().contains(Modifier.STATIC)
+                    ? CodeBlock.of("$T", implClassName(methodData.element))
+                    : CodeBlock.of("this");
+                if (isMapperAssignable(methodData.element.getReturnType(), defaultMapper.type(), defaultMapper.mapper())) {
+                    b.add("  $L$L.$L.apply(_response);\n", returnPrefix, ref, responseMapperName);
+                } else {
+                    b.add("  throw $L.$L.apply(_response);\n", ref, responseMapperName);
+                }
+            }
+            b.add("}\n");
         }
         return b.build();
     }
@@ -674,7 +680,7 @@ public class ClientClassGenerator {
                 }
             } else {
                 for (var codeMapper : methodData.codeMappers()) {
-                    var responseMapperName = "" + method.getSimpleName() + (codeMapper.code() > 0 ? codeMapper.code() : "Default") + "ResponseMapper";
+                    var responseMapperName = codeMapper.mapperFieldName(method.getSimpleName());
                     if (codeMapper.mapper() != null && CommonUtils.hasDefaultConstructorAndFinal(this.types, codeMapper.mapper())) {
                         var mapperTypeElement = (TypeElement) codeMapper.mapper().asElement();
                         var mapperTypeName = ClassName.get(mapperTypeElement);
@@ -781,7 +787,29 @@ public class ClientClassGenerator {
                && bodyDeclaredType.asElement().toString().equals("io.koraframework.common.Either");
     }
 
-    record ResponseCodeMapperData(int code, @Nullable TypeMirror type, @Nullable DeclaredType mapper) {
+    record ResponseCodeMapperData(int code, int codeTo, @Nullable TypeMirror type, @Nullable DeclaredType mapper) {
+        public boolean isDefault() {
+            return this.code == -1;
+        }
+
+        public boolean isRange() {
+            return this.codeTo != -1;
+        }
+
+        public int specificity() {
+            return this.isRange() ? this.codeTo - this.code : 0;
+        }
+
+        public String mapperFieldName(CharSequence methodName) {
+            if (this.isDefault()) {
+                return methodName + "DefaultResponseMapper";
+            } else if (this.isRange()) {
+                return methodName + "" + this.code + "To" + this.codeTo + "ResponseMapper";
+            } else {
+                return methodName + "" + this.code + "ResponseMapper";
+            }
+        }
+
         public TypeName responseMapperType(TypeMirror returnType) {
             if (this.mapper() != null) {
                 var mapperElement = (TypeElement) this.mapper().asElement();
@@ -873,13 +901,23 @@ public class ClientClassGenerator {
         if (annotations.isEmpty()) {
             return List.of();
         }
-        return annotations.stream()
+        var mappers = annotations.stream()
             .map(a -> this.parseMapperData(element, a))
             .toList();
+        this.validateMapperRanges(element, mappers);
+        return mappers;
     }
 
     private ResponseCodeMapperData parseMapperData(ExecutableElement method, AnnotationMirror annotation) {
         var code = Objects.requireNonNull(AnnotationUtils.<Integer>parseAnnotationValueWithoutDefault(annotation, "code"));
+        var codeTo = AnnotationUtils.<Integer>parseAnnotationValueWithoutDefault(annotation, "codeTo");
+        codeTo = codeTo == null ? -1 : codeTo;
+        if (codeTo != -1 && code == -1) {
+            throw new ProcessingErrorException("@ResponseCodeMapper#codeTo can't be used with code = DEFAULT", method);
+        }
+        if (codeTo != -1 && codeTo < code) {
+            throw new ProcessingErrorException("@ResponseCodeMapper#codeTo (" + codeTo + ") must be greater than or equal to #code (" + code + ")", method);
+        }
         var type = AnnotationUtils.<TypeMirror>parseAnnotationValueWithoutDefault(annotation, "type");
         var mapper = AnnotationUtils.<DeclaredType>parseAnnotationValueWithoutDefault(annotation, "mapper");
         if (mapper == null && type == null) {
@@ -887,9 +925,37 @@ public class ClientClassGenerator {
             if (returnType.getKind() == TypeKind.VOID) {
                 returnType = elements.getTypeElement("java.lang.Void").asType();
             }
-            return new ResponseCodeMapperData(code, null, null);
+            return new ResponseCodeMapperData(code, codeTo, null, null);
         }
-        return new ResponseCodeMapperData(code, type, mapper);
+        return new ResponseCodeMapperData(code, codeTo, type, mapper);
+    }
+
+    private void validateMapperRanges(ExecutableElement method, List<ResponseCodeMapperData> mappers) {
+        var defaults = mappers.stream().filter(ResponseCodeMapperData::isDefault).count();
+        if (defaults > 1) {
+            throw new ProcessingErrorException("@ResponseCodeMapper duplicate DEFAULT mapping", method);
+        }
+        var ranged = mappers.stream().filter(m -> !m.isDefault()).toList();
+        for (var i = 0; i < ranged.size(); i++) {
+            for (var j = i + 1; j < ranged.size(); j++) {
+                var a = ranged.get(i);
+                var b = ranged.get(j);
+                var aTo = a.isRange() ? a.codeTo() : a.code();
+                var bTo = b.isRange() ? b.codeTo() : b.code();
+                var overlaps = a.code() <= bTo && b.code() <= aTo;
+                if (!overlaps) {
+                    continue;
+                }
+                var aContainsB = a.code() <= b.code() && bTo <= aTo;
+                var bContainsA = b.code() <= a.code() && aTo <= bTo;
+                if (a.code() == b.code() && aTo == bTo) {
+                    throw new ProcessingErrorException("@ResponseCodeMapper duplicate mapping for codes " + a.code() + ".." + aTo, method);
+                }
+                if (!aContainsB && !bContainsA) {
+                    throw new ProcessingErrorException("@ResponseCodeMapper ranges " + a.code() + ".." + aTo + " and " + b.code() + ".." + bTo + " partially overlap, ranges must be disjoint or nested", method);
+                }
+            }
+        }
     }
 
     private Map<String, ParameterizedTypeName> parseParameterConverters(List<MethodData> methods) {

--- a/http/http-client-annotation-processor/src/test/java/io/koraframework/http/client/annotation/processor/ResponseCodeMapperTest.java
+++ b/http/http-client-annotation-processor/src/test/java/io/koraframework/http/client/annotation/processor/ResponseCodeMapperTest.java
@@ -3,6 +3,7 @@ package io.koraframework.http.client.annotation.processor;
 import io.koraframework.common.Either;
 import org.junit.jupiter.api.Test;
 import io.koraframework.http.client.common.exception.HttpClientResponseException;
+import io.koraframework.http.client.common.response.HttpClientResponseMapper;
 
 import java.util.List;
 
@@ -389,5 +390,279 @@ public class ResponseCodeMapperTest extends AbstractHttpClientTest {
         onRequest("GET", "http://test-url:8080/test", rs -> rs.withCode(404));
         assertThat(client.<Either<String, Throwable>>invoke("test"))
             .isEqualTo(Either.left("default-string-from-mapper"));
+    }
+
+    @Test
+    public void testCodeRange() {
+        compileClient(List.of(newGeneratedObject("OkMapper"), newGeneratedObject("ErrorMapper")), """
+            @HttpClient
+            public interface TestClient {
+              @ResponseCodeMapper(code = 200, codeTo = 299, mapper = OkMapper.class)
+              @ResponseCodeMapper(code = 400, codeTo = 599, mapper = ErrorMapper.class)
+              @HttpRoute(method = "GET", path = "/test")
+              String test();
+            }
+            """, """
+            public class OkMapper implements HttpClientResponseMapper<String> {
+              public String apply(HttpClientResponse rs) {
+                  return "ok";
+              }
+            }
+            """, """
+            public class ErrorMapper implements HttpClientResponseMapper<String> {
+              public String apply(HttpClientResponse rs) {
+                  return "error";
+              }
+            }
+            """);
+
+        for (var code : List.of(200, 204, 299)) {
+            reset(httpClient);
+            onRequest("GET", "http://test-url:8080/test", rs -> rs.withCode(code));
+            assertThat(client.<String>invoke("test")).isEqualTo("ok");
+        }
+
+        for (var code : List.of(400, 500, 599)) {
+            reset(httpClient);
+            onRequest("GET", "http://test-url:8080/test", rs -> rs.withCode(code));
+            assertThat(client.<String>invoke("test")).isEqualTo("error");
+        }
+
+        reset(httpClient);
+        onRequest("GET", "http://test-url:8080/test", rs -> rs.withCode(300));
+        assertThatThrownBy(() -> client.invoke("test")).isInstanceOf(HttpClientResponseException.class);
+    }
+
+    @Test
+    public void testCodeRangeWithNestedExactCode() {
+        compileClient(List.of(newGeneratedObject("RangeMapper"), newGeneratedObject("ExactMapper")), """
+            @HttpClient
+            public interface TestClient {
+              @ResponseCodeMapper(code = 200, codeTo = 299, mapper = RangeMapper.class)
+              @ResponseCodeMapper(code = 201, mapper = ExactMapper.class)
+              @HttpRoute(method = "GET", path = "/test")
+              String test();
+            }
+            """, """
+            public class RangeMapper implements HttpClientResponseMapper<String> {
+              public String apply(HttpClientResponse rs) {
+                  return "range";
+              }
+            }
+            """, """
+            public class ExactMapper implements HttpClientResponseMapper<String> {
+              public String apply(HttpClientResponse rs) {
+                  return "exact";
+              }
+            }
+            """);
+
+        reset(httpClient);
+        onRequest("GET", "http://test-url:8080/test", rs -> rs.withCode(201));
+        assertThat(client.<String>invoke("test")).isEqualTo("exact");
+
+        reset(httpClient);
+        onRequest("GET", "http://test-url:8080/test", rs -> rs.withCode(200));
+        assertThat(client.<String>invoke("test")).isEqualTo("range");
+
+        reset(httpClient);
+        onRequest("GET", "http://test-url:8080/test", rs -> rs.withCode(202));
+        assertThat(client.<String>invoke("test")).isEqualTo("range");
+    }
+
+    @Test
+    public void testCodeRangeWithDefault() {
+        compileClient(List.of(newGeneratedObject("OkMapper"), newGeneratedObject("DefaultMapper")), """
+            @HttpClient
+            public interface TestClient {
+              @ResponseCodeMapper(code = 200, codeTo = 299, mapper = OkMapper.class)
+              @ResponseCodeMapper(code = ResponseCodeMapper.DEFAULT, mapper = DefaultMapper.class)
+              @HttpRoute(method = "GET", path = "/test")
+              String test();
+            }
+            """, """
+            public class OkMapper implements HttpClientResponseMapper<String> {
+              public String apply(HttpClientResponse rs) {
+                  return "ok";
+              }
+            }
+            """, """
+            public class DefaultMapper implements HttpClientResponseMapper<String> {
+              public String apply(HttpClientResponse rs) {
+                  return "default";
+              }
+            }
+            """);
+
+        reset(httpClient);
+        onRequest("GET", "http://test-url:8080/test", rs -> rs.withCode(200));
+        assertThat(client.<String>invoke("test")).isEqualTo("ok");
+
+        reset(httpClient);
+        onRequest("GET", "http://test-url:8080/test", rs -> rs.withCode(404));
+        assertThat(client.<String>invoke("test")).isEqualTo("default");
+    }
+
+    @Test
+    public void testCodeRangeWithExceptionType() {
+        compileClient(List.of(newGeneratedObject("OkMapper"), newGeneratedObject("ExceptionMapper")), """
+            @HttpClient
+            public interface TestClient {
+              @ResponseCodeMapper(code = 200, codeTo = 299, mapper = OkMapper.class)
+              @ResponseCodeMapper(code = 400, codeTo = 599, mapper = ExceptionMapper.class)
+              @HttpRoute(method = "GET", path = "/test")
+              String test();
+            }
+            """, """
+            public class OkMapper implements HttpClientResponseMapper<String> {
+              public String apply(HttpClientResponse rs) {
+                  return "ok";
+              }
+            }
+            """, """
+            public class ExceptionMapper implements HttpClientResponseMapper<RuntimeException> {
+              public RuntimeException apply(HttpClientResponse rs) {
+                  return new RuntimeException("range-error");
+              }
+            }
+            """);
+
+        reset(httpClient);
+        onRequest("GET", "http://test-url:8080/test", rs -> rs.withCode(500));
+        assertThatThrownBy(() -> client.<String>invoke("test"))
+            .isExactlyInstanceOf(RuntimeException.class)
+            .hasMessage("range-error");
+    }
+
+    @Test
+    public void testCodeRangeVoid() {
+        compileClient(List.of((HttpClientResponseMapper<Void>) rs -> null), """
+            @HttpClient
+            public interface TestClient {
+              @ResponseCodeMapper(code = 200, codeTo = 299)
+              @HttpRoute(method = "GET", path = "/test")
+              void test();
+            }
+            """);
+
+        reset(httpClient);
+        onRequest("GET", "http://test-url:8080/test", rs -> rs.withCode(204));
+        Object result = client.invoke("test");
+        assertThat(result).isNull();
+    }
+
+    @Test
+    public void testCodeRangeInjectedMapper() {
+        compileClient(List.of(newGeneratedObject("RangeMapper")), """
+            @HttpClient
+            public interface TestClient {
+              @ResponseCodeMapper(code = 200, codeTo = 299, mapper = RangeMapper.class)
+              @HttpRoute(method = "GET", path = "/test")
+              String test();
+            }
+            """, """
+            public class RangeMapper implements HttpClientResponseMapper<String> {
+              public String apply(HttpClientResponse rs) {
+                  return "injected";
+              }
+            }
+            """);
+
+        reset(httpClient);
+        onRequest("GET", "http://test-url:8080/test", rs -> rs.withCode(250));
+        assertThat(client.<String>invoke("test")).isEqualTo("injected");
+    }
+
+    @Test
+    public void testCodeToLessThanCodeFails() {
+        assertThatThrownBy(() -> compileClient(List.of(), """
+            @HttpClient
+            public interface TestClient {
+              @ResponseCodeMapper(code = 299, codeTo = 200, mapper = TestMapper.class)
+              @HttpRoute(method = "GET", path = "/test")
+              String test();
+            }
+            """, """
+            public class TestMapper implements HttpClientResponseMapper<String> {
+              public String apply(HttpClientResponse rs) {
+                  return "ok";
+              }
+            }
+            """)).hasMessageContaining("codeTo");
+    }
+
+    @Test
+    public void testCodeToWithDefaultCodeFails() {
+        assertThatThrownBy(() -> compileClient(List.of(), """
+            @HttpClient
+            public interface TestClient {
+              @ResponseCodeMapper(code = ResponseCodeMapper.DEFAULT, codeTo = 299, mapper = TestMapper.class)
+              @HttpRoute(method = "GET", path = "/test")
+              String test();
+            }
+            """, """
+            public class TestMapper implements HttpClientResponseMapper<String> {
+              public String apply(HttpClientResponse rs) {
+                  return "ok";
+              }
+            }
+            """)).hasMessageContaining("codeTo");
+    }
+
+    @Test
+    public void testPartialOverlapFails() {
+        assertThatThrownBy(() -> compileClient(List.of(), """
+            @HttpClient
+            public interface TestClient {
+              @ResponseCodeMapper(code = 200, codeTo = 299, mapper = TestMapper.class)
+              @ResponseCodeMapper(code = 250, codeTo = 350, mapper = TestMapper.class)
+              @HttpRoute(method = "GET", path = "/test")
+              String test();
+            }
+            """, """
+            public class TestMapper implements HttpClientResponseMapper<String> {
+              public String apply(HttpClientResponse rs) {
+                  return "ok";
+              }
+            }
+            """)).hasMessageContaining("partially overlap");
+    }
+
+    @Test
+    public void testDuplicateExactCodeFails() {
+        assertThatThrownBy(() -> compileClient(List.of(), """
+            @HttpClient
+            public interface TestClient {
+              @ResponseCodeMapper(code = 200, mapper = TestMapper.class)
+              @ResponseCodeMapper(code = 200, mapper = TestMapper.class)
+              @HttpRoute(method = "GET", path = "/test")
+              String test();
+            }
+            """, """
+            public class TestMapper implements HttpClientResponseMapper<String> {
+              public String apply(HttpClientResponse rs) {
+                  return "ok";
+              }
+            }
+            """)).hasMessageContaining("duplicate mapping");
+    }
+
+    @Test
+    public void testDuplicateDefaultFails() {
+        assertThatThrownBy(() -> compileClient(List.of(), """
+            @HttpClient
+            public interface TestClient {
+              @ResponseCodeMapper(code = ResponseCodeMapper.DEFAULT, mapper = TestMapper.class)
+              @ResponseCodeMapper(code = ResponseCodeMapper.DEFAULT, mapper = TestMapper.class)
+              @HttpRoute(method = "GET", path = "/test")
+              String test();
+            }
+            """, """
+            public class TestMapper implements HttpClientResponseMapper<String> {
+              public String apply(HttpClientResponse rs) {
+                  return "ok";
+              }
+            }
+            """)).hasMessageContaining("duplicate DEFAULT");
     }
 }

--- a/http/http-client-common/src/main/java/io/koraframework/http/client/common/annotation/ResponseCodeMapper.java
+++ b/http/http-client-common/src/main/java/io/koraframework/http/client/common/annotation/ResponseCodeMapper.java
@@ -45,6 +45,15 @@ public @interface ResponseCodeMapper {
      */
     int code();
 
+    /**
+     * @return <b>Русский</b>: Указывает верхнюю границу (включительно) диапазона HTTP статус кодов, для которых будет зарегистрирован обработчик.
+     * Если не указано (равно {@link #DEFAULT}), обработчик регистрируется только для {@link #code()}.
+     * <hr>
+     * <b>English</b>: Specifies the inclusive upper bound of the HTTP status code range for which to register the handler.
+     * When unset (equal to {@link #DEFAULT}), the handler is registered only for {@link #code()}.
+     */
+    int codeTo() default DEFAULT;
+
     Class<?> type() default Object.class;
 
     /**

--- a/http/http-client-symbol-processor/src/main/kotlin/io/koraframework/http/client/symbol/processor/ClientClassGenerator.kt
+++ b/http/http-client-symbol-processor/src/main/kotlin/io/koraframework/http/client/symbol/processor/ClientClassGenerator.kt
@@ -571,34 +571,41 @@ class ClientClassGenerator(private val resolver: Resolver) {
             b.add("val _code = _response.code()\n")
             b.controlFlow("return when (_code)") {
                 var defaultMapper: ResponseCodeMapperData? = null
+                val rangedMappers = ArrayList<ResponseCodeMapperData>()
                 methodData.codeMappers.forEach { codeMapper ->
-                    if (codeMapper.code == -1) {
+                    if (codeMapper.isDefault) {
                         defaultMapper = codeMapper
                     } else {
-                        val responseMapperName = method.simpleName.asString() + codeMapper.code.toString() + "ResponseMapper"
-                        if (codeMapper.assignable) {
-                            if (isNullableResult) {
-                                add("%L -> %L.apply(_response)", codeMapper.code, responseMapperName)
-                            } else {
-                                add("%L -> %L.apply(_response)!!", codeMapper.code, responseMapperName)
-                            }
-                        } else {
-                            add("%L -> throw %L.apply(_response)!!", codeMapper.code, responseMapperName)
-                        }
-                        b.add("\n")
+                        rangedMappers.add(codeMapper)
                     }
+                }
+                rangedMappers.sortBy { it.specificity }
+                rangedMappers.forEach { codeMapper ->
+                    val condition = if (codeMapper.isRange) "in ${codeMapper.code}..${codeMapper.codeTo}" else codeMapper.code.toString()
+                    val responseMapperName = codeMapper.mapperFieldName(method.simpleName.asString())
+                    if (codeMapper.assignable) {
+                        if (isNullableResult) {
+                            add("%L -> %L.apply(_response)", condition, responseMapperName)
+                        } else {
+                            add("%L -> %L.apply(_response)!!", condition, responseMapperName)
+                        }
+                    } else {
+                        add("%L -> throw %L.apply(_response)!!", condition, responseMapperName)
+                    }
+                    b.add("\n")
                 }
                 if (defaultMapper == null) {
                     add("else -> throw %T.fromResponse(_response)", httpClientResponseException)
                 } else {
+                    val responseMapperName = defaultMapper.mapperFieldName(method.simpleName.asString())
                     if (defaultMapper.assignable) {
                         if (isNullableResult) {
-                            add("else -> %L.apply(_response)", method.simpleName.asString() + "DefaultResponseMapper")
+                            add("else -> %L.apply(_response)", responseMapperName)
                         } else {
-                            add("else -> %L.apply(_response)!!", method.simpleName.asString() + "DefaultResponseMapper")
+                            add("else -> %L.apply(_response)!!", responseMapperName)
                         }
                     } else {
-                        add("else -> throw %L.apply(_response)!!", method.simpleName.asString() + "DefaultResponseMapper")
+                        add("else -> throw %L.apply(_response)!!", responseMapperName)
                     }
                     b.add("\n")
                 }
@@ -780,7 +787,7 @@ class ClientClassGenerator(private val resolver: Resolver) {
                 }
             } else {
                 for (codeMapper in methodData.codeMappers) {
-                    val responseMapperName = method.simpleName.asString() + (if (codeMapper.code > 0) codeMapper.code else "Default").toString() + "ResponseMapper"
+                    val responseMapperName = codeMapper.mapperFieldName(method.simpleName.asString())
                     val responseMapperType = codeMapper.responseMapperType(method.returnType!!.resolve())
                     addResponseMapper(responseMapperName, codeMapper.mapper, responseMapperType, methodData, tb, builder)
                 }
@@ -871,12 +878,19 @@ class ClientClassGenerator(private val resolver: Resolver) {
     }
 
     private fun parseMapperData(declaration: KSFunctionDeclaration): List<ResponseCodeMapperData> {
-        return declaration.findRepeatableAnnotation(responseCodeMapper, responseCodeMappers).map { mapper ->
+        val mappers = declaration.findRepeatableAnnotation(responseCodeMapper, responseCodeMappers).map { mapper ->
             val type = mapper.findValueNoDefault<KSType>("type")
             val mapperType = mapper.findValueNoDefault<KSType>("mapper")
             val code = mapper.findValueNoDefault<Int>("code")!!
+            val codeTo = mapper.findValueNoDefault<Int>("codeTo") ?: -1
+            if (codeTo != -1 && code == -1) {
+                throw ProcessingErrorException("@ResponseCodeMapper#codeTo can't be used with code = DEFAULT", declaration)
+            }
+            if (codeTo != -1 && codeTo < code) {
+                throw ProcessingErrorException("@ResponseCodeMapper#codeTo ($codeTo) must be greater than or equal to #code ($code)", declaration)
+            }
             if (type == null && mapperType == null) {
-                return@map ResponseCodeMapperData(code, null, null, true)
+                return@map ResponseCodeMapperData(code, codeTo, null, null, true)
             }
             val isAssignable = when {
                 type != null -> declaration.returnType!!.resolve().isAssignableFrom(type)
@@ -894,7 +908,36 @@ class ClientClassGenerator(private val resolver: Resolver) {
                 else -> throw IllegalStateException("Kora internal error: response code mapper has neither response type nor mapper type for ${declaration.simpleName.asString()}")
             }
 
-            ResponseCodeMapperData(code, type, mapperType, isAssignable)
+            ResponseCodeMapperData(code, codeTo, type, mapperType, isAssignable)
+        }
+        validateMapperRanges(declaration, mappers)
+        return mappers
+    }
+
+    private fun validateMapperRanges(declaration: KSFunctionDeclaration, mappers: List<ResponseCodeMapperData>) {
+        val defaults = mappers.count { it.isDefault }
+        if (defaults > 1) {
+            throw ProcessingErrorException("@ResponseCodeMapper duplicate DEFAULT mapping", declaration)
+        }
+        val ranged = mappers.filterNot { it.isDefault }
+        for (i in ranged.indices) {
+            for (j in (i + 1) until ranged.size) {
+                val a = ranged[i]
+                val b = ranged[j]
+                val aTo = if (a.isRange) a.codeTo else a.code
+                val bTo = if (b.isRange) b.codeTo else b.code
+                if (a.code > bTo || b.code > aTo) {
+                    continue
+                }
+                if (a.code == b.code && aTo == bTo) {
+                    throw ProcessingErrorException("@ResponseCodeMapper duplicate mapping for codes ${a.code}..$aTo", declaration)
+                }
+                val aContainsB = a.code <= b.code && bTo <= aTo
+                val bContainsA = b.code <= a.code && aTo <= bTo
+                if (!aContainsB && !bContainsA) {
+                    throw ProcessingErrorException("@ResponseCodeMapper ranges ${a.code}..$aTo and ${b.code}..$bTo partially overlap, ranges must be disjoint or nested", declaration)
+                }
+            }
         }
     }
 
@@ -908,7 +951,17 @@ class ClientClassGenerator(private val resolver: Resolver) {
         fun responseMapperType() = httpClientResponseMapper.parameterizedBy(returnType.toTypeName())
     }
 
-    data class ResponseCodeMapperData(val code: Int, val type: KSType?, val mapper: KSType?, val assignable: Boolean) {
+    data class ResponseCodeMapperData(val code: Int, val codeTo: Int, val type: KSType?, val mapper: KSType?, val assignable: Boolean) {
+        val isDefault get() = code == -1
+        val isRange get() = codeTo != -1
+        val specificity get() = if (isRange) codeTo - code else 0
+
+        fun mapperFieldName(methodName: String): String = when {
+            isDefault -> methodName + "DefaultResponseMapper"
+            isRange -> methodName + code.toString() + "To" + codeTo.toString() + "ResponseMapper"
+            else -> methodName + code.toString() + "ResponseMapper"
+        }
+
         fun responseMapperType(returnType: KSType): TypeName {
             if (type != null) {
                 val typeName = type.toTypeName().copy(nullable = false)

--- a/http/http-client-symbol-processor/src/test/kotlin/io/koraframework/http/client/symbol/processor/ResponseCodeMapperTest.kt
+++ b/http/http-client-symbol-processor/src/test/kotlin/io/koraframework/http/client/symbol/processor/ResponseCodeMapperTest.kt
@@ -1,6 +1,8 @@
 package io.koraframework.http.client.symbol.processor
 
 import io.koraframework.common.Either
+import io.koraframework.http.client.common.exception.HttpClientResponseException
+import io.koraframework.ksp.common.TestUtils
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
@@ -337,5 +339,315 @@ class ResponseCodeMapperTest : AbstractHttpClientTest() {
         onRequest("GET", "http://test-url:8080/test") { rs -> rs.withCode(500) }
         assertThat(client.invoke<Either<String, Throwable>>("test"))
             .isEqualTo(Either.left<String, Throwable>("default-string-from-mapper"))
+    }
+
+    @Test
+    fun testCodeRange() {
+        val client = compile(
+            listOf<Any>(), """
+            @HttpClient
+            interface TestClient {
+              @ResponseCodeMapper(code = 200, codeTo = 299, mapper = OkMapper::class)
+              @ResponseCodeMapper(code = 400, codeTo = 599, mapper = ErrorMapper::class)
+              @HttpRoute(method = "GET", path = "/test")
+              fun test(): String
+            }
+            """.trimIndent(), """
+            class OkMapper : HttpClientResponseMapper<String> {
+              override fun apply(rs: HttpClientResponse): String {
+                  return "ok"
+              }
+            }
+            """.trimIndent(), """
+            class ErrorMapper : HttpClientResponseMapper<String> {
+              override fun apply(rs: HttpClientResponse): String {
+                  return "error"
+              }
+            }
+            """.trimIndent()
+        )
+
+        for (code in listOf(200, 204, 299)) {
+            reset(httpClient)
+            onRequest("GET", "http://test-url:8080/test") { rs -> rs.withCode(code) }
+            assertThat(client.invoke<String>("test")).isEqualTo("ok")
+        }
+
+        for (code in listOf(400, 500, 599)) {
+            reset(httpClient)
+            onRequest("GET", "http://test-url:8080/test") { rs -> rs.withCode(code) }
+            assertThat(client.invoke<String>("test")).isEqualTo("error")
+        }
+
+        reset(httpClient)
+        onRequest("GET", "http://test-url:8080/test") { rs -> rs.withCode(300) }
+        assertThatThrownBy { client.invoke<String>("test") }.isInstanceOf(HttpClientResponseException::class.java)
+    }
+
+    @Test
+    fun testCodeRangeWithNestedExactCode() {
+        val client = compile(
+            listOf<Any>(), """
+            @HttpClient
+            interface TestClient {
+              @ResponseCodeMapper(code = 200, codeTo = 299, mapper = RangeMapper::class)
+              @ResponseCodeMapper(code = 201, mapper = ExactMapper::class)
+              @HttpRoute(method = "GET", path = "/test")
+              fun test(): String
+            }
+            """.trimIndent(), """
+            class RangeMapper : HttpClientResponseMapper<String> {
+              override fun apply(rs: HttpClientResponse): String {
+                  return "range"
+              }
+            }
+            """.trimIndent(), """
+            class ExactMapper : HttpClientResponseMapper<String> {
+              override fun apply(rs: HttpClientResponse): String {
+                  return "exact"
+              }
+            }
+            """.trimIndent()
+        )
+
+        reset(httpClient)
+        onRequest("GET", "http://test-url:8080/test") { rs -> rs.withCode(201) }
+        assertThat(client.invoke<String>("test")).isEqualTo("exact")
+
+        reset(httpClient)
+        onRequest("GET", "http://test-url:8080/test") { rs -> rs.withCode(200) }
+        assertThat(client.invoke<String>("test")).isEqualTo("range")
+
+        reset(httpClient)
+        onRequest("GET", "http://test-url:8080/test") { rs -> rs.withCode(202) }
+        assertThat(client.invoke<String>("test")).isEqualTo("range")
+    }
+
+    @Test
+    fun testCodeRangeWithDefault() {
+        val client = compile(
+            listOf<Any>(), """
+            @HttpClient
+            interface TestClient {
+              @ResponseCodeMapper(code = 200, codeTo = 299, mapper = OkMapper::class)
+              @ResponseCodeMapper(code = ResponseCodeMapper.DEFAULT, mapper = DefaultMapper::class)
+              @HttpRoute(method = "GET", path = "/test")
+              fun test(): String
+            }
+            """.trimIndent(), """
+            class OkMapper : HttpClientResponseMapper<String> {
+              override fun apply(rs: HttpClientResponse): String {
+                  return "ok"
+              }
+            }
+            """.trimIndent(), """
+            class DefaultMapper : HttpClientResponseMapper<String> {
+              override fun apply(rs: HttpClientResponse): String {
+                  return "default"
+              }
+            }
+            """.trimIndent()
+        )
+
+        reset(httpClient)
+        onRequest("GET", "http://test-url:8080/test") { rs -> rs.withCode(200) }
+        assertThat(client.invoke<String>("test")).isEqualTo("ok")
+
+        reset(httpClient)
+        onRequest("GET", "http://test-url:8080/test") { rs -> rs.withCode(404) }
+        assertThat(client.invoke<String>("test")).isEqualTo("default")
+    }
+
+    @Test
+    fun testCodeRangeWithExceptionMapper() {
+        val client = compile(
+            listOf<Any>(), """
+            @HttpClient
+            interface TestClient {
+              @ResponseCodeMapper(code = 200, codeTo = 299, mapper = OkMapper::class)
+              @ResponseCodeMapper(code = 400, codeTo = 599, mapper = ExceptionMapper::class)
+              @HttpRoute(method = "GET", path = "/test")
+              fun test(): String
+            }
+            """.trimIndent(), """
+            class OkMapper : HttpClientResponseMapper<String> {
+              override fun apply(rs: HttpClientResponse): String {
+                  return "ok"
+              }
+            }
+            """.trimIndent(), """
+            class ExceptionMapper : HttpClientResponseMapper<Exception> {
+              override fun apply(rs: HttpClientResponse): Exception {
+                  return RuntimeException("range-error")
+              }
+            }
+            """.trimIndent()
+        )
+
+        reset(httpClient)
+        onRequest("GET", "http://test-url:8080/test") { rs -> rs.withCode(500) }
+        assertThatThrownBy { client.invoke<String>("test") }
+            .isExactlyInstanceOf(RuntimeException::class.java)
+            .hasMessage("range-error")
+    }
+
+    @Test
+    fun testCodeRangeVoid() {
+        val client = compile(
+            listOf<Any>(), """
+            @HttpClient
+            interface TestClient {
+              @ResponseCodeMapper(code = 200, codeTo = 299, mapper = OkMapper::class)
+              @HttpRoute(method = "GET", path = "/test")
+              fun test(): Unit
+            }
+            """.trimIndent(), """
+            class OkMapper : HttpClientResponseMapper<Unit> {
+              override fun apply(rs: HttpClientResponse) {
+              }
+            }
+            """.trimIndent()
+        )
+
+        reset(httpClient)
+        onRequest("GET", "http://test-url:8080/test") { rs -> rs.withCode(204) }
+        client.invoke<Unit>("test")
+    }
+
+    @Test
+    fun testCodeRangeInjectedMapper() {
+        val client = compile(
+            listOf<Any>(newGenerated("RangeMapper")), """
+            @HttpClient
+            interface TestClient {
+              @ResponseCodeMapper(code = 200, codeTo = 299, mapper = RangeMapper::class)
+              @HttpRoute(method = "GET", path = "/test")
+              fun test(): String
+            }
+            """.trimIndent(), """
+            open class RangeMapper : HttpClientResponseMapper<String> {
+              override fun apply(rs: HttpClientResponse): String {
+                  return "injected"
+              }
+            }
+            """.trimIndent()
+        )
+
+        reset(httpClient)
+        onRequest("GET", "http://test-url:8080/test") { rs -> rs.withCode(250) }
+        assertThat(client.invoke<String>("test")).isEqualTo("injected")
+    }
+
+    @Test
+    fun testCodeToLessThanCodeFails() {
+        compile0(
+            listOf(HttpClientSymbolProcessorProvider()), """
+            @HttpClient
+            interface TestClient {
+              @ResponseCodeMapper(code = 299, codeTo = 200, mapper = TestMapper::class)
+              @HttpRoute(method = "GET", path = "/test")
+              fun test(): String
+            }
+            """.trimIndent(), """
+            class TestMapper : HttpClientResponseMapper<String> {
+              override fun apply(rs: HttpClientResponse): String {
+                  return "ok"
+              }
+            }
+            """.trimIndent()
+        )
+        val failure = compileResult as TestUtils.ProcessingResult.Failure
+        assertThat(failure.messages.joinToString("\n")).contains("codeTo")
+    }
+
+    @Test
+    fun testCodeToWithDefaultCodeFails() {
+        compile0(
+            listOf(HttpClientSymbolProcessorProvider()), """
+            @HttpClient
+            interface TestClient {
+              @ResponseCodeMapper(code = ResponseCodeMapper.DEFAULT, codeTo = 299, mapper = TestMapper::class)
+              @HttpRoute(method = "GET", path = "/test")
+              fun test(): String
+            }
+            """.trimIndent(), """
+            class TestMapper : HttpClientResponseMapper<String> {
+              override fun apply(rs: HttpClientResponse): String {
+                  return "ok"
+              }
+            }
+            """.trimIndent()
+        )
+        val failure = compileResult as TestUtils.ProcessingResult.Failure
+        assertThat(failure.messages.joinToString("\n")).contains("codeTo")
+    }
+
+    @Test
+    fun testPartialOverlapFails() {
+        compile0(
+            listOf(HttpClientSymbolProcessorProvider()), """
+            @HttpClient
+            interface TestClient {
+              @ResponseCodeMapper(code = 200, codeTo = 299, mapper = TestMapper::class)
+              @ResponseCodeMapper(code = 250, codeTo = 350, mapper = TestMapper::class)
+              @HttpRoute(method = "GET", path = "/test")
+              fun test(): String
+            }
+            """.trimIndent(), """
+            class TestMapper : HttpClientResponseMapper<String> {
+              override fun apply(rs: HttpClientResponse): String {
+                  return "ok"
+              }
+            }
+            """.trimIndent()
+        )
+        val failure = compileResult as TestUtils.ProcessingResult.Failure
+        assertThat(failure.messages.joinToString("\n")).contains("partially overlap")
+    }
+
+    @Test
+    fun testDuplicateExactCodeFails() {
+        compile0(
+            listOf(HttpClientSymbolProcessorProvider()), """
+            @HttpClient
+            interface TestClient {
+              @ResponseCodeMapper(code = 200, mapper = TestMapper::class)
+              @ResponseCodeMapper(code = 200, mapper = TestMapper::class)
+              @HttpRoute(method = "GET", path = "/test")
+              fun test(): String
+            }
+            """.trimIndent(), """
+            class TestMapper : HttpClientResponseMapper<String> {
+              override fun apply(rs: HttpClientResponse): String {
+                  return "ok"
+              }
+            }
+            """.trimIndent()
+        )
+        val failure = compileResult as TestUtils.ProcessingResult.Failure
+        assertThat(failure.messages.joinToString("\n")).contains("duplicate mapping")
+    }
+
+    @Test
+    fun testDuplicateDefaultFails() {
+        compile0(
+            listOf(HttpClientSymbolProcessorProvider()), """
+            @HttpClient
+            interface TestClient {
+              @ResponseCodeMapper(code = ResponseCodeMapper.DEFAULT, mapper = TestMapper::class)
+              @ResponseCodeMapper(code = ResponseCodeMapper.DEFAULT, mapper = TestMapper::class)
+              @HttpRoute(method = "GET", path = "/test")
+              fun test(): String
+            }
+            """.trimIndent(), """
+            class TestMapper : HttpClientResponseMapper<String> {
+              override fun apply(rs: HttpClientResponse): String {
+                  return "ok"
+              }
+            }
+            """.trimIndent()
+        )
+        val failure = compileResult as TestUtils.ProcessingResult.Failure
+        assertThat(failure.messages.joinToString("\n")).contains("duplicate DEFAULT")
     }
 }


### PR DESCRIPTION
Added `@ResponseCodeMapper` status code ranges with `codeTo`, exact-code precedence over overlapping ranges, and compile-time overlap validation

**Description:**

## EN

### Description

Added an optional `codeTo()` member to `@ResponseCodeMapper` so a single mapper can be registered for an inclusive HTTP status code range (e.g. `code = 400, codeTo = 499`) instead of repeating the annotation once per status code. When a range and an exact `code` on the same method both match a response, the exact `code` takes precedence; nested ranges are allowed but partially overlapping ranges and duplicate `DEFAULT` mappings are rejected at compile time. Existing single-code usages compile and behave identically.

### Intention & Motivation

Real HTTP APIs are usually described in status bands (2xx success, 4xx client error, 5xx server error), and repeating `@ResponseCodeMapper` per status code or collapsing everything into `DEFAULT` was the only option before this change.

---

## RU

### Описание

В `@ResponseCodeMapper` добавлен необязательный параметр `codeTo()`, позволяющий зарегистрировать один обработчик для включительного диапазона HTTP статус кодов (например, `code = 400, codeTo = 499`) вместо повторения аннотации для каждого кода отдельно. Если на одном методе диапазон и точный `code` одновременно соответствуют ответу, приоритет отдаётся точному `code`; вложенные диапазоны допустимы, а частично пересекающиеся диапазоны и повторное объявление `DEFAULT` отклоняются на этапе компиляции. Существующее использование с одиночными кодами компилируется и работает без изменений.

### Намерение и мотивация

Реальные HTTP API обычно описываются диапазонами статусов (2xx успех, 4xx ошибка клиента, 5xx ошибка сервера), а до этого изменения единственными вариантами были повторение `@ResponseCodeMapper` для каждого кода или сведение всего к `DEFAULT`.

---

## Changelog

- Added `codeTo()` to `@ResponseCodeMapper` for inclusive HTTP status code ranges, with exact-code precedence over an overlapping range on the same method.
- Added compile-time validation (Java annotation processor and Kotlin KSP processor) rejecting `codeTo < code`, `codeTo` combined with `code = DEFAULT`, partially overlapping ranges, duplicate exact-code mappings, and duplicate `DEFAULT` mappings.

---

## Design

`ResponseCodeMapperData` (Java: `ClientClassGenerator.java`; Kotlin: `ClientClassGenerator.kt`) now carries `codeTo` alongside `code`. Specificity is `codeTo - code` (`0` for an exact code), and mappers are emitted narrowest-first so an exact code inside a range always wins; `DEFAULT` remains the terminal fallback branch.

The Java generator's dispatch changed from a `switch (_code) { case N -> ... }` to a sorted if/else chain, since `switch` cannot express ranges:

```java
var _code = _response.code();
if (_code == 404) {
  throw this.getUser404ResponseMapper.apply(_response);
} else if (_code >= 200 && _code <= 299) {
  return this.getUser200To299ResponseMapper.apply(_response);
} else {
  throw HttpClientResponseException.fromResponse(_response);
}
```

The Kotlin generator keeps its `when (_code)` structure, since `when` branches already support `in a..b`; `when` is first-match, so the same narrowest-first ordering gives identical precedence to the Java side.

Generated mapper field/constructor-parameter names now follow one shared rule in both generators: `DEFAULT` → `<method>DefaultResponseMapper`, exact code → `<method><code>ResponseMapper` (unchanged), range → `<method><code>To<codeTo>ResponseMapper`. This also fixes a latent naming mismatch where `code = 0` previously declared a `...DefaultResponseMapper` field but dispatched against `...0ResponseMapper`.

```java
@ResponseCodeMapper(code = 200, codeTo = 299, mapper = OkMapper.class)
@ResponseCodeMapper(code = 400, codeTo = 499, type = ClientError.class)
@ResponseCodeMapper(code = 500, codeTo = 599, type = ServerError.class)
@HttpRoute(method = HttpMethod.GET, path = "/users/{id}")
User getUser(@Path String id);
```

`codeTo` defaults to `ResponseCodeMapper.DEFAULT` (unset, meaning "single code" — unchanged behavior) and is validated once per method in `parseMapperData`/`validateMapperRanges`: `codeTo` cannot be combined with `code = DEFAULT`, `codeTo` must be `>= code`, two mappers cannot declare the identical `(code, codeTo)` pair or overlap without one fully containing the other, and at most one `DEFAULT` mapper is allowed per method. All other resolution — DI wiring by `HttpClientResponseMapper<T>` type shape plus method-level `@Tag`, the OpenAPI generator's per-response-code annotations, and the `@Mapping`-only dispatch path — is unchanged.