### PR TITLE
fix(test-junit5): inject the component itself when it also wraps a value

### DIFF
--- a/test/test-junit5/src/main/java/io/koraframework/test/extension/junit5/KoraJUnit5Extension.java
+++ b/test/test-junit5/src/main/java/io/koraframework/test/extension/junit5/KoraJUnit5Extension.java
@@ -799,7 +799,9 @@ final class KoraJUnit5Extension implements BeforeAllCallback, BeforeEachCallback
             var object = graph.initializedGraph().get(node);
             boolean isNodeWrapped = GraphUtils.isWrapped(node.type());
             boolean isCandidateWrapped = GraphUtils.isWrapped(candidate.type());
-            if (isNodeWrapped && !isCandidateWrapped && object instanceof Wrapped<?> w) {
+            // a component can wrap a value and implement the requested contract itself, the way JdbcDataSource and
+            // CassandraSession do, and then the component is what was asked for, not the value it wraps
+            if (isNodeWrapped && !isCandidateWrapped && object instanceof Wrapped<?> w && !isInstanceOfCandidate(object, candidate.type())) {
                 return w.value();
             } else {
                 return object;
@@ -810,6 +812,11 @@ final class KoraJUnit5Extension implements BeforeAllCallback, BeforeEachCallback
         }
 
         throw new ExtensionConfigurationException(candidate + " wasn't found in graph, please check @KoraAppTest configuration");
+    }
+
+    private static boolean isInstanceOfCandidate(Object object, Type candidateType) {
+        var candidateFlat = GraphUtils.getTypeFlat(candidateType);
+        return !candidateFlat.isEmpty() && candidateFlat.get(0).isInstance(object);
     }
 
     private static boolean isCandidate(AnnotatedElement element) {

--- a/test/test-junit5/src/test/java/io/koraframework/test/extension/junit5/inject/InjectSelfWrappedComponentTests.java
+++ b/test/test-junit5/src/test/java/io/koraframework/test/extension/junit5/inject/InjectSelfWrappedComponentTests.java
@@ -1,0 +1,39 @@
+package io.koraframework.test.extension.junit5.inject;
+
+import io.koraframework.test.extension.junit5.KoraAppTest;
+import io.koraframework.test.extension.junit5.TestComponent;
+import io.koraframework.test.extension.junit5.testdata.TestApplication;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * A component can be a {@code Wrapped<X>} and implement a contract of its own at the same time, the way
+ * {@code JdbcDataSource}, {@code CassandraSession} and {@code MongoDataSource} do. Asking for that contract must hand
+ * out the component itself, not the value it wraps.
+ */
+@KoraAppTest(TestApplication.class)
+public class InjectSelfWrappedComponentTests {
+
+    @TestComponent
+    private TestApplication.ComplexOther fieldInjected;
+
+    @Test
+    void testFieldInjectionPrefersTheComponentOverItsWrappedValue() {
+        assertNotNull(this.fieldInjected);
+        assertEquals("1", this.fieldInjected.other());
+    }
+
+    @Test
+    void testParameterInjectionPrefersTheComponentOverItsWrappedValue(@TestComponent TestApplication.ComplexOther other) {
+        assertNotNull(other);
+        assertEquals("1", other.other());
+    }
+
+    @Test
+    void testWrappedValueIsStillAvailableByItsOwnType(@TestComponent TestApplication.ComplexWrapped wrapped) {
+        assertNotNull(wrapped);
+        assertEquals("1", wrapped.wrapped());
+    }
+}


### PR DESCRIPTION
### Problem

A graph node can implement `Wrapped<X>` and the contract being asked for at the same time. All three database modules do exactly that:

- `JdbcDataSource implements Lifecycle, Wrapped<DataSource>, JdbcExecutor`
- `CassandraSession implements CassandraExecutor, Wrapped<CqlSession>, Lifecycle`
- `ComplexHolder implements Wrapped<ComplexWrapped>, Lifecycle, ComplexOther` (existing test data)

`KoraJUnit5Extension.getComponentFromGraph` unwrapped such a node whenever the *requested* type was not itself `Wrapped`, so asking for the contract handed out the wrapped value instead of the component:

```
ExtensionConfigurationException: Failed to inject field 'executor' due to:
Can not set ...JdbcExecutor field ... to com.zaxxer.hikari.HikariDataSource
```

So `@TestComponent JdbcExecutor` / `CassandraExecutor` cannot be injected today. Production DI is unaffected — this is only the JUnit 5 extension.

### Fix

Unwrap only when the component is not already an instance of the requested type. When it is, the component is what was asked for.

### Tests

`InjectSelfWrappedComponentTests` covers field injection, parameter injection, and that the wrapped value is still reachable by its own type. All three fail on `master` and pass with the fix; the full `test-junit5` suite (263 tests) stays green.