### PR TITLE
fix(http-server-undertow): apply the socket timeouts and keep-alive to accepted connections

### DIFF
--- a/http/http-server-common/src/testFixtures/java/io/koraframework/http/server/common/HttpServerTestKit.java
+++ b/http/http-server-common/src/testFixtures/java/io/koraframework/http/server/common/HttpServerTestKit.java
@@ -44,6 +44,9 @@ import org.mockito.verification.VerificationMode;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketTimeoutException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -63,6 +66,8 @@ import static org.mockito.Mockito.*;
 
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)
 public abstract class HttpServerTestKit {
+    private static final Duration SOCKET_TIMEOUT = Duration.ofSeconds(1);
+
     protected static MetricsScraper registry = Mockito.mock(MetricsScraper.class);
     private final ReadinessProbe readinessProbe = Mockito.mock(ReadinessProbe.class);
     private final SettablePromiseOf<ReadinessProbe> readinessProbePromise = new SettablePromiseOf<>(readinessProbe);
@@ -751,6 +756,45 @@ public abstract class HttpServerTestKit {
     }
 
     @Test
+    void testSocketReadTimeoutOnUnfinishedRequestBody() throws Exception {
+        var bodyReadStarted = new CountDownLatch(1);
+        var handler = handler(POST, "/", (request) -> {
+            try (var body = request.body(); var is = body.asInputStream()) {
+                bodyReadStarted.countDown();
+                is.readAllBytes();
+                return HttpServerResponse.of(200);
+            }
+        });
+        this.startServer(handler);
+
+        var awaitTimeout = SOCKET_TIMEOUT.multipliedBy(10);
+        try (var socket = new Socket()) {
+            socket.connect(new InetSocketAddress("localhost", this.httpServer.port()), (int) awaitTimeout.toMillis());
+            socket.setSoTimeout((int) awaitTimeout.toMillis());
+            var out = socket.getOutputStream();
+            out.write("POST / HTTP/1.1\r\nHost: localhost\r\nContent-Length: 16\r\n\r\n".getBytes(StandardCharsets.US_ASCII));
+            out.flush();
+
+            assertThat(bodyReadStarted.await(awaitTimeout.toMillis(), TimeUnit.MILLISECONDS))
+                .as("server should have routed the request and started reading the announced body")
+                .isTrue();
+
+            var start = now();
+            var in = socket.getInputStream();
+            try {
+                while (in.read() != -1) {
+                    // the server may still flush an error response before dropping the connection
+                }
+            } catch (SocketTimeoutException e) {
+                fail("server kept the connection with an unfinished request body open for %s, socketReadTimeout %s was not applied to it"
+                    .formatted(Duration.between(start, now()), SOCKET_TIMEOUT));
+            } catch (IOException e) {
+                // a connection reset means the server dropped the connection as well
+            }
+        }
+    }
+
+    @Test
     void testRequestBody() throws IOException {
         var httpResponse = HttpServerResponse.of(200, HttpBody.plaintext("hello world"));
         var executor = Executors.newSingleThreadExecutor();
@@ -968,8 +1012,8 @@ public abstract class HttpServerTestKit {
         var config = new HttpServerConfig_Impl(
             0,
             ignoreTrailingSlash,
-            Duration.ofSeconds(1),
-            Duration.ofSeconds(1),
+            SOCKET_TIMEOUT,
+            SOCKET_TIMEOUT,
             false,
             false,
             true,

--- a/http/http-server-undertow/src/main/java/io/koraframework/http/server/undertow/UndertowHttpServer.java
+++ b/http/http-server-undertow/src/main/java/io/koraframework/http/server/undertow/UndertowHttpServer.java
@@ -104,9 +104,9 @@ public class UndertowHttpServer implements HttpServer, ReadinessProbe {
             .setHandler(this.gracefulShutdown)
             .addHttpListener(config.port(), "0.0.0.0")
             .setWorker(this.xnioWorker)
-            .setServerOption(Options.READ_TIMEOUT, ((int) config.socketReadTimeout().toMillis()))
-            .setServerOption(Options.WRITE_TIMEOUT, ((int) config.socketWriteTimeout().toMillis()))
-            .setServerOption(Options.KEEP_ALIVE, config.socketKeepAliveEnabled())
+            .setSocketOption(Options.READ_TIMEOUT, ((int) config.socketReadTimeout().toMillis()))
+            .setSocketOption(Options.WRITE_TIMEOUT, ((int) config.socketWriteTimeout().toMillis()))
+            .setSocketOption(Options.KEEP_ALIVE, config.socketKeepAliveEnabled())
             .setServerOption(UndertowOptions.ALWAYS_SET_KEEP_ALIVE, config.headerKeepAliveEnabled())
             .setServerOption(UndertowOptions.ALWAYS_SET_DATE, config.headerServerDateEnabled())
             .setServerOption(UndertowOptions.MAX_ENTITY_SIZE, config.maxRequestBodySize().toBytes());


### PR DESCRIPTION
## Problem

`httpServer.socketReadTimeout` (and `socketWriteTimeout`, `socketKeepAliveEnabled`) currently have no effect.

`UndertowHttpServer#createServer` passes them through `Undertow.Builder#setServerOption`:

```java
.setServerOption(Options.READ_TIMEOUT, ((int) config.socketReadTimeout().toMillis()))
.setServerOption(Options.WRITE_TIMEOUT, ((int) config.socketWriteTimeout().toMillis()))
.setServerOption(Options.KEEP_ALIVE, config.socketKeepAliveEnabled())
```

All three are XNIO options of an *accepted connection*, not of the listener:

* `setServerOption` stores into `serverOptions`, which is handed to the protocol open listener; `setSocketOption` stores into `socketOptions`, and only that map reaches `worker.createStreamConnectionServer`.
* `NioTcpServer#accept` copies `READ_TIMEOUT` / `WRITE_TIMEOUT` onto every accepted connection, and applies `KEEP_ALIVE` to the accepted socket via `socket.setKeepAlive(...)`.
* `HttpOpenListener` then reads the timeouts back off the connection (`channel.getOption(Options.READ_TIMEOUT)`) and installs `ReadTimeoutStreamSourceConduit` / `WriteTimeoutStreamSinkConduit` only when the value is greater than zero.

Since the values never reach a connection, the conduits are never installed. `Options.KEEP_ALIVE` is not read as a server option anywhere in undertow-core, so it is inert as well.

## Impact

A client that opens a connection, announces a `Content-Length` and never sends the body parks a blocking worker thread forever — no configured timeout can release it. With `blockingThreads` bounded (`min(max(cores, 2) * 8, 200)`), a modest number of such connections exhausts the pool.

This was found in production code that reads form bodies from a blocking handler: with `socketReadTimeout = 1s` the connection still sat idle for the full 20s of the test.

Note that this is distinct from `UndertowOptions.NO_REQUEST_TIMEOUT` (60s by default), which covers an *idle* connection between requests — it does not fire once request headers have been parsed and the body is awaited.

## Fix

Move the three connection options to `setSocketOption`. The neighbouring `UndertowOptions.*` entries are genuine server options and are left untouched.

## Test

`HttpServerTestKit#testSocketReadTimeoutOnUnfinishedRequestBody` opens a socket, sends request headers with a `Content-Length`, never sends the body, and asserts that the server closes the connection at roughly `socketReadTimeout`.

Before the fix it fails:

```
server kept the connection open for PT10.001315S, socketReadTimeout PT1S was not applied
```

After the fix it passes in ~1.0s, stable across repeated runs. The full build of the affected modules is green (373 tests).

## Compatibility

The default is `Duration.ZERO`, so services that never configured these values are unaffected. Services that *did* configure a non-zero `socketReadTimeout` / `socketWriteTimeout` will see it enforced for the first time — that is the intended fix, but it is a behaviour change worth a release note.
