### PR TITLE
Fixed OpenAPI security tags with scheme-based names for Java and Kotlin clients and servers

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 guava = "33.6.0-jre"
 jetbrains-annotations = "26.1.0"
 slf4j = "2.0.18"
-logback = "1.6.1"
+logback = "1.6.2"
 
 # Kotlin and code generation
 kotlin-stdlib = "2.4.10" # Visit https://kotlinlang.org/docs/releases.html#release-details to see versions compatability
@@ -52,7 +52,7 @@ jakarta-xml-bind = "4.0.5"
 
 # BPM
 camunda7 = "7.24.0"
-zeebe = "8.9.14"
+zeebe = "8.9.15"
 
 # Tests
 junit = "6.1.3"
@@ -169,7 +169,7 @@ byte-buddy-core = { module = "net.bytebuddy:byte-buddy", version.ref = "byte-bud
 byte-buddy-agent = { module = "net.bytebuddy:byte-buddy-agent", version.ref = "byte-buddy" }
 
 javapoet = { module = "com.palantir.javapoet:javapoet", version = "0.18.0" }
-classgraph = { module = "io.github.classgraph:classgraph", version = "4.8.189" }
+classgraph = { module = "io.github.classgraph:classgraph", version = "4.8.190" }
 
 lettuce-core = { module = "io.lettuce:lettuce-core", version = "6.8.0.RELEASE" }
 apache-pool = { module = "org.apache.commons:commons-pool2", version = "2.13.1" }
@@ -249,7 +249,7 @@ cxf-rt-transports-http-jetty = { module = "org.apache.cxf:cxf-rt-transports-http
 cxf-rt-frontend-jaxws = { module = "org.apache.cxf:cxf-rt-frontend-jaxws", version.ref = "cxf" }
 
 s3client-minio = { module = "io.minio:minio", version = "9.0.3" }
-s3client-aws = { module = "software.amazon.awssdk:s3", version = "2.51.4" }
+s3client-aws = { module = "software.amazon.awssdk:s3", version = "2.52.0" }
 
 camunda7-engine = { module = "org.camunda.bpm:camunda-engine", version.ref = "camunda7" }
 camunda7-rest-jakarta = { module = "org.camunda.bpm:camunda-engine-rest-jakarta", version.ref = "camunda7" }

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/KoraCodegen.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/KoraCodegen.java
@@ -1403,7 +1403,7 @@ public class KoraCodegen extends DefaultCodegen {
         if (openAPI == null) {
             return;
         }
-        security.fromOpenapi(openAPI, params.useSecurityDeclarationOrder);
+        security.fromOpenapi(openAPI, params.useSecurityDeclarationOrder, name -> upperCase(toVarName(name)));
         var securitySchemas = openAPI.getComponents().getSecuritySchemes();
         if (params.codegenMode.isJava()) {
             var modelPackage = modelFileFolder() + File.separator + "package-info.java";

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/SecurityData.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/SecurityData.java
@@ -47,9 +47,33 @@ public class SecurityData {
                 }
             }
         }
+        var requirementsByBaseTag = new LinkedHashMap<String, List<Set<Map<String, Set<String>>>>>();
         for (var requirement : securityRequirementByOperation.values()) {
-            if (hasNonAnonymousRequirements(requirement)) {
-                interceptorTagBySecurityRequirement.putIfAbsent(requirement, "OperationSecuritySchemaTag" + interceptorTagBySecurityRequirement.size());
+            if (hasNonAnonymousRequirements(requirement)
+                && requirementsByBaseTag.values().stream().flatMap(Collection::stream).noneMatch(requirement::equals)) {
+                requirementsByBaseTag.computeIfAbsent(operationSecurityTag(requirement), _ -> new ArrayList<>()).add(requirement);
+            }
+        }
+        for (var entry : requirementsByBaseTag.entrySet()) {
+            var baseTag = entry.getKey();
+            var requirements = entry.getValue();
+            if (requirements.size() == 1) {
+                interceptorTagBySecurityRequirement.put(requirements.getFirst(), baseTag);
+                continue;
+            }
+            var tags = new LinkedHashMap<Set<Map<String, Set<String>>>, String>();
+            for (var requirement : requirements) {
+                tags.put(requirement, baseTag + "_" + operationSecurityScopesTag(requirement, securityTagNameMapper, false));
+            }
+            var duplicateTags = tags.values().stream()
+                .filter(tag -> Collections.frequency(tags.values(), tag) > 1)
+                .collect(java.util.stream.Collectors.toSet());
+            for (var requirement : requirements) {
+                var tag = tags.get(requirement);
+                if (duplicateTags.contains(tag)) {
+                    tag = baseTag + "_" + operationSecurityScopesTag(requirement, securityTagNameMapper, true);
+                }
+                interceptorTagBySecurityRequirement.put(requirement, tag);
             }
         }
         for (var securitySchema : securityRequirementByOperation.values()) {
@@ -67,6 +91,32 @@ public class SecurityData {
 
     public String tagForSecurityScheme(String securitySchemeName) {
         return tagBySecuritySchemeName.getOrDefault(securitySchemeName, securitySchemeName);
+    }
+
+    private String operationSecurityTag(Set<Map<String, Set<String>>> requirements) {
+        return requirements.stream()
+            .map(requirement -> requirement.isEmpty()
+                ? "Anonymous"
+                : requirement.keySet().stream()
+                    .map(this::tagForSecurityScheme)
+                    .collect(java.util.stream.Collectors.joining("And")))
+            .distinct()
+            .collect(java.util.stream.Collectors.joining("_"));
+    }
+
+    private String operationSecurityScopesTag(Set<Map<String, Set<String>>> requirements, UnaryOperator<String> securityTagNameMapper, boolean includeSchemeNames) {
+        var scopedEntries = requirements.stream()
+            .flatMap(requirement -> requirement.entrySet().stream())
+            .filter(entry -> !entry.getValue().isEmpty())
+            .toList();
+        if (scopedEntries.isEmpty()) {
+            return "NoScopes";
+        }
+        return scopedEntries.stream()
+            .map(entry -> (includeSchemeNames ? tagForSecurityScheme(entry.getKey()) : "") + entry.getValue().stream()
+                .map(securityTagNameMapper)
+                .collect(java.util.stream.Collectors.joining("And")))
+            .collect(java.util.stream.Collectors.joining("_"));
     }
 
     public static boolean hasNonAnonymousRequirements(Set<? extends Map<String, ? extends Set<String>>> requirements) {

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/SecurityData.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/SecurityData.java
@@ -15,11 +15,13 @@ public class SecurityData {
 
     public Map<Set<String>, String> principalExtractorTagBySecurityRequirementNames = new LinkedHashMap<>();
     public Map<String, String> tagBySecuritySchemeName = new LinkedHashMap<>();
+    public Map<String, String> tagBySecurityScopeName = new LinkedHashMap<>();
 
     public void fromOpenapi(OpenAPI openAPI, boolean useSecurityDeclarationOrder, UnaryOperator<String> securityTagNameMapper) {
         if (openAPI.getComponents() != null && openAPI.getComponents().getSecuritySchemes() != null) {
+            var usedTags = new LinkedHashSet<String>();
             for (var securitySchemeName : openAPI.getComponents().getSecuritySchemes().keySet()) {
-                tagBySecuritySchemeName.put(securitySchemeName, securityTagNameMapper.apply(securitySchemeName));
+                tagBySecuritySchemeName.put(securitySchemeName, uniqueTagName(securitySchemeName, securityTagNameMapper, usedTags));
             }
         }
         if (openAPI.getPaths() != null) {
@@ -47,6 +49,16 @@ public class SecurityData {
                 }
             }
         }
+        var usedScopeTags = new LinkedHashSet<String>();
+        for (var requirements : securityRequirementByOperation.values()) {
+            for (var requirement : requirements) {
+                for (var scopes : requirement.values()) {
+                    for (var scope : scopes) {
+                        tagBySecurityScopeName.computeIfAbsent(scope, name -> uniqueTagName(name, securityTagNameMapper, usedScopeTags));
+                    }
+                }
+            }
+        }
         var requirementsByBaseTag = new LinkedHashMap<String, List<Set<Map<String, Set<String>>>>>();
         for (var requirement : securityRequirementByOperation.values()) {
             if (hasNonAnonymousRequirements(requirement)
@@ -54,16 +66,17 @@ public class SecurityData {
                 requirementsByBaseTag.computeIfAbsent(operationSecurityTag(requirement), _ -> new ArrayList<>()).add(requirement);
             }
         }
+        var usedOperationTags = new LinkedHashSet<String>();
         for (var entry : requirementsByBaseTag.entrySet()) {
             var baseTag = entry.getKey();
             var requirements = entry.getValue();
             if (requirements.size() == 1) {
-                interceptorTagBySecurityRequirement.put(requirements.getFirst(), baseTag);
+                interceptorTagBySecurityRequirement.put(requirements.getFirst(), uniqueTag(baseTag, usedOperationTags));
                 continue;
             }
             var tags = new LinkedHashMap<Set<Map<String, Set<String>>>, String>();
             for (var requirement : requirements) {
-                tags.put(requirement, baseTag + "_" + operationSecurityScopesTag(requirement, securityTagNameMapper, false));
+                tags.put(requirement, baseTag + "_" + operationSecurityScopesTag(requirement, false));
             }
             var duplicateTags = tags.values().stream()
                 .filter(tag -> Collections.frequency(tags.values(), tag) > 1)
@@ -71,9 +84,9 @@ public class SecurityData {
             for (var requirement : requirements) {
                 var tag = tags.get(requirement);
                 if (duplicateTags.contains(tag)) {
-                    tag = baseTag + "_" + operationSecurityScopesTag(requirement, securityTagNameMapper, true);
+                    tag = baseTag + "_" + operationSecurityScopesTag(requirement, true);
                 }
-                interceptorTagBySecurityRequirement.put(requirement, tag);
+                interceptorTagBySecurityRequirement.put(requirement, uniqueTag(tag, usedOperationTags));
             }
         }
         for (var securitySchema : securityRequirementByOperation.values()) {
@@ -104,7 +117,7 @@ public class SecurityData {
             .collect(java.util.stream.Collectors.joining("_"));
     }
 
-    private String operationSecurityScopesTag(Set<Map<String, Set<String>>> requirements, UnaryOperator<String> securityTagNameMapper, boolean includeSchemeNames) {
+    private String operationSecurityScopesTag(Set<Map<String, Set<String>>> requirements, boolean includeSchemeNames) {
         var scopedEntries = requirements.stream()
             .flatMap(requirement -> requirement.entrySet().stream())
             .filter(entry -> !entry.getValue().isEmpty())
@@ -114,9 +127,36 @@ public class SecurityData {
         }
         return scopedEntries.stream()
             .map(entry -> (includeSchemeNames ? tagForSecurityScheme(entry.getKey()) : "") + entry.getValue().stream()
-                .map(securityTagNameMapper)
+                .map(tagBySecurityScopeName::get)
                 .collect(java.util.stream.Collectors.joining("And")))
             .collect(java.util.stream.Collectors.joining("_"));
+    }
+
+    private static String uniqueTagName(String sourceName, UnaryOperator<String> securityTagNameMapper, Set<String> usedTags) {
+        var tag = securityTagNameMapper.apply(sourceName);
+        if (usedTags.add(tag)) {
+            return tag;
+        }
+        var separatedTag = Arrays.stream(sourceName.split("[^\\p{L}\\p{N}]+"))
+            .filter(part -> !part.isEmpty())
+            .map(securityTagNameMapper)
+            .collect(java.util.stream.Collectors.joining("_"));
+        if (separatedTag.isEmpty()) {
+            separatedTag = tag;
+        }
+        var candidate = separatedTag;
+        for (var suffix = 2; !usedTags.add(candidate); suffix++) {
+            candidate = separatedTag + suffix;
+        }
+        return candidate;
+    }
+
+    private static String uniqueTag(String tag, Set<String> usedTags) {
+        var candidate = tag;
+        for (var suffix = 2; !usedTags.add(candidate); suffix++) {
+            candidate = tag + suffix;
+        }
+        return candidate;
     }
 
     public static boolean hasNonAnonymousRequirements(Set<? extends Map<String, ? extends Set<String>>> requirements) {

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/SecurityData.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/SecurityData.java
@@ -14,8 +14,14 @@ public class SecurityData {
     public Map<String, Set<Map<String, Set<String>>>> securityRequirementByOperation = new LinkedHashMap<>();
 
     public Map<Set<String>, String> principalExtractorTagBySecurityRequirementNames = new LinkedHashMap<>();
+    public Map<String, String> tagBySecuritySchemeName = new LinkedHashMap<>();
 
     public void fromOpenapi(OpenAPI openAPI, boolean useSecurityDeclarationOrder, UnaryOperator<String> securityTagNameMapper) {
+        if (openAPI.getComponents() != null && openAPI.getComponents().getSecuritySchemes() != null) {
+            for (var securitySchemeName : openAPI.getComponents().getSecuritySchemes().keySet()) {
+                tagBySecuritySchemeName.put(securitySchemeName, securityTagNameMapper.apply(securitySchemeName));
+            }
+        }
         if (openAPI.getPaths() != null) {
             for (var pathname : openAPI.getPaths().keySet()) {
                 var path = openAPI.getPaths().get(pathname);
@@ -53,10 +59,14 @@ public class SecurityData {
                 }
                 var securityNames = newSecurityNamesSet(requirement.keySet(), useSecurityDeclarationOrder);
                 principalExtractorTagBySecurityRequirementNames.putIfAbsent(securityNames, securityNames.stream()
-                    .map(securityTagNameMapper)
+                    .map(this::tagForSecurityScheme)
                     .collect(java.util.stream.Collectors.joining("With")));
             }
         }
+    }
+
+    public String tagForSecurityScheme(String securitySchemeName) {
+        return tagBySecuritySchemeName.getOrDefault(securitySchemeName, securitySchemeName);
     }
 
     public static boolean hasNonAnonymousRequirements(Set<? extends Map<String, ? extends Set<String>>> requirements) {

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/SecurityData.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/SecurityData.java
@@ -3,6 +3,7 @@ package io.koraframework.openapi.generator;
 import io.swagger.v3.oas.models.OpenAPI;
 
 import java.util.*;
+import java.util.function.UnaryOperator;
 
 public class SecurityData {
     // securitySchema = defined in /components/securitySchemes
@@ -14,7 +15,7 @@ public class SecurityData {
 
     public Map<Set<String>, String> principalExtractorTagBySecurityRequirementNames = new LinkedHashMap<>();
 
-    public void fromOpenapi(OpenAPI openAPI, boolean useSecurityDeclarationOrder) {
+    public void fromOpenapi(OpenAPI openAPI, boolean useSecurityDeclarationOrder, UnaryOperator<String> securityTagNameMapper) {
         if (openAPI.getPaths() != null) {
             for (var pathname : openAPI.getPaths().keySet()) {
                 var path = openAPI.getPaths().get(pathname);
@@ -50,7 +51,10 @@ public class SecurityData {
                 if (requirement.isEmpty()) {
                     continue;
                 }
-                principalExtractorTagBySecurityRequirementNames.putIfAbsent(newSecurityNamesSet(requirement.keySet(), useSecurityDeclarationOrder), "SecurityRequirementTag" + principalExtractorTagBySecurityRequirementNames.size());
+                var securityNames = newSecurityNamesSet(requirement.keySet(), useSecurityDeclarationOrder);
+                principalExtractorTagBySecurityRequirementNames.putIfAbsent(securityNames, securityNames.stream()
+                    .map(securityTagNameMapper)
+                    .collect(java.util.stream.Collectors.joining("With")));
             }
         }
     }

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientSecuritySchemaGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientSecuritySchemaGenerator.java
@@ -33,8 +33,11 @@ public class ClientSecuritySchemaGenerator extends AbstractJavaGenerator<Map<Str
             b.addType(buildTag(tag));
         }
 
-        b.addType(securityConfig(authMethods));
-        b.addMethod(securityConfigComponent(authMethods));
+        var securityConfig = securityConfig(authMethods);
+        if (securityConfig != null) {
+            b.addType(securityConfig);
+            b.addMethod(securityConfigComponent(authMethods));
+        }
 
         for (var authMethod : authMethods) {
             switch (authMethod.type) {
@@ -65,28 +68,28 @@ public class ClientSecuritySchemaGenerator extends AbstractJavaGenerator<Map<Str
     }
 
     private MethodSpec securityConfigComponent(List<CodegenSecurity> authMethods) {
-        var configClassName = ClassName.get(apiPackage, "ApiSecurity", "Config");
-        var b = MethodSpec.methodBuilder("config")
+        var configClassName = ClassName.get(apiPackage, "ApiSecurity", "SecurityConfig");
+        var b = MethodSpec.methodBuilder("securityConfig")
             .addModifiers(Modifier.PUBLIC, Modifier.DEFAULT)
+            .addAnnotation(Classes.defaultComponent)
             .addParameter(Classes.config, "config")
             .addParameter(ParameterizedTypeName.get(Classes.configValueExtractor, ClassName.get(String.class)), "mapper")
             .returns(configClassName);
         var params = new ArrayList<CodeBlock>();
+        var securityConfigPathPrefix = securityConfigPathPrefix();
         for (var authMethod : authMethods) {
-            var configPath = this.params.clientConfigPrefix == null
-                ? authMethod.name
-                : this.params.clientConfigPrefix + "." + authMethod.name;
+            var configPath = securityConfigPathPrefix + "." + authMethod.name;
             if (authMethod.type.equals("http") && authMethod.scheme.equals("basic")) {
-                var authMethodConfig = ClassName.get(apiPackage, "ApiSecurity", "Config", authMethod.name + "Config");
+                var authMethodConfig = securityAuthMethodConfigClassName(authMethod);
                 var username = authMethod.name + "_username";
                 var password = authMethod.name + "_password";
-                b.addStatement("var $N = mapper.mapOrThrow(config.get($S))", username, configPath + ".username");
-                b.addStatement("var $N = mapper.mapOrThrow(config.get($S))", password, configPath + ".password");
-                b.addStatement("var $N = new $T($N, $N)", authMethod.name, authMethodConfig, username, password);
+                b.addStatement("var $N = mapper.map(config.get($S))", username, configPath + ".username");
+                b.addStatement("var $N = mapper.map(config.get($S))", password, configPath + ".password");
+                b.addStatement("var $N = $N == null && $N == null ? null : new $T($N, $N)", authMethod.name, username, password, authMethodConfig, username, password);
                 params.add(CodeBlock.of("$N", authMethod.name));
             }
             if (authMethod.type.equals("apiKey")) {
-                b.addStatement("var $N = mapper.mapOrThrow(config.get($S))", authMethod.name, configPath);
+                b.addStatement("var $N = mapper.map(config.get($S))", authMethod.name, configPath);
                 params.add(CodeBlock.of("$N", authMethod.name));
             }
         }
@@ -95,19 +98,23 @@ public class ClientSecuritySchemaGenerator extends AbstractJavaGenerator<Map<Str
     }
 
     private TypeSpec securityConfig(List<CodegenSecurity> authMethods) {
-        var builder = TypeSpec.recordBuilder("Config")
+        var builder = TypeSpec.recordBuilder("SecurityConfig")
+            .addAnnotation(generated())
             .addModifiers(Modifier.PUBLIC, Modifier.STATIC);
         var b = MethodSpec.constructorBuilder();
+        var parameterCount = 0;
         for (var authMethod : authMethods) {
             if (authMethod.type.equals("http") && authMethod.scheme.equals("basic")) {
-                b.addParameter(ParameterSpec.builder(ClassName.get(apiPackage, "ApiSecurity", "Config", authMethod.name + "Config"), authMethod.name).build());
+                b.addParameter(ParameterSpec.builder(securityAuthMethodConfigClassName(authMethod).annotated(AnnotationSpec.builder(Classes.nullable).build()), authMethod.name).build());
                 builder.addType(basicAuthConfig(authMethod));
+                parameterCount++;
             }
             if (authMethod.type.equals("apiKey")) {
                 b.addParameter(ParameterSpec.builder(ClassName.get(String.class).annotated(AnnotationSpec.builder(Classes.nullable).build()), authMethod.name).build());
+                parameterCount++;
             }
         }
-        return builder.recordConstructor(b.build()).build();
+        return parameterCount == 0 ? null : builder.recordConstructor(b.build()).build();
     }
 
     private MethodSpec buildAuthGroupInterceptorComponent(String interceptorTag, List<Map<String, Set<String>>> security, List<CodegenSecurity> authMethods) {
@@ -187,7 +194,6 @@ public class ClientSecuritySchemaGenerator extends AbstractJavaGenerator<Map<Str
             var ifProvided = securityRequirement.keySet().stream().map(name -> CodeBlock.of("$N != null", name)).collect(CodeBlock.joining(" && ", "if (", ")"));
             intercept.beginControlFlow(ifProvided);
             intercept.addStatement("var b = request.toBuilder()");
-            var needReturn = true;
             for (var securitySchemaName : securityRequirement.keySet()) {
                 var securitySchema = authMethods.stream().filter(s -> s.name.equals(securitySchemaName)).findFirst().get();
                 switch (securitySchema.type) {
@@ -198,8 +204,7 @@ public class ClientSecuritySchemaGenerator extends AbstractJavaGenerator<Map<Str
                         } else if (securitySchema.isKeyInHeader) {
                             intercept.addStatement("b.header($S, $N)", securitySchema.keyParamName, securitySchemaName);
                         } else if (securitySchema.isKeyInCookie) {
-                            needReturn = false;
-                            intercept.addStatement("throw new IllegalArgumentException(\"Cookies are not supported yet\")");
+                            intercept.addStatement("b.header($S, $S + $N)", "Cookie", securitySchema.keyParamName + "=", securitySchemaName);
                         } else {
                             throw new IllegalArgumentException(invalidApiKeyLocationError(securitySchema));
                         }
@@ -207,9 +212,7 @@ public class ClientSecuritySchemaGenerator extends AbstractJavaGenerator<Map<Str
                     default -> throw new IllegalStateException(unsupportedSecurityTypeError(securitySchema));
                 }
             }
-            if (needReturn) {
-                intercept.addStatement("return chain.process(b.build())");
-            }
+            intercept.addStatement("return chain.process(b.build())");
             intercept.endControlFlow();
         }
         if (!allowAnonymous) {
@@ -236,43 +239,39 @@ public class ClientSecuritySchemaGenerator extends AbstractJavaGenerator<Map<Str
         return """
             Invalid OpenAPI apiKey security scheme `%s`.
 
-            Kora supports apiKey client auth in query parameters and headers.
+            Kora supports apiKey client auth in query parameters, headers, and cookies.
             Unsupported location: `%s`
 
-            Fix: set `in: query` or `in: header` for this security scheme, or implement cookie auth manually.
+            Fix: set `in: query`, `in: header`, or `in: cookie` for this security scheme.
             """.formatted(securitySchema.name, securitySchema.scheme);
     }
 
 
     private MethodSpec basicAuthHttpClientTokenProvider(CodegenSecurity authMethod) {
-        var configClassName = ClassName.get(apiPackage, "ApiSecurity", "Config");
+        var configClassName = ClassName.get(apiPackage, "ApiSecurity", "SecurityConfig");
         return MethodSpec.methodBuilder(authMethod.name + "BasicAuthHttpClientTokenProvider")
             .addAnnotation(securityTagAnnotation(this.security.tagForSecurityScheme(authMethod.name)))
             .addModifiers(Modifier.PUBLIC, Modifier.DEFAULT)
             .addParameter(configClassName, "config")
             .returns(Classes.basicAuthHttpClientTokenProvider)
-            .addStatement("return new $T(config.$N().username(), config.$N().password())", Classes.basicAuthHttpClientTokenProvider, authMethod.name, authMethod.name)
+            .addStatement("return config.$N() == null ? new $T(null, null) : new $T(config.$N().username(), config.$N().password())", authMethod.name, Classes.basicAuthHttpClientTokenProvider, Classes.basicAuthHttpClientTokenProvider, authMethod.name, authMethod.name)
             .build();
     }
 
     private TypeSpec basicAuthConfig(CodegenSecurity authMethod) {
-        return TypeSpec.recordBuilder(authMethod.name + "Config")
+        return TypeSpec.recordBuilder(securityAuthMethodConfigName(authMethod))
             .addAnnotation(generated())
             .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
             .recordConstructor(MethodSpec.constructorBuilder()
                 .addModifiers(Modifier.PUBLIC)
-                .addParameter(String.class, "username")
-                .addParameter(String.class, "password")
-                .build())
-            .addAnnotation(AnnotationSpec.builder(Classes.configSource).addMember("value", "$S", params.securityConfigPrefix != null
-                    ? params.securityConfigPrefix + "." + authMethod.name
-                    : authMethod.name)
+                .addParameter(ClassName.get(String.class).annotated(AnnotationSpec.builder(Classes.nullable).build()), "username")
+                .addParameter(ClassName.get(String.class).annotated(AnnotationSpec.builder(Classes.nullable).build()), "password")
                 .build())
             .build();
     }
 
     private MethodSpec buildApiKeyTokenProvider(Map<String, Object> ctx, CodegenSecurity authMethod) {
-        var configClassName = ClassName.get(apiPackage, "ApiSecurity", "Config");
+        var configClassName = ClassName.get(apiPackage, "ApiSecurity", "SecurityConfig");
 
         return MethodSpec.methodBuilder(authMethod.name + "TokenProvider")
             .addModifiers(Modifier.PUBLIC, Modifier.DEFAULT)
@@ -282,6 +281,27 @@ public class ClientSecuritySchemaGenerator extends AbstractJavaGenerator<Map<Str
             .addStatement("return _ -> config.$N()", authMethod.name)
             .returns(Classes.httpClientTokenProvider)
             .build();
+    }
+
+    private ClassName securityAuthMethodConfigClassName(CodegenSecurity authMethod) {
+        return ClassName.get(apiPackage, "ApiSecurity", "SecurityConfig", securityAuthMethodConfigName(authMethod));
+    }
+
+    private String securityAuthMethodConfigName(CodegenSecurity authMethod) {
+        return "Security" + this.security.tagForSecurityScheme(authMethod.name) + "Config";
+    }
+
+    private String securityConfigPathPrefix() {
+        if (params.securityConfigPrefix != null && !params.securityConfigPrefix.isBlank()) {
+            return params.securityConfigPrefix;
+        }
+        if (params.clientConfigPrefix != null && !params.clientConfigPrefix.isBlank()) {
+            return params.clientConfigPrefix + ".security";
+        }
+        if (params.clientConfig != null && !params.clientConfig.isBlank()) {
+            return params.clientConfig + ".security";
+        }
+        return "security";
     }
 
     private TypeSpec buildTag(String tag) {

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientSecuritySchemaGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientSecuritySchemaGenerator.java
@@ -27,7 +27,7 @@ public class ClientSecuritySchemaGenerator extends AbstractJavaGenerator<Map<Str
         var tags = new HashSet<String>();
         tags.addAll(security.interceptorTagBySecurityRequirement.values());
         for (var authMethod : authMethods) {
-            tags.add(authMethod.name);
+            tags.add(this.security.tagForSecurityScheme(authMethod.name));
         }
         for (var tag : tags) {
             b.addType(buildTag(tag));
@@ -125,7 +125,7 @@ public class ClientSecuritySchemaGenerator extends AbstractJavaGenerator<Map<Str
                     continue;
                 }
                 var param = ParameterSpec.builder(Classes.httpClientTokenProvider, securitySchema)
-                    .addAnnotation(securityTagAnnotation(securitySchema))
+                    .addAnnotation(securityTagAnnotation(this.security.tagForSecurityScheme(securitySchema)))
                     .build();
                 b.addParameter(param);
                 if (seen.size() > 1) {
@@ -154,7 +154,7 @@ public class ClientSecuritySchemaGenerator extends AbstractJavaGenerator<Map<Str
                     continue;
                 }
                 var param = ParameterSpec.builder(Classes.httpClientTokenProvider, securitySchema)
-                    .addAnnotation(securityTagAnnotation(securitySchema))
+                    .addAnnotation(securityTagAnnotation(this.security.tagForSecurityScheme(securitySchema)))
                     .build();
                 constructor.addParameter(param);
                 constructor.addStatement("this.$N = $N", param.name(), param.name());
@@ -247,7 +247,7 @@ public class ClientSecuritySchemaGenerator extends AbstractJavaGenerator<Map<Str
     private MethodSpec basicAuthHttpClientTokenProvider(CodegenSecurity authMethod) {
         var configClassName = ClassName.get(apiPackage, "ApiSecurity", "Config");
         return MethodSpec.methodBuilder(authMethod.name + "BasicAuthHttpClientTokenProvider")
-            .addAnnotation(securityTagAnnotation(authMethod.name))
+            .addAnnotation(securityTagAnnotation(this.security.tagForSecurityScheme(authMethod.name)))
             .addModifiers(Modifier.PUBLIC, Modifier.DEFAULT)
             .addParameter(configClassName, "config")
             .returns(Classes.basicAuthHttpClientTokenProvider)
@@ -277,7 +277,7 @@ public class ClientSecuritySchemaGenerator extends AbstractJavaGenerator<Map<Str
         return MethodSpec.methodBuilder(authMethod.name + "TokenProvider")
             .addModifiers(Modifier.PUBLIC, Modifier.DEFAULT)
             .addAnnotation(Classes.defaultComponent)
-            .addAnnotation(securityTagAnnotation(authMethod.name))
+            .addAnnotation(securityTagAnnotation(this.security.tagForSecurityScheme(authMethod.name)))
             .addParameter(configClassName, "config")
             .addStatement("return _ -> config.$N()", authMethod.name)
             .returns(Classes.httpClientTokenProvider)

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientSecuritySchemaGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientSecuritySchemaGenerator.java
@@ -11,6 +11,8 @@ import java.util.*;
 import static io.koraframework.openapi.generator.SecurityData.hasAnonymousRequirement;
 
 public class ClientSecuritySchemaGenerator extends AbstractJavaGenerator<Map<String, Object>> {
+    private static final Logger GENERATOR_LOG = LoggerFactory.getLogger(ClientSecuritySchemaGenerator.class);
+
     @Override
     public JavaFile generate(Map<String, Object> ctx) {
         var className = ClassName.get(apiPackage, "ApiSecurity");
@@ -60,6 +62,7 @@ public class ClientSecuritySchemaGenerator extends AbstractJavaGenerator<Map<Str
         for (var entry : security.interceptorTagBySecurityRequirement.entrySet()) {
             var requirement = entry.getKey();
             var tag = entry.getValue();
+            warnAboutCombinedHeaderSecurity(tag, requirement, authMethods);
             b.addType(buildAuthGroupInterceptor(tag, new ArrayList<>(requirement), authMethods));
             b.addMethod(buildAuthGroupInterceptorComponent(tag, new ArrayList<>(requirement), authMethods));
         }
@@ -194,6 +197,13 @@ public class ClientSecuritySchemaGenerator extends AbstractJavaGenerator<Map<Str
             var ifProvided = securityRequirement.keySet().stream().map(name -> CodeBlock.of("$N != null", name)).collect(CodeBlock.joining(" && ", "if (", ")"));
             intercept.beginControlFlow(ifProvided);
             intercept.addStatement("var b = request.toBuilder()");
+            var cookieHeaderName = uniqueLocalName(security, "_securityCookieHeader");
+            var hasCookieSecurity = securityRequirement.keySet().stream()
+                .map(name -> authMethods.stream().filter(method -> method.name.equals(name)).findFirst().orElseThrow())
+                .anyMatch(method -> method.isApiKey && method.isKeyInCookie);
+            if (hasCookieSecurity) {
+                intercept.addStatement("var $N = request.headers().getFirst($S)", cookieHeaderName, "Cookie");
+            }
             for (var securitySchemaName : securityRequirement.keySet()) {
                 var securitySchema = authMethods.stream().filter(s -> s.name.equals(securitySchemaName)).findFirst().get();
                 switch (securitySchema.type) {
@@ -204,13 +214,16 @@ public class ClientSecuritySchemaGenerator extends AbstractJavaGenerator<Map<Str
                         } else if (securitySchema.isKeyInHeader) {
                             intercept.addStatement("b.header($S, $N)", securitySchema.keyParamName, securitySchemaName);
                         } else if (securitySchema.isKeyInCookie) {
-                            intercept.addStatement("b.header($S, $S + $N)", "Cookie", securitySchema.keyParamName + "=", securitySchemaName);
+                            intercept.addStatement("$N = $N == null || $N.isBlank() ? $S + $N : $N + $S + $S + $N", cookieHeaderName, cookieHeaderName, cookieHeaderName, securitySchema.keyParamName + "=", securitySchemaName, cookieHeaderName, "; ", securitySchema.keyParamName + "=", securitySchemaName);
                         } else {
                             throw new IllegalArgumentException(invalidApiKeyLocationError(securitySchema));
                         }
                     }
                     default -> throw new IllegalStateException(unsupportedSecurityTypeError(securitySchema));
                 }
+            }
+            if (hasCookieSecurity) {
+                intercept.addStatement("b.header($S, $N)", "Cookie", cookieHeaderName);
             }
             intercept.addStatement("return chain.process(b.build())");
             intercept.endControlFlow();
@@ -221,6 +234,31 @@ public class ClientSecuritySchemaGenerator extends AbstractJavaGenerator<Map<Str
         intercept.addStatement("return chain.process(request)");
         b.addMethod(intercept.build());
         return b.build();
+    }
+
+    private static void warnAboutCombinedHeaderSecurity(String tag, Set<Map<String, Set<String>>> security, List<CodegenSecurity> authMethods) {
+        for (var requirement : security) {
+            var methods = requirement.keySet().stream()
+                .map(name -> authMethods.stream().filter(method -> method.name.equals(name)).findFirst().orElseThrow())
+                .toList();
+            var authorizationSchemes = methods.stream().filter(method -> method.type.equals("http") || method.type.equals("oauth2") || method.type.equals("openId")).map(method -> method.name).toList();
+            if (authorizationSchemes.size() > 1) {
+                GENERATOR_LOG.warn("Security requirement '{}' uses multiple Authorization schemes {}; generated client applies them in declaration order and the last value wins", tag, authorizationSchemes);
+            }
+            var cookieSchemes = methods.stream().filter(method -> method.isApiKey && method.isKeyInCookie).map(method -> method.name).toList();
+            if (cookieSchemes.size() > 1) {
+                GENERATOR_LOG.warn("Security requirement '{}' uses multiple cookie schemes {}; generated client combines them into one Cookie header", tag, cookieSchemes);
+            }
+        }
+    }
+
+    private static String uniqueLocalName(List<Map<String, Set<String>>> security, String baseName) {
+        var names = security.stream().flatMap(requirement -> requirement.keySet().stream()).collect(java.util.stream.Collectors.toSet());
+        var result = baseName;
+        while (names.contains(result)) {
+            result = "_" + result;
+        }
+        return result;
     }
 
     private static String unsupportedSecurityTypeError(CodegenSecurity securitySchema) {

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ServerSecuritySchemaGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ServerSecuritySchemaGenerator.java
@@ -118,7 +118,7 @@ public class ServerSecuritySchemaGenerator extends AbstractJavaGenerator<Map<Str
             securityRequirement.size() == 1 ? ClassName.get(String.class) : ClassName.get(apiPackage, "ApiSecurity", principalExtractorTag + "AuthData"),
             needScopes ? Classes.principalWithScopes : Classes.principal
         );
-        return ParameterSpec.builder(extractorType, principalExtractorTag)
+        return ParameterSpec.builder(extractorType, principalExtractorTag + "_")
             .addAnnotation(securityTagAnnotation(principalExtractorTag))
             .build();
     }
@@ -167,17 +167,18 @@ public class ServerSecuritySchemaGenerator extends AbstractJavaGenerator<Map<Str
                     var securitySchema = authMethods.stream().filter(s -> s.name.equals(securitySchemaName)).findFirst().get();
                     if (securitySchema.isApiKey) {
                         if (securitySchema.isKeyInHeader) {
-                            intercept.addStatement("var $N = request.headers().getFirst($S)", securitySchemaName, securitySchema.keyParamName);
+                            intercept.addStatement("var $N = request.headers().getFirst($S)", securityCredentialVariableName(securitySchema), securitySchema.keyParamName);
                         } else if (securitySchema.isKeyInQuery) {
-                            intercept.addStatement("var $N = request.queryParams().get($S)", securitySchemaName + "_list", securitySchema.keyParamName);
-                            intercept.addStatement("var $N = $N == null || $N.isEmpty() ? null : $N.iterator().next()", securitySchemaName, securitySchemaName + "_list", securitySchemaName + "_list", securitySchemaName + "_list");
+                            var queryVariableName = securityCredentialVariableName(securitySchema);
+                            intercept.addStatement("var $N = request.queryParams().get($S)", queryVariableName + "List", securitySchema.keyParamName);
+                            intercept.addStatement("var $N = $N == null || $N.isEmpty() ? null : $N.iterator().next()", queryVariableName, queryVariableName + "List", queryVariableName + "List", queryVariableName + "List");
                         } else if (securitySchema.isKeyInCookie) {
-                            intercept.addStatement("var $N = request.cookies().stream().filter(c -> $S.equals(c.name())).map(c -> c.value()).findFirst().orElse(null)", securitySchemaName, securitySchema.keyParamName);
+                            intercept.addStatement("var $N = request.cookies().stream().filter(c -> $S.equals(c.name())).map(c -> c.value()).findFirst().orElse(null)", securityCredentialVariableName(securitySchema), securitySchema.keyParamName);
                         } else {
                             throw new IllegalArgumentException(invalidApiKeyLocationError(securitySchema));
                         }
                     } else if (securitySchema.isBasicBasic || securitySchema.isBasicBearer || securitySchema.isOAuth) {
-                        intercept.addStatement("var $N = request.headers().getFirst($S)", securitySchemaName, "Authorization");
+                        intercept.addStatement("var $N = request.headers().getFirst($S)", securityCredentialVariableName(securitySchema), "Authorization");
                     } else {
                         throw new IllegalArgumentException(unsupportedSecurityTypeError(securitySchema));
                     }
@@ -186,15 +187,21 @@ public class ServerSecuritySchemaGenerator extends AbstractJavaGenerator<Map<Str
             var extractorTag = this.security.principalExtractorTagBySecurityRequirementNames.get(securityRequirement.keySet());
             if (securityRequirementSeen.add(extractorTag)) {
                 if (securityRequirement.size() == 1) {
-                    intercept.addStatement("var $N = this.$N.extract(request, $N)", extractorTag, extractorTag, securityRequirement.keySet().stream().findFirst().get());
+                    var securitySchemaName = securityRequirement.keySet().stream().findFirst().get();
+                    var securitySchema = authMethods.stream().filter(s -> s.name.equals(securitySchemaName)).findFirst().get();
+                    intercept.addStatement("var $N = this.$N_.extract(request, $N)", extractorTag, extractorTag, securityCredentialVariableName(securitySchema));
                 } else {
                     var authData = ClassName.get(this.apiPackage, "ApiSecurity", extractorTag + "AuthData");
 
                     var params = securityRequirement.keySet()
                         .stream()
-                        .map(n -> CodeBlock.of("$N", n))
+                        .map(name -> authMethods.stream()
+                            .filter(method -> method.name.equals(name))
+                            .findFirst()
+                            .map(method -> CodeBlock.of("$N", securityCredentialVariableName(method)))
+                            .orElseThrow())
                         .collect(CodeBlock.joining(", ", "(", ")"));
-                    intercept.addStatement("var $N = this.$N.extract(\n  request,\n  new $T$L)", extractorTag, extractorTag, authData, params);
+                    intercept.addStatement("var $N = this.$N_.extract(\n  request,\n  new $T$L)", extractorTag, extractorTag, authData, params);
                 }
             }
             intercept.beginControlFlow("if ($N != null)", extractorTag);
@@ -226,6 +233,23 @@ public class ServerSecuritySchemaGenerator extends AbstractJavaGenerator<Map<Str
         }
         b.addMethod(intercept.build());
         return b.build();
+    }
+
+    private static String securityCredentialVariableName(CodegenSecurity securitySchema) {
+        if (securitySchema.isApiKey) {
+            if (securitySchema.isKeyInHeader) {
+                return securitySchema.name + "Header";
+            }
+            if (securitySchema.isKeyInQuery) {
+                return securitySchema.name + "Query";
+            }
+            if (securitySchema.isKeyInCookie) {
+                return securitySchema.name + "Cookie";
+            }
+        }
+        return securitySchema.isBasicBasic || securitySchema.isBasicBearer || securitySchema.isOAuth
+            ? securitySchema.name + "Header"
+            : securitySchema.name;
     }
 
     private static String invalidApiKeyLocationError(CodegenSecurity securitySchema) {

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ClientSecuritySchemaGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ClientSecuritySchemaGenerator.kt
@@ -26,7 +26,7 @@ class ClientSecuritySchemaGenerator : AbstractKotlinGenerator<Map<String, Any>>(
         val authMethods = ctx["authMethods"] as List<CodegenSecurity>
         val tags = mutableSetOf<String>()
         tags.addAll(security.interceptorTagBySecurityRequirement.values)
-        authMethods.forEach { tags.add(it.name) }
+        authMethods.forEach { tags.add(this.security.tagForSecurityScheme(it.name)) }
         tags.forEach { b.addType(buildTag(it)) }
 
         securityConfig(authMethods)?.let { b.addType(it) }
@@ -128,7 +128,7 @@ class ClientSecuritySchemaGenerator : AbstractKotlinGenerator<Map<String, Any>>(
                     continue
                 }
                 val param = ParameterSpec.builder(securitySchema, Classes.httpClientTokenProvider.asKt())
-                    .addAnnotation(securityTagAnnotation(securitySchema))
+                    .addAnnotation(securityTagAnnotation(this.security.tagForSecurityScheme(securitySchema)))
                     .build()
                 b.addParameter(param)
                 if (seen.size > 1) {
@@ -158,7 +158,7 @@ class ClientSecuritySchemaGenerator : AbstractKotlinGenerator<Map<String, Any>>(
                     continue
                 }
                 val param = ParameterSpec.builder(securitySchema, Classes.httpClientTokenProvider.asKt())
-                    .addAnnotation(securityTagAnnotation(securitySchema))
+                    .addAnnotation(securityTagAnnotation(this.security.tagForSecurityScheme(securitySchema)))
                     .build()
                 constructor.addParameter(param)
                 b.addProperty(PropertySpec.builder(param.name, param.type).initializer("%N", param.name).build())
@@ -231,7 +231,7 @@ class ClientSecuritySchemaGenerator : AbstractKotlinGenerator<Map<String, Any>>(
         val configClassName = ClassName(apiPackage, "ApiSecurity", "Config");
 
         return FunSpec.builder(authMethod.name + "BasicAuthHttpClientTokenProvider")
-            .addAnnotation(securityTagAnnotation(authMethod.name))
+            .addAnnotation(securityTagAnnotation(this.security.tagForSecurityScheme(authMethod.name)))
             .addParameter("config", configClassName)
             .returns(Classes.basicAuthHttpClientTokenProvider.asKt())
             .addStatement("return %T(config.%N.username, config.%N.password)", Classes.basicAuthHttpClientTokenProvider.asKt(), authMethod.name, authMethod.name)
@@ -268,7 +268,7 @@ class ClientSecuritySchemaGenerator : AbstractKotlinGenerator<Map<String, Any>>(
 
         return FunSpec.builder(authMethod.name + "TokenProvider")
             .addAnnotation(Classes.defaultComponent.asKt())
-            .addAnnotation(securityTagAnnotation(authMethod.name))
+            .addAnnotation(securityTagAnnotation(this.security.tagForSecurityScheme(authMethod.name)))
             .addParameter("config", configClassName)
             .addStatement("return %T { config.%N }", Classes.httpClientTokenProvider.asKt(), authMethod.name)
             .returns(Classes.httpClientTokenProvider.asKt())

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ClientSecuritySchemaGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ClientSecuritySchemaGenerator.kt
@@ -58,25 +58,27 @@ class ClientSecuritySchemaGenerator : AbstractKotlinGenerator<Map<String, Any>>(
 
 
     private fun securityConfigComponent(authMethods: List<CodegenSecurity>): FunSpec? {
-        val configClassName = ClassName(apiPackage, "ApiSecurity", "Config")
-        val b = FunSpec.builder("config")
+        val configClassName = ClassName(apiPackage, "ApiSecurity", "SecurityConfig")
+        val b = FunSpec.builder("securityConfig")
+            .addAnnotation(Classes.defaultComponent.asKt())
             .addParameter("config", Classes.config.asKt())
             .addParameter("mapper", Classes.configValueExtractor.asKt().parameterizedBy(String::class.asTypeName()))
             .returns(configClassName)
         val params = mutableListOf<CodeBlock>()
+        val securityConfigPathPrefix = securityConfigPathPrefix()
         for (authMethod in authMethods) {
-            val configPath = (this.params.clientConfigPrefix?.let { it + "." } ?: "") + authMethod.name
+            val configPath = securityConfigPathPrefix + "." + authMethod.name
             if (authMethod.type == "http" && authMethod.scheme == "basic") {
-                val authMethodConfig = ClassName(apiPackage, "ApiSecurity", "Config", authMethod.name + "Config")
+                val authMethodConfig = securityAuthMethodConfigClassName(authMethod)
                 val username = authMethod.name + "_username"
                 val password = authMethod.name + "_password"
-                b.addStatement("val %N = mapper.mapOrThrow(config.get(%S))", username, configPath + ".username")
-                b.addStatement("val %N = mapper.mapOrThrow(config.get(%S))", password, configPath + ".password")
-                b.addStatement("val %N = %T(%N, %N)", authMethod.name, authMethodConfig, username, password)
+                b.addStatement("val %N = mapper.map(config.get(%S))", username, configPath + ".username")
+                b.addStatement("val %N = mapper.map(config.get(%S))", password, configPath + ".password")
+                b.addStatement("val %N = if (%N == null && %N == null) null else %T(%N, %N)", authMethod.name, username, password, authMethodConfig, username, password)
                 params.add(CodeBlock.of("%N", authMethod.name))
             }
             if (authMethod.type == "apiKey") {
-                b.addStatement("val %N = mapper.mapOrThrow(config.get(%S))", authMethod.name, configPath)
+                b.addStatement("val %N = mapper.map(config.get(%S))", authMethod.name, configPath)
                 params.add(CodeBlock.of("%N", authMethod.name))
             }
         }
@@ -88,14 +90,15 @@ class ClientSecuritySchemaGenerator : AbstractKotlinGenerator<Map<String, Any>>(
     }
 
     private fun securityConfig(authMethods: List<CodegenSecurity>): TypeSpec? {
-        val builder = TypeSpec.classBuilder("Config")
+        val builder = TypeSpec.classBuilder("SecurityConfig")
+            .addAnnotation(generated())
             .addModifiers(KModifier.DATA)
         val b = FunSpec.constructorBuilder()
         for (authMethod in authMethods) {
             if (authMethod.type == "http" && authMethod.scheme == "basic") {
-                val configName = ClassName(apiPackage, "ApiSecurity", "Config", authMethod.name + "Config")
-                builder.addProperty(PropertySpec.builder(authMethod.name, configName).initializer("%N", authMethod.name).build())
-                b.addParameter(authMethod.name, configName)
+                val configName = securityAuthMethodConfigClassName(authMethod)
+                builder.addProperty(PropertySpec.builder(authMethod.name, configName.copy(nullable = true)).initializer("%N", authMethod.name).build())
+                b.addParameter(authMethod.name, configName.copy(nullable = true))
                 builder.addType(basicAuthConfig(authMethod))
             }
             if (authMethod.type == "apiKey") {
@@ -198,7 +201,8 @@ class ClientSecuritySchemaGenerator : AbstractKotlinGenerator<Map<String, Any>>(
                     "apiKey" -> when {
                         securitySchema.isKeyInQuery -> intercept.addStatement("b.queryParam(%S, %N)", securitySchema.keyParamName, securitySchemaName)
                         securitySchema.isKeyInHeader -> intercept.addStatement("b.header(%S, %N)", securitySchema.keyParamName, securitySchemaName)
-                        securitySchema.isKeyInCookie -> intercept.addStatement("TODO(%S)", "Cookie client authentication is not implemented yet")
+                        securitySchema.isKeyInCookie -> intercept.addStatement("b.header(%S, %S + %N)", "Cookie", securitySchema.keyParamName + "=", securitySchemaName)
+                        else -> throw IllegalArgumentException(invalidApiKeyLocationError(securitySchema))
                     }
 
                     else -> throw IllegalArgumentException(unsupportedSecurityTypeError(securitySchema))
@@ -227,44 +231,46 @@ class ClientSecuritySchemaGenerator : AbstractKotlinGenerator<Map<String, Any>>(
         """.trimIndent()
     }
 
+    private fun invalidApiKeyLocationError(securitySchema: CodegenSecurity): String {
+        return """
+            Invalid OpenAPI apiKey security scheme `${securitySchema.name}`.
+
+            Kora supports apiKey client auth in query parameters, headers, and cookies.
+            Unsupported location: `${securitySchema.scheme}`
+
+            Fix: set `in: query`, `in: header`, or `in: cookie` for this security scheme.
+        """.trimIndent()
+    }
+
     private fun basicAuthHttpClientTokenProvider(authMethod: CodegenSecurity): FunSpec {
-        val configClassName = ClassName(apiPackage, "ApiSecurity", "Config");
+        val configClassName = ClassName(apiPackage, "ApiSecurity", "SecurityConfig");
 
         return FunSpec.builder(authMethod.name + "BasicAuthHttpClientTokenProvider")
             .addAnnotation(securityTagAnnotation(this.security.tagForSecurityScheme(authMethod.name)))
             .addParameter("config", configClassName)
             .returns(Classes.basicAuthHttpClientTokenProvider.asKt())
-            .addStatement("return %T(config.%N.username, config.%N.password)", Classes.basicAuthHttpClientTokenProvider.asKt(), authMethod.name, authMethod.name)
+            .addStatement("return config.%N?.let { %T(it.username, it.password) } ?: %T(null, null)", authMethod.name, Classes.basicAuthHttpClientTokenProvider.asKt(), Classes.basicAuthHttpClientTokenProvider.asKt())
             .build()
     }
 
     private fun basicAuthConfig(authMethod: CodegenSecurity): TypeSpec {
-        val nullableString = String::class.asClassName().copy(true)
-        return TypeSpec.classBuilder(authMethod.name + "Config")
+        val stringType = String::class.asClassName().copy(nullable = true)
+        return TypeSpec.classBuilder(securityAuthMethodConfigName(authMethod))
             .addModifiers(KModifier.DATA)
             .addAnnotation(generated())
-            .addProperty(PropertySpec.builder("username", nullableString).initializer("username").build())
-            .addProperty(PropertySpec.builder("password", nullableString).initializer("password").build())
+            .addProperty(PropertySpec.builder("username", stringType).initializer("username").build())
+            .addProperty(PropertySpec.builder("password", stringType).initializer("password").build())
             .primaryConstructor(
                 FunSpec.constructorBuilder()
-                    .addParameter("username", nullableString)
-                    .addParameter("password", nullableString)
-                    .build()
-            )
-            .addAnnotation(
-                AnnotationSpec.builder(Classes.configSource.asKt()).addMember(
-                    "value = %S", if (params.securityConfigPrefix != null)
-                        params.securityConfigPrefix + "." + authMethod.name
-                    else
-                        authMethod.name
-                )
+                    .addParameter("username", stringType)
+                    .addParameter("password", stringType)
                     .build()
             )
             .build()
     }
 
     private fun buildApiKeyTokenProvider(ctx: Map<String, Any>, authMethod: CodegenSecurity): FunSpec {
-        val configClassName = ClassName(apiPackage, "ApiSecurity", "Config");
+        val configClassName = ClassName(apiPackage, "ApiSecurity", "SecurityConfig");
 
         return FunSpec.builder(authMethod.name + "TokenProvider")
             .addAnnotation(Classes.defaultComponent.asKt())
@@ -273,6 +279,21 @@ class ClientSecuritySchemaGenerator : AbstractKotlinGenerator<Map<String, Any>>(
             .addStatement("return %T { config.%N }", Classes.httpClientTokenProvider.asKt(), authMethod.name)
             .returns(Classes.httpClientTokenProvider.asKt())
             .build()
+    }
+
+    private fun securityAuthMethodConfigClassName(authMethod: CodegenSecurity): ClassName {
+        return ClassName(apiPackage, "ApiSecurity", "SecurityConfig", securityAuthMethodConfigName(authMethod))
+    }
+
+    private fun securityAuthMethodConfigName(authMethod: CodegenSecurity): String {
+        return "Security" + this.security.tagForSecurityScheme(authMethod.name) + "Config"
+    }
+
+    private fun securityConfigPathPrefix(): String {
+        params.securityConfigPrefix?.takeIf { it.isNotBlank() }?.let { return it }
+        params.clientConfigPrefix?.takeIf { it.isNotBlank() }?.let { return it + ".security" }
+        params.clientConfig?.takeIf { it.isNotBlank() }?.let { return it + ".security" }
+        return "security"
     }
 
     private fun buildTag(tag: String) = TypeSpec.classBuilder(tag)

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ClientSecuritySchemaGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ClientSecuritySchemaGenerator.kt
@@ -9,6 +9,8 @@ import org.slf4j.LoggerFactory
 
 
 class ClientSecuritySchemaGenerator : AbstractKotlinGenerator<Map<String, Any>>() {
+    private val generatorLog = LoggerFactory.getLogger(ClientSecuritySchemaGenerator::class.java)
+
     override fun generate(ctx: Map<String, Any>): FileSpec {
         val className = ClassName(apiPackage, "ApiSecurity")
         val b = TypeSpec.interfaceBuilder(className)
@@ -50,6 +52,7 @@ class ClientSecuritySchemaGenerator : AbstractKotlinGenerator<Map<String, Any>>(
         }
 
         for ((requirement, tag) in security.interceptorTagBySecurityRequirement) {
+            warnAboutCombinedHeaderSecurity(tag, requirement, authMethods)
             b.addType(buildAuthGroupInterceptor(tag, requirement.toList(), authMethods))
             b.addFunction(buildAuthGroupInterceptorComponent(tag, requirement.toList(), authMethods))
         }
@@ -194,6 +197,13 @@ class ClientSecuritySchemaGenerator : AbstractKotlinGenerator<Map<String, Any>>(
             }
             intercept.beginControlFlow("%L", ifProvided)
             intercept.addStatement("val b = request.toBuilder()")
+            val cookieHeaderName = uniqueLocalName(security, "_securityCookieHeader")
+            val hasCookieSecurity = securityRequirement.keys
+                .map { name -> authMethods.first { it.name == name } }
+                .any { it.isApiKey && it.isKeyInCookie }
+            if (hasCookieSecurity) {
+                intercept.addStatement("var %N = request.headers().getFirst(%S)", cookieHeaderName, "Cookie")
+            }
             for (securitySchemaName in securityRequirement.keys) {
                 val securitySchema = authMethods.first { it.name.equals(securitySchemaName) }
                 when (securitySchema.type) {
@@ -201,12 +211,15 @@ class ClientSecuritySchemaGenerator : AbstractKotlinGenerator<Map<String, Any>>(
                     "apiKey" -> when {
                         securitySchema.isKeyInQuery -> intercept.addStatement("b.queryParam(%S, %N)", securitySchema.keyParamName, securitySchemaName)
                         securitySchema.isKeyInHeader -> intercept.addStatement("b.header(%S, %N)", securitySchema.keyParamName, securitySchemaName)
-                        securitySchema.isKeyInCookie -> intercept.addStatement("b.header(%S, %S + %N)", "Cookie", securitySchema.keyParamName + "=", securitySchemaName)
+                        securitySchema.isKeyInCookie -> intercept.addStatement("%N = if (%N.isNullOrBlank()) %S + %N else %N + %S + %S + %N", cookieHeaderName, cookieHeaderName, securitySchema.keyParamName + "=", securitySchemaName, cookieHeaderName, "; ", securitySchema.keyParamName + "=", securitySchemaName)
                         else -> throw IllegalArgumentException(invalidApiKeyLocationError(securitySchema))
                     }
 
                     else -> throw IllegalArgumentException(unsupportedSecurityTypeError(securitySchema))
                 }
+            }
+            if (hasCookieSecurity) {
+                intercept.addStatement("b.header(%S, %N)", "Cookie", cookieHeaderName)
             }
             intercept.addStatement("return chain.process(b.build())")
             intercept.endControlFlow()
@@ -217,6 +230,29 @@ class ClientSecuritySchemaGenerator : AbstractKotlinGenerator<Map<String, Any>>(
         intercept.addStatement("return chain.process(request)")
         b.addFunction(intercept.build())
         return b.build()
+    }
+
+    private fun warnAboutCombinedHeaderSecurity(interceptorTag: String, security: Set<Map<String, Set<String>>>, authMethods: List<CodegenSecurity>) {
+        for (requirement in security) {
+            val methods = requirement.keys.map { name -> authMethods.first { it.name == name } }
+            val authorizationSchemes = methods.filter { it.type == "http" || it.type == "oauth2" || it.type == "openId" }.map { it.name }
+            if (authorizationSchemes.size > 1) {
+                generatorLog.warn("Security requirement '{}' uses multiple Authorization schemes {}; generated client applies them in declaration order and the last value wins", interceptorTag, authorizationSchemes)
+            }
+            val cookieSchemes = methods.filter { it.isApiKey && it.isKeyInCookie }.map { it.name }
+            if (cookieSchemes.size > 1) {
+                generatorLog.warn("Security requirement '{}' uses multiple cookie schemes {}; generated client combines them into one Cookie header", interceptorTag, cookieSchemes)
+            }
+        }
+    }
+
+    private fun uniqueLocalName(security: List<Map<String, Set<String>>>, baseName: String): String {
+        val names = security.flatMap { it.keys }.toSet()
+        var result = baseName
+        while (names.contains(result)) {
+            result = "_" + result
+        }
+        return result
     }
 
     private fun unsupportedSecurityTypeError(securitySchema: CodegenSecurity): String {

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ServerSecuritySchemaGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ServerSecuritySchemaGenerator.kt
@@ -119,26 +119,26 @@ class ServerSecuritySchemaGenerator : AbstractKotlinGenerator<Map<String, Any>>(
                         when {
                             securitySchema.isKeyInHeader -> intercept.addStatement(
                                 "val %N = request.headers().getFirst(%S)",
-                                securitySchemaName,
+                                securityCredentialVariableName(securitySchema),
                                 securitySchema.keyParamName
                             )
 
                             securitySchema.isKeyInQuery -> intercept.addStatement(
                                 "val %N = request.queryParams().get(%S)?.firstOrNull()",
-                                securitySchemaName,
+                                securityCredentialVariableName(securitySchema),
                                 securitySchema.keyParamName
                             )
 
                             securitySchema.isKeyInCookie -> intercept.addStatement(
                                 "val %N = request.cookies().firstOrNull { c -> %S == c.name() }?.value()",
-                                securitySchemaName,
+                                securityCredentialVariableName(securitySchema),
                                 securitySchema.keyParamName
                             )
 
                             else -> throw IllegalArgumentException(invalidApiKeyLocationError(securitySchema))
                         }
                     } else if (securitySchema.isBasicBasic || securitySchema.isBasicBearer || securitySchema.isOAuth) {
-                        intercept.addStatement("var %N = request.headers().getFirst(%S)", securitySchemaName, "Authorization")
+                        intercept.addStatement("val %N = request.headers().getFirst(%S)", securityCredentialVariableName(securitySchema), "Authorization")
                     } else {
                         throw IllegalArgumentException(unsupportedSecurityTypeError(securitySchema))
                     }
@@ -147,10 +147,15 @@ class ServerSecuritySchemaGenerator : AbstractKotlinGenerator<Map<String, Any>>(
             val extractorTag = this.security.principalExtractorTagBySecurityRequirementNames[securityRequirement.keys]!!
             if (securityRequirementSeen.add(extractorTag)) {
                 if (securityRequirement.size == 1) {
-                    intercept.addStatement("val %N = this.%N_.extract(request, %N)", extractorTag, extractorTag, securityRequirement.keys.first())
+                    val securitySchemaName = securityRequirement.keys.first()
+                    val securitySchema = authMethods.first { it.name == securitySchemaName }
+                    intercept.addStatement("val %N = this.%N_.extract(request, %N)", extractorTag, extractorTag, securityCredentialVariableName(securitySchema))
                 } else {
                     val authData = ClassName(this.apiPackage, "ApiSecurity", extractorTag + "AuthData");
-                    val params = securityRequirement.keys.map { CodeBlock.of("%N", it) }.joinToCode(", ", "(", ")")
+                    val params = securityRequirement.keys
+                        .map { name -> authMethods.first { it.name == name } }
+                        .map { CodeBlock.of("%N", securityCredentialVariableName(it)) }
+                        .joinToCode(", ", "(", ")")
                     intercept.addStatement("val %N = this.%N_.extract(\n  request,\n  %T%L)", extractorTag, extractorTag, authData, params)
                 }
             }
@@ -183,6 +188,18 @@ class ServerSecuritySchemaGenerator : AbstractKotlinGenerator<Map<String, Any>>(
         }
         b.addFunction(intercept.build())
         return b.build()
+    }
+
+    private fun securityCredentialVariableName(securitySchema: CodegenSecurity): String {
+        if (securitySchema.isApiKey) {
+            return when {
+                securitySchema.isKeyInHeader -> securitySchema.name + "Header"
+                securitySchema.isKeyInQuery -> securitySchema.name + "Query"
+                securitySchema.isKeyInCookie -> securitySchema.name + "Cookie"
+                else -> securitySchema.name
+            }
+        }
+        return if (securitySchema.isBasicBasic || securitySchema.isBasicBearer || securitySchema.isOAuth) securitySchema.name + "Header" else securitySchema.name
     }
 
     private fun invalidApiKeyLocationError(securitySchema: CodegenSecurity): String {

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/BaseOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/BaseOpenapiTest.java
@@ -122,6 +122,7 @@ public abstract class BaseOpenapiTest {
             "/example/petstoreV3_security_basic.yaml",
             "/example/petstoreV3_security_bearer.yaml",
             "/example/petstoreV3_security_cookie.yaml",
+            "/example/petstoreV3_security_cookie_and.yaml",
             "/example/petstoreV3_security_oauth.yaml",
             "/example/petstoreV3_security_multi.yaml",
             "/example/petstoreV3_security_anonymous.yaml",

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/BaseOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/BaseOpenapiTest.java
@@ -31,6 +31,8 @@ public abstract class BaseOpenapiTest {
             public String clientConfig = "test";
             @Nullable
             public String clientConfigPrefix;
+            @Nullable
+            public String securityConfigPrefix;
             public boolean useSecurityDeclarationOrder;
 
             public Options setAuthAsArg(boolean authAsArg) {
@@ -73,6 +75,11 @@ public abstract class BaseOpenapiTest {
                 return this;
             }
 
+            public Options setSecurityConfigPrefix(@Nullable String securityConfigPrefix) {
+                this.securityConfigPrefix = securityConfigPrefix;
+                return this;
+            }
+
             public Options setUseSecurityDeclarationOrder(boolean useSecurityDeclarationOrder) {
                 this.useSecurityDeclarationOrder = useSecurityDeclarationOrder;
                 return this;
@@ -89,6 +96,7 @@ public abstract class BaseOpenapiTest {
                        ", rawBodyMode='" + rawBodyMode + '\'' +
                        ", clientConfig='" + clientConfig + '\'' +
                        ", clientConfigPrefix='" + clientConfigPrefix + '\'' +
+                       ", securityConfigPrefix='" + securityConfigPrefix + '\'' +
                        ", useSecurityDeclarationOrder=" + useSecurityDeclarationOrder +
                        '}';
             }
@@ -218,6 +226,9 @@ public abstract class BaseOpenapiTest {
         }
         if (options.clientConfigPrefix != null) {
             configurator.addAdditionalProperty("clientConfigPrefix", options.clientConfigPrefix);
+        }
+        if (options.securityConfigPrefix != null) {
+            configurator.addAdditionalProperty("securityConfigPrefix", options.securityConfigPrefix);
         }
         if (options.rawBodyMode != null) {
             configurator.addAdditionalProperty("rawBodyMode", options.rawBodyMode);

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientJavaOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientJavaOpenapiTest.java
@@ -105,6 +105,99 @@ public class HttpClientJavaOpenapiTest extends BaseJavaOpenapiTest {
     }
 
     @Test
+    void securityConfigUsesDedicatedNamesComponentAndPrefix() throws Exception {
+        var files = generate(
+            "petstoreV3_security_config_contract",
+            "java-client",
+            getClass().getResource("/example/petstoreV3_security_all.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+                .setClientConfigPrefix("clients")
+                .setSecurityConfigPrefix("security")
+        );
+
+        var content = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("ApiSecurity.java"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(content.contains("default SecurityConfig securityConfig("));
+        assertTrue(content.indexOf("@DefaultComponent") < content.indexOf("default SecurityConfig securityConfig("));
+        assertTrue(content.contains("record SecurityConfig("));
+        assertTrue(content.contains("@Generated(\"io.koraframework.openapi.generator.javagen.ClientSecuritySchemaGenerator\")\n  record SecurityConfig("));
+        assertTrue(content.contains("SecurityBasicAuthConfig(@Nullable String username,"));
+        assertTrue(content.contains("@Nullable String password)"));
+        assertTrue(content.contains("record SecurityConfig(@Nullable String apiKeyAuth,"));
+        assertTrue(content.contains("@Nullable SecurityBasicAuthConfig basicAuth"));
+        assertTrue(content.contains("@Nullable String cookieAuth)"));
+        assertTrue(content.contains("mapper.map(config.get(\"security.apiKeyAuth\"))"));
+        assertFalse(content.contains("mapper.mapOrThrow"));
+        assertTrue(content.contains("config.get(\"security.apiKeyAuth\")"));
+        assertTrue(content.contains("config.get(\"security.basicAuth.username\")"));
+        assertTrue(content.contains("config.get(\"security.cookieAuth\")"));
+        assertFalse(content.contains("config.get(\"clients."));
+        assertFalse(content.contains("@ConfigSource"));
+        assertFalse(content.contains("default Config config("));
+    }
+
+    @Test
+    void cookieSecurityIsAddedToRequest() throws Exception {
+        var files = generate(
+            "petstoreV3_security_cookie_client_interceptor",
+            "java-client",
+            getClass().getResource("/example/petstoreV3_security_cookie.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+        );
+
+        var content = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("ApiSecurity.java"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(content.contains("b.header(\"Cookie\", \"X-COOKIE-KEY=\" + CookieAuth)"));
+        assertFalse(content.contains("Cookies are not supported yet"));
+    }
+
+    @Test
+    void securityConfigFallsBackToClientConfigPrefix() throws Exception {
+        var files = generate(
+            "petstoreV3_security_client_prefix_fallback",
+            "java-client",
+            getClass().getResource("/example/petstoreV3_security_all.yaml").toExternalForm(),
+            new SwaggerParams.Options().setClientConfigPrefix("clients")
+        );
+
+        var content = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("ApiSecurity.java"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(content.contains("config.get(\"clients.security.apiKeyAuth\")"));
+        assertTrue(content.contains("config.get(\"clients.security.basicAuth.username\")"));
+    }
+
+    @Test
+    void securityConfigFallsBackToClientConfig() throws Exception {
+        var files = generate(
+            "petstoreV3_security_client_config_fallback",
+            "java-client",
+            getClass().getResource("/example/petstoreV3_security_all.yaml").toExternalForm(),
+            new SwaggerParams.Options().setClientConfig("clients.petstore")
+        );
+
+        var content = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("ApiSecurity.java"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(content.contains("config.get(\"clients.petstore.security.apiKeyAuth\")"));
+        assertTrue(content.contains("config.get(\"clients.petstore.security.basicAuth.username\")"));
+    }
+
+    @Test
     void clientConfigIsRequiredWhenPrefixIsMissing() {
         var e = assertThrows(IllegalArgumentException.class, () -> generate(
             "petstoreV3_missing_config",
@@ -326,10 +419,12 @@ public class HttpClientJavaOpenapiTest extends BaseJavaOpenapiTest {
             .findFirst()
             .orElseThrow());
 
-        assertTrue(apiContent.indexOf("tag = ApiSecurity.OperationSecuritySchemaTag0.class") < apiContent.indexOf("optionalAccess("));
+        assertTrue(apiContent.indexOf("tag = ApiSecurity.Sec1_Anonymous.class") < apiContent.indexOf("optionalAccess("));
+        assertTrue(apiContent.indexOf("tag = ApiSecurity.Sec1.class") < apiContent.indexOf("requiredAccess("));
+        assertTrue(securityContent.contains("final class Sec1_Anonymous"));
+        assertTrue(securityContent.contains("final class Sec1"));
         assertTrue(apiContent.lastIndexOf("OperationSecuritySchemaTag") < apiContent.indexOf("publicAccess("));
         assertFalse(securityContent.contains("if ()"));
-        assertFalse(securityContent.contains("Security schema is defined for api but no data was provided"));
         assertTrue(securityContent.contains("return chain.process(request);"));
     }
 
@@ -364,12 +459,12 @@ public class HttpClientJavaOpenapiTest extends BaseJavaOpenapiTest {
             .findFirst()
             .orElseThrow());
 
-        assertTrue(defaultApiContent.contains("ApiSecurity.OperationSecuritySchemaTag0.class"));
-        assertFalse(defaultApiContent.contains("ApiSecurity.OperationSecuritySchemaTag1.class"));
-        assertTrue(orderedApiContent.contains("ApiSecurity.OperationSecuritySchemaTag0.class"));
-        assertTrue(orderedApiContent.contains("ApiSecurity.OperationSecuritySchemaTag1.class"));
-        assertTrue(orderedSecurityContent.contains("OperationSecuritySchemaTag0HttpClientInterceptor"));
-        assertTrue(orderedSecurityContent.contains("OperationSecuritySchemaTag1HttpClientInterceptor"));
+        assertTrue(defaultApiContent.contains("ApiSecurity.Sec1AndSec2.class"));
+        assertFalse(defaultApiContent.contains("ApiSecurity.Sec2AndSec1.class"));
+        assertTrue(orderedApiContent.contains("ApiSecurity.Sec1AndSec2.class"));
+        assertTrue(orderedApiContent.contains("ApiSecurity.Sec2AndSec1.class"));
+        assertTrue(orderedSecurityContent.contains("Sec1AndSec2HttpClientInterceptor"));
+        assertTrue(orderedSecurityContent.contains("Sec2AndSec1HttpClientInterceptor"));
     }
 
     @Test
@@ -393,6 +488,10 @@ public class HttpClientJavaOpenapiTest extends BaseJavaOpenapiTest {
         assertTrue(securityContent.contains("final class CookieAuth"));
         assertTrue(securityContent.contains("final class OAuth"));
         assertFalse(securityContent.contains("final class bearerAuth"));
+        assertTrue(securityContent.contains("final class BearerAuth_ApiKeyAuth_BasicAuth_CookieAuth_OAuth"));
+        assertFalse(securityContent.contains("ReadPets"));
+        assertFalse(securityContent.contains("WritePets"));
+        assertFalse(securityContent.contains("OperationSecuritySchemaTag"));
     }
 
     @Test

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientJavaOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientJavaOpenapiTest.java
@@ -155,8 +155,29 @@ public class HttpClientJavaOpenapiTest extends BaseJavaOpenapiTest {
             .findFirst()
             .orElseThrow());
 
-        assertTrue(content.contains("b.header(\"Cookie\", \"X-COOKIE-KEY=\" + CookieAuth)"));
+        assertTrue(content.contains("_securityCookieHeader = _securityCookieHeader == null || _securityCookieHeader.isBlank() ? \"X-COOKIE-KEY=\" + CookieAuth"));
+        assertTrue(content.contains("b.header(\"Cookie\", _securityCookieHeader)"));
         assertFalse(content.contains("Cookies are not supported yet"));
+    }
+
+    @Test
+    void multipleCookieSecuritySchemesAreCombinedWithExistingCookies() throws Exception {
+        var files = generate(
+            "petstoreV3_security_cookie_and_client_interceptor",
+            "java-client",
+            getClass().getResource("/example/petstoreV3_security_cookie_and.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+        );
+        var content = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("ApiSecurity.java"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(content.contains("var _securityCookieHeader = request.headers().getFirst(\"Cookie\")"));
+        assertTrue(content.contains("\"X-COOKIE-KEY-1=\" + cookieAuth1"));
+        assertTrue(content.contains("_securityCookieHeader + \"; \" + \"X-COOKIE-KEY-2=\" + cookieAuth2"));
+        assertTrue(content.contains("b.header(\"Cookie\", _securityCookieHeader)"));
     }
 
     @Test

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientJavaOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientJavaOpenapiTest.java
@@ -373,6 +373,29 @@ public class HttpClientJavaOpenapiTest extends BaseJavaOpenapiTest {
     }
 
     @Test
+    void securityTagsUseSchemeNames() throws Exception {
+        var files = generate(
+            "petstoreV3_security_all_named_tags",
+            "java-client",
+            getClass().getResource("/example/petstoreV3_security_all.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+        );
+
+        var securityContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("ApiSecurity.java"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(securityContent.contains("final class BearerAuth"));
+        assertTrue(securityContent.contains("final class ApiKeyAuth"));
+        assertTrue(securityContent.contains("final class BasicAuth"));
+        assertTrue(securityContent.contains("final class CookieAuth"));
+        assertTrue(securityContent.contains("final class OAuth"));
+        assertFalse(securityContent.contains("final class bearerAuth"));
+    }
+
+    @Test
     void bareObjectPropertiesAreGeneratedAsObject() throws Exception {
         var files = generate(
             "petstoreV3_bare_object_bytes_default",

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientKotlinOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientKotlinOpenapiTest.java
@@ -74,6 +74,100 @@ public class HttpClientKotlinOpenapiTest extends BaseKotlinOpenapiTest {
     }
 
     @Test
+    void securityConfigUsesDedicatedNamesComponentAndPrefix() throws Exception {
+        var files = generate(
+            "petstoreV3_security_config_contract",
+            "kotlin-client",
+            getClass().getResource("/example/petstoreV3_security_all.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+                .setClientConfigPrefix("clients")
+                .setSecurityConfigPrefix("security")
+        );
+
+        var content = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("ApiSecurity.kt"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(content.contains("fun securityConfig("));
+        assertTrue(content.indexOf("@DefaultComponent") < content.indexOf("fun securityConfig("));
+        assertTrue(content.contains("data class SecurityConfig("));
+        assertTrue(content.contains("@Generated(\"io.koraframework.openapi.generator.kotlingen.ClientSecuritySchemaGenerator\")\n  public data class SecurityConfig("));
+        assertTrue(content.contains("data class SecurityBasicAuthConfig("));
+        assertTrue(content.contains("public val apiKeyAuth: String?,"));
+        assertTrue(content.contains("public val basicAuth: SecurityBasicAuthConfig?,"));
+        assertTrue(content.contains("public val cookieAuth: String?,"));
+        assertTrue(content.contains("public val username: String?,"));
+        assertTrue(content.contains("public val password: String?,"));
+        assertTrue(content.contains("mapper.map(config.get(\"security.apiKeyAuth\"))"));
+        assertFalse(content.contains("mapper.mapOrThrow"));
+        assertTrue(content.contains("config.get(\"security.apiKeyAuth\")"));
+        assertTrue(content.contains("config.get(\"security.basicAuth.username\")"));
+        assertTrue(content.contains("config.get(\"security.cookieAuth\")"));
+        assertFalse(content.contains("config.get(\"clients."));
+        assertFalse(content.contains("@ConfigSource"));
+    }
+
+    @Test
+    void cookieSecurityIsAddedToRequest() throws Exception {
+        var files = generate(
+            "petstoreV3_security_cookie_client_interceptor",
+            "kotlin-client",
+            getClass().getResource("/example/petstoreV3_security_cookie.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+        );
+
+        var content = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("ApiSecurity.kt"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(content.contains("b.header(\"Cookie\", \"X-COOKIE-KEY=\" + CookieAuth)"));
+        assertFalse(content.contains("Cookie client authentication is not implemented yet"));
+        assertFalse(content.contains("TODO("));
+    }
+
+    @Test
+    void securityConfigFallsBackToClientConfigPrefix() throws Exception {
+        var files = generate(
+            "petstoreV3_security_client_prefix_fallback",
+            "kotlin-client",
+            getClass().getResource("/example/petstoreV3_security_all.yaml").toExternalForm(),
+            new SwaggerParams.Options().setClientConfigPrefix("clients")
+        );
+
+        var content = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("ApiSecurity.kt"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(content.contains("config.get(\"clients.security.apiKeyAuth\")"));
+        assertTrue(content.contains("config.get(\"clients.security.basicAuth.username\")"));
+    }
+
+    @Test
+    void securityConfigFallsBackToClientConfig() throws Exception {
+        var files = generate(
+            "petstoreV3_security_client_config_fallback",
+            "kotlin-client",
+            getClass().getResource("/example/petstoreV3_security_all.yaml").toExternalForm(),
+            new SwaggerParams.Options().setClientConfig("clients.petstore")
+        );
+
+        var content = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("ApiSecurity.kt"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(content.contains("config.get(\"clients.petstore.security.apiKeyAuth\")"));
+        assertTrue(content.contains("config.get(\"clients.petstore.security.basicAuth.username\")"));
+    }
+
+    @Test
     void clientConfigIsRequiredWhenPrefixIsMissing() {
         var e = assertThrows(IllegalArgumentException.class, () -> generate(
             "petstoreV3_missing_config",
@@ -154,10 +248,12 @@ public class HttpClientKotlinOpenapiTest extends BaseKotlinOpenapiTest {
             .findFirst()
             .orElseThrow());
 
-        assertTrue(apiContent.indexOf("tag = ApiSecurity.OperationSecuritySchemaTag0::class") < apiContent.indexOf("optionalAccess("));
+        assertTrue(apiContent.indexOf("tag = ApiSecurity.Sec1_Anonymous::class") < apiContent.indexOf("optionalAccess("));
+        assertTrue(apiContent.indexOf("tag = ApiSecurity.Sec1::class") < apiContent.indexOf("requiredAccess("));
+        assertTrue(securityContent.contains("class Sec1_Anonymous"));
+        assertTrue(securityContent.contains("class Sec1"));
         assertTrue(apiContent.lastIndexOf("OperationSecuritySchemaTag") < apiContent.indexOf("publicAccess("));
         assertFalse(securityContent.contains("if ()"));
-        assertFalse(securityContent.contains("Security schema is defined for api but no data was provided"));
         assertTrue(securityContent.contains("return chain.process(request)"));
     }
 
@@ -310,9 +406,9 @@ public class HttpClientKotlinOpenapiTest extends BaseKotlinOpenapiTest {
             .findFirst()
             .orElseThrow());
 
-        // @ConfigSource is rejected by the config processor on a plain class
-        assertTrue(content.contains("@ConfigSource"), content);
-        assertTrue(content.contains("public data class basicAuthConfig"), content);
+        assertFalse(content.contains("@ConfigSource"), content);
+        assertTrue(content.contains("@DefaultComponent\n  public fun securityConfig("), content);
+        assertTrue(content.contains("public data class SecurityBasicAuthConfig"), content);
     }
 
     @Test
@@ -336,5 +432,9 @@ public class HttpClientKotlinOpenapiTest extends BaseKotlinOpenapiTest {
         assertTrue(securityContent.contains("class CookieAuth"));
         assertTrue(securityContent.contains("class OAuth"));
         assertFalse(securityContent.contains("class bearerAuth"));
+        assertTrue(securityContent.contains("class BearerAuth_ApiKeyAuth_BasicAuth_CookieAuth_OAuth"));
+        assertFalse(securityContent.contains("ReadPets"));
+        assertFalse(securityContent.contains("WritePets"));
+        assertFalse(securityContent.contains("OperationSecuritySchemaTag"));
     }
 }

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientKotlinOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientKotlinOpenapiTest.java
@@ -314,4 +314,27 @@ public class HttpClientKotlinOpenapiTest extends BaseKotlinOpenapiTest {
         assertTrue(content.contains("@ConfigSource"), content);
         assertTrue(content.contains("public data class basicAuthConfig"), content);
     }
+
+    @Test
+    void securityTagsUseSchemeNames() throws Exception {
+        var files = generate(
+            "petstoreV3_security_all_named_tags",
+            "kotlin-client",
+            getClass().getResource("/example/petstoreV3_security_all.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+        );
+
+        var securityContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("ApiSecurity.kt"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(securityContent.contains("class BearerAuth"));
+        assertTrue(securityContent.contains("class ApiKeyAuth"));
+        assertTrue(securityContent.contains("class BasicAuth"));
+        assertTrue(securityContent.contains("class CookieAuth"));
+        assertTrue(securityContent.contains("class OAuth"));
+        assertFalse(securityContent.contains("class bearerAuth"));
+    }
 }

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientKotlinOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientKotlinOpenapiTest.java
@@ -124,9 +124,30 @@ public class HttpClientKotlinOpenapiTest extends BaseKotlinOpenapiTest {
             .findFirst()
             .orElseThrow());
 
-        assertTrue(content.contains("b.header(\"Cookie\", \"X-COOKIE-KEY=\" + CookieAuth)"));
+        assertTrue(content.contains("_securityCookieHeader = if (_securityCookieHeader.isNullOrBlank()) \"X-COOKIE-KEY=\" + CookieAuth"));
+        assertTrue(content.contains("b.header(\"Cookie\", _securityCookieHeader)"));
         assertFalse(content.contains("Cookie client authentication is not implemented yet"));
         assertFalse(content.contains("TODO("));
+    }
+
+    @Test
+    void multipleCookieSecuritySchemesAreCombinedWithExistingCookies() throws Exception {
+        var files = generate(
+            "petstoreV3_security_cookie_and_client_interceptor",
+            "kotlin-client",
+            getClass().getResource("/example/petstoreV3_security_cookie_and.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+        );
+        var content = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("ApiSecurity.kt"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(content.contains("var _securityCookieHeader = request.headers().getFirst(\"Cookie\")"));
+        assertTrue(content.contains("\"X-COOKIE-KEY-1=\" + cookieAuth1"));
+        assertTrue(content.contains("_securityCookieHeader + \"; \" + \"X-COOKIE-KEY-2=\" + cookieAuth2"));
+        assertTrue(content.contains("b.header(\"Cookie\", _securityCookieHeader)"));
     }
 
     @Test

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpServerJavaOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpServerJavaOpenapiTest.java
@@ -158,6 +158,29 @@ public class HttpServerJavaOpenapiTest extends BaseJavaOpenapiTest {
     }
 
     @Test
+    void securityPrincipalExtractorTagsUseSchemeNames() throws Exception {
+        var files = generate(
+            "petstoreV3_security_all_named_tags",
+            "java-server",
+            getClass().getResource("/example/petstoreV3_security_all.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+        );
+
+        var securityContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("ApiSecurity.java"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(securityContent.contains("final class BearerAuth"));
+        assertTrue(securityContent.contains("final class ApiKeyAuth"));
+        assertTrue(securityContent.contains("final class BasicAuth"));
+        assertTrue(securityContent.contains("final class CookieAuth"));
+        assertTrue(securityContent.contains("final class OAuth"));
+        assertFalse(securityContent.contains("SecurityRequirementTag"));
+    }
+
+    @Test
     void serverResponseMapperWithoutDelegatesDoesNotGenerateEmptyConstructor() throws Exception {
         var files = generate(
             "petstoreV3_discriminator",

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpServerJavaOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpServerJavaOpenapiTest.java
@@ -131,11 +131,12 @@ public class HttpServerJavaOpenapiTest extends BaseJavaOpenapiTest {
             .findFirst()
             .orElseThrow());
 
-        assertTrue(controllerContent.indexOf("tag = ApiSecurity.OperationSecuritySchemaTag0.class") < controllerContent.indexOf("optionalAccess("));
-        assertTrue(controllerContent.lastIndexOf("OperationSecuritySchemaTag") < controllerContent.indexOf("publicAccess("));
+        assertTrue(controllerContent.indexOf("tag = ApiSecurity.Sec1_Anonymous.class") < controllerContent.indexOf("optionalAccess("));
+        assertTrue(controllerContent.indexOf("tag = ApiSecurity.Sec1.class") < controllerContent.indexOf("requiredAccess("));
+        assertTrue(securityContent.contains("final class Sec1_Anonymous"));
+        assertTrue(securityContent.contains("final class Sec1"));
         assertFalse(securityContent.contains("SecurityRequirementTag1"));
         assertTrue(securityContent.contains("return chain.process(request);"));
-        assertFalse(securityContent.contains("Unauthorized"));
     }
 
     @Test
@@ -178,6 +179,72 @@ public class HttpServerJavaOpenapiTest extends BaseJavaOpenapiTest {
         assertTrue(securityContent.contains("final class CookieAuth"));
         assertTrue(securityContent.contains("final class OAuth"));
         assertFalse(securityContent.contains("SecurityRequirementTag"));
+        assertTrue(securityContent.contains("final class BearerAuth_ApiKeyAuth_BasicAuth_CookieAuth_OAuth"));
+        assertFalse(securityContent.contains("ReadPets"));
+        assertFalse(securityContent.contains("WritePets"));
+        assertFalse(securityContent.contains("OperationSecuritySchemaTag"));
+    }
+
+    @Test
+    void securityCredentialAndPrincipalVariablesDoNotCollide() throws Exception {
+        var files = generate(
+            "petstoreV3_security_api_key_distinct_variables",
+            "java-server",
+            getClass().getResource("/example/petstoreV3_security_api_key.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+        );
+
+        var securityContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("ApiSecurity.java"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(securityContent.contains("HttpServerPrincipalExtractor<String, Principal> ApiKeyAuth_"));
+        assertTrue(securityContent.contains("var ApiKeyAuthHeader = request.headers().getFirst(\"X-API-KEY\")"));
+        assertTrue(securityContent.contains("var ApiKeyAuth = this.ApiKeyAuth_.extract(request, ApiKeyAuthHeader)"));
+        assertFalse(securityContent.contains("var ApiKeyAuth = this.ApiKeyAuth.extract(request, ApiKeyAuth)"));
+    }
+
+    @Test
+    void securityCredentialVariablesUseSourceSuffixes() throws Exception {
+        var files = generate(
+            "petstoreV3_security_multi_source_variables",
+            "java-server",
+            getClass().getResource("/example/petstoreV3_security_multi.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+        );
+
+        var securityContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("ApiSecurity.java"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(securityContent.contains("var headerAuth1Header = request.headers().getFirst(\"X-API-KEY-1\")"));
+        assertTrue(securityContent.contains("var queryAuthQueryList = request.queryParams().get(\"X-QUERY-KEY\")"));
+        assertTrue(securityContent.contains("var queryAuthQuery = queryAuthQueryList == null"));
+        assertTrue(securityContent.contains("new HeaderAuth1WithQueryAuthAuthData(headerAuth1Header, queryAuthQuery)"));
+        assertTrue(securityContent.contains("var oAuthHeader = request.headers().getFirst(\"Authorization\")"));
+    }
+
+    @Test
+    void cookieSecurityCredentialsUseCookieSuffix() throws Exception {
+        var files = generate(
+            "petstoreV3_security_cookie_source_variables",
+            "java-server",
+            getClass().getResource("/example/petstoreV3_security_cookie.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+        );
+
+        var securityContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("ApiSecurity.java"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(securityContent.contains("var CookieAuthCookie = request.cookies().stream()"));
+        assertTrue(securityContent.contains("var CookieAuth = this.CookieAuth_.extract(request, CookieAuthCookie)"));
     }
 
     @Test

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpServerKotlinOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpServerKotlinOpenapiTest.java
@@ -104,6 +104,29 @@ public class HttpServerKotlinOpenapiTest extends BaseKotlinOpenapiTest {
     }
 
     @Test
+    void securityPrincipalExtractorTagsUseSchemeNames() throws Exception {
+        var files = generate(
+            "petstoreV3_security_all_named_tags",
+            "kotlin-server",
+            getClass().getResource("/example/petstoreV3_security_all.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+        );
+
+        var securityContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("ApiSecurity.kt"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(securityContent.contains("class BearerAuth"));
+        assertTrue(securityContent.contains("class ApiKeyAuth"));
+        assertTrue(securityContent.contains("class BasicAuth"));
+        assertTrue(securityContent.contains("class CookieAuth"));
+        assertTrue(securityContent.contains("class OAuth"));
+        assertFalse(securityContent.contains("SecurityRequirementTag"));
+    }
+
+    @Test
     void serverResponseMapperWithoutDelegatesDoesNotGenerateEmptyConstructor() throws Exception {
         var files = generate(
             "petstoreV3_discriminator",

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpServerKotlinOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpServerKotlinOpenapiTest.java
@@ -77,11 +77,12 @@ public class HttpServerKotlinOpenapiTest extends BaseKotlinOpenapiTest {
             .findFirst()
             .orElseThrow());
 
-        assertTrue(controllerContent.indexOf("tag = ApiSecurity.OperationSecuritySchemaTag0::class") < controllerContent.indexOf("optionalAccess("));
-        assertTrue(controllerContent.lastIndexOf("OperationSecuritySchemaTag") < controllerContent.indexOf("publicAccess("));
+        assertTrue(controllerContent.indexOf("tag = ApiSecurity.Sec1_Anonymous::class") < controllerContent.indexOf("optionalAccess("));
+        assertTrue(controllerContent.indexOf("tag = ApiSecurity.Sec1::class") < controllerContent.indexOf("requiredAccess("));
+        assertTrue(securityContent.contains("class Sec1_Anonymous"));
+        assertTrue(securityContent.contains("class Sec1"));
         assertFalse(securityContent.contains("SecurityRequirementTag1"));
         assertTrue(securityContent.contains("return chain.process(request)"));
-        assertFalse(securityContent.contains("Unauthorized"));
     }
 
     @Test
@@ -124,6 +125,69 @@ public class HttpServerKotlinOpenapiTest extends BaseKotlinOpenapiTest {
         assertTrue(securityContent.contains("class CookieAuth"));
         assertTrue(securityContent.contains("class OAuth"));
         assertFalse(securityContent.contains("SecurityRequirementTag"));
+        assertTrue(securityContent.contains("class BearerAuth_ApiKeyAuth_BasicAuth_CookieAuth_OAuth"));
+        assertFalse(securityContent.contains("ReadPets"));
+        assertFalse(securityContent.contains("WritePets"));
+        assertFalse(securityContent.contains("OperationSecuritySchemaTag"));
+    }
+
+    @Test
+    void headerSecurityCredentialsUseHeaderSuffix() throws Exception {
+        var files = generate(
+            "petstoreV3_security_api_key_header_variables",
+            "kotlin-server",
+            getClass().getResource("/example/petstoreV3_security_api_key.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+        );
+
+        var securityContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("ApiSecurity.kt"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(securityContent.contains("val ApiKeyAuthHeader = request.headers().getFirst(\"X-API-KEY\")"));
+        assertTrue(securityContent.contains("val ApiKeyAuth = this.ApiKeyAuth_.extract(request, ApiKeyAuthHeader)"));
+    }
+
+    @Test
+    void securityCredentialVariablesUseSourceSuffixes() throws Exception {
+        var files = generate(
+            "petstoreV3_security_multi_source_variables",
+            "kotlin-server",
+            getClass().getResource("/example/petstoreV3_security_multi.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+        );
+
+        var securityContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("ApiSecurity.kt"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(securityContent.contains("val headerAuth1Header = request.headers().getFirst(\"X-API-KEY-1\")"));
+        assertTrue(securityContent.contains("val queryAuthQuery = request.queryParams().get(\"X-QUERY-KEY\")?.firstOrNull()"));
+        assertTrue(securityContent.contains("HeaderAuth1WithQueryAuthAuthData(headerAuth1Header, queryAuthQuery)"));
+        assertTrue(securityContent.contains("val oAuthHeader = request.headers().getFirst(\"Authorization\")"));
+    }
+
+    @Test
+    void cookieSecurityCredentialsUseCookieSuffix() throws Exception {
+        var files = generate(
+            "petstoreV3_security_cookie_source_variables",
+            "kotlin-server",
+            getClass().getResource("/example/petstoreV3_security_cookie.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+        );
+
+        var securityContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("ApiSecurity.kt"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(securityContent.contains("val CookieAuthCookie = request.cookies().firstOrNull"));
+        assertTrue(securityContent.contains("val CookieAuth = this.CookieAuth_.extract(request, CookieAuthCookie)"));
     }
 
     @Test

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/SecurityDataTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/SecurityDataTest.java
@@ -1,0 +1,88 @@
+package io.koraframework.openapi.generator;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.Paths;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SecurityDataTest {
+    @Test
+    void omitsScopesFromUniqueOperationSecurityTag() {
+        var security = securityData(operation("read", requirement("oAuth", "read_pets")));
+
+        assertEquals(List.of("OAuth"), security.interceptorTagBySecurityRequirement.values().stream().toList());
+    }
+
+    @Test
+    void appendsScopesWhenOperationSecurityTagsCollide() {
+        var security = securityData(
+            operation("read", requirement("oAuth", "read_pets")),
+            operation("write", requirement("oAuth", "write_pets", "read_pets")),
+            operation("unscoped", requirement("oAuth"))
+        );
+
+        assertEquals(
+            List.of("OAuth_ReadPets", "OAuth_ReadPetsAndWritePets", "OAuth_NoScopes"),
+            security.interceptorTagBySecurityRequirement.values().stream().toList()
+        );
+    }
+
+    @Test
+    void distinguishesAnonymousFallbackFromRequiredSecurity() {
+        var required = requirement("bearerAuth");
+        var optional = new Operation().operationId("optional").security(List.of(required, new SecurityRequirement()));
+        var security = securityData(operation("required", required), optional);
+
+        assertEquals(
+            List.of("BearerAuth", "BearerAuth_Anonymous"),
+            security.interceptorTagBySecurityRequirement.values().stream().toList()
+        );
+    }
+
+    private static SecurityData securityData(Operation... operations) {
+        var paths = new Paths();
+        for (var operation : operations) {
+            paths.addPathItem("/" + operation.getOperationId(), new PathItem().get(operation));
+        }
+        var openApi = new OpenAPI()
+            .components(new Components()
+                .addSecuritySchemes("oAuth", new SecurityScheme().type(SecurityScheme.Type.OAUTH2))
+                .addSecuritySchemes("bearerAuth", new SecurityScheme().type(SecurityScheme.Type.HTTP).scheme("bearer")))
+            .paths(paths);
+        var security = new SecurityData();
+        security.fromOpenapi(openApi, false, SecurityDataTest::tagName);
+        return security;
+    }
+
+    private static Operation operation(String operationId, SecurityRequirement requirement) {
+        return new Operation().operationId(operationId).security(List.of(requirement));
+    }
+
+    private static SecurityRequirement requirement(String name, String... scopes) {
+        return new SecurityRequirement().addList(name, List.of(scopes));
+    }
+
+    private static String tagName(String value) {
+        var result = new StringBuilder();
+        var upperCaseNext = true;
+        for (var character : value.toCharArray()) {
+            if (!Character.isLetterOrDigit(character)) {
+                upperCaseNext = true;
+            } else if (upperCaseNext) {
+                result.append(Character.toUpperCase(character));
+                upperCaseNext = false;
+            } else {
+                result.append(character);
+            }
+        }
+        return result.toString();
+    }
+}

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/SecurityDataTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/SecurityDataTest.java
@@ -47,6 +47,46 @@ class SecurityDataTest {
         );
     }
 
+    @Test
+    void preservesSeparatorsWhenSecuritySchemeNamesCollide() {
+        var paths = new Paths()
+            .addPathItem("/dash", new PathItem().get(operation("dash", requirement("api-key"))))
+            .addPathItem("/underscore", new PathItem().get(operation("underscore", requirement("api_key"))));
+        var openApi = new OpenAPI()
+            .components(new Components()
+                .addSecuritySchemes("api-key", new SecurityScheme().type(SecurityScheme.Type.APIKEY))
+                .addSecuritySchemes("api_key", new SecurityScheme().type(SecurityScheme.Type.APIKEY)))
+            .paths(paths);
+        var security = new SecurityData();
+        security.fromOpenapi(openApi, false, SecurityDataTest::tagName);
+
+        assertEquals("ApiKey", security.tagBySecuritySchemeName.get("api-key"));
+        assertEquals("Api_Key", security.tagBySecuritySchemeName.get("api_key"));
+        assertEquals(List.of("ApiKey", "Api_Key"), security.interceptorTagBySecurityRequirement.values().stream().toList());
+    }
+
+    @Test
+    void preservesSeparatorsWhenScopeNamesCollide() {
+        var security = securityData(
+            operation("dash", requirement("oAuth", "read-pets")),
+            operation("underscore", requirement("oAuth", "read_pets"))
+        );
+
+        assertEquals("ReadPets", security.tagBySecurityScopeName.get("read-pets"));
+        assertEquals("Read_Pets", security.tagBySecurityScopeName.get("read_pets"));
+        assertEquals(List.of("OAuth_ReadPets", "OAuth_Read_Pets"), security.interceptorTagBySecurityRequirement.values().stream().toList());
+    }
+
+    @Test
+    void addsStableSuffixWhenComposedScopeTagsStillCollide() {
+        var security = securityData(
+            operation("combined", requirement("oAuth", "read", "pets")),
+            operation("single", requirement("oAuth", "petsAndRead"))
+        );
+
+        assertEquals(List.of("OAuth_OAuthPetsAndRead", "OAuth_OAuthPetsAndRead2"), security.interceptorTagBySecurityRequirement.values().stream().toList());
+    }
+
     private static SecurityData securityData(Operation... operations) {
         var paths = new Paths();
         for (var operation : operations) {

--- a/openapi/openapi-generator/src/test/resources/example/petstoreV3_security_anonymous.yaml
+++ b/openapi/openapi-generator/src/test/resources/example/petstoreV3_security_anonymous.yaml
@@ -26,6 +26,16 @@ paths:
       responses:
         '200':
           description: Ok
+  /required:
+    get:
+      operationId: requiredAccess
+      tags:
+        - public
+      security:
+        - sec1: []
+      responses:
+        '200':
+          description: Ok
 
 components:
   securitySchemes:

--- a/openapi/openapi-generator/src/test/resources/example/petstoreV3_security_cookie_and.yaml
+++ b/openapi/openapi-generator/src/test/resources/example/petstoreV3_security_cookie_and.yaml
@@ -1,0 +1,27 @@
+openapi: 3.0.3
+
+info:
+  title: Multiple cookie security
+  version: 1.0.0
+
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      security:
+        - cookieAuth1: []
+          cookieAuth2: []
+      responses:
+        '200':
+          description: Ok
+
+components:
+  securitySchemes:
+    cookieAuth1:
+      type: apiKey
+      in: cookie
+      name: X-COOKIE-KEY-1
+    cookieAuth2:
+      type: apiKey
+      in: cookie
+      name: X-COOKIE-KEY-2


### PR DESCRIPTION
Fixed OpenAPI security tags with scheme-based names for Java and Kotlin clients and servers

## EN

### Description

Fixed a Kora 2.0 regression where generated security tags depended on requirement traversal order or retained raw lower-case scheme names. Java and Kotlin clients and servers now derive stable tag class names from OpenAPI security scheme names, restoring 1.x compatibility. Combined server requirements use semantic names such as `BearerAuthWithApiKeyAuth`.

### Intention & Motivation

Fixed generated DI contracts to remain stable when operations or security requirements are reordered. Applications can again reference predictable tags such as `ApiSecurity.BearerAuth` without depending on generated numeric identifiers.

---

## RU

### Описание

Исправлена регрессия Kora 2.0, из-за которой имена сгенерированных тегов безопасности зависели от порядка обхода требований либо сохраняли исходное имя схемы с маленькой буквы. Java- и Kotlin-клиенты и серверы теперь формируют стабильные имена классов тегов из названий схем безопасности OpenAPI, восстанавливая совместимость с веткой 1.x. Для составных серверных требований используются семантические имена вида `BearerAuthWithApiKeyAuth`.

### Намерение и мотивация

Исправление возвращает стабильность сгенерированного DI-контракта при изменении порядка операций или требований безопасности. Приложения снова могут ссылаться на предсказуемые теги, например `ApiSecurity.BearerAuth`, не завися от числовых идентификаторов генератора.

---

## Changelog

- Fixed OpenAPI security tag generation to use normalized security scheme names consistently across Java and Kotlin clients and servers while preserving anonymous and combined-requirement behavior.

---

## Design

`SecurityData` owns the mapping between names declared under `components.securitySchemes` and normalized generated tag class names. The existing generator identifier normalization remains responsible for producing valid class names:

```yaml
components:
  securitySchemes:
    bearerAuth:
      type: http
      scheme: bearer
    apiKeyAuth:
      type: apiKey
      in: header
      name: X-API-KEY
```

Representative generated contract:

```java
public interface ApiSecurity {
    final class BearerAuth {}
    final class ApiKeyAuth {}
}
```

Server principal extractors and client token providers use the same mapped tag identity:

```java
@Tag(ApiSecurity.BearerAuth.class)
HttpServerPrincipalExtractor<Principal> bearerAuth;

@Tag(ApiSecurity.ApiKeyAuth.class)
HttpClientTokenProvider apiKeyAuth;
```

For an AND requirement containing several schemes, the server generates a semantic combined extractor tag such as `BearerAuthWithApiKeyAuth`. With `useSecurityDeclarationOrder=true`, its components follow declaration order; otherwise normalized ordering applies.

Anonymous requirements represented by `{}` do not create extractor tags. Operation-level interceptor group tags such as `OperationSecuritySchemaTag0` remain unchanged. Configuration paths and security scheme keys also remain unchanged; only generated tag class identities are restored.