### PR TITLE
Fixed(openapi-generator): restore `fromValue` static factory and `Constants` value holder on generated enums.

### DIFF
--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ModelGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ModelGenerator.java
@@ -363,7 +363,7 @@ public class ModelGenerator extends AbstractJavaGenerator<ModelsMap> {
         for (var i = 0; i < enumVars.size(); i++) {
             var enumVar = enumVars.get(i);
             var enumName = enumVar.get("name").toString();
-            var enumConstant = TypeSpec.anonymousClassBuilder("$L", enumVar.get("value"));
+            var enumConstant = TypeSpec.anonymousClassBuilder("Constants.$L", enumName);
             var description = enumValueDescription(model, enumVar, i);
             if (description != null && !description.isBlank()) {
                 enumConstant.addJavadoc("$L\n", description);
@@ -386,6 +386,31 @@ public class ModelGenerator extends AbstractJavaGenerator<ModelsMap> {
             .addModifiers(Modifier.PUBLIC)
             .returns(String.class)
             .addStatement("return String.valueOf(value)")
+            .build());
+        var constants = TypeSpec.classBuilder("Constants")
+            .addAnnotation(generated())
+            .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL);
+        for (var enumVar : enumVars) {
+            var enumName = enumVar.get("name").toString();
+            constants.addField(FieldSpec.builder(enumValueType(model), enumName, Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
+                .initializer("$L", enumVar.get("value"))
+                .build());
+        }
+        b.addType(constants.build());
+        var selfType = ClassName.bestGuess(model.name);
+        b.addField(FieldSpec.builder(ArrayTypeName.of(selfType), "VALUES", Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
+            .initializer("values()")
+            .build());
+        b.addMethod(MethodSpec.methodBuilder("fromValue")
+            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+            .returns(selfType)
+            .addParameter(enumValueType(model), "value")
+            .beginControlFlow("for (var candidate : VALUES)")
+            .beginControlFlow("if (candidate.value.equals(value))")
+            .addStatement("return candidate")
+            .endControlFlow()
+            .endControlFlow()
+            .addStatement("throw new $T(\"Unexpected value '\" + value + \"'\")", IllegalArgumentException.class)
             .build());
         return b.build();
     }

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ModelGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ModelGenerator.kt
@@ -267,6 +267,19 @@ class ModelGenerator : AbstractKotlinGenerator<ModelsMap>() {
                 .addStatement("return value.toString()")
                 .build()
         )
+        b.addType(
+            TypeSpec.companionObjectBuilder()
+                .addProperty(PropertySpec.builder("values", ARRAY.parameterizedBy(enumClassName), KModifier.PRIVATE).initializer("entries.toTypedArray()").build())
+                .addFunction(
+                    FunSpec.builder("fromValue")
+                        .addAnnotation(JvmStatic::class)
+                        .addParameter("value", enumValueType(model))
+                        .returns(enumClassName)
+                        .addStatement("return values.firstOrNull { it.value == value } ?: throw %T(%S + value + %S)", IllegalArgumentException::class, "Unexpected value '", "'")
+                        .build()
+                )
+                .build()
+        )
         val constants = TypeSpec.objectBuilder("Constants")
             .addAnnotation(generated())
         for (enumVar in enumVars) {

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientJavaOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientJavaOpenapiTest.java
@@ -193,10 +193,11 @@ public class HttpClientJavaOpenapiTest extends BaseJavaOpenapiTest {
             .orElseThrow());
 
         assertFalse(petDogContent.contains("MapperModule"));
-        assertTrue(petDogContent.contains("DINGO_DON(\"Dingo-Don\")"));
-        assertTrue(petDogContent.contains("NUMBER_5(5)"));
-        assertFalse(petDogContent.contains("Constants."));
-        assertFalse(petDogContent.contains("public static final class Constants"));
+        assertTrue(petDogContent.contains("DINGO_DON(Constants.DINGO_DON)"));
+        assertTrue(petDogContent.contains("NUMBER_5(Constants.NUMBER_5)"));
+        assertTrue(petDogContent.contains("public static final class Constants"));
+        assertTrue(petDogContent.contains("public static final String DINGO_DON = \"Dingo-Don\""));
+        assertTrue(petDogContent.contains("public static final Integer NUMBER_5 = 5"));
         assertFalse(petDogContent.contains("public static final class JsonWriter"));
         assertFalse(petDogContent.contains("public static final class JsonReader"));
         assertFalse(petDogContent.contains("public static final class StringParameterConverter"));


### PR DESCRIPTION
Fixed OpenAPI generator enums with restored `fromValue` lookup and `Constants` value holder

## Description

## EN

### Description

Fixed generated Java and Kotlin enums to restore the `fromValue(value)` static factory that resolves an enum constant from its raw value, throwing `IllegalArgumentException` when no constant matches. Fixed generated Java enums to restore the nested `Constants` class holding the raw value of each constant as a `public static final` field, with enum constants now referencing `Constants.NAME` instead of inlining literals, matching the existing Kotlin generator contract. Both language generators cache their enum values array once instead of calling `values()`/re-copying `entries` on every lookup.

### Intention & Motivation

The 2.0 rewrite of the OpenAPI generator (mustache templates replaced by JavaPoet/KotlinPoet) silently dropped `fromValue` for both languages and the `Constants` holder for Java, breaking consumers who relied on parsing raw values back into enum constants or referencing constant values directly (for example, in annotations or `switch` cases that require compile-time constants). This restores the pre-2.0 contract without introducing new configuration.

---

## RU

### Описание

Исправлена генерация Java- и Kotlin-перечислений: восстановлен статический метод `fromValue(value)`, который находит константу перечисления по её сырому значению и выбрасывает `IllegalArgumentException`, если совпадений нет. Для Java также восстановлен вложенный класс `Constants` с полями `public static final` для сырых значений каждой константы, а сами константы перечисления теперь ссылаются на `Constants.NAME` вместо встроенных литералов — как уже было устроено в Kotlin-генераторе. Оба генератора теперь кешируют массив значений перечисления один раз вместо повторного вызова `values()`/копирования `entries` при каждом поиске.

### Намерение и мотивация

При переходе генератора OpenAPI 2.0 с mustache-шаблонов на JavaPoet/KotlinPoet метод `fromValue` был незаметно потерян для обоих языков, а класс `Constants` — для Java, что ломало код, зависящий от разбора сырых значений обратно в константы перечисления или от прямого использования значений констант (например, в аннотациях или `switch`, где нужны константы времени компиляции). Это изменение восстанавливает контракт, существовавший до версии 2.0, без добавления новой конфигурации.

---

## Changelog

- Fixed generated Java and Kotlin enums to expose `fromValue(value)`, resolving a constant by its raw value and throwing `IllegalArgumentException` on no match, backed by a values array cached once instead of recomputed per call.
- Fixed generated Java enums to declare a nested `Constants` class with `public static final` fields for each raw enum value, with enum constants referencing `Constants.NAME` instead of inline literals.

---

## Design

`ModelGenerator` (Java, `io.koraframework.openapi.generator.javagen`) and `ModelGenerator` (Kotlin, `io.koraframework.openapi.generator.kotlingen`) both build enum types through `buildEnum`. For Java, the enum constant list now feeds a `Constants` inner class first (`public static final <valueType> NAME = <literal>;`), then each enum constant is declared as `NAME(Constants.NAME)`. A private static `VALUES` array (Java) is initialized once from `values()` and reused inside `fromValue`; Kotlin reuses `entries` similarly inside a `companion object`. The `fromValue` method is `public static` (Java) / `@JvmStatic` in a `companion object` (Kotlin), takes the enum's raw value type (`String`, `Integer`, `Long`, etc., from `enumValueType`), and throws `IllegalArgumentException` with the unmatched value in the message if nothing matches. This applies uniformly to both top-level model enums and inline field-nested enums, since both paths go through the same `buildEnum`.

Example of the restored Java contract:

```java
public enum BreedEnum {
  DINGO_DON(Constants.DINGO_DON),
  HUSKY(Constants.HUSKY);

  private static final BreedEnum[] VALUES = values();
  private final String value;

  public static BreedEnum fromValue(String value) {
    for (var candidate : VALUES) {
      if (candidate.value.equals(value)) {
        return candidate;
      }
    }
    throw new IllegalArgumentException("Unexpected value '" + value + "'");
  }

  public static final class Constants {
    public static final String DINGO_DON = "Dingo-Don";
    public static final String HUSKY = "Husky";
  }
}
```

No configuration option controls this behavior — it is always generated for enum models, matching the pre-2.0 default. `JsonWriter`/`JsonReader`/`StringParameterConverter`/`StringParameterReader` mapper generation (extracted into separate `*MapperModule` files in 2.0) is unchanged.