### PR TITLE
[Draft] Kotlin Structured Concurrency discussion

### DIFF
--- a/core/common/build.gradle
+++ b/core/common/build.gradle
@@ -1,8 +1,17 @@
+apply from: "${project.rootDir}/gradle/kotlin-plugin.gradle"
+
 dependencies {
+    compileOnly libs.kotlin.stdlib.lib
+    compileOnly libs.kotlinx.coroutines.core
+
     api project(":core:application-graph")
-    api libs.slf4j.api
     api project(":telemetry:micrometer-common")
+    api libs.slf4j.api
     api libs.opentelemetry.api
+
+    testImplementation project(":logging:logging-common")
+    testImplementation libs.kotlin.stdlib.lib
+    testImplementation libs.kotlinx.coroutines.core
 }
 
 sourceSets.main {

--- a/core/common/src/main/java/io/koraframework/common/concurrent/KoraContextSnapshot.java
+++ b/core/common/src/main/java/io/koraframework/common/concurrent/KoraContextSnapshot.java
@@ -1,0 +1,93 @@
+package io.koraframework.common.concurrent;
+
+import io.koraframework.common.Principal;
+import io.koraframework.common.context.ThreadContextPropagator;
+import io.koraframework.common.telemetry.Observation;
+import io.koraframework.common.telemetry.OpentelemetryContext;
+import io.opentelemetry.context.Context;
+import org.jspecify.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.function.Supplier;
+
+final class KoraContextSnapshot {
+    private static final List<ThreadContextPropagator> PROPAGATORS = ServiceLoader
+        .load(ThreadContextPropagator.class, ThreadContextPropagator.class.getClassLoader())
+        .stream()
+        .map(ServiceLoader.Provider::get)
+        .toList();
+
+    private final Context opentelemetryContext;
+    private final @Nullable Principal principal;
+    private final @Nullable Observation observation;
+    private final List<ThreadContextPropagator.Snapshot> propagatedContexts;
+
+    private KoraContextSnapshot(
+        Context opentelemetryContext,
+        @Nullable Principal principal,
+        @Nullable Observation observation,
+        List<ThreadContextPropagator.Snapshot> propagatedContexts
+    ) {
+        this.opentelemetryContext = opentelemetryContext;
+        this.principal = principal;
+        this.observation = observation;
+        this.propagatedContexts = propagatedContexts;
+    }
+
+    static KoraContextSnapshot capture() {
+        var propagatedContexts = new ArrayList<ThreadContextPropagator.Snapshot>(PROPAGATORS.size());
+        for (var propagator : PROPAGATORS) {
+            var snapshot = propagator.capture();
+            if (snapshot != null) {
+                propagatedContexts.add(snapshot);
+            }
+        }
+        return new KoraContextSnapshot(
+            Context.current(),
+            Principal.current(),
+            Observation.VALUE.isBound() ? Observation.VALUE.get() : null,
+            Collections.unmodifiableList(propagatedContexts)
+        );
+    }
+
+    KoraContextSnapshot fork() {
+        var forks = new ArrayList<ThreadContextPropagator.Snapshot>(this.propagatedContexts.size());
+        for (ThreadContextPropagator.Snapshot context : this.propagatedContexts) {
+            forks.add(context.fork());
+        }
+
+        return new KoraContextSnapshot(
+            this.opentelemetryContext,
+            this.principal,
+            this.observation,
+            Collections.unmodifiableList(forks)
+        );
+    }
+
+    void run(Runnable block) {
+        this.call(() -> {
+            block.run();
+            return null;
+        });
+    }
+
+    <T> T call(Supplier<T> operation) {
+        var carrier = ScopedValue.where(OpentelemetryContext.VALUE, this.opentelemetryContext);
+        if (this.principal != null) {
+            carrier = carrier.where(Principal.VALUE, this.principal);
+        }
+        if (this.observation != null) {
+            carrier = carrier.where(Observation.VALUE, this.observation);
+        }
+        Supplier<T> propagatedOperation = operation;
+        for (var i = this.propagatedContexts.size() - 1; i >= 0; i--) {
+            var snapshot = this.propagatedContexts.get(i);
+            var nestedOperation = propagatedOperation;
+            propagatedOperation = () -> snapshot.call(nestedOperation);
+        }
+        return carrier.call(propagatedOperation::get);
+    }
+}

--- a/core/common/src/main/java/io/koraframework/common/context/ThreadContextPropagator.java
+++ b/core/common/src/main/java/io/koraframework/common/context/ThreadContextPropagator.java
@@ -1,0 +1,45 @@
+package io.koraframework.common.context;
+
+import org.jspecify.annotations.Nullable;
+
+import java.util.function.Supplier;
+
+/**
+ * Captures framework context that must cross a thread boundary.
+ *
+ * <p>Implementations are discovered through {@link java.util.ServiceLoader}. A captured snapshot
+ * belongs to the structured scope that captured it; each concurrent child receives a
+ * {@linkplain Snapshot#fork() fork}.</p>
+ */
+public interface ThreadContextPropagator {
+
+    /**
+     * Captures the context currently bound to the calling thread.
+     *
+     * @return captured context, or {@code null} when this context is not bound
+     */
+    @Nullable
+    Snapshot capture();
+
+    interface Snapshot {
+        /**
+         * Creates a snapshot for an isolated concurrent child.
+         */
+        Snapshot fork();
+
+        /**
+         * Calls {@code operation} with this snapshot bound to the current thread.
+         */
+        <T> T call(Supplier<T> operation);
+
+        /**
+         * Runs {@code runnable} with this snapshot bound to the current thread.
+         */
+        default void run(Runnable runnable) {
+            this.call(() -> {
+                runnable.run();
+                return null;
+            });
+        }
+    }
+}

--- a/core/common/src/main/java/module-info.java
+++ b/core/common/src/main/java/module-info.java
@@ -8,10 +8,15 @@ module kora.common {
     requires transitive io.opentelemetry.context;
     requires transitive micrometer.core;
     requires transitive org.slf4j;
+    requires static kotlin.stdlib;
+    requires static kotlinx.coroutines.core;
 
+    uses io.koraframework.common.context.ThreadContextPropagator;
     provides io.opentelemetry.context.ContextStorageProvider with io.koraframework.common.telemetry.OpentelemetryContextStorageProvider;
     exports io.koraframework.common;
     exports io.koraframework.common.annotation;
+    exports io.koraframework.common.concurrent;
+    exports io.koraframework.common.context;
     exports io.koraframework.common.liveness;
     exports io.koraframework.common.naming;
     exports io.koraframework.common.readiness;

--- a/core/common/src/main/kotlin/io/koraframework/common/concurrent/Structured.kt
+++ b/core/common/src/main/kotlin/io/koraframework/common/concurrent/Structured.kt
@@ -1,0 +1,111 @@
+package io.koraframework.common.concurrent
+
+import kotlinx.coroutines.*
+import java.lang.Runnable
+import java.lang.Thread
+import java.util.concurrent.ThreadFactory
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Runs a structured group of blocking operations and returns its result synchronously.
+ *
+ * A failure in one child cancels its siblings. Cancellation interrupts the thread while it is
+ * executing an interruptible blocking operation. Operations run on virtual threads by default
+ * and may select another dispatcher with [StructuredCoroutineScope.asyncOn].
+ *
+ * Example using virtual threads:
+ * ```kotlin
+ * fun getProfile(id: Long): Profile =
+ *     structured {
+ *         val user = asyncVirtual {
+ *             userRepository.find(id)
+ *         }
+ *         val orders = asyncVirtual {
+ *             orderRepository.findByUser(id)
+ *         }
+ *
+ *         Profile(
+ *             user.await(),
+ *             orders.await(),
+ *         )
+ *     }
+ * ```
+ *
+ * A custom dispatcher may be selected for an individual operation:
+ * ```kotlin
+ * structured {
+ *     val result = asyncOn(Dispatchers.IO) {
+ *         repository.find(id)
+ *     }
+ *
+ *     result.await()
+ * }
+ * ```
+ */
+fun <T> structured(block: suspend StructuredCoroutineScope.() -> T): T {
+    val snapshot = KoraContextSnapshot.capture()
+    return runBlocking {
+        StructuredCoroutineScopeImpl(this, snapshot).block()
+    }
+}
+
+private class StructuredCoroutineScopeImpl(
+    private val scope: CoroutineScope,
+    private val snapshot: KoraContextSnapshot,
+) : StructuredCoroutineScope {
+    override fun <T> asyncVirtual(block: () -> T): Deferred<T> {
+        val childSnapshot = snapshot.fork()
+        return scope.async(KoraContextElement(childSnapshot)) {
+            runInterruptible(VirtualThreadDispatcher, block)
+        }
+    }
+
+    override fun <T> asyncOn(dispatcher: CoroutineDispatcher, block: () -> T): Deferred<T> {
+        val childSnapshot = snapshot.fork()
+        return scope.async {
+            runInterruptible(dispatcher) {
+                childSnapshot.call(block)
+            }
+        }
+    }
+
+    override fun launchVirtual(block: () -> Unit): Job {
+        val childSnapshot = snapshot.fork()
+        return scope.launch(KoraContextElement(childSnapshot)) {
+            runInterruptible(VirtualThreadDispatcher, block)
+        }
+    }
+
+    override fun launchOn(dispatcher: CoroutineDispatcher, block: () -> Unit): Job {
+        val childSnapshot = snapshot.fork()
+        return scope.launch {
+            runInterruptible(dispatcher) {
+                childSnapshot.call(block)
+            }
+        }
+    }
+}
+
+private object VirtualThreadDispatcher : CoroutineDispatcher() {
+    private val threadFactory: ThreadFactory = Thread.ofVirtual()
+        .name("kora-kvtd-", 0)
+        .factory()
+
+    override fun dispatch(context: CoroutineContext, block: Runnable) {
+        val snapshot = context[KoraContextElement]?.snapshot
+        threadFactory.newThread {
+            if (snapshot == null) {
+                block.run()
+            } else {
+                snapshot.run(block)
+            }
+        }.start()
+    }
+}
+
+private class KoraContextElement(
+    val snapshot: KoraContextSnapshot,
+) : AbstractCoroutineContextElement(KoraContextElement) {
+    companion object : CoroutineContext.Key<KoraContextElement>
+}

--- a/core/common/src/main/kotlin/io/koraframework/common/concurrent/StructuredCoroutineScope.kt
+++ b/core/common/src/main/kotlin/io/koraframework/common/concurrent/StructuredCoroutineScope.kt
@@ -1,0 +1,94 @@
+package io.koraframework.common.concurrent
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Job
+import java.util.concurrent.Semaphore
+
+/**
+ * Scope for running blocking operations concurrently, on virtual threads by default.
+ *
+ * Instances are only valid for the duration of [structured].
+ */
+interface StructuredCoroutineScope {
+    /**
+     * Starts [block] on a new virtual thread.
+     *
+     * Cancelling the returned task interrupts the virtual thread while the block is running.
+     */
+    fun <T> asyncVirtual(block: () -> T): Deferred<T>
+
+    /**
+     * Starts [block] on [dispatcher] with the captured Kora context.
+     *
+     * Cancelling the returned task interrupts the dispatcher thread while the block is running.
+     */
+    fun <T> asyncOn(dispatcher: CoroutineDispatcher, block: () -> T): Deferred<T>
+
+    /**
+     * Starts [block] on a new virtual thread without producing a result.
+     *
+     * The task remains a child of [structured], which waits for its completion and propagates its
+     * failure even when the returned job is not joined explicitly.
+     */
+    fun launchVirtual(block: () -> Unit): Job
+
+    /**
+     * Starts [block] on [dispatcher] without producing a result.
+     *
+     * The task remains a child of [structured], which waits for its completion and propagates its
+     * failure even when the returned job is not joined explicitly.
+     */
+    fun launchOn(dispatcher: CoroutineDispatcher, block: () -> Unit): Job
+
+    /**
+     * Starts one virtual-thread task for every element in this iterable.
+     *
+     * Use [kotlinx.coroutines.awaitAll] to await all returned tasks.
+     */
+    fun <T, R> Iterable<T>.mapVirtual(block: (T) -> R): List<Deferred<R>> =
+        map { value ->
+            asyncVirtual {
+                block(value)
+            }
+        }
+
+    /**
+     * Starts one virtual-thread task for every element in this iterable while allowing at most
+     * [parallelism] task bodies to run concurrently.
+     *
+     * Use this overload when a downstream resource, such as a connection pool or remote service,
+     * has a lower concurrency limit than virtual threads. [parallelism] must be positive.
+     */
+    fun <T, R> Iterable<T>.mapVirtual(
+        parallelism: Int,
+        block: (T) -> R,
+    ): List<Deferred<R>> {
+        require(parallelism > 0) { "parallelism must be positive" }
+        val semaphore = Semaphore(parallelism)
+        return mapVirtual { value ->
+            semaphore.acquire()
+            try {
+                block(value)
+            } finally {
+                semaphore.release()
+            }
+        }
+    }
+
+    /**
+     * Starts one task on [dispatcher] for every element in this iterable.
+     *
+     * Use [kotlinx.coroutines.awaitAll] to await all returned tasks.
+     */
+    fun <T, R> Iterable<T>.mapOn(
+        dispatcher: CoroutineDispatcher,
+        block: (T) -> R,
+    ): List<Deferred<R>> =
+        map { value ->
+            asyncOn(dispatcher) {
+                block(value)
+            }
+        }
+
+}

--- a/core/common/src/test/java/io/koraframework/common/concurrent/KoraContextTestHelper.java
+++ b/core/common/src/test/java/io/koraframework/common/concurrent/KoraContextTestHelper.java
@@ -1,0 +1,24 @@
+package io.koraframework.common.concurrent;
+
+import io.koraframework.common.Principal;
+import io.koraframework.common.telemetry.Observation;
+import io.koraframework.common.telemetry.OpentelemetryContext;
+import io.koraframework.logging.common.MDC;
+import io.opentelemetry.context.Context;
+
+import java.util.concurrent.Callable;
+
+final class KoraContextTestHelper {
+    private KoraContextTestHelper() {}
+
+    static <T> T withContexts(Context context, Principal principal, Observation observation, Callable<T> block) throws Exception {
+        return ScopedValue.where(OpentelemetryContext.VALUE, context)
+            .where(Principal.VALUE, principal)
+            .where(Observation.VALUE, observation)
+            .call(block::call);
+    }
+
+    static <T> T withMdc(MDC mdc, Callable<T> block) throws Exception {
+        return ScopedValue.where(MDC.VALUE, mdc).call(block::call);
+    }
+}

--- a/core/common/src/test/kotlin/io/koraframework/common/concurrent/StructuredTest.kt
+++ b/core/common/src/test/kotlin/io/koraframework/common/concurrent/StructuredTest.kt
@@ -1,0 +1,294 @@
+package io.koraframework.common.concurrent
+
+import io.koraframework.common.Principal
+import io.koraframework.common.telemetry.Observation
+import io.koraframework.logging.common.MDC
+import io.opentelemetry.api.trace.Span
+import io.opentelemetry.context.Context
+import io.opentelemetry.context.ContextKey
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.yield
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.atomic.AtomicInteger
+
+class StructuredTest {
+    @Test
+    fun `executes blocking operation on virtual thread`() {
+        val isVirtual = structured {
+            asyncVirtual { Thread.currentThread().isVirtual }.await()
+        }
+
+        assertThat(isVirtual).isTrue()
+    }
+
+    @Test
+    fun `executes children concurrently`() {
+        val ready = CountDownLatch(2)
+
+        val results = structured {
+            val first = asyncVirtual {
+                ready.countDown()
+                ready.await(5, TimeUnit.SECONDS)
+            }
+            val second = asyncVirtual {
+                ready.countDown()
+                ready.await(5, TimeUnit.SECONDS)
+            }
+            listOf(first.await(), second.await())
+        }
+
+        assertThat(results).containsExactly(true, true)
+    }
+
+    @Test
+    fun `maps iterable on virtual threads`() {
+        val results = structured {
+            listOf(1, 2, 3).mapVirtual { value ->
+                check(Thread.currentThread().isVirtual)
+                value * 2
+            }.awaitAll()
+        }
+
+        assertThat(results).containsExactly(2, 4, 6)
+    }
+
+    @Test
+    fun `executes on custom dispatcher with captured context`() {
+        val parentMdc = MDC().apply {
+            put0("requestId", "request-value")
+        }
+
+        Executors.newSingleThreadExecutor { runnable ->
+            Thread(runnable, "custom-dispatcher")
+        }.asCoroutineDispatcher().use { dispatcher ->
+            val result = KoraContextTestHelper.withMdc(parentMdc) {
+                structured {
+                    asyncOn(dispatcher) {
+                        Triple(
+                            Thread.currentThread().name,
+                            Thread.currentThread().isVirtual,
+                            MDC.get().values().keys,
+                        )
+                    }.await()
+                }
+            }
+
+            assertThat(result.first).startsWith("custom-dispatcher")
+            assertThat(result.second).isFalse()
+            assertThat(result.third).contains("requestId")
+        }
+    }
+
+    @Test
+    fun `waits for launched virtual task`() {
+        val thread = AtomicReference<Thread>()
+
+        structured {
+            launchVirtual {
+                Thread.sleep(50)
+                thread.set(Thread.currentThread())
+            }
+        }
+
+        assertThat(thread.get()).isNotNull
+        assertThat(thread.get().isVirtual).isTrue()
+    }
+
+    @Test
+    fun `waits for launched task on custom dispatcher`() {
+        val threadName = AtomicReference<String>()
+
+        Executors.newSingleThreadExecutor { runnable ->
+            Thread(runnable, "custom-launch-dispatcher")
+        }.asCoroutineDispatcher().use { dispatcher ->
+            structured {
+                launchOn(dispatcher) {
+                    threadName.set(Thread.currentThread().name)
+                }
+            }
+        }
+
+        assertThat(threadName.get()).startsWith("custom-launch-dispatcher")
+    }
+
+    @Test
+    fun `propagates launched task failure`() {
+        assertThatThrownBy {
+            structured {
+                launchVirtual { throw TestException() }
+            }
+        }.isInstanceOf(TestException::class.java)
+    }
+
+    @Test
+    fun `maps iterable on custom dispatcher`() {
+        Executors.newSingleThreadExecutor { runnable ->
+            Thread(runnable, "custom-map-dispatcher")
+        }.asCoroutineDispatcher().use { dispatcher ->
+            val results = structured {
+                listOf(1, 2, 3).mapOn(dispatcher) { value ->
+                    check(Thread.currentThread().name.startsWith("custom-map-dispatcher"))
+                    value * 2
+                }.awaitAll()
+            }
+
+            assertThat(results).containsExactly(2, 4, 6)
+        }
+    }
+
+    @Test
+    fun `limits virtual map parallelism`() {
+        val active = AtomicInteger()
+        val maximumActive = AtomicInteger()
+        val release = CountDownLatch(1)
+
+        val results = structured {
+            val tasks = (1..6).mapVirtual(parallelism = 2) { value ->
+                val current = active.incrementAndGet()
+                maximumActive.accumulateAndGet(current, ::maxOf)
+                try {
+                    release.await(5, TimeUnit.SECONDS)
+                    value * 2
+                } finally {
+                    active.decrementAndGet()
+                }
+            }
+
+            withTimeout(5_000) {
+                while (maximumActive.get() < 2) {
+                    yield()
+                }
+            }
+            release.countDown()
+            tasks.awaitAll()
+        }
+
+        assertThat(results).containsExactly(2, 4, 6, 8, 10, 12)
+        assertThat(maximumActive.get()).isEqualTo(2)
+    }
+
+    @Test
+    fun `rejects non-positive virtual map parallelism`() {
+        assertThatThrownBy {
+            structured {
+                listOf(1).mapVirtual(parallelism = 0) { it }
+            }
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessage("parallelism must be positive")
+    }
+
+    @Test
+    fun `propagates child failure`() {
+        assertThatThrownBy {
+            structured {
+                asyncVirtual { throw TestException() }
+            }
+        }.isInstanceOf(TestException::class.java)
+    }
+
+    @Test
+    fun `interrupts blocking sibling after failure`() {
+        val blockingStarted = CountDownLatch(1)
+        val interrupted = CountDownLatch(1)
+
+        assertThatThrownBy {
+            structured {
+                asyncVirtual {
+                    try {
+                        blockingStarted.countDown()
+                        Thread.sleep(60_000)
+                    } catch (e: InterruptedException) {
+                        interrupted.countDown()
+                        throw e
+                    }
+                }
+                asyncVirtual {
+                    check(blockingStarted.await(5, TimeUnit.SECONDS))
+                    throw TestException()
+                }
+            }
+        }.isInstanceOf(TestException::class.java)
+
+        assertThat(interrupted.await(5, TimeUnit.SECONDS)).isTrue()
+    }
+
+    @Test
+    fun `propagates common contexts`() {
+        val contextKey = ContextKey.named<String>("structured-virtual-test")
+        val context = Context.current().with(contextKey, "context-value")
+        val principal = TestPrincipal
+        val observation = TestObservation
+
+        val result = KoraContextTestHelper.withContexts(context, principal, observation) {
+            structured {
+                asyncVirtual {
+                    Context.current()[contextKey] == "context-value" &&
+                        Principal.current() === principal &&
+                        Observation.current(TestObservation::class.java) === observation
+                }.await()
+            }
+        }
+
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `supports nested structured scopes`() {
+        val nestedIsVirtual = structured {
+            asyncVirtual {
+                structured {
+                    asyncVirtual { Thread.currentThread().isVirtual }.await()
+                }
+            }.await()
+        }
+
+        assertThat(nestedIsVirtual).isTrue()
+    }
+
+    @Test
+    fun `propagates and isolates MDC between children`() {
+        val parentMdc = MDC().apply {
+            put0("requestId", "request-value")
+        }
+        val firstChildChangedMdc = CountDownLatch(1)
+
+        val result = KoraContextTestHelper.withMdc(parentMdc) {
+            structured {
+                val first = asyncVirtual {
+                    MDC.put("first-child", "value")
+                    firstChildChangedMdc.countDown()
+                    MDC.get().values().keys
+                }
+                val second = asyncVirtual {
+                    check(firstChildChangedMdc.await(5, TimeUnit.SECONDS))
+                    MDC.get().values().keys
+                }
+                first.await() to second.await()
+            }
+        }
+
+        assertThat(result.first).contains("requestId", "first-child")
+        assertThat(result.second).contains("requestId").doesNotContain("first-child")
+        assertThat(parentMdc.values()).containsKey("requestId").doesNotContainKey("first-child")
+    }
+
+    private class TestException : RuntimeException()
+
+    private data object TestPrincipal : Principal
+
+    private data object TestObservation : Observation {
+        override fun span(): Span = Span.getInvalid()
+
+        override fun end() = Unit
+
+        override fun observeError(e: Throwable) = Unit
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ logback = "1.6.1"
 
 # Kotlin and code generation
 kotlin-stdlib = "2.4.10" # Visit https://kotlinlang.org/docs/releases.html#release-details to see versions compatability
+kotlinx-coroutines = "1.11.0"
 ksp = "2.3.11"
 kotlinpoet = "2.3.0"
 mapstruct = "1.6.3"
@@ -112,6 +113,7 @@ kotlin-stdlib-common = { module = "org.jetbrains.kotlin:kotlin-stdlib-common", v
 kotlin-stdlib-lib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin-stdlib" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin-stdlib" }
 kotlin-compiler = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin-stdlib" }
+kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "jetbrains-annotations" }
 
 jackson-core = { module = "tools.jackson.core:jackson-core", version.ref = "jackson" }

--- a/logging/logging-common/src/main/java/io/koraframework/logging/common/internal/MdcThreadContextPropagator.java
+++ b/logging/logging-common/src/main/java/io/koraframework/logging/common/internal/MdcThreadContextPropagator.java
@@ -1,0 +1,30 @@
+package io.koraframework.logging.common.internal;
+
+import io.koraframework.common.context.ThreadContextPropagator;
+import io.koraframework.logging.common.MDC;
+import org.jspecify.annotations.Nullable;
+
+import java.util.function.Supplier;
+
+public final class MdcThreadContextPropagator implements ThreadContextPropagator {
+    @Override
+    @Nullable
+    public Snapshot capture() {
+        if (!MDC.VALUE.isBound()) {
+            return null;
+        }
+        return new MdcSnapshot(MDC.get());
+    }
+
+    private record MdcSnapshot(MDC mdc) implements Snapshot {
+        @Override
+        public Snapshot fork() {
+            return new MdcSnapshot(this.mdc.fork());
+        }
+
+        @Override
+        public <T> T call(Supplier<T> operation) {
+            return ScopedValue.where(MDC.VALUE, this.mdc).call(operation::get);
+        }
+    }
+}

--- a/logging/logging-common/src/main/java/module-info.java
+++ b/logging/logging-common/src/main/java/module-info.java
@@ -1,3 +1,4 @@
+import io.koraframework.logging.common.internal.MdcThreadContextPropagator;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
@@ -8,8 +9,11 @@ module kora.logging.common {
     requires transitive org.slf4j;
     requires transitive jul.to.slf4j;
 
+    provides io.koraframework.common.context.ThreadContextPropagator with MdcThreadContextPropagator;
+
     exports io.koraframework.logging.common;
     exports io.koraframework.logging.common.annotation;
     exports io.koraframework.logging.common.arg;
     exports io.koraframework.logging.common.masking;
+    exports io.koraframework.logging.common.internal;
 }

--- a/logging/logging-common/src/main/resources/META-INF/services/io.koraframework.common.context.ThreadContextPropagator
+++ b/logging/logging-common/src/main/resources/META-INF/services/io.koraframework.common.context.ThreadContextPropagator
@@ -1,0 +1,1 @@
+io.koraframework.logging.common.internal.MdcThreadContextPropagator


### PR DESCRIPTION
Added Kotlin structured concurrency with virtual-thread execution, custom dispatchers, and isolated Kora context propagation

## EN

### Description

Added a synchronous Kotlin structured concurrency API for executing multiple blocking operations concurrently without converting controller, service, or repository contracts to `suspend`. The new `structured` scope provides virtual-thread execution by default, optional custom `CoroutineDispatcher` selection, result-producing and result-less child tasks, collection mapping, fail-fast exception propagation, sibling cancellation, and interruption of cancellable blocking operations.

Kora execution context is captured once when entering `structured` and propagated automatically to every child. OpenTelemetry `Context`, current `Span`, `Principal`, `Observation`, and registered framework contexts are restored on the actual execution thread. MDC contributes its propagation through a pluggable SPI and creates an isolated `MDC.fork()` for every concurrent child.

### Intention & Motivation

Added a local structured-concurrency boundary suitable for Kora's virtual-thread-first architecture. Blocking application APIs can remain ordinary synchronous functions while Kotlin users receive familiar `Deferred`, `Job`, `await`, cancellation, and parallel composition semantics without manually managing dispatchers, `ScopedValue`, tracing, MDC, or coroutine context bridges.

---

## RU

### Описание

Добавлен синхронный Kotlin API структурированной конкурентности для параллельного выполнения блокирующих операций без преобразования контрактов контроллеров, сервисов и репозиториев в `suspend`. Новый scope `structured` поддерживает выполнение на виртуальных потоках по умолчанию, выбор пользовательского `CoroutineDispatcher`, дочерние задачи с результатом и без результата, обработку коллекций, быстрое распространение ошибок, отмену соседних задач и прерывание отменяемых блокирующих операций.

Контекст Kora захватывается один раз при входе в `structured` и автоматически передаётся каждой дочерней задаче. OpenTelemetry `Context`, текущий `Span`, `Principal`, `Observation` и зарегистрированные контексты фреймворка восстанавливаются непосредственно на потоке выполнения. MDC подключается через расширяемый механизм переноса контекста и создаёт отдельный `MDC.fork()` для каждой параллельной задачи.

### Намерение и мотивация

Добавлена локальная граница структурированной конкурентности, соответствующая архитектуре Kora, ориентированной на виртуальные потоки. Прикладные блокирующие API остаются обычными синхронными функциями, а Kotlin-пользователь получает привычные `Deferred`, `Job`, `await`, отмену и параллельную композицию без ручного управления диспетчерами, `ScopedValue`, трассировкой, MDC и мостами coroutine context.

---

## Changelog

- Added `structured` as a synchronous structured-concurrency boundary that captures the current Kora context, owns all child tasks, waits for their completion, returns the computed result synchronously, and propagates child failures to the caller.
- Added `asyncVirtual` for result-producing blocking operations executed on dedicated virtual threads and exposed through the standard Kotlin `Deferred<T>` contract.
- Added `asyncOn` for result-producing blocking operations executed on a caller-provided `CoroutineDispatcher` with the same cancellation and Kora context propagation semantics.
- Added `launchVirtual` and `launchOn` for structured operations without a result; both return a standard `Job`, remain children of `structured`, and are awaited by the parent scope even when the caller does not invoke `join()`.
- Added `mapVirtual` for concurrent collection processing on virtual threads, including a `parallelism` overload that protects bounded downstream resources from unrestricted fan-out.
- Added `mapOn` for concurrent collection processing on a caller-provided dispatcher.
- Added automatic propagation of OpenTelemetry `Context`, current `Span`, `Principal`, and `Observation` across coroutine and thread boundaries.
- Added the extensible `ThreadContextPropagator` SPI for optional thread-bound framework contexts discovered through `ServiceLoader`.
- Added MDC propagation from `logging-common`; each concurrent child receives an isolated `MDC.fork()`, preventing mutations from leaking into siblings or the parent request.
- Added Kotlin stdlib and `kotlinx-coroutines-core` as optional `compileOnly` dependencies, keeping them outside the runtime classpath and published POM for Java-only Kora applications.

---

## Design

### Synchronous structured boundary

`structured` bridges ordinary synchronous application code to a local coroutine scope through `runBlocking`. The coroutine implementation remains local to the operation and does not require `suspend` to propagate through the application call graph.

```kotlin
fun getProfile(id: Long): Profile =
    structured {
        val user = asyncVirtual {
            userRepository.find(id)
        }

        val orders = asyncVirtual {
            orderRepository.findByUser(id)
        }

        Profile(
            user.await(),
            orders.await(),
        )
    }
```

The repository contracts remain regular blocking APIs:

```kotlin
fun find(id: Long): User

fun findByUser(id: Long): List<Order>
```

All tasks started through `StructuredCoroutineScope` are children of the same coroutine scope. `structured` does not return until its block and every child have completed.

### Virtual-thread execution

`asyncVirtual` executes its blocking body on a dedicated virtual thread:

```kotlin
val user: Deferred<User> = asyncVirtual {
    userRepository.find(id)
}
```

A framework-owned `CoroutineDispatcher` starts a new virtual thread for each dispatched operation. It does not use `Dispatchers.IO`, `Dispatchers.Default`, a bounded platform-thread pool, or an additional executor queue.

Cancellation is connected to blocking execution through `runInterruptible`. When the coroutine is cancelled, an interrupt is sent to the executing thread. Actual termination remains dependent on whether the blocking operation or its underlying driver supports `Thread.interrupt()`.

### Custom dispatchers

`asyncOn` allows an individual operation to use a custom dispatcher while retaining the same structured lifecycle and context propagation:

```kotlin
val result = structured {
    asyncOn(Dispatchers.IO) {
        legacyRepository.find(id)
    }.await()
}
```

Virtual-thread and custom-dispatcher operations may be combined in the same scope:

```kotlin
val profile = structured {
    val user = asyncVirtual {
        userRepository.find(id)
    }

    val orders = asyncOn(customDispatcher) {
        orderRepository.findByUser(id)
    }

    Profile(user.await(), orders.await())
}
```

The dispatcher only determines where the blocking body executes. Ownership, exception propagation, sibling cancellation, context capture, and context restoration remain controlled by `structured`.

### Result-less structured tasks

`launchVirtual` and `launchOn` support operations that produce no result:

```kotlin
structured {
    launchVirtual {
        auditRepository.save(id)
    }

    launchOn(Dispatchers.IO) {
        cache.invalidate(id)
    }
}
```

Both functions return a standard `Job`, allowing explicit `join()` or cancellation when required. They are not detached fire-and-forget operations: `structured` waits for them even when the returned job is ignored.

A failure in a launched task fails the parent scope and cancels its siblings:

```text
launch child fails
    → parent scope is cancelled
    → sibling tasks are cancelled
    → structured throws the original failure
```

### Collection operations

`mapVirtual` starts one result-producing virtual-thread task for every element:

```kotlin
val users = structured {
    ids.mapVirtual(userRepository::find)
        .awaitAll()
}
```

For downstream resources with bounded capacity, the `parallelism` overload limits the number of concurrently executing blocking bodies:

```kotlin
val users = structured {
    ids.mapVirtual(parallelism = 16) { id ->
        userRepository.find(id)
    }.awaitAll()
}
```

This is useful when virtual threads are cheaper and more numerous than the constrained resource behind the operation, such as a JDBC connection pool or remote service concurrency allowance. `parallelism` must be greater than zero; invalid values fail immediately with:

```text
IllegalArgumentException: parallelism must be positive
```

`mapOn` provides equivalent collection composition for a custom dispatcher:

```kotlin
val users = structured {
    ids.mapOn(Dispatchers.IO, userRepository::find)
        .awaitAll()
}
```

The API intentionally does not add `forEachVirtual` or `forEachOn`. Side-effecting collection operations can use `mapVirtual` or `mapOn` with `awaitAll()`, while individually controlled result-less operations can use `launchVirtual` or `launchOn`.

### Failure and cancellation semantics

The API uses regular Kotlin structured-concurrency semantics:

- a non-cancellation exception in one child fails the parent scope;
- sibling tasks are cancelled;
- `runInterruptible` attempts to interrupt blocking children;
- exceptions leave `structured` synchronously;
- no child task remains detached after `structured` returns;
- nested `structured` scopes remain independently structured and use the same context propagation mechanism.

Example:

```kotlin
fun load(id: Long): Result =
    structured {
        val first = asyncVirtual {
            operationA(id)
        }

        val second = asyncVirtual {
            operationB(id)
        }

        Result(first.await(), second.await())
    }
```

If `operationA` fails, `operationB` is cancelled and interrupted when its blocking implementation supports interruption.

### Context capture and restoration

`KoraContextSnapshot` captures context once when entering `structured`:

```text
structured entry
    ├── OpenTelemetry Context
    ├── Principal
    ├── Observation
    └── registered ThreadContextPropagator snapshots
```

Each child receives a fork of the captured snapshot:

```text
parent snapshot
    ├── fork → child A
    ├── fork → child B
    └── fork → child C
```

The snapshot is installed lexically through `ScopedValue` around the actual blocking body. This preserves the behavior of existing Kora APIs such as:

```kotlin
Context.current()
Span.current()
Principal.current()
Observation.current(...)
MDC.get()
```

Context restoration is exception-safe because every value is bound only for the dynamic extent of `ScopedValue.Carrier.call(...)` or `run(...)`.

### Extensible thread-bound context propagation

`ThreadContextPropagator` allows modules to contribute optional context propagation without creating reverse dependencies from `core:common`:

```java
public interface ThreadContextPropagator {
    @Nullable
    Snapshot capture();

    interface Snapshot {
        Snapshot fork();

        <T> T call(Supplier<T> operation);

        default void run(Runnable runnable) {
            call(() -> {
                runnable.run();
                return null;
            });
        }
    }
}
```

Providers are discovered once through `ServiceLoader`. A provider may return `null` when its context is not currently bound.

The SPI separates three responsibilities:

- `capture()` reads the current thread-bound value at `structured` entry;
- `fork()` creates an isolated child representation;
- `call()` installs the child value around execution and restores the previous state afterward.

This allows future security, tenant, diagnostic, or application context modules to integrate without changing the structured-concurrency implementation.

### MDC propagation and isolation

`logging-common` contributes `MdcThreadContextPropagator` through both JPMS `provides` and `META-INF/services`.

When MDC is bound, the parent value is captured once. Every child receives:

```java
new MdcSnapshot(parentMdc.fork())
```

Therefore:

```text
parent MDC: requestId=123
    ├── child A: requestId=123, adds child=A
    └── child B: requestId=123, does not observe child=A
```

Changes made by a child do not leak into sibling tasks, the parent request, or subsequent work.

### Contexts intentionally not propagated

Only explicitly supported context values are transferred. Arbitrary `ScopedValue` instances cannot be enumerated automatically.

Resource-bound contexts that are unsafe to share concurrently, such as a JDBC transaction connection or transport-specific request object, are not propagated. Parallel repository operations should therefore acquire independent connections instead of attempting to share one transaction-bound JDBC connection across children.

### Optional Kotlin dependencies

The API is hosted in `core:common`, but Kotlin stdlib and `kotlinx-coroutines-core` are declared as `compileOnly`:

```groovy
dependencies {
    compileOnly libs.kotlin.stdlib.lib
    compileOnly libs.kotlinx.coroutines.core
}
```

This keeps Kotlin and coroutine artifacts out of the Java application's runtime dependency graph and published POM. Kotlin applications that use the API must provide the coroutine runtime explicitly:

```kotlin
dependencies {
    implementation("io.koraframework:common:$koraVersion")
    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.11.0")
}
```

The public API intentionally exposes standard coroutine contracts such as `Deferred<T>`, `Job`, and `CoroutineDispatcher` instead of introducing framework-specific task abstractions.