### PR TITLE
Improved(openapi): simplify generated enum mappers and validation

### DIFF
--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/AbstractGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/AbstractGenerator.java
@@ -101,6 +101,12 @@ public abstract class AbstractGenerator<C, R> {
         public static final ClassName valid = ClassName.get("io.koraframework.validation.common.annotation", "Valid");
         public static final ClassName validate = ClassName.get("io.koraframework.validation.common.annotation", "Validate");
         public static final ClassName range = ClassName.get("io.koraframework.validation.common.annotation", "Range");
+        public static final ClassName min = ClassName.get("io.koraframework.validation.common.annotation", "Min");
+        public static final ClassName max = ClassName.get("io.koraframework.validation.common.annotation", "Max");
+        public static final ClassName positive = ClassName.get("io.koraframework.validation.common.annotation", "Positive");
+        public static final ClassName positiveOrZero = ClassName.get("io.koraframework.validation.common.annotation", "PositiveOrZero");
+        public static final ClassName negative = ClassName.get("io.koraframework.validation.common.annotation", "Negative");
+        public static final ClassName negativeOrZero = ClassName.get("io.koraframework.validation.common.annotation", "NegativeOrZero");
         public static final ClassName size = ClassName.get("io.koraframework.validation.common.annotation", "Size");
         public static final ClassName pattern = ClassName.get("io.koraframework.validation.common.annotation", "Pattern");
         public static final ClassName boundary = ClassName.get("io.koraframework.validation.common.annotation", "Range", "Boundary");

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/AbstractJavaGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/AbstractJavaGenerator.java
@@ -143,6 +143,10 @@ public abstract class AbstractJavaGenerator<C> extends AbstractGenerator<C, Java
     @Nullable
     protected AnnotationSpec getValidation(IJsonSchemaValidationProperties variable) {
         if (variable.getMinimum() != null || variable.getMaximum() != null) {
+            var singleIntegralBound = singleIntegralBoundValidation(variable);
+            if (singleIntegralBound != null) {
+                return singleIntegralBound;
+            }
             CodeBlock minimum;
             if (variable.getMinimum() != null) {
                 if (!variable.getMinimum().contains(".")) {
@@ -190,16 +194,28 @@ public abstract class AbstractJavaGenerator<C> extends AbstractGenerator<C, Java
                 .build();
         }
         if (variable.getMinLength() != null || variable.getMaxLength() != null) {
-            return AnnotationSpec.builder(Classes.size)
-                .addMember("min", "$L", variable.getMinLength() != null ? variable.getMinLength() : 0)
-                .addMember("max", "$L", variable.getMaxLength() != null ? variable.getMaxLength() : Integer.MAX_VALUE)
-                .build();
+            var size = AnnotationSpec.builder(Classes.size);
+            if (variable.getMinLength() != null) {
+                size.addMember("min", "$L", variable.getMinLength());
+            }
+            if (variable.getMaxLength() != null) {
+                size.addMember("max", "$L", variable.getMaxLength());
+            } else {
+                size.addMember("max", "$T.MAX_VALUE", Integer.class);
+            }
+            return size.build();
         }
         if (variable.getMaxItems() != null || variable.getMinItems() != null) {
-            return AnnotationSpec.builder(Classes.size)
-                .addMember("min", "$L", variable.getMinItems() != null ? variable.getMinItems() : 0)
-                .addMember("max", "$L", variable.getMaxItems() != null ? variable.getMaxItems() : Integer.MAX_VALUE)
-                .build();
+            var size = AnnotationSpec.builder(Classes.size);
+            if (variable.getMinItems() != null) {
+                size.addMember("min", "$L", variable.getMinItems());
+            }
+            if (variable.getMaxItems() != null) {
+                size.addMember("max", "$L", variable.getMaxItems());
+            } else {
+                size.addMember("max", "$T.MAX_VALUE", Integer.class);
+            }
+            return size.build();
         }
         if (variable.getPattern() != null) {
             return AnnotationSpec.builder(Classes.pattern)
@@ -210,6 +226,35 @@ public abstract class AbstractJavaGenerator<C> extends AbstractGenerator<C, Java
             return AnnotationSpec.builder(Classes.valid).build();
         }
         return null;
+    }
+
+    @Nullable
+    private AnnotationSpec singleIntegralBoundValidation(IJsonSchemaValidationProperties variable) {
+        if (!(variable.getIsInteger() || variable.getIsLong()) || (variable.getMinimum() != null) == (variable.getMaximum() != null)) {
+            return null;
+        }
+        try {
+            if (variable.getMinimum() != null) {
+                var value = new java.math.BigDecimal(variable.getMinimum()).longValueExact();
+                if (variable.getExclusiveMinimum()) {
+                    if (value == 0) return AnnotationSpec.builder(Classes.positive).build();
+                    value = Math.incrementExact(value);
+                } else if (value == 0) {
+                    return AnnotationSpec.builder(Classes.positiveOrZero).build();
+                }
+                return AnnotationSpec.builder(Classes.min).addMember("value", "$LL", value).build();
+            }
+            var value = new java.math.BigDecimal(variable.getMaximum()).longValueExact();
+            if (variable.getExclusiveMaximum()) {
+                if (value == 0) return AnnotationSpec.builder(Classes.negative).build();
+                value = Math.decrementExact(value);
+            } else if (value == 0) {
+                return AnnotationSpec.builder(Classes.negativeOrZero).build();
+            }
+            return AnnotationSpec.builder(Classes.max).addMember("value", "$LL", value).build();
+        } catch (ArithmeticException e) {
+            return null;
+        }
     }
 
     private static String invalidNumericValidationTypeError(IJsonSchemaValidationProperties variable) {

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ModelGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ModelGenerator.java
@@ -14,6 +14,7 @@ import java.util.*;
 
 public class ModelGenerator extends AbstractJavaGenerator<ModelsMap> {
     private record Field(String name, String jsonName, TypeName type, boolean required, boolean nullable, String description, String defaultValue, String example) {}
+    private record EnumMapping(ClassName className, CodegenModel model) {}
 
     @Override
     public JavaFile generate(ModelsMap ctx) {
@@ -420,18 +421,24 @@ public class ModelGenerator extends AbstractJavaGenerator<ModelsMap> {
         var modules = new LinkedHashMap<String, JavaFile>();
         if (model.isEnum) {
             var enumClassName = ClassName.get(modelPackage, model.name);
-            modules.put(enumMapperModuleName(enumClassName), buildEnumMapperModuleFile(enumClassName, model));
+            var moduleName = enumMapperModuleName(enumClassName);
+            modules.put(moduleName, buildEnumMapperModuleFile(moduleName, List.of(new EnumMapping(enumClassName, model))));
         }
         if (model.discriminator != null) {
             return;
         }
+        var nestedEnums = new ArrayList<EnumMapping>();
         for (var field : model.allVars) {
             if (!field.isInnerEnum) {
                 continue;
             }
             var enumModel = enumModel(field);
             var enumClassName = ClassName.get(modelPackage, model.getClassname(), enumModel.name);
-            modules.put(enumMapperModuleName(enumClassName), buildEnumMapperModuleFile(enumClassName, enumModel));
+            nestedEnums.add(new EnumMapping(enumClassName, enumModel));
+        }
+        if (!nestedEnums.isEmpty()) {
+            var moduleName = nestedEnumMapperModuleName(model.classname);
+            modules.put(moduleName, buildEnumMapperModuleFile(moduleName, nestedEnums));
         }
         for (var module : modules.entrySet()) {
             try {
@@ -506,22 +513,43 @@ public class ModelGenerator extends AbstractJavaGenerator<ModelsMap> {
         return null;
     }
 
-    private JavaFile buildEnumMapperModuleFile(ClassName enumClassName, CodegenModel model) {
-        var module = buildEnumMapperModule(enumMapperModuleName(enumClassName), enumClassName, model);
-        return JavaFile.builder(modelPackage, module).build();
+    private JavaFile buildEnumMapperModuleFile(String moduleName, List<EnumMapping> enums) {
+        var module = TypeSpec.interfaceBuilder(moduleName)
+            .addAnnotation(generated())
+            .addAnnotation(Classes.module)
+            .addModifiers(Modifier.PUBLIC);
+        for (var enumMapping : enums) {
+            addEnumMapperFactories(module, enumMapping.className(), enumMapping.model());
+        }
+        return JavaFile.builder(modelPackage, module.build()).build();
     }
 
     private String enumMapperModuleName(ClassName enumClassName) {
         return String.join("", enumClassName.simpleNames()) + "MapperModule";
     }
 
-    private TypeSpec buildEnumMapperModule(String moduleName, ClassName enumClassName, CodegenModel model) {
+    private String nestedEnumMapperModuleName(String ownerName) {
+        var baseName = ownerName + "__NestedEnumMapperModule";
+        var reserved = new HashSet<String>();
+        for (var modelsMap : models.values()) {
+            for (var modelMap : modelsMap.getModels()) {
+                var model = modelMap.getModel();
+                reserved.add(model.classname);
+                if (model.isEnum) {
+                    reserved.add(enumMapperModuleName(ClassName.get(modelPackage, model.name)));
+                }
+            }
+        }
+        var candidate = baseName;
+        for (var suffix = 2; reserved.contains(candidate); suffix++) {
+            candidate = baseName + suffix;
+        }
+        return candidate;
+    }
+
+    private void addEnumMapperFactories(TypeSpec.Builder module, ClassName enumClassName, CodegenModel model) {
         var enumValueType = enumValueType(model);
         var enumSimpleName = enumClassName.simpleName();
-        var module = TypeSpec.interfaceBuilder(moduleName)
-            .addAnnotation(generated())
-            .addAnnotation(Classes.module)
-            .addModifiers(Modifier.PUBLIC);
 
         var jsonWriter = MethodSpec.methodBuilder(StringUtils.uncapitalize(enumSimpleName) + "JsonWriter")
             .addModifiers(Modifier.PUBLIC, Modifier.DEFAULT)
@@ -565,7 +593,6 @@ public class ModelGenerator extends AbstractJavaGenerator<ModelsMap> {
                 .build());
         }
 
-        return module.build();
     }
 
     private boolean isInlineEnumJsonValueType(TypeName enumValueType) {

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/AbstractKotlinGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/AbstractKotlinGenerator.kt
@@ -278,6 +278,7 @@ abstract class AbstractKotlinGenerator<C : Any> : AbstractGenerator<C, FileSpec>
 
     protected fun getValidation(variable: IJsonSchemaValidationProperties): AnnotationSpec? {
         if (variable.minimum != null || variable.maximum != null) {
+            singleIntegralBoundValidation(variable)?.let { return it }
             val minimum = when {
                 variable.minimum != null && !variable.minimum.contains(".") -> CodeBlock.of("%L.0", variable.minimum)
                 variable.minimum != null -> CodeBlock.of("%L", variable.minimum)
@@ -308,16 +309,16 @@ abstract class AbstractKotlinGenerator<C : Any> : AbstractGenerator<C, FileSpec>
                 .build()
         }
         if (variable.minLength != null || variable.maxLength != null) {
-            return AnnotationSpec.builder(Classes.size.asKt())
-                .addMember("min = %L", variable.minLength ?: 0)
-                .addMember("max = %L", variable.maxLength ?: Int.MAX_VALUE)
-                .build()
+            return AnnotationSpec.builder(Classes.size.asKt()).apply {
+                variable.minLength?.let { addMember("min = %L", it) }
+                if (variable.maxLength != null) addMember("max = %L", variable.maxLength) else addMember("max = %T.MAX_VALUE", INT)
+            }.build()
         }
         if (variable.maxItems != null || variable.minItems != null) {
-            return AnnotationSpec.builder(Classes.size.asKt())
-                .addMember("min = %L", variable.minItems ?: 0)
-                .addMember("max = %L", variable.maxItems ?: Int.MAX_VALUE)
-                .build()
+            return AnnotationSpec.builder(Classes.size.asKt()).apply {
+                variable.minItems?.let { addMember("min = %L", it) }
+                if (variable.maxItems != null) addMember("max = %L", variable.maxItems) else addMember("max = %T.MAX_VALUE", INT)
+            }.build()
         }
         if (variable.pattern != null) {
             return AnnotationSpec.builder(Classes.pattern.asKt())
@@ -328,6 +329,33 @@ abstract class AbstractKotlinGenerator<C : Any> : AbstractGenerator<C, FileSpec>
             return AnnotationSpec.builder(Classes.valid.asKt()).build()
         }
         return null
+    }
+
+    private fun singleIntegralBoundValidation(variable: IJsonSchemaValidationProperties): AnnotationSpec? {
+        if (!(variable.isInteger || variable.isLong) || (variable.minimum != null) == (variable.maximum != null)) return null
+        return try {
+            if (variable.minimum != null) {
+                var value = variable.minimum.toBigDecimal().longValueExact()
+                if (variable.exclusiveMinimum) {
+                    if (value == 0L) return AnnotationSpec.builder(Classes.positive.asKt()).build()
+                    value = Math.incrementExact(value)
+                } else if (value == 0L) {
+                    return AnnotationSpec.builder(Classes.positiveOrZero.asKt()).build()
+                }
+                AnnotationSpec.builder(Classes.min.asKt()).addMember("value = %LL", value).build()
+            } else {
+                var value = variable.maximum.toBigDecimal().longValueExact()
+                if (variable.exclusiveMaximum) {
+                    if (value == 0L) return AnnotationSpec.builder(Classes.negative.asKt()).build()
+                    value = Math.decrementExact(value)
+                } else if (value == 0L) {
+                    return AnnotationSpec.builder(Classes.negativeOrZero.asKt()).build()
+                }
+                AnnotationSpec.builder(Classes.max.asKt()).addMember("value = %LL", value).build()
+            }
+        } catch (_: ArithmeticException) {
+            null
+        }
     }
 
 

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ModelGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ModelGenerator.kt
@@ -5,6 +5,7 @@ import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import org.openapitools.codegen.CodegenModel
 import org.openapitools.codegen.CodegenProperty
 import org.openapitools.codegen.model.ModelsMap
+import java.nio.file.Path
 
 
 class ModelGenerator : AbstractKotlinGenerator<ModelsMap>() {
@@ -15,6 +16,7 @@ class ModelGenerator : AbstractKotlinGenerator<ModelsMap>() {
             model.discriminator != null -> buildSealed(ctx, model)
             else -> buildRecord(ctx, model)
         }
+        writeEnumMapperModules(ctx)
         return FileSpec.get(modelPackage, type)
     }
 
@@ -158,7 +160,7 @@ class ModelGenerator : AbstractKotlinGenerator<ModelsMap>() {
                 p.addAnnotation(AnnotationSpec.builder(Classes.jsonField.asKt()).useSiteTarget(AnnotationSpec.UseSiteTarget.PARAM).addMember("value = %S", field.baseName).build())
             }
             if (params.enableValidation) {
-                getValidation(field)?.let { p.addAnnotation(it) }
+                getValidation(field)?.let { p.addAnnotation(it.toBuilder().useSiteTarget(AnnotationSpec.UseSiteTarget.FIELD).build()) }
             }
             if (field.isNullable) {
                 if (field.required) {
@@ -288,101 +290,112 @@ class ModelGenerator : AbstractKotlinGenerator<ModelsMap>() {
         }
         b.addType(constants.build())
 
-        b.addType(
-            TypeSpec.classBuilder("JsonWriter")
-                .addAnnotation(generated())
-                .addAnnotation(Classes.component.asKt())
-                .addSuperinterface(Classes.jsonWriter.asKt().parameterizedBy(enumClassName))
-                .primaryConstructor(
-                    FunSpec.constructorBuilder()
-                        .addParameter("delegate", Classes.jsonWriter.asKt().parameterizedBy(enumValueType(model)))
-                        .build()
-                )
-                .addProperty(
-                    PropertySpec.builder("delegate", Classes.enumJsonWriter.asKt().parameterizedBy(enumClassName, enumValueType(model)))
-                        .initializer("%T(entries.toTypedArray(), %T::value, delegate)", Classes.enumJsonWriter.asKt(), enumClassName)
-                        .build()
-                )
-                .addFunction(
-                    FunSpec.builder("write")
-                        .addModifiers(KModifier.OVERRIDE)
-                        .addParameter("gen", Classes.jsonGenerator.asKt())
-                        .addParameter("value", enumClassName.copy(true))
-                        .addStatement("this.delegate.write(gen, value)")
-                        .build()
-                )
-                .build()
-        )
-        b.addType(
-            TypeSpec.classBuilder("JsonReader")
-                .addAnnotation(generated())
-                .addAnnotation(Classes.component.asKt())
-                .addSuperinterface(Classes.jsonReader.asKt().parameterizedBy(enumClassName))
-                .addProperty(
-                    PropertySpec.builder("delegate", Classes.enumJsonReader.asKt().parameterizedBy(enumClassName, enumValueType(model)))
-                        .initializer("%T(entries.toTypedArray(), %T::value, delegate)", Classes.enumJsonReader.asKt(), enumClassName)
-                        .build()
-                )
-                .primaryConstructor(
-                    FunSpec.constructorBuilder()
-                        .addParameter("delegate", Classes.jsonReader.asKt().parameterizedBy(enumValueType(model)))
-                        .build()
-                )
-                .addFunction(
-                    FunSpec.builder("read")
-                        .addModifiers(KModifier.OVERRIDE)
-                        .addParameter("parser", Classes.jsonParser.asKt())
-                        .addStatement("return this.delegate.read(parser)")
-                        .returns(enumClassName.copy(true))
-                        .build()
-                )
-                .build()
-        )
+        return b.build()
+    }
 
-        if (params.codegenMode.isClient()) {
-            b.addType(
-                TypeSpec.classBuilder("StringParameterConverter")
-                    .addAnnotation(generated())
-                    .addAnnotation(Classes.component.asKt())
-                    .addSuperinterface(Classes.stringParameterConverter.asKt().parameterizedBy(enumClassName))
-                    .addProperty(
-                        PropertySpec.builder("delegate", Classes.enumStringParameterConverter.asKt().parameterizedBy(enumClassName))
-                            .initializer("%T(entries.toTypedArray()) { it.value.toString() }", Classes.enumStringParameterConverter.asKt())
-                            .build()
-                    )
-                    .addFunction(
-                        FunSpec.builder("convert")
-                            .addModifiers(KModifier.OVERRIDE)
-                            .addParameter("value", enumClassName)
-                            .addStatement("return this.delegate.convert(value)")
-                            .returns(String::class)
-                            .build()
-                    )
+    private fun writeEnumMapperModules(ctx: ModelsMap) {
+        val model = ctx.models.first().model
+        if (model.isEnum) {
+            val enumClassName = ClassName(modelPackage, model.name)
+            buildEnumMapperModuleFile(enumMapperModuleName(enumClassName), listOf(enumClassName to model)).writeTo(Path.of(outputFolder))
+            return
+        }
+        if (model.discriminator != null) {
+            return
+        }
+        val nestedEnums = model.allVars.filter { it.isInnerEnum }.map { field ->
+            val enumModel = enumModel(field)
+            ClassName(modelPackage, model.classname, enumModel.name) to enumModel
+        }
+        if (nestedEnums.isEmpty()) {
+            return
+        }
+        val moduleName = nestedEnumMapperModuleName(model.classname)
+        buildEnumMapperModuleFile(moduleName, nestedEnums).writeTo(Path.of(outputFolder))
+    }
+
+    private fun enumModel(field: CodegenProperty): CodegenModel {
+        val source = if (field.isContainer) field.items else field
+        return CodegenModel().also {
+            it.name = source.enumName
+            it.allowableValues = source.allowableValues
+            it.dataType = source.dataType
+            it.description = source.description
+            it.vendorExtensions = source.vendorExtensions
+            it.isString = source.isString
+            it.isLong = source.isLong
+            it.isInteger = source.isInteger
+            it.isBoolean = source.isBoolean
+            it.isFloat = source.isFloat
+            it.isDouble = source.isDouble
+            it.isDecimal = source.isDecimal
+            it.isNumber = source.isNumber
+        }
+    }
+
+    private fun enumMapperModuleName(enumClassName: ClassName): String = enumClassName.simpleNames.joinToString("") + "MapperModule"
+
+    private fun nestedEnumMapperModuleName(ownerName: String): String {
+        val baseName = ownerName + "__NestedEnumMapperModule"
+        val allModels = models.values.flatMap { value -> value.models.map { it.model } }
+        val reserved = buildSet {
+            allModels.mapTo(this) { it.classname }
+            allModels.filter { it.isEnum }.mapTo(this) { enumMapperModuleName(ClassName(modelPackage, it.name)) }
+        }
+        var candidate = baseName
+        var suffix = 2
+        while (candidate in reserved) {
+            candidate = baseName + suffix++
+        }
+        return candidate
+    }
+
+    private fun buildEnumMapperModuleFile(moduleName: String, enums: List<Pair<ClassName, CodegenModel>>): FileSpec {
+        val module = TypeSpec.interfaceBuilder(moduleName)
+            .addAnnotation(generated())
+            .addAnnotation(Classes.module.asKt())
+        for ((enumClassName, model) in enums) {
+            addEnumMapperFactories(module, enumClassName, model)
+        }
+        return FileSpec.get(modelPackage, module.build())
+    }
+
+    private fun addEnumMapperFactories(module: TypeSpec.Builder, enumClassName: ClassName, model: CodegenModel) {
+        val valueType = enumValueType(model)
+        val methodPrefix = enumClassName.simpleName.replaceFirstChar { it.lowercase() }
+        module.addFunction(
+            FunSpec.builder(methodPrefix + "JsonWriter")
+                .addAnnotation(Classes.defaultComponent.asKt())
+                .addParameter("delegate", Classes.jsonWriter.asKt().parameterizedBy(valueType))
+                .returns(Classes.jsonWriter.asKt().parameterizedBy(enumClassName))
+                .addStatement("return %T(%T.entries.toTypedArray(), %T::value, delegate)", Classes.enumJsonWriter.asKt(), enumClassName, enumClassName)
+                .build()
+        )
+        module.addFunction(
+            FunSpec.builder(methodPrefix + "JsonReader")
+                .addAnnotation(Classes.defaultComponent.asKt())
+                .addParameter("delegate", Classes.jsonReader.asKt().parameterizedBy(valueType))
+                .returns(Classes.jsonReader.asKt().parameterizedBy(enumClassName))
+                .addStatement("return %T(%T.entries.toTypedArray(), %T::value, delegate)", Classes.enumJsonReader.asKt(), enumClassName, enumClassName)
+                .build()
+        )
+        if (params.codegenMode.isClient) {
+            module.addFunction(
+                FunSpec.builder(methodPrefix + "StringParameterConverter")
+                    .addAnnotation(Classes.defaultComponent.asKt())
+                    .returns(Classes.stringParameterConverter.asKt().parameterizedBy(enumClassName))
+                    .addStatement("return %T(%T.entries.toTypedArray()) { it.value.toString() }", Classes.enumStringParameterConverter.asKt(), enumClassName)
                     .build()
             )
         } else {
-            b.addType(
-                TypeSpec.classBuilder("StringParameterReader")
-                    .addAnnotation(generated())
-                    .addAnnotation(Classes.component.asKt())
-                    .addSuperinterface(Classes.stringParameterReader.asKt().parameterizedBy(enumClassName))
-                    .addProperty(
-                        PropertySpec.builder("delegate", Classes.enumStringParameterReader.asKt().parameterizedBy(enumClassName))
-                            .initializer("%T(entries.toTypedArray()) { it.value.toString() }", Classes.enumStringParameterReader.asKt())
-                            .build()
-                    )
-                    .addFunction(
-                        FunSpec.builder("read")
-                            .addModifiers(KModifier.OVERRIDE)
-                            .addParameter("value", String::class)
-                            .addStatement("return this.delegate.read(value)")
-                            .returns(enumClassName)
-                            .build()
-                    )
+            module.addFunction(
+                FunSpec.builder(methodPrefix + "StringParameterReader")
+                    .addAnnotation(Classes.defaultComponent.asKt())
+                    .returns(Classes.stringParameterReader.asKt().parameterizedBy(enumClassName))
+                    .addStatement("return %T(%T.entries.toTypedArray()) { it.value.toString() }", Classes.enumStringParameterReader.asKt(), enumClassName)
                     .build()
             )
         }
-        return b.build()
     }
 
     private fun fieldType(field: CodegenProperty): TypeName {

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientJavaOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientJavaOpenapiTest.java
@@ -9,6 +9,28 @@ import java.nio.file.Files;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class HttpClientJavaOpenapiTest extends BaseJavaOpenapiTest {
+    @Test
+    void validationAnnotationsUseConciseBounds() throws Exception {
+        var files = generate(
+            "petstoreV3_validation_concise_bounds",
+            "java-client",
+            getClass().getResource("/example/petstoreV3_validation.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+        );
+        var content = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("Pet.java"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(content.contains("@Max(99L)"), content);
+        assertTrue(content.contains("@Min(2L)"), content);
+        assertTrue(content.contains("@Min(1L)"), content);
+        assertTrue(content.contains("@Size(min = 1, max = Integer.MAX_VALUE)"), content);
+        assertTrue(content.contains("@Size(max = 10)"), content);
+        assertFalse(content.contains("2147483647"), content);
+    }
+
     @ParameterizedTest
     @MethodSource("generateParams")
     void test(SwaggerParams params) throws Exception {
@@ -302,7 +324,7 @@ public class HttpClientJavaOpenapiTest extends BaseJavaOpenapiTest {
 
         var moduleContent = Files.readString(files.stream()
             .map(java.io.File::toPath)
-            .filter(path -> path.getFileName().toString().equals("PetDogBreedEnumMapperModule.java"))
+            .filter(path -> path.getFileName().toString().equals("PetDog__NestedEnumMapperModule.java"))
             .findFirst()
             .orElseThrow());
 
@@ -318,11 +340,14 @@ public class HttpClientJavaOpenapiTest extends BaseJavaOpenapiTest {
         assertTrue(petDogContent.contains("* Dingo breed"));
         assertTrue(petDogContent.contains("* enum with int value"));
 
-        assertTrue(moduleContent.contains("public interface PetDogBreedEnumMapperModule"));
+        assertTrue(moduleContent.contains("public interface PetDog__NestedEnumMapperModule"));
         assertTrue(moduleContent.contains("@DefaultComponent"));
         assertTrue(moduleContent.contains("default JsonWriter<PetDog.BreedEnum> breedEnumJsonWriter()"));
         assertTrue(moduleContent.contains("default JsonReader<PetDog.BreedEnum> breedEnumJsonReader()"));
         assertTrue(moduleContent.contains("default HttpClientParameterWriter<PetDog.BreedEnum> breedEnumStringParameterConverter()"));
+        assertTrue(moduleContent.contains("default JsonWriter<PetDog.IntBreedEnum> intBreedEnumJsonWriter()"));
+        assertTrue(moduleContent.contains("default JsonReader<PetDog.IntBreedEnum> intBreedEnumJsonReader()"));
+        assertTrue(moduleContent.contains("default HttpClientParameterWriter<PetDog.IntBreedEnum> intBreedEnumStringParameterConverter()"));
         assertTrue(moduleContent.contains("new EnumJsonWriter<>(PetDog.BreedEnum.values(), PetDog.BreedEnum::getValue, (gen, object) ->"));
         assertTrue(moduleContent.contains("new EnumJsonReader<>(PetDog.BreedEnum.values(), PetDog.BreedEnum::getValue, parser -> switch (parser.currentToken())"));
     }
@@ -338,7 +363,7 @@ public class HttpClientJavaOpenapiTest extends BaseJavaOpenapiTest {
 
         var moduleContent = Files.readString(files.stream()
             .map(java.io.File::toPath)
-            .filter(path -> path.getFileName().toString().equals("PetNonReqDoubleEnumMapperModule.java"))
+            .filter(path -> path.getFileName().toString().equals("Pet__NestedEnumMapperModule.java"))
             .findFirst()
             .orElseThrow());
 
@@ -346,7 +371,31 @@ public class HttpClientJavaOpenapiTest extends BaseJavaOpenapiTest {
         assertTrue(moduleContent.contains("return new EnumJsonWriter<>(Pet.NonReqDoubleEnum.values(), Pet.NonReqDoubleEnum::getValue, delegate)"));
         assertTrue(moduleContent.contains("default JsonReader<Pet.NonReqDoubleEnum> nonReqDoubleEnumJsonReader(JsonReader<Double> delegate)"));
         assertTrue(moduleContent.contains("return new EnumJsonReader<>(Pet.NonReqDoubleEnum.values(), Pet.NonReqDoubleEnum::getValue, delegate)"));
-        assertFalse(moduleContent.contains("parser -> switch"));
+    }
+
+    @Test
+    void nestedEnumMappersAreAggregatedByModel() throws Exception {
+        var files = generate(
+            "petstoreV3_validation_nested_enum",
+            "java-client",
+            getClass().getResource("/example/petstoreV3_validation.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+        );
+
+        var moduleContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("PetTO__NestedEnumMapperModule.java"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(moduleContent.contains("public interface PetTO__NestedEnumMapperModule"));
+        assertTrue(moduleContent.contains("JsonWriter<PetTO.StatusEnum> statusEnumJsonWriter()"));
+        assertTrue(moduleContent.contains("JsonReader<PetTO.StatusEnum> statusEnumJsonReader()"));
+        assertTrue(moduleContent.contains("JsonWriter<PetTO.AvailabilityEnum> availabilityEnumJsonWriter()"));
+        assertTrue(moduleContent.contains("JsonReader<PetTO.AvailabilityEnum> availabilityEnumJsonReader()"));
+        assertEquals(1, files.stream()
+            .filter(file -> file.getName().startsWith("PetTO") && file.getName().endsWith("NestedEnumMapperModule.java"))
+            .count());
     }
 
     @Test

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientKotlinOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientKotlinOpenapiTest.java
@@ -242,11 +242,43 @@ public class HttpClientKotlinOpenapiTest extends BaseKotlinOpenapiTest {
             .filter(path -> path.getFileName().toString().equals("Pet.kt"))
             .findFirst()
             .orElseThrow());
+        var moduleContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("Pet__NestedEnumMapperModule.kt"))
+            .findFirst()
+            .orElseThrow());
 
         assertTrue(content.contains("public enum class NonReqDoubleEnum private constructor("));
         assertTrue(content.contains("public val `value`: Double"));
-        assertTrue(content.contains("`delegate`: io.koraframework.json.common.JsonWriter<Double>"));
-        assertTrue(content.contains("`delegate`: io.koraframework.json.common.JsonReader<Double>"));
+        assertFalse(content.contains("class JsonWriter"));
+        assertTrue(moduleContent.contains("nonReqDoubleEnumJsonWriter("));
+        assertTrue(moduleContent.contains("JsonWriter<Double>"));
+        assertTrue(moduleContent.contains("JsonReader<Double>"));
+    }
+
+    @Test
+    void nestedEnumMappersAreAggregatedByModel() throws Exception {
+        var files = generate(
+            "petstoreV3_validation_nested_enum",
+            "kotlin-client",
+            getClass().getResource("/example/petstoreV3_validation.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+        );
+
+        var moduleContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("PetTO__NestedEnumMapperModule.kt"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(moduleContent.contains("public interface PetTO__NestedEnumMapperModule"));
+        assertTrue(moduleContent.contains("JsonWriter<PetTO.StatusEnum>"));
+        assertTrue(moduleContent.contains("JsonReader<PetTO.StatusEnum>"));
+        assertTrue(moduleContent.contains("JsonWriter<PetTO.AvailabilityEnum>"));
+        assertTrue(moduleContent.contains("JsonReader<PetTO.AvailabilityEnum>"));
+        assertEquals(1, files.stream()
+            .filter(file -> file.getName().startsWith("PetTO") && file.getName().endsWith("NestedEnumMapperModule.kt"))
+            .count());
     }
 
     @Test

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpServerJavaOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpServerJavaOpenapiTest.java
@@ -68,8 +68,8 @@ public class HttpServerJavaOpenapiTest extends BaseJavaOpenapiTest {
             .filter(path -> path.getFileName().toString().equals("PetApiDelegate.java"))
             .findFirst()
             .orElseThrow());
-        // the schema declares minimum: 1 only, so the upper bound is the type maximum
-        assertTrue(pet.contains("@Range(from = 1.0, to = %s.0".formatted(Long.MAX_VALUE)), pet);
+        // a single inclusive integral bound can use the more concise annotation
+        assertTrue(pet.contains("@Min(1L)"), pet);
     }
 
     @ParameterizedTest

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpServerKotlinOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpServerKotlinOpenapiTest.java
@@ -191,6 +191,54 @@ public class HttpServerKotlinOpenapiTest extends BaseKotlinOpenapiTest {
     }
 
     @Test
+    void enumMappersAreDefaultComponents() throws Exception {
+        var files = generate(
+            "petstoreV3_filter_enum_default_components",
+            "kotlin-server",
+            getClass().getResource("/example/petstoreV3_filter.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+        );
+        var modelContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("PetDog.kt"))
+            .findFirst()
+            .orElseThrow());
+        var moduleContent = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("PetDog__NestedEnumMapperModule.kt"))
+            .findFirst()
+            .orElseThrow());
+
+        assertFalse(modelContent.contains("class JsonWriter"));
+        assertTrue(moduleContent.contains("public interface PetDog__NestedEnumMapperModule"));
+        assertTrue(moduleContent.contains("@DefaultComponent\n  public fun breedEnumJsonWriter("));
+        assertTrue(moduleContent.contains("@DefaultComponent\n  public fun breedEnumJsonReader("));
+        assertTrue(moduleContent.contains("@DefaultComponent\n  public fun breedEnumStringParameterReader("));
+    }
+
+    @Test
+    void modelValidationAnnotationsTargetFields() throws Exception {
+        var files = generate(
+            "petstoreV3_validation_field_annotations",
+            "kotlin-server",
+            getClass().getResource("/example/petstoreV3_validation.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+        );
+        var content = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("Pet.kt"))
+            .findFirst()
+            .orElseThrow());
+
+        assertTrue(content.contains("@field:Max(value = 99L)"), content);
+        assertTrue(content.contains("@field:Min(value = 1L)"), content);
+        assertTrue(content.contains("max = Int.MAX_VALUE"), content);
+        assertTrue(content.contains("@field:Size("));
+        assertTrue(content.contains("@field:Pattern("));
+        assertTrue(content.contains("@field:Valid"));
+    }
+
+    @Test
     void serverResponseMapperWithoutDelegatesDoesNotGenerateEmptyConstructor() throws Exception {
         var files = generate(
             "petstoreV3_discriminator",

--- a/openapi/openapi-generator/src/test/resources/example/petstoreV3_validation.yaml
+++ b/openapi/openapi-generator/src/test/resources/example/petstoreV3_validation.yaml
@@ -433,6 +433,12 @@ components:
               maxLength: 50
             category:
               $ref: '#/components/schemas/CategoryTO'
+            availability:
+              type: string
+              description: pet availability in the store
+              enum:
+                - in_stock
+                - pre_order
     PetCreateTO:
       required:
         - name


### PR DESCRIPTION
Improved Java and Kotlin generation with aggregate modules for nested enum mappers and concise validation annotations.

- Added DefaultComponent enum mapper factories in collision-resistant <Model>__NestedEnumMapperModule modules.
- Added field-targeted validation annotations for Kotlin models.
- Replaced one-sided integral ranges with Min, Max, Positive, and Negative variants.
- Replaced numeric size limits with Integer.MAX_VALUE and Int.MAX_VALUE constants.

This keeps Java and Kotlin output consistent while producing cleaner generated models and DI-ready enum mappers.