### PR TITLE
Removed(ksp): reject suspend processor methods

### DIFF
--- a/database/database-symbol-processor/src/main/kotlin/io/koraframework/database/symbol/processor/RepositoryBuilder.kt
+++ b/database/database-symbol-processor/src/main/kotlin/io/koraframework/database/symbol/processor/RepositoryBuilder.kt
@@ -12,9 +12,11 @@ import com.squareup.kotlinpoet.ksp.toClassName
 import com.squareup.kotlinpoet.ksp.toTypeName
 import io.koraframework.database.symbol.processor.cassandra.CassandraRepositoryGenerator
 import io.koraframework.database.symbol.processor.jdbc.JdbcRepositoryGenerator
+import io.koraframework.database.symbol.processor.DbUtils.findQueryMethods
 import io.koraframework.ksp.common.AnnotationUtils.findAnnotation
 import io.koraframework.ksp.common.CommonAopUtils.extendsKeepAopAll
 import io.koraframework.ksp.common.CommonClassNames
+import io.koraframework.ksp.common.FunctionUtils.isSuspend
 import io.koraframework.ksp.common.KspCommonUtils.addOriginatingKSFile
 import io.koraframework.ksp.common.KspCommonUtils.generated
 import io.koraframework.ksp.common.exception.ProcessingErrorException
@@ -34,6 +36,37 @@ class RepositoryBuilder(
 
     fun build(repositoryDeclaration: KSClassDeclaration): TypeSpec? {
         log.debug("Generating Repository for {}", repositoryDeclaration.simpleName.asString())
+        repositoryDeclaration.findQueryMethods().firstOrNull { it.isSuspend() }?.let { method ->
+            throw ProcessingErrorException(
+                """
+                Repository method is invalid:
+                  ${method.simpleName.asString()}
+
+                Problem:
+                  Suspend methods are not supported by the repository generator.
+
+                Hint:
+                  Generated repositories support regular blocking signatures and supported async wrapper return types, not Kotlin suspend functions.
+                  For structured concurrency, enable Java preview features with --enable-preview and use StructuredTaskScope, for example:
+
+                    fun getProfile(id: Long): Profile =
+                        StructuredTaskScope.open(
+                            StructuredTaskScope.Joiner.awaitAllSuccessfulOrThrow<Any>(),
+                        ).use { scope ->
+                            val user = scope.fork(Callable { userRepository.find(id) })
+                            val orders = scope.fork(Callable { orderRepository.findByUser(id) })
+
+                            scope.join()
+
+                            Profile(user.get(), orders.get())
+                        }
+
+                Fix:
+                  Remove suspend from the method or expose an async return type supported by the repository backend.
+                """.trimIndent(),
+                method
+            )
+        }
         val name = repositoryDeclaration.getOuterClassesAsPrefix() + repositoryDeclaration.simpleName.asString() + "_Impl"
         val builder = repositoryDeclaration.extendsKeepAopAll(name, resolver)
             .generated(RepositoryBuilder::class)

--- a/database/database-symbol-processor/src/test/kotlin/io/koraframework/database/symbol/processor/MethodModifiersRepositoryTest.kt
+++ b/database/database-symbol-processor/src/test/kotlin/io/koraframework/database/symbol/processor/MethodModifiersRepositoryTest.kt
@@ -1,9 +1,32 @@
 package io.koraframework.database.symbol.processor
 
 import io.koraframework.database.symbol.processor.jdbc.AbstractJdbcRepositoryTest
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class MethodModifiersRepositoryTest : AbstractJdbcRepositoryTest() {
+    @Test
+    fun testSuspendFunIsRejected() {
+        val result = compile0(
+            listOf(RepositorySymbolProcessorProvider()),
+            """
+            @Repository
+            interface TestRepository : JdbcRepository {
+                @Query("SELECT 1")
+                suspend fun test(): Int
+            }
+            """.trimIndent()
+        ).assertFailure()
+
+        assertThat(result.messages).anySatisfy {
+            assertThat(it)
+                .contains("Suspend methods are not supported by the repository generator")
+                .contains("--enable-preview")
+                .contains("StructuredTaskScope.open")
+                .contains("Remove suspend from the method")
+        }
+    }
+
     @Test
     fun testInterfacePublicFun() {
         val repository = compile(listOf<Any>(), """

--- a/database/database-symbol-processor/src/test/kotlin/io/koraframework/database/symbol/processor/app/TestKoraAppTagged.kt
+++ b/database/database-symbol-processor/src/test/kotlin/io/koraframework/database/symbol/processor/app/TestKoraAppTagged.kt
@@ -13,7 +13,7 @@ interface TestKoraAppTagged {
     @Repository(executorTag = ExampleTag::class)
     interface TestRepository : JdbcRepository {
         @Query("INSERT INTO table(value) VALUES (:value)")
-        suspend fun abstractMethod(value: String?)
+        fun abstractMethod(value: String?)
     }
 
     class ExampleTag

--- a/experimental/s3-client-symbol-processor/src/main/kotlin/io/koraframework/s3/client/kora/symbol/processor/gen/ClientGenerator.kt
+++ b/experimental/s3-client-symbol-processor/src/main/kotlin/io/koraframework/s3/client/kora/symbol/processor/gen/ClientGenerator.kt
@@ -17,6 +17,7 @@ import io.koraframework.ksp.common.CommonAopUtils.overridingKeepAop
 import io.koraframework.ksp.common.CommonClassNames
 import io.koraframework.ksp.common.CommonClassNames.isCollection
 import io.koraframework.ksp.common.CommonClassNames.isMap
+import io.koraframework.ksp.common.FunctionUtils.isSuspend
 import io.koraframework.ksp.common.KotlinPoetUtils.controlFlow
 import io.koraframework.ksp.common.KspCommonUtils.generated
 import io.koraframework.ksp.common.KspCommonUtils.resolveToUnderlying
@@ -70,6 +71,37 @@ object ClientGenerator {
         for (function in s3client.getAllFunctions()) {
             if (!function.isAbstract) {
                 continue
+            }
+            if (function.isSuspend()) {
+                throw ProcessingErrorException(
+                    """
+                    S3 client method is invalid:
+                      ${function.simpleName.asString()}
+
+                    Problem:
+                      Suspend methods are not supported by the S3 client generator.
+
+                    Hint:
+                      Generated S3 clients support regular blocking signatures, not Kotlin suspend functions.
+                      For structured concurrency, enable Java preview features with --enable-preview and use StructuredTaskScope, for example:
+
+                        fun getUserAssets(userId: Long): UserAssets =
+                            StructuredTaskScope.open(
+                                StructuredTaskScope.Joiner.awaitAllSuccessfulOrThrow<Any>(),
+                            ).use { scope ->
+                                val avatar = scope.fork(Callable { s3Client.get("avatars/${'$'}userId") })
+                                val documents = scope.fork(Callable { s3Client.list("documents/${'$'}userId/") })
+
+                                scope.join()
+
+                                UserAssets(avatar.get(), documents.get())
+                            }
+
+                    Fix:
+                      Remove suspend from the method.
+                    """.trimIndent(),
+                    function
+                )
             }
             b.addFunction(generateFunction(resolver, function))
         }

--- a/experimental/s3-client-symbol-processor/src/test/kotlin/io/koraframework/s3/client/symbol/processor/S3ClientSymbolProcessorTest.kt
+++ b/experimental/s3-client-symbol-processor/src/test/kotlin/io/koraframework/s3/client/symbol/processor/S3ClientSymbolProcessorTest.kt
@@ -2,6 +2,9 @@ package io.koraframework.s3.client.symbol.processor
 
 import io.koraframework.common.annotation.Tag
 import io.koraframework.s3.client.kora.symbol.processor.AbstractS3ClientTest
+import io.koraframework.s3.client.kora.symbol.processor.S3ClientSymbolProvider
+import io.koraframework.ksp.common.exception.ProcessingErrorException
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -27,5 +30,27 @@ class S3ClientSymbolProcessorTest : AbstractS3ClientTest() {
         val clientFactoryTag = clientImpl.parameters[0].getAnnotation(Tag::class.java)
 
         assertThat(clientFactoryTag.value.java).isEqualTo(loadClass("Client\$CustomS3FactoryTag"))
+    }
+
+    @Test
+    fun testSuspendMethodIsRejected() {
+        assertThatThrownBy {
+            compile0(
+                listOf(S3ClientSymbolProvider()),
+                """
+                @S3.Client
+                interface Client {
+                    @S3.List
+                    suspend fun list(@Bucket bucket: String): List<String>
+                }
+                """.trimIndent()
+            )
+        }.isInstanceOfSatisfying(ProcessingErrorException::class.java) {
+            assertThat(it.message)
+                .contains("Suspend methods are not supported by the S3 client generator")
+                .contains("--enable-preview")
+                .contains("StructuredTaskScope.open")
+                .contains("Remove suspend from the method")
+        }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,7 +32,7 @@ resteasy = "6.2.17.Final"
 # Data and messaging
 kafka = "4.3.1"
 cassandra = "4.19.3"
-flyway = "13.2.0"
+flyway = "13.3.0"
 
 # gRPC and protobuf
 grpc-java = "1.83.1"
@@ -169,7 +169,7 @@ byte-buddy-core = { module = "net.bytebuddy:byte-buddy", version.ref = "byte-bud
 byte-buddy-agent = { module = "net.bytebuddy:byte-buddy-agent", version.ref = "byte-buddy" }
 
 javapoet = { module = "com.palantir.javapoet:javapoet", version = "0.18.0" }
-classgraph = { module = "io.github.classgraph:classgraph", version = "4.8.190" }
+classgraph = { module = "io.github.classgraph:classgraph", version = "4.8.191" }
 
 lettuce-core = { module = "io.lettuce:lettuce-core", version = "6.8.0.RELEASE" }
 apache-pool = { module = "org.apache.commons:commons-pool2", version = "2.13.1" }
@@ -249,7 +249,7 @@ cxf-rt-transports-http-jetty = { module = "org.apache.cxf:cxf-rt-transports-http
 cxf-rt-frontend-jaxws = { module = "org.apache.cxf:cxf-rt-frontend-jaxws", version.ref = "cxf" }
 
 s3client-minio = { module = "io.minio:minio", version = "9.0.3" }
-s3client-aws = { module = "software.amazon.awssdk:s3", version = "2.52.0" }
+s3client-aws = { module = "software.amazon.awssdk:s3", version = "2.52.1" }
 
 camunda7-engine = { module = "org.camunda.bpm:camunda-engine", version.ref = "camunda7" }
 camunda7-rest-jakarta = { module = "org.camunda.bpm:camunda-engine-rest-jakarta", version.ref = "camunda7" }

--- a/http/http-client-symbol-processor/src/main/kotlin/io/koraframework/http/client/symbol/processor/ClientClassGenerator.kt
+++ b/http/http-client-symbol-processor/src/main/kotlin/io/koraframework/http/client/symbol/processor/ClientClassGenerator.kt
@@ -88,6 +88,19 @@ class ClientClassGenerator(private val resolver: Resolver) {
 
                     Hint:
                       Generated HTTP clients currently support regular blocking signatures and supported async wrapper return types, not Kotlin suspend functions.
+                      For structured concurrency, enable Java preview features with --enable-preview and use StructuredTaskScope, for example:
+
+                        fun getDashboard(userId: Long): Dashboard =
+                            StructuredTaskScope.open(
+                                StructuredTaskScope.Joiner.awaitAllSuccessfulOrThrow<Any>(),
+                            ).use { scope ->
+                                val profile = scope.fork(Callable { profileHttpClient.getProfile(userId) })
+                                val recommendations = scope.fork(Callable { recommendationsHttpClient.getForUser(userId) })
+
+                                scope.join()
+
+                                Dashboard(profile.get(), recommendations.get())
+                            }
 
                     Fix:
                       Remove suspend from the method or expose an async return type supported by Kora HTTP client.

--- a/http/http-client-symbol-processor/src/test/kotlin/io/koraframework/http/client/symbol/processor/BlockingApiTest.kt
+++ b/http/http-client-symbol-processor/src/test/kotlin/io/koraframework/http/client/symbol/processor/BlockingApiTest.kt
@@ -22,6 +22,28 @@ import kotlin.reflect.full.primaryConstructor
 class BlockingApiTest : AbstractHttpClientTest() {
 
     @Test
+    fun testSuspendMethodIsRejected() {
+        val result = compile0(
+            listOf(HttpClientSymbolProcessorProvider()),
+            """
+            @HttpClient
+            interface TestClient {
+                @HttpRoute(method = "GET", path = "/test")
+                suspend fun request(): String
+            }
+            """.trimIndent()
+        ).assertFailure()
+
+        Assertions.assertThat(result.messages).anySatisfy {
+            Assertions.assertThat(it)
+                .contains("Suspend methods are not supported by the HTTP client generator")
+                .contains("--enable-preview")
+                .contains("StructuredTaskScope.open")
+                .contains("Remove suspend from the method")
+        }
+    }
+
+    @Test
     fun testComponentAnnotationPreserved() {
         val client = compile(
             listOf<Any>(), """

--- a/http/http-server-symbol-processor/src/main/kotlin/io/koraframework/http/server/symbol/procesor/RouteProcessor.kt
+++ b/http/http-server-symbol-processor/src/main/kotlin/io/koraframework/http/server/symbol/procesor/RouteProcessor.kt
@@ -26,6 +26,7 @@ import io.koraframework.ksp.common.AnnotationUtils.isAnnotationPresent
 import io.koraframework.ksp.common.CommonClassNames.isCollection
 import io.koraframework.ksp.common.CommonClassNames.isList
 import io.koraframework.ksp.common.CommonClassNames.isSet
+import io.koraframework.ksp.common.FunctionUtils.isSuspend
 import io.koraframework.ksp.common.KotlinPoetUtils.controlFlow
 import io.koraframework.ksp.common.KspCommonUtils.findRepeatableAnnotation
 import io.koraframework.ksp.common.TagUtils.parseTag
@@ -35,13 +36,39 @@ import io.koraframework.ksp.common.exception.ProcessingErrorException
 
 
 class RouteProcessor {
-    private val future = MemberName("kotlinx.coroutines.future", "future")
-    private val coroutineScope = MemberName("kotlinx.coroutines", "CoroutineScope")
-    private val dispatchers = ClassName("kotlinx.coroutines", "Dispatchers")
-
     data class Route(val method: String, val pathTemplate: String)
 
     internal fun buildHttpRouteFunction(declaration: KSClassDeclaration, rootPath: String, function: KSFunctionDeclaration): FunSpec.Builder {
+        if (function.isSuspend()) {
+            throw ProcessingErrorException(
+                """
+                HTTP server controller method is invalid:
+                  ${function.simpleName.asString()}
+
+                Problem:
+                  Suspend methods are not supported by the HTTP server controller generator.
+
+                Hint:
+                  Generated HTTP handlers use regular blocking controller signatures. For structured concurrency, enable Java preview features with --enable-preview and use StructuredTaskScope, for example:
+
+                    fun getDashboard(userId: Long): Dashboard =
+                        StructuredTaskScope.open(
+                            StructuredTaskScope.Joiner.awaitAllSuccessfulOrThrow<Any>(),
+                        ).use { scope ->
+                            val profile = scope.fork(Callable { profileService.getProfile(userId) })
+                            val recommendations = scope.fork(Callable { recommendationService.getForUser(userId) })
+
+                            scope.join()
+
+                            Dashboard(profile.get(), recommendations.get())
+                        }
+
+                Fix:
+                  Remove suspend from the controller method.
+                """.trimIndent(),
+                function
+            )
+        }
         val requestMappingData = extractRoute(rootPath, function)
         val parent = function.parent as KSClassDeclaration
         val funName = requestMappingData.funName()
@@ -66,7 +93,6 @@ class RouteProcessor {
             funBuilder.addAnnotation(tags.toTagAnnotation())
         }
 
-        val isSuspend = function.modifiers.contains(Modifier.SUSPEND)
         val bodyParams = mutableListOf<KSValueParameter>()
         function.parameters.forEach {
             when {
@@ -143,13 +169,7 @@ class RouteProcessor {
                 }
             }
 
-            if (isSuspend) {
-                controlFlow("val _result = %M", MemberName("kotlinx.coroutines", "runBlocking")) {
-                    addStatement("_controller.%L(%L)", function.simpleName.asString(), params)
-                }
-            } else {
-                addStatement("val _result = _controller.%L(%L)", function.simpleName.asString(), params)
-            }
+            addStatement("val _result = _controller.%L(%L)", function.simpleName.asString(), params)
             if (returnTypeName == UNIT) {
                 addStatement("return@process %T.of(200)", httpServerResponse)
             } else if (returnTypeName == httpServerResponse) {

--- a/http/http-server-symbol-processor/src/test/kotlin/io/koraframework/http/server/symbol/processor/ControllerParamsTest.kt
+++ b/http/http-server-symbol-processor/src/test/kotlin/io/koraframework/http/server/symbol/processor/ControllerParamsTest.kt
@@ -21,22 +21,22 @@ class ControllerParamsTest : AbstractHttpControllerTest() {
             class Controller {
             
                 @HttpRoute(method = GET, path = "/pathString/{valueSome}")
-                suspend fun pathString(@Path(value = "valueSome") value: String) { }
+                fun pathString(@Path(value = "valueSome") value: String) { }
             
                 @HttpRoute(method = GET, path = "/pathInteger/{value}")
-                suspend fun pathInteger(@Path value: Int) { }
+                fun pathInteger(@Path value: Int) { }
             
                 @HttpRoute(method = GET, path = "/pathLong/{value}")
-                suspend fun pathLong(@Path value: Long) { }
+                fun pathLong(@Path value: Long) { }
             
                 @HttpRoute(method = GET, path = "/pathDouble/{value}")
-                suspend fun pathDouble(@Path value: Double) { }
+                fun pathDouble(@Path value: Double) { }
             
                 @HttpRoute(method = GET, path = "/pathUUID/{value}")
-                suspend fun pathUUID(@Path value: UUID) { }
+                fun pathUUID(@Path value: UUID) { }
             
                 @HttpRoute(method = GET, path = "/pathBoolean/{value}")
-                suspend fun pathBoolean(@Path value: Boolean) { }
+                fun pathBoolean(@Path value: Boolean) { }
             }
             """.trimIndent()
         )
@@ -53,94 +53,94 @@ class ControllerParamsTest : AbstractHttpControllerTest() {
             class Controller {
             
                 @HttpRoute(method = GET, path = "/headerString")
-                suspend fun headerString(@Header(value = "valueSome") value: String) { }
+                fun headerString(@Header(value = "valueSome") value: String) { }
             
                 @HttpRoute(method = GET, path = "/headerStringNullable")
-                suspend fun headerStringNullable(@Header value: String?) { }
+                fun headerStringNullable(@Header value: String?) { }
             
                 @HttpRoute(method = GET, path = "/headerStringList")
-                suspend fun headerStringList(@Header values: List<String>) { }
+                fun headerStringList(@Header values: List<String>) { }
             
                 @HttpRoute(method = GET, path = "/headerStringListNullable")
-                suspend fun headerStringListNullable(@Header values: List<String>?) { }
+                fun headerStringListNullable(@Header values: List<String>?) { }
             
                 @HttpRoute(method = GET, path = "/headerStringSet")
-                suspend fun headerStringSet(@Header values: Set<String>) { }
+                fun headerStringSet(@Header values: Set<String>) { }
             
                 @HttpRoute(method = GET, path = "/headerStringSetNullable")
-                suspend fun headerStringSetNullable(@Header values: Set<String>?) { }
+                fun headerStringSetNullable(@Header values: Set<String>?) { }
             
                 @HttpRoute(method = GET, path = "/headerInteger")
-                suspend fun headerInteger(@Header(value = "valueSome") value: Int) { }
+                fun headerInteger(@Header(value = "valueSome") value: Int) { }
             
                 @HttpRoute(method = GET, path = "/headerIntegerNullable")
-                suspend fun headerIntegerNullable(@Header value: Int?) { }
+                fun headerIntegerNullable(@Header value: Int?) { }
             
                 @HttpRoute(method = GET, path = "/headerIntegerList")
-                suspend fun headerIntegerList(@Header values: List<Int>) { }
+                fun headerIntegerList(@Header values: List<Int>) { }
             
                 @HttpRoute(method = GET, path = "/headerIntegerListNullable")
-                suspend fun headerIntegerListNullable(@Header values: List<Int>?) { }
+                fun headerIntegerListNullable(@Header values: List<Int>?) { }
             
                 @HttpRoute(method = GET, path = "/headerIntegerSet")
-                suspend fun headerIntegerSet(@Header values: Set<Int>) { }
+                fun headerIntegerSet(@Header values: Set<Int>) { }
             
                 @HttpRoute(method = GET, path = "/headerIntegerSetNullable")
-                suspend fun headerIntegerSetNullable(@Header values: Set<Int>?) { }
+                fun headerIntegerSetNullable(@Header values: Set<Int>?) { }
             
                 @HttpRoute(method = GET, path = "/headerLong")
-                suspend fun headerLong(@Header("valueSome") value: Long) { }
+                fun headerLong(@Header("valueSome") value: Long) { }
             
                 @HttpRoute(method = GET, path = "/headerLongNullable")
-                suspend fun headerLongNullable(@Header value: Long?) { }
+                fun headerLongNullable(@Header value: Long?) { }
             
                 @HttpRoute(method = GET, path = "/headerLongList")
-                suspend fun headerLongList(@Header values: List<Long>) { }
+                fun headerLongList(@Header values: List<Long>) { }
             
                 @HttpRoute(method = GET, path = "/headerLongListNullable")
-                suspend fun headerLongListNullable(@Header values: List<Long>) { }
+                fun headerLongListNullable(@Header values: List<Long>) { }
             
                 @HttpRoute(method = GET, path = "/headerLongSet")
-                suspend fun headerLongSet(@Header values: Set<Long>) { }
+                fun headerLongSet(@Header values: Set<Long>) { }
             
                 @HttpRoute(method = GET, path = "/headerLongSetNullable")
-                suspend fun headerLongSetNullable(@Header values: Set<Long>?) { }
+                fun headerLongSetNullable(@Header values: Set<Long>?) { }
             
                 @HttpRoute(method = GET, path = "/headerDouble")
-                suspend fun headerDouble(@Header("valueSome") value: Double) { }
+                fun headerDouble(@Header("valueSome") value: Double) { }
             
                 @HttpRoute(method = GET, path = "/headerDoubleNullable")
-                suspend fun headerDoubleNullable(@Header value: Double?) { }
+                fun headerDoubleNullable(@Header value: Double?) { }
             
                 @HttpRoute(method = GET, path = "/headerDoubleList")
-                suspend fun headerDoubleList(@Header values: List<Double>) { }
+                fun headerDoubleList(@Header values: List<Double>) { }
             
                 @HttpRoute(method = GET, path = "/headerDoubleListNullable")
-                suspend fun headerDoubleListNullable(@Header values: List<Double>?) { }
+                fun headerDoubleListNullable(@Header values: List<Double>?) { }
             
                 @HttpRoute(method = GET, path = "/headerDoubleSet")
-                suspend fun headerDoubleSet(@Header values: Set<Double>) { }
+                fun headerDoubleSet(@Header values: Set<Double>) { }
             
                 @HttpRoute(method = GET, path = "/headerDoubleSetNullable")
-                suspend fun headerDoubleSetNullable(@Header values: Set<Double>) { }
+                fun headerDoubleSetNullable(@Header values: Set<Double>) { }
             
                 @HttpRoute(method = GET, path = "/headerUUID")
-                suspend fun headerUUID(@Header("valueSome") value: UUID) { }
+                fun headerUUID(@Header("valueSome") value: UUID) { }
             
                 @HttpRoute(method = GET, path = "/headerUUIDNullable")
-                suspend fun headerUUIDNullable(@Header value: UUID?) { }
+                fun headerUUIDNullable(@Header value: UUID?) { }
             
                 @HttpRoute(method = GET, path = "/headerUUIDList")
-                suspend fun headerUUIDList(@Header values: List<UUID>) { }
+                fun headerUUIDList(@Header values: List<UUID>) { }
             
                 @HttpRoute(method = GET, path = "/headerUUIDListNullable")
-                suspend fun headerUUIDListNullable(@Header values: List<UUID>?) { }
+                fun headerUUIDListNullable(@Header values: List<UUID>?) { }
             
                 @HttpRoute(method = GET, path = "/headerUUIDSet")
-                suspend fun headerUUIDSet(@Header values: Set<UUID>) { }
+                fun headerUUIDSet(@Header values: Set<UUID>) { }
             
                 @HttpRoute(method = GET, path = "/headerUUIDSetNullable")
-                suspend fun headerUUIDSetNullable(@Header values: Set<UUID>?) { }
+                fun headerUUIDSetNullable(@Header values: Set<UUID>?) { }
             }
             """.trimIndent()
         )
@@ -157,22 +157,22 @@ class ControllerParamsTest : AbstractHttpControllerTest() {
             class Controller {
             
                 @HttpRoute(method = GET, path = "/headerBigInteger")
-                suspend fun headerBigInteger(@Header(value = "valueSome") value: BigInteger) { }
+                fun headerBigInteger(@Header(value = "valueSome") value: BigInteger) { }
             
                 @HttpRoute(method = GET, path = "/headerBigIntegerNullable")
-                suspend fun headerBigIntegerNullable(@Header value: BigInteger?) { }
+                fun headerBigIntegerNullable(@Header value: BigInteger?) { }
             
                 @HttpRoute(method = GET, path = "/headerBigIntegerList")
-                suspend fun headerBigIntegerList(@Header values: List<BigInteger>) { }
+                fun headerBigIntegerList(@Header values: List<BigInteger>) { }
             
                 @HttpRoute(method = GET, path = "/headerBigIntegerListNullable")
-                suspend fun headerBigIntegerListNullable(@Header values: List<BigInteger>?) { }
+                fun headerBigIntegerListNullable(@Header values: List<BigInteger>?) { }
             
                 @HttpRoute(method = GET, path = "/headerBigIntegerSet")
-                suspend fun headerBigIntegerSet(@Header values: Set<BigInteger>) { }
+                fun headerBigIntegerSet(@Header values: Set<BigInteger>) { }
             
                 @HttpRoute(method = GET, path = "/headerBigIntegerSetNullable")
-                suspend fun headerBigIntegerSetNullable(@Header values: Set<BigInteger>?) { }
+                fun headerBigIntegerSetNullable(@Header values: Set<BigInteger>?) { }
             }
             """.trimIndent()
         )
@@ -195,112 +195,112 @@ class ControllerParamsTest : AbstractHttpControllerTest() {
             class Controller {
             
                 @HttpRoute(method = GET, path = "/queryString")
-                suspend fun queryString(@Query(value = "valueSome") value: String) { }
+                fun queryString(@Query(value = "valueSome") value: String) { }
             
                 @HttpRoute(method = GET, path = "/queryStringNullable")
-                suspend fun queryStringNullable(@Query value: String?) { }
+                fun queryStringNullable(@Query value: String?) { }
             
                 @HttpRoute(method = GET, path = "/queryStringList")
-                suspend fun queryStringList(@Query values: List<String>) { }
+                fun queryStringList(@Query values: List<String>) { }
             
                 @HttpRoute(method = GET, path = "/queryStringListNullable")
-                suspend fun queryStringListNullable(@Query values: List<String>?) { }
+                fun queryStringListNullable(@Query values: List<String>?) { }
             
                 @HttpRoute(method = GET, path = "/queryStringSet")
-                suspend fun queryStringSet(@Query values: Set<String>) { }
+                fun queryStringSet(@Query values: Set<String>) { }
             
                 @HttpRoute(method = GET, path = "/queryStringSetNullable")
-                suspend fun queryStringSetNullable(@Query values: Set<String>?) { }
+                fun queryStringSetNullable(@Query values: Set<String>?) { }
             
                 @HttpRoute(method = GET, path = "/queryInteger")
-                suspend fun queryInteger(@Query(value = "valueSome") value: Int) { }
+                fun queryInteger(@Query(value = "valueSome") value: Int) { }
             
                 @HttpRoute(method = GET, path = "/queryIntegerNullable")
-                suspend fun queryIntegerNullable(@Query value: Int?) { }
+                fun queryIntegerNullable(@Query value: Int?) { }
             
                 @HttpRoute(method = GET, path = "/queryIntegerList")
-                suspend fun queryIntegerList(@Query values: List<Int>) { }
+                fun queryIntegerList(@Query values: List<Int>) { }
             
                 @HttpRoute(method = GET, path = "/queryIntegerListNullable")
-                suspend fun queryIntegerListNullable(@Query values: List<Int>?) { }
+                fun queryIntegerListNullable(@Query values: List<Int>?) { }
             
                 @HttpRoute(method = GET, path = "/queryIntegerSet")
-                suspend fun queryIntegerSet(@Query values: Set<Int>) { }
+                fun queryIntegerSet(@Query values: Set<Int>) { }
             
                 @HttpRoute(method = GET, path = "/queryIntegerSetNullable")
-                suspend fun queryIntegerSetNullable(@Query values: Set<Int>?) { }
+                fun queryIntegerSetNullable(@Query values: Set<Int>?) { }
             
                 @HttpRoute(method = GET, path = "/queryLong")
-                suspend fun queryLong(@Query("valueSome") value: Long) { }
+                fun queryLong(@Query("valueSome") value: Long) { }
             
                 @HttpRoute(method = GET, path = "/queryLongNullable")
-                suspend fun queryLongNullable(@Query value: Long?) { }
+                fun queryLongNullable(@Query value: Long?) { }
             
                 @HttpRoute(method = GET, path = "/queryLongList")
-                suspend fun queryLongList(@Query values: List<Long>) { }
+                fun queryLongList(@Query values: List<Long>) { }
             
                 @HttpRoute(method = GET, path = "/queryLongListNullable")
-                suspend fun queryLongListNullable(@Query values: List<Long>) { }
+                fun queryLongListNullable(@Query values: List<Long>) { }
             
                 @HttpRoute(method = GET, path = "/queryLongSet")
-                suspend fun queryLongSet(@Query values: Set<Long>) { }
+                fun queryLongSet(@Query values: Set<Long>) { }
             
                 @HttpRoute(method = GET, path = "/queryLongSetNullable")
-                suspend fun queryLongSetNullable(@Query values: Set<Long>?) { }
+                fun queryLongSetNullable(@Query values: Set<Long>?) { }
             
                 @HttpRoute(method = GET, path = "/queryDouble")
-                suspend fun queryDouble(@Query("valueSome") value: Double) { }
+                fun queryDouble(@Query("valueSome") value: Double) { }
             
                 @HttpRoute(method = GET, path = "/queryDoubleNullable")
-                suspend fun queryDoubleNullable(@Query value: Double?) { }
+                fun queryDoubleNullable(@Query value: Double?) { }
             
                 @HttpRoute(method = GET, path = "/queryDoubleList")
-                suspend fun queryDoubleList(@Query values: List<Double>) { }
+                fun queryDoubleList(@Query values: List<Double>) { }
             
                 @HttpRoute(method = GET, path = "/queryDoubleListNullable")
-                suspend fun queryDoubleListNullable(@Query values: List<Double>?) { }
+                fun queryDoubleListNullable(@Query values: List<Double>?) { }
             
                 @HttpRoute(method = GET, path = "/queryDoubleSet")
-                suspend fun queryDoubleSet(@Query values: Set<Double>) { }
+                fun queryDoubleSet(@Query values: Set<Double>) { }
             
                 @HttpRoute(method = GET, path = "/queryDoubleSetNullable")
-                suspend fun queryDoubleSetNullable(@Query values: Set<Double>) { }
+                fun queryDoubleSetNullable(@Query values: Set<Double>) { }
             
                 @HttpRoute(method = GET, path = "/queryUUID")
-                suspend fun queryUUID(@Query("valueSome") value: UUID) { }
+                fun queryUUID(@Query("valueSome") value: UUID) { }
             
                 @HttpRoute(method = GET, path = "/queryUUIDNullable")
-                suspend fun queryUUIDNullable(@Query value: UUID?) { }
+                fun queryUUIDNullable(@Query value: UUID?) { }
             
                 @HttpRoute(method = GET, path = "/queryUUIDList")
-                suspend fun queryUUIDList(@Query values: List<UUID>) { }
+                fun queryUUIDList(@Query values: List<UUID>) { }
             
                 @HttpRoute(method = GET, path = "/queryUUIDListNullable")
-                suspend fun queryUUIDListNullable(@Query values: List<UUID>?) { }
+                fun queryUUIDListNullable(@Query values: List<UUID>?) { }
             
                 @HttpRoute(method = GET, path = "/queryUUIDSet")
-                suspend fun queryUUIDSet(@Query values: Set<UUID>) { }
+                fun queryUUIDSet(@Query values: Set<UUID>) { }
             
                 @HttpRoute(method = GET, path = "/queryUUIDSetNullable")
-                suspend fun queryUUIDSetNullable(@Query values: Set<UUID>?) { }
+                fun queryUUIDSetNullable(@Query values: Set<UUID>?) { }
             
                 @HttpRoute(method = GET, path = "/queryBoolean")
-                suspend fun queryBoolean(@Query("valueSome") value: Boolean) { }
+                fun queryBoolean(@Query("valueSome") value: Boolean) { }
             
                 @HttpRoute(method = GET, path = "/queryBooleanNullable")
-                suspend fun queryBooleanNullable(@Query value: Boolean?) { }
+                fun queryBooleanNullable(@Query value: Boolean?) { }
             
                 @HttpRoute(method = GET, path = "/queryBooleanList")
-                suspend fun queryBooleanList(@Query values: List<Boolean>) { }
+                fun queryBooleanList(@Query values: List<Boolean>) { }
             
                 @HttpRoute(method = GET, path = "/queryBooleanListNullable")
-                suspend fun queryBooleanListNullable(@Query values: List<Boolean>?) { }
+                fun queryBooleanListNullable(@Query values: List<Boolean>?) { }
             
                 @HttpRoute(method = GET, path = "/queryBooleanSet")
-                suspend fun queryBooleanSet(@Query values: Set<Boolean>) { }
+                fun queryBooleanSet(@Query values: Set<Boolean>) { }
             
                 @HttpRoute(method = GET, path = "/queryBooleanSetNullable")
-                suspend fun queryBooleanSetNullable(@Query values: Set<Boolean>?) { }
+                fun queryBooleanSetNullable(@Query values: Set<Boolean>?) { }
             }
             
             """.trimIndent()
@@ -318,22 +318,22 @@ class ControllerParamsTest : AbstractHttpControllerTest() {
             class Controller {
             
                 @HttpRoute(method = GET, path = "/queryBigInteger")
-                suspend fun queryBigInteger(@Query(value = "valueSome") value: BigInteger) { }
+                fun queryBigInteger(@Query(value = "valueSome") value: BigInteger) { }
             
                 @HttpRoute(method = GET, path = "/queryBigIntegerNullable")
-                suspend fun queryBigIntegerNullable(@Query value: BigInteger?) { }
+                fun queryBigIntegerNullable(@Query value: BigInteger?) { }
             
                 @HttpRoute(method = GET, path = "/queryBigIntegerList")
-                suspend fun queryBigIntegerList(@Query values: List<BigInteger>) { }
+                fun queryBigIntegerList(@Query values: List<BigInteger>) { }
             
                 @HttpRoute(method = GET, path = "/queryBigIntegerListNullable")
-                suspend fun queryBigIntegerListNullable(@Query values: List<BigInteger>?) { }
+                fun queryBigIntegerListNullable(@Query values: List<BigInteger>?) { }
             
                 @HttpRoute(method = GET, path = "/queryBigIntegerSet")
-                suspend fun queryBigIntegerSet(@Query values: Set<BigInteger>) { }
+                fun queryBigIntegerSet(@Query values: Set<BigInteger>) { }
             
                 @HttpRoute(method = GET, path = "/queryBigIntegerSetNullable")
-                suspend fun queryBigIntegerSetNullable(@Query values: Set<BigInteger>?) { }
+                fun queryBigIntegerSetNullable(@Query values: Set<BigInteger>?) { }
             }
             
             """.trimIndent()
@@ -361,16 +361,16 @@ class ControllerParamsTest : AbstractHttpControllerTest() {
                 }
             
                 @HttpRoute(method = GET, path = "/queryEnum")
-                suspend fun queryEnum(@Query("value") value1: TestEnum) { }
+                fun queryEnum(@Query("value") value1: TestEnum) { }
             
                 @HttpRoute(method = GET, path = "/queryNullableEnum")
-                suspend fun queryNullableEnum(@Query value: TestEnum?) { }
+                fun queryNullableEnum(@Query value: TestEnum?) { }
 
                 @HttpRoute(method = GET, path = "/queryEnumList")
-                suspend fun queryEnumList(@Query value: List<TestEnum>) { }
+                fun queryEnumList(@Query value: List<TestEnum>) { }
 
                 @HttpRoute(method = GET, path = "/queryNullableEnumList")
-                suspend fun queryNullableEnumList(@Query value: List<TestEnum>?) { }
+                fun queryNullableEnumList(@Query value: List<TestEnum>?) { }
             }
             """.trimIndent()
         )
@@ -397,16 +397,16 @@ class ControllerParamsTest : AbstractHttpControllerTest() {
                 }
             
                 @HttpRoute(method = GET, path = "/headerEnum")
-                suspend fun queryEnum(@Header("value") value1: TestEnum) { }
+                fun queryEnum(@Header("value") value1: TestEnum) { }
             
                 @HttpRoute(method = GET, path = "/headerNullableEnum")
-                suspend fun queryNullableEnum(@Header("value") value: TestEnum?) { }
+                fun queryNullableEnum(@Header("value") value: TestEnum?) { }
 
                 @HttpRoute(method = GET, path = "/headerEnumList")
-                suspend fun queryEnumList(@Header("value") value: List<TestEnum>) { }
+                fun queryEnumList(@Header("value") value: List<TestEnum>) { }
 
                 @HttpRoute(method = GET, path = "/headerNullableEnumList")
-                suspend fun queryNullableEnumList(@Header("value") value: List<TestEnum>?) { }
+                fun queryNullableEnumList(@Header("value") value: List<TestEnum>?) { }
             }
             """.trimIndent()
         )
@@ -429,27 +429,27 @@ class ControllerParamsTest : AbstractHttpControllerTest() {
             class Controller {
 
                 @HttpRoute(method = GET, path = "/headerString")
-                suspend fun headerString(@Header(value = "string-header") string: String) {
+                fun headerString(@Header(value = "string-header") string: String) {
                 }
                         
                 @HttpRoute(method = GET, path = "/headerNullableString")
-                suspend fun headerNullableString(@Header string: String?) {
+                fun headerNullableString(@Header string: String?) {
                 }
                         
                 @HttpRoute(method = GET, path = "/headerStringList")
-                suspend fun headerNullableString(@Header string: List<String>) {
+                fun headerNullableString(@Header string: List<String>) {
                 }
                         
                 @HttpRoute(method = GET, path = "/headerInteger")
-                suspend fun headerInteger(@Header(value = "integer-header") integer: Int) {
+                fun headerInteger(@Header(value = "integer-header") integer: Int) {
                 }
                         
                 @HttpRoute(method = GET, path = "/headerNullableInteger")
-                suspend fun headerNullableInteger(@Header(value = "integer-header") integer: Int?) {
+                fun headerNullableInteger(@Header(value = "integer-header") integer: Int?) {
                 }
                         
                 @HttpRoute(method = GET, path = "/headerIntegerList")
-                suspend fun headerStringList(@Header(value = "integer-header") integers: List<Int>) {
+                fun headerStringList(@Header(value = "integer-header") integers: List<Int>) {
                 }
             }
             
@@ -467,16 +467,16 @@ class ControllerParamsTest : AbstractHttpControllerTest() {
             class Controller {
 
                 @HttpRoute(method = GET, path = "/cookieString")
-                suspend fun headerString(@Cookie(value = "someCookie") string: String) {}
+                fun headerString(@Cookie(value = "someCookie") string: String) {}
 
                 @HttpRoute(method = GET, path = "/cookieNullableString")
-                suspend fun headerNullableString(@Cookie string: String?) {}
+                fun headerNullableString(@Cookie string: String?) {}
 
                 @HttpRoute(method = GET, path = "/cookieCookie")
-                suspend fun headerInteger(@Cookie cookie: io.koraframework.http.common.cookie.Cookie) {}
+                fun headerInteger(@Cookie cookie: io.koraframework.http.common.cookie.Cookie) {}
 
                 @HttpRoute(method = GET, path = "/cookieNullableCookie")
-                suspend fun headerNullableInteger(@Cookie cookie: io.koraframework.http.common.cookie.Cookie?) {}
+                fun headerNullableInteger(@Cookie cookie: io.koraframework.http.common.cookie.Cookie?) {}
             }
             
             """.trimIndent()
@@ -492,7 +492,7 @@ class ControllerParamsTest : AbstractHttpControllerTest() {
             @HttpController
             class Controller {
                 @HttpRoute(method = GET, path = "/request")
-                suspend fun request(request: HttpServerRequest) {
+                fun request(request: HttpServerRequest) {
                 }
             }
             
@@ -509,7 +509,7 @@ class ControllerParamsTest : AbstractHttpControllerTest() {
             @HttpController
             class Controller {
                 @HttpRoute(method = GET, path = "/request")
-                suspend fun request(request: String) {
+                fun request(request: String) {
                 }
             }
             
@@ -555,7 +555,7 @@ class ControllerParamsTest : AbstractHttpControllerTest() {
             @HttpController
             class Controller {
                 @HttpRoute(method = GET, path = "/request")
-                suspend fun request(@io.koraframework.common.annotation.Mapping(Mapper::class) request: String) {
+                fun request(@io.koraframework.common.annotation.Mapping(Mapper::class) request: String) {
                 }
             }
             """.trimIndent(), """
@@ -676,7 +676,7 @@ class ControllerParamsTest : AbstractHttpControllerTest() {
             @HttpController
             class Controller {
                 @HttpRoute(method = "POST", path = "/test")
-                suspend fun test(string: Any) {
+                fun test(string: Any) {
                 }
             }
             """.trimIndent()
@@ -725,7 +725,7 @@ class ControllerParamsTest : AbstractHttpControllerTest() {
             class Controller {
             
                 @HttpRoute(method = GET, path = "/pathString/{valueSome}")
-                suspend fun pathString(@Path(value = "valueSome") value: String) { }
+                fun pathString(@Path(value = "valueSome") value: String) { }
             }
             """.trimIndent()
         )

--- a/http/http-server-symbol-processor/src/test/kotlin/io/koraframework/http/server/symbol/processor/SuspendHttpControllerTest.kt
+++ b/http/http-server-symbol-processor/src/test/kotlin/io/koraframework/http/server/symbol/processor/SuspendHttpControllerTest.kt
@@ -1,175 +1,29 @@
 package io.koraframework.http.server.symbol.processor
 
+import io.koraframework.http.server.symbol.procesor.HttpControllerProcessorProvider
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import io.koraframework.http.server.common.request.HttpServerRequestHandler
-import io.koraframework.http.server.common.response.mapper.HttpServerResponseEntityMapper
 
 class SuspendHttpControllerTest : AbstractHttpControllerTest() {
     @Test
-    fun testReturnSuspendResponse() {
-        val module = this.compile(
+    fun testSuspendMethodIsRejected() {
+        val result = compile0(
+            listOf(HttpControllerProcessorProvider()),
             """
             @HttpController
             class Controller {
                 @HttpRoute(method = "GET", path = "/test")
-                suspend fun test(): HttpServerResponse {
-                    return HttpServerResponse.of(200)
-                }
+                suspend fun test(): HttpServerResponse = HttpServerResponse.of(200)
             }
-            
             """.trimIndent()
-        )
-        val handler: HttpServerRequestHandler = module.getHandler("get_test")
-        assertThat(handler, "GET", "/test")
-            .hasStatus(200)
-            .hasBody(ByteArray(0))
-    }
+        ).assertFailure()
 
-    @Test
-    fun testReturnSuspendResponseWithQueryParameter() {
-        val module = this.compile(
-            """
-            @HttpController
-            class Controller {
-                @HttpRoute(method = "GET", path = "/test")
-                suspend fun test(@Query queryParameter: String): HttpServerResponse {
-                    return HttpServerResponse.of(200)
-                }
-            }
-            
-            """.trimIndent()
-        )
-        val handler: HttpServerRequestHandler = module.getHandler("get_test")
-        assertThat(handler, "GET", "/test?queryParameter=test")
-            .hasStatus(200)
-            .hasBody(ByteArray(0))
-        assertThat(handler, "GET", "/test?queryParameter")
-            .hasStatus(400)
-            .hasBody("Query parameter 'queryParameter' is required")
-    }
-
-    @Test
-    fun testReturnSuspendResponseWithRequestParameter() {
-        val module = this.compile(
-            """
-            @HttpController
-            class Controller {
-                @HttpRoute(method = "GET", path = "/test")
-                suspend fun test(bodyParameter: String): HttpServerResponse {
-                    return HttpServerResponse.of(200, HttpBody.plaintext(bodyParameter))
-                }
-            }
-            
-            """.trimIndent()
-        )
-        val handler: HttpServerRequestHandler = module.getHandler("get_test", stringRequestMapper())
-        assertThat(handler, "POST", "/test", "test")
-            .hasStatus(200)
-            .hasBody("test")
-    }
-
-    @Test
-    fun testReturnSuspendVoid() {
-        val module = this.compile(
-            """
-            @HttpController
-            class Controller {
-                @HttpRoute(method = "GET", path = "/test")
-                suspend fun test() {
-                }
-            }
-            
-            """.trimIndent()
-        )
-        val handler: HttpServerRequestHandler = module.getHandler("get_test")
-        assertThat(handler, "GET", "/test")
-            .hasStatus(200)
-            .hasBody(ByteArray(0))
-    }
-
-    @Test
-    fun testReturnSuspendObject() {
-        val module = this.compile(
-            """
-            @HttpController
-            class Controller {
-                @HttpRoute(method = "GET", path = "/test")
-                suspend fun test(): String {
-                    return "test"
-                }
-            }
-            
-            """.trimIndent()
-        )
-        val handler: HttpServerRequestHandler = module.getHandler("get_test", strResponseMapper())
-        assertThat(handler, "GET", "/test")
-            .hasStatus(200)
-            .hasBody("test")
-    }
-
-    @Test
-    fun testReturnSuspendResponseEntityObject() {
-        val module = this.compile(
-            """
-            @HttpController
-            class Controller {
-                @HttpRoute(method = "GET", path = "/test")
-                suspend fun test(): HttpResponseEntity<String> {
-                    return HttpResponseEntity.of(403, HttpHeaders.of("test-header", "test-value"), "test")
-                }
-            }
-            
-            """.trimIndent()
-        )
-        val handler: HttpServerRequestHandler = module.getHandler("get_test",
-            HttpServerResponseEntityMapper(
-                strResponseMapper()
-            )
-        )
-        assertThat(handler, "GET", "/test")
-            .hasStatus(403)
-            .hasBody("test")
-            .hasHeader("test-header", "test-value")
-    }
-
-    @Test
-    fun testWithInterceptor() {
-        val module = this.compile(
-            """
-            @HttpController
-            @InterceptWith(TestInterceptor1::class)
-            class Controller {
-                @HttpRoute(method = "GET", path = "/test")
-                @InterceptWith(TestInterceptor2::class)
-                suspend fun test(): HttpServerResponse {
-                    return HttpServerResponse.of(200)
-                }
-            }
-            
-            """.trimIndent(), """
-            class TestInterceptor1 : HttpServerInterceptor {
-                override fun intercept(request: HttpServerRequest, chain: HttpServerInterceptor.InterceptChain) : HttpServerResponse {
-                    if (request.queryParams().isEmpty()) return HttpServerResponse.of(400)
-                    return chain.process(request)
-                }
-            }
-            
-            """.trimIndent(), """
-            class TestInterceptor2 : HttpServerInterceptor {
-                override fun intercept(request: HttpServerRequest, chain: HttpServerInterceptor.InterceptChain) : HttpServerResponse {
-                    if (request.queryParams().isEmpty()) return HttpServerResponse.of(400)
-                    return chain.process(request)
-                }
-            }
-            
-            """.trimIndent()
-        )
-        val handler: HttpServerRequestHandler = module.getHandler("get_test", new("TestInterceptor1"), new("TestInterceptor2"))
-        assertThat(handler, "GET", "/test?test")
-            .hasStatus(200)
-            .hasBody(ByteArray(0))
-        assertThat(handler, "POST", "/test")
-            .hasStatus(400)
-            .hasBody(ByteArray(0))
+        assertThat(result.messages).anySatisfy {
+            assertThat(it)
+                .contains("Suspend methods are not supported by the HTTP server controller generator")
+                .contains("--enable-preview")
+                .contains("StructuredTaskScope.open")
+                .contains("Remove suspend from the controller method")
+        }
     }
 }

--- a/scheduling/scheduling-symbol-processor/src/main/kotlin/io/koraframework/scheduling/symbol/processor/SchedulingSymbolProcessor.kt
+++ b/scheduling/scheduling-symbol-processor/src/main/kotlin/io/koraframework/scheduling/symbol/processor/SchedulingSymbolProcessor.kt
@@ -11,6 +11,7 @@ import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.ksp.writeTo
 import io.koraframework.ksp.common.BaseSymbolProcessor
+import io.koraframework.ksp.common.FunctionUtils.isSuspend
 import io.koraframework.ksp.common.KspCommonUtils.generated
 import io.koraframework.ksp.common.exception.ProcessingErrorException
 import kotlin.collections.iterator
@@ -41,6 +42,9 @@ class SchedulingSymbolProcessor(val env: SymbolProcessorEnvironment) : BaseSymbo
                         }
                         if (func.functionKind != FunctionKind.MEMBER) {
                             throw ProcessingErrorException(invalidSchedulingFunctionError(annotationName, func), func)
+                        }
+                        if (func.isSuspend()) {
+                            throw ProcessingErrorException(suspendSchedulingFunctionError(annotationName, func), func)
                         }
                         func.parentDeclaration!! as KSClassDeclaration to func
                     }
@@ -107,6 +111,30 @@ class SchedulingSymbolProcessor(val env: SymbolProcessorEnvironment) : BaseSymbo
             Top-level or local functions cannot be scheduled because Kora needs a component instance to call.
 
             Fix: move the function into a component class and annotate that member function.
+        """.trimIndent()
+    }
+
+    private fun suspendSchedulingFunctionError(annotationName: String, function: KSFunctionDeclaration): String {
+        val shortName = annotationName.substringAfterLast('.')
+        return """
+            Invalid scheduled function: `${function.qualifiedName?.asString()}`.
+
+            Suspend methods are not supported by the scheduling generator.
+            `@$shortName` can be applied only to regular member functions.
+
+            For structured concurrency, enable Java preview features with --enable-preview and use StructuredTaskScope, for example:
+
+              fun refreshCaches() =
+                  StructuredTaskScope.open(
+                      StructuredTaskScope.Joiner.awaitAllSuccessfulOrThrow<Any>(),
+                  ).use { scope ->
+                      scope.fork(Callable { userCache.refresh() })
+                      scope.fork(Callable { productCache.refresh() })
+
+                      scope.join()
+                  }
+
+            Fix: remove suspend from the function.
         """.trimIndent()
     }
 

--- a/scheduling/scheduling-symbol-processor/src/test/kotlin/io/koraframework/scheduling/symbol/processor/SchedulingSymbolProcessorTest.kt
+++ b/scheduling/scheduling-symbol-processor/src/test/kotlin/io/koraframework/scheduling/symbol/processor/SchedulingSymbolProcessorTest.kt
@@ -3,9 +3,11 @@ package io.koraframework.scheduling.symbol.processor
 import com.google.devtools.ksp.processing.SymbolProcessorProvider
 import com.squareup.kotlinpoet.asClassName
 import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.quartz.DisallowConcurrentExecution
 import io.koraframework.ksp.common.AbstractSymbolProcessorTest
+import io.koraframework.ksp.common.exception.ProcessingErrorException
 import io.koraframework.ksp.common.symbolProcess
 import io.koraframework.scheduling.symbol.processor.controller.ScheduledJdkAtFixedDelayTest
 import io.koraframework.scheduling.symbol.processor.controller.ScheduledJdkAtFixedRateTest
@@ -14,8 +16,30 @@ import io.koraframework.scheduling.symbol.processor.controller.ScheduledJdkWithC
 import io.koraframework.scheduling.symbol.processor.controller.ScheduledQuartzWithCron
 import io.koraframework.scheduling.symbol.processor.controller.ScheduledQuartzWithTrigger
 import kotlin.reflect.KClass
+import org.assertj.core.api.Assertions.assertThatThrownBy
 
 internal class SchedulingSymbolProcessorTest : AbstractSymbolProcessorTest() {
+    @Test
+    fun testSuspendFunctionIsRejected() {
+        assertThatThrownBy {
+            compile0(
+                listOf(SchedulingSymbolProcessorProvider()),
+                """
+                class TestClass {
+                    @io.koraframework.scheduling.jdk.annotation.ScheduleAtFixedRate(period = "1s")
+                    suspend fun job() {}
+                }
+                """.trimIndent()
+            )
+        }.isInstanceOfSatisfying(ProcessingErrorException::class.java) {
+            assertThat(it.message)
+                .contains("Suspend methods are not supported by the scheduling generator")
+                .contains("--enable-preview")
+                .contains("StructuredTaskScope.open")
+                .contains("remove suspend from the function")
+        }
+    }
+
     @Test
     internal fun testScheduledJdkAtFixedDelayTest() {
         process(ScheduledJdkAtFixedDelayTest::class)


### PR DESCRIPTION
Removed(ksp): Breaking: reject suspend methods in database repositories, HTTP clients and controllers, S3 clients, and scheduled jobs. Diagnostics recommend Java StructuredTaskScope with --enable-preview.

This removes incomplete coroutine support that could lose ScopedValue-backed context and block HTTP worker threads through runBlocking.