### PR TITLE
Fixed(http-client): correct transport integration for HTTP-client Apache

### DIFF
--- a/http/http-client-apache/src/main/java/io/koraframework/http/client/apache/ApacheHttpClient.java
+++ b/http/http-client-apache/src/main/java/io/koraframework/http/client/apache/ApacheHttpClient.java
@@ -41,7 +41,7 @@ public class ApacheHttpClient implements HttpClient {
         }
     }
 
-    private ClassicHttpRequest convertToApacheRequest(HttpClientRequest request) {
+    ClassicHttpRequest convertToApacheRequest(HttpClientRequest request) {
         var apacheRequest = new HttpUriRequestBase(request.method(), request.uri());
         if (request.requestTimeout() != null) {
             apacheRequest.setConfig(RequestConfig.custom()
@@ -50,6 +50,12 @@ public class ApacheHttpClient implements HttpClient {
         }
 
         for (var header : request.headers()) {
+            // Apache derives entity framing from HttpEntity. Copying either header makes
+            // RequestContent reject otherwise valid requests (for example AWS SDK uploads).
+            if (header.getKey().equalsIgnoreCase("content-length")
+                || header.getKey().equalsIgnoreCase("transfer-encoding")) {
+                continue;
+            }
             var values = header.getValue();
             for (var value : values) {
                 apacheRequest.addHeader(header.getKey(), value);

--- a/http/http-client-apache/src/main/java/io/koraframework/http/client/apache/ApacheHttpClientConfig.java
+++ b/http/http-client-apache/src/main/java/io/koraframework/http/client/apache/ApacheHttpClientConfig.java
@@ -1,10 +1,9 @@
 package io.koraframework.http.client.apache;
 
 import io.koraframework.config.common.annotation.ConfigMapper;
-import io.koraframework.http.client.common.HttpClientConfig;
 
 @ConfigMapper
-public interface ApacheHttpClientConfig extends HttpClientConfig {
+public interface ApacheHttpClientConfig {
 
     default boolean followRedirects() {
         return true;

--- a/http/http-client-apache/src/main/java/io/koraframework/http/client/apache/ApacheHttpClientWrapper.java
+++ b/http/http-client-apache/src/main/java/io/koraframework/http/client/apache/ApacheHttpClientWrapper.java
@@ -49,11 +49,11 @@ public class ApacheHttpClientWrapper implements Lifecycle, Wrapped<org.apache.hc
     private CloseableHttpClient createApacheHttpClient() {
         RequestConfig.Builder requestConfigBuilder = RequestConfig.custom();
 
-        if (apacheConfig.connectTimeout() != null) {
-            requestConfigBuilder.setConnectTimeout(apacheConfig.connectTimeout().toMillis(), TimeUnit.MILLISECONDS);
+        if (baseConfig.connectTimeout() != null) {
+            requestConfigBuilder.setConnectTimeout(baseConfig.connectTimeout().toMillis(), TimeUnit.MILLISECONDS);
         }
-        if (apacheConfig.readTimeout() != null) {
-            requestConfigBuilder.setResponseTimeout(apacheConfig.readTimeout().toMillis(), TimeUnit.MILLISECONDS);
+        if (baseConfig.readTimeout() != null) {
+            requestConfigBuilder.setResponseTimeout(baseConfig.readTimeout().toMillis(), TimeUnit.MILLISECONDS);
         }
 
         requestConfigBuilder = requestConfigBuilder
@@ -72,7 +72,7 @@ public class ApacheHttpClientWrapper implements Lifecycle, Wrapped<org.apache.hc
             .setMaxConnTotal(apacheConfig.maxConnections())
             .setMaxConnPerRoute(apacheConfig.maxConnections())
             .setDefaultConnectionConfig(ConnectionConfig.custom()
-                .setConnectTimeout(apacheConfig.connectTimeout().toMillis(), TimeUnit.MILLISECONDS)
+                .setConnectTimeout(baseConfig.connectTimeout().toMillis(), TimeUnit.MILLISECONDS)
                 .setIdleTimeout(30, TimeUnit.SECONDS)
                 .setValidateAfterInactivity(30, TimeUnit.SECONDS)
                 .build());

--- a/http/http-client-apache/src/test/java/io/koraframework/http/client/apache/ApacheHttpClientTest.java
+++ b/http/http-client-apache/src/test/java/io/koraframework/http/client/apache/ApacheHttpClientTest.java
@@ -3,15 +3,40 @@ package io.koraframework.http.client.apache;
 import io.koraframework.http.client.common.HttpClient;
 import io.koraframework.http.client.common.HttpClientConfig;
 import io.koraframework.http.client.common.HttpClientTest;
+import io.koraframework.http.client.common.request.HttpClientRequest;
+import io.koraframework.http.common.body.HttpBody;
 import org.apache.hc.client5.http.config.ConnectionConfig;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
 import org.apache.hc.core5.pool.PoolConcurrencyPolicy;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.TimeUnit;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 public class ApacheHttpClientTest extends HttpClientTest {
+
+    @Test
+    void transportFramingHeadersAreOwnedByApacheEntity() {
+        var request = HttpClientRequest.post("/")
+            .header("Content-Length", "4")
+            .header("Transfer-Encoding", "chunked")
+            .body(HttpBody.plaintext("test"))
+            .build();
+
+        var apacheRequest = ((ApacheHttpClient) createClient(new HttpClientConfig() {
+            @Override
+            public HttpClientProxyConfig proxy() {
+                return null;
+            }
+        })).convertToApacheRequest(request);
+
+        assertThat(apacheRequest.containsHeader("Content-Length")).isFalse();
+        assertThat(apacheRequest.containsHeader("Transfer-Encoding")).isFalse();
+        assertThat(apacheRequest.getEntity().getContentLength()).isEqualTo(4);
+    }
 
     @Override
     protected HttpClient createClient(HttpClientConfig config) {


### PR DESCRIPTION
- keep Apache-specific config separate from common client timeouts
- let Apache derive Content-Length and Transfer-Encoding from the entity
- add regression coverage for transport-owned headers