### PR TITLE
Fixed(http-client): correct transport integration for HTTP-client JDK

### DIFF
--- a/http/http-client-jdk/src/main/java/io/koraframework/http/client/jdk/JdkHttpClient.java
+++ b/http/http-client-jdk/src/main/java/io/koraframework/http/client/jdk/JdkHttpClient.java
@@ -13,6 +13,7 @@ import java.net.ProtocolException;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.ByteBuffer;
+import java.util.Locale;
 import java.util.concurrent.Flow;
 
 public class JdkHttpClient implements HttpClient {
@@ -30,7 +31,7 @@ public class JdkHttpClient implements HttpClient {
             httpClientRequest.timeout(request.requestTimeout());
         }
         for (var header : request.headers()) {
-            if (header.getKey().equalsIgnoreCase("content-length")) {
+            if (isRestrictedHeader(header.getKey())) {
                 continue;
             }
             if (header.getKey().equalsIgnoreCase("content-type") && request.body().contentType() != null) {
@@ -76,6 +77,13 @@ public class JdkHttpClient implements HttpClient {
         } catch (IOException e) {
             throw new HttpClientUnknownException(e);
         }
+    }
+
+    static boolean isRestrictedHeader(String name) {
+        return switch (name.toLowerCase(Locale.ROOT)) {
+            case "connection", "content-length", "expect", "host", "upgrade" -> true;
+            default -> false;
+        };
     }
 
     private HttpRequest.BodyPublisher toBodyPublisher(HttpBodyOutput body) throws IOException {

--- a/http/http-client-jdk/src/test/java/io/koraframework/http/client/jdk/JdkHttpClientTest.java
+++ b/http/http-client-jdk/src/test/java/io/koraframework/http/client/jdk/JdkHttpClientTest.java
@@ -3,10 +3,18 @@ package io.koraframework.http.client.jdk;
 import io.koraframework.http.client.common.HttpClient;
 import io.koraframework.http.client.common.HttpClientConfig;
 import io.koraframework.http.client.common.HttpClientTest;
+import org.junit.jupiter.api.Test;
 
-import java.time.Duration;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class JdkHttpClientTest extends HttpClientTest {
+
+    @Test
+    void transportOwnedHeadersAreNotCopiedToJdkRequest() {
+        assertThat(JdkHttpClient.isRestrictedHeader("Host")).isTrue();
+        assertThat(JdkHttpClient.isRestrictedHeader("Content-Length")).isTrue();
+        assertThat(JdkHttpClient.isRestrictedHeader("Authorization")).isFalse();
+    }
 
     @Override
     protected HttpClient createClient(HttpClientConfig config) {


### PR DESCRIPTION
- skip JDK-restricted headers supplied by S3 request signing (S3 signing includes Host in the request headers, but the JDK client must derive it from the request URI)