### PR TITLE
Improved(json): Improved JSON reader parse-error messages

### DIFF
--- a/json/json-annotation-processor/src/main/java/io/koraframework/json/annotation/processor/reader/JsonReaderGenerator.java
+++ b/json/json-annotation-processor/src/main/java/io/koraframework/json/annotation/processor/reader/JsonReaderGenerator.java
@@ -98,7 +98,7 @@ public class JsonReaderGenerator {
         }
 
 
-        method.addCode("default -> {$>\n_parser.nextToken();\n_parser.skipChildren();$<\n}");
+        method.addCode("default -> {$>\n__parser.nextToken();\n__parser.skipChildren();$<\n}");
         method.addCode("$<\n}\n");
         method.addCode("__token = __parser.nextToken();");
 
@@ -384,7 +384,7 @@ public class JsonReaderGenerator {
         var code = switch (knownType) {
             case STRING -> CodeBlock.of("""
                     if (__token == $T.VALUE_STRING) {
-                      $L_parser.getText()$L;
+                      $L__parser.getText()$L;
                     }""",
                 JsonTypes.jsonToken, prefix, suffix);
             case BOOLEAN_OBJECT, BOOLEAN_PRIMITIVE -> CodeBlock.of("""
@@ -396,37 +396,37 @@ public class JsonReaderGenerator {
                 JsonTypes.jsonToken, prefix, suffix, JsonTypes.jsonToken, prefix, suffix);
             case INTEGER_OBJECT, INTEGER_PRIMITIVE -> CodeBlock.of("""
                     if (__token == $T.VALUE_NUMBER_INT) {
-                      $L_parser.getIntValue()$L;
+                      $L__parser.getIntValue()$L;
                     }""",
                 JsonTypes.jsonToken, prefix, suffix);
             case BIG_INTEGER -> CodeBlock.of("""
                     if (__token == $T.VALUE_NUMBER_INT) {
-                      $L_parser.getBigIntegerValue()$L;
+                      $L__parser.getBigIntegerValue()$L;
                     }""",
                 JsonTypes.jsonToken, prefix, suffix);
             case DOUBLE_OBJECT, DOUBLE_PRIMITIVE -> CodeBlock.of("""
                     if (__token == $T.VALUE_NUMBER_FLOAT || __token == $T.VALUE_NUMBER_INT) {
-                      $L_parser.getDoubleValue()$L;
+                      $L__parser.getDoubleValue()$L;
                     }""",
                 JsonTypes.jsonToken, JsonTypes.jsonToken, prefix, suffix);
             case FLOAT_OBJECT, FLOAT_PRIMITIVE -> CodeBlock.of("""
                     if (__token == $T.VALUE_NUMBER_FLOAT || __token == $T.VALUE_NUMBER_INT) {
-                      $L_parser.getFloatValue()$L;
+                      $L__parser.getFloatValue()$L;
                     }""",
                 JsonTypes.jsonToken, JsonTypes.jsonToken, prefix, suffix);
             case LONG_OBJECT, LONG_PRIMITIVE -> CodeBlock.of("""
                     if (__token == $T.VALUE_NUMBER_INT) {
-                      $L_parser.getLongValue()$L;
+                      $L__parser.getLongValue()$L;
                     }""",
                 JsonTypes.jsonToken, prefix, suffix);
             case SHORT_OBJECT, SHORT_PRIMITIVE -> CodeBlock.of("""
                     if (__token == $T.VALUE_NUMBER_INT) {
-                      $L_parser.getShortValue()$L;
+                      $L__parser.getShortValue()$L;
                     }""",
                 JsonTypes.jsonToken, prefix, suffix);
             case BINARY -> CodeBlock.of("""
                     if (__token == $T.VALUE_STRING) {
-                      $L_parser.getBinaryValue()$L;
+                      $L__parser.getBinaryValue()$L;
                     }""",
                 JsonTypes.jsonToken, prefix, suffix);
             case UUID -> CodeBlock.of("""

--- a/json/json-annotation-processor/src/main/java/io/koraframework/json/annotation/processor/reader/JsonReaderGenerator.java
+++ b/json/json-annotation-processor/src/main/java/io/koraframework/json/annotation/processor/reader/JsonReaderGenerator.java
@@ -64,16 +64,16 @@ public class JsonReaderGenerator {
 
         var method = MethodSpec.methodBuilder("read")
             .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-            .addParameter(JsonTypes.jsonParser, "_parser")
+            .addParameter(JsonTypes.jsonParser, "__parser")
             .returns(TypeName.get(meta.typeElement().asType()).withoutAnnotations().annotated(CommonClassNames.nullableAnnotation));
-        method.addStatement("var _token = _parser.currentToken()");
-        method.addCode("if (_token == $T.VALUE_NULL) $>\nreturn null;$<\n", JsonTypes.jsonToken);
+        method.addStatement("var __token = __parser.currentToken()");
+        method.addCode("if (__token == $T.VALUE_NULL) $>\nreturn null;$<\n", JsonTypes.jsonToken);
         assertTokenType(method, "START_OBJECT", "an object '{...}'");
 
         if (meta.fields().size() <= 32) {
-            method.addStatement("int _receivedFields = NULLABLE_FIELDS_RECEIVED");
+            method.addStatement("int __receivedFields = NULLABLE_FIELDS_RECEIVED");
         } else {
-            method.addStatement("var _receivedFields = ($T) NULLABLE_FIELDS_RECEIVED.clone()", BitSet.class);
+            method.addStatement("var __receivedFields = ($T) NULLABLE_FIELDS_RECEIVED.clone()", BitSet.class);
         }
         method.addCode("\n");
 
@@ -81,18 +81,18 @@ public class JsonReaderGenerator {
         this.addFastPath(method, meta);
 
         if (meta.fields().isEmpty()) {
-            method.addStatement("_token = _parser.nextToken()");
+            method.addStatement("__token = __parser.nextToken()");
         } else {
-            method.addStatement("_token = _parser.currentToken()");
+            method.addStatement("__token = __parser.currentToken()");
         }
-        method.addCode("while (_token != $T.END_OBJECT) {$>\n", JsonTypes.jsonToken);
+        method.addCode("while (__token != $T.END_OBJECT) {$>\n", JsonTypes.jsonToken);
         assertTokenType(method, "PROPERTY_NAME", "a field name");
-        method.addStatement("var _fieldName = _parser.currentName()");
-        method.addCode("switch (_fieldName) {$>\n");
+        method.addStatement("var __fieldName = __parser.currentName()");
+        method.addCode("switch (__fieldName) {$>\n");
         for (int i = 0, fieldsSize = meta.fields().size(); i < fieldsSize; i++) {
             var field = meta.fields().get(i);
             method.addCode("case $S -> {$>\n", field.jsonName());
-            method.addCode("$L = $L(_parser);\n", field.parameter(), this.readerMethodName(field));
+            method.addCode("$L = $L(__parser);\n", field.parameter(), this.readerMethodName(field));
             method.addCode(markReceived(meta, i));
             method.addCode("$<\n}\n");
         }
@@ -100,11 +100,11 @@ public class JsonReaderGenerator {
 
         method.addCode("default -> {$>\n_parser.nextToken();\n_parser.skipChildren();$<\n}");
         method.addCode("$<\n}\n");
-        method.addCode("_token = _parser.nextToken();");
+        method.addCode("__token = __parser.nextToken();");
 
         method.addCode("$<\n}\n");
         var errorSwitch = CodeBlock.builder()
-            .add("switch (_i) {$>");
+            .add("switch (__i) {$>");
         for (int i = 0; i < meta.fields().size(); i++) {
             var field = meta.fields().get(i);
             errorSwitch.add("\n    case $L -> $S;", i, field.jsonName());
@@ -114,28 +114,28 @@ public class JsonReaderGenerator {
 
         if (meta.fields().size() > 32) {
             method.addCode("""
-                if (!_receivedFields.equals(ALL_FIELDS_RECEIVED)) {
-                  _receivedFields.flip(0, $L);
-                  var _missing = new $T();
-                  for (int _i = _receivedFields.nextSetBit(0); _i >= 0; _i = _receivedFields.nextSetBit(_i+1)) {
-                    if (_missing.length() > 0) _missing.append(", ");
-                    _missing.append($L);
+                if (!__receivedFields.equals(ALL_FIELDS_RECEIVED)) {
+                  __receivedFields.flip(0, $L);
+                  var __missing = new $T();
+                  for (int __i = __receivedFields.nextSetBit(0); __i >= 0; __i = __receivedFields.nextSetBit(__i+1)) {
+                    if (__missing.length() > 0) __missing.append(", ");
+                    __missing.append($L);
                   }
-                  throw _missingRequiredFields(_parser, _missing.toString());
+                  throw __missingRequiredFields(__parser, __missing.toString());
                 }
                 """, meta.fields().size(), StringBuilder.class, errorSwitch.build());
         } else {
             method.addCode("""
-                if (_receivedFields != ALL_FIELDS_RECEIVED) {
-                  var _nonReceivedFields = (~_receivedFields) & ALL_FIELDS_RECEIVED;
-                  var _missing = new $T();
-                  for (int _i = 0; _i < $L; _i++) {
-                    if ((_nonReceivedFields & (1 << _i)) != 0) {
-                      if (_missing.length() > 0) _missing.append(", ");
-                      _missing.append($L);
+                if (__receivedFields != ALL_FIELDS_RECEIVED) {
+                  var _nonReceivedFields = (~__receivedFields) & ALL_FIELDS_RECEIVED;
+                  var __missing = new $T();
+                  for (int __i = 0; __i < $L; __i++) {
+                    if ((_nonReceivedFields & (1 << __i)) != 0) {
+                      if (__missing.length() > 0) __missing.append(", ");
+                      __missing.append($L);
                     }
                   }
-                  throw _missingRequiredFields(_parser, _missing.toString());
+                  throw __missingRequiredFields(__parser, __missing.toString());
                 }
                 """, StringBuilder.class, meta.fields().size(), errorSwitch.build());
         }
@@ -200,16 +200,16 @@ public class JsonReaderGenerator {
     private void addFastPath(MethodSpec.Builder method, JsonClassReaderMeta meta) {
         for (int i = 0; i < meta.fields().size(); i++) {
             var field = meta.fields().get(i);
-            method.addCode("if (_parser.nextName($L)) {$>\n", jsonNameStaticName(field));
-            method.addCode("$L = $L(_parser);\n", field.parameter(), readerMethodName(field));
+            method.addCode("if (__parser.nextName($L)) {$>\n", jsonNameStaticName(field));
+            method.addCode("$L = $L(__parser);\n", field.parameter(), readerMethodName(field));
             method.addCode(markReceived(meta, i));
             if (i == meta.fields().size() - 1) {
                 method.addCode("""
-                    _token = _parser.nextToken();
-                    while (_token != JsonToken.END_OBJECT) {
-                        _parser.nextToken();
-                        _parser.skipChildren();
-                        _token = _parser.nextToken();
+                    __token = __parser.nextToken();
+                    while (__token != JsonToken.END_OBJECT) {
+                        __parser.nextToken();
+                        __parser.skipChildren();
+                        __token = __parser.nextToken();
                     }
                     """);
                 method.addCode("return new $T(", meta.typeMirror());
@@ -316,20 +316,20 @@ public class JsonReaderGenerator {
     private MethodSpec readParamMethod(int index, int size, FieldMeta field) {
         var method = MethodSpec.methodBuilder(this.readerMethodName(field))
             .addModifiers(Modifier.PRIVATE)
-            .addParameter(JsonTypes.jsonParser, "_parser")
+            .addParameter(JsonTypes.jsonParser, "__parser")
             .returns(field.typeName());
         if (field.reader() != null) {
-            method.addCode("var _token = _parser.nextToken();\n");
+            method.addCode("var __token = __parser.nextToken();\n");
             if (!isNullable(field)) {
                 method.addCode("""
-                    if (_token == $T.VALUE_NULL)
-                      throw _requiredFieldNull(_parser, $S);
+                    if (__token == $T.VALUE_NULL)
+                      throw __requiredFieldNull(__parser, $S);
                     """, JsonTypes.jsonToken, "." + field.jsonName());
             }
-            method.addCode("return $L.read(_parser);\n", this.readerFieldName(field));
+            method.addCode("return $L.read(__parser);\n", this.readerFieldName(field));
             return method.build();
         }
-        method.addStatement("var _token = _parser.nextToken()");
+        method.addStatement("var __token = __parser.nextToken()");
         if (field.typeMeta() instanceof KnownTypeReaderMeta meta) {
             method.addModifiers(Modifier.STATIC);
             var block = CodeBlock.builder();
@@ -350,27 +350,27 @@ public class JsonReaderGenerator {
 
         if (field.typeMeta() != null && field.typeMeta().isJsonNullable()) {
             method.addCode("""
-                if (_token == $T.VALUE_NULL) {
+                if (__token == $T.VALUE_NULL) {
                   return $T.nullValue();
                 }
                 """, JsonTypes.jsonToken, JsonTypes.jsonNullable);
         } else if (isNullable(field)) {
             method.addCode("""
-                if (_token == $T.VALUE_NULL) {
+                if (__token == $T.VALUE_NULL) {
                   return null;
                 }
                 """, JsonTypes.jsonToken);
         } else {
             method.addCode("""
-                if (_token == $T.VALUE_NULL)
-                  throw _requiredFieldNull(_parser, $S);
+                if (__token == $T.VALUE_NULL)
+                  throw __requiredFieldNull(__parser, $S);
                 """, JsonTypes.jsonToken, "." + field.jsonName());
         }
 
         if (field.typeMeta() != null && field.typeMeta().isJsonNullable()) {
-            method.addStatement("return $T.ofNullable($L.read(_parser))", JsonTypes.jsonNullable, readerFieldName(field));
+            method.addStatement("return $T.ofNullable($L.read(__parser))", JsonTypes.jsonNullable, readerFieldName(field));
         } else {
-            method.addStatement("return $L.read(_parser)", readerFieldName(field));
+            method.addStatement("return $L.read(__parser)", readerFieldName(field));
         }
         return method.build();
     }
@@ -383,67 +383,67 @@ public class JsonReaderGenerator {
         var method = CodeBlock.builder();
         var code = switch (knownType) {
             case STRING -> CodeBlock.of("""
-                    if (_token == $T.VALUE_STRING) {
+                    if (__token == $T.VALUE_STRING) {
                       $L_parser.getText()$L;
                     }""",
                 JsonTypes.jsonToken, prefix, suffix);
             case BOOLEAN_OBJECT, BOOLEAN_PRIMITIVE -> CodeBlock.of("""
-                    if (_token == $T.VALUE_TRUE) {
+                    if (__token == $T.VALUE_TRUE) {
                       $Ltrue$L;
-                    } else if (_token == $T.VALUE_FALSE) {
+                    } else if (__token == $T.VALUE_FALSE) {
                       $Lfalse$L;
                     }""",
                 JsonTypes.jsonToken, prefix, suffix, JsonTypes.jsonToken, prefix, suffix);
             case INTEGER_OBJECT, INTEGER_PRIMITIVE -> CodeBlock.of("""
-                    if (_token == $T.VALUE_NUMBER_INT) {
+                    if (__token == $T.VALUE_NUMBER_INT) {
                       $L_parser.getIntValue()$L;
                     }""",
                 JsonTypes.jsonToken, prefix, suffix);
             case BIG_INTEGER -> CodeBlock.of("""
-                    if (_token == $T.VALUE_NUMBER_INT) {
+                    if (__token == $T.VALUE_NUMBER_INT) {
                       $L_parser.getBigIntegerValue()$L;
                     }""",
                 JsonTypes.jsonToken, prefix, suffix);
             case DOUBLE_OBJECT, DOUBLE_PRIMITIVE -> CodeBlock.of("""
-                    if (_token == $T.VALUE_NUMBER_FLOAT || _token == $T.VALUE_NUMBER_INT) {
+                    if (__token == $T.VALUE_NUMBER_FLOAT || __token == $T.VALUE_NUMBER_INT) {
                       $L_parser.getDoubleValue()$L;
                     }""",
                 JsonTypes.jsonToken, JsonTypes.jsonToken, prefix, suffix);
             case FLOAT_OBJECT, FLOAT_PRIMITIVE -> CodeBlock.of("""
-                    if (_token == $T.VALUE_NUMBER_FLOAT || _token == $T.VALUE_NUMBER_INT) {
+                    if (__token == $T.VALUE_NUMBER_FLOAT || __token == $T.VALUE_NUMBER_INT) {
                       $L_parser.getFloatValue()$L;
                     }""",
                 JsonTypes.jsonToken, JsonTypes.jsonToken, prefix, suffix);
             case LONG_OBJECT, LONG_PRIMITIVE -> CodeBlock.of("""
-                    if (_token == $T.VALUE_NUMBER_INT) {
+                    if (__token == $T.VALUE_NUMBER_INT) {
                       $L_parser.getLongValue()$L;
                     }""",
                 JsonTypes.jsonToken, prefix, suffix);
             case SHORT_OBJECT, SHORT_PRIMITIVE -> CodeBlock.of("""
-                    if (_token == $T.VALUE_NUMBER_INT) {
+                    if (__token == $T.VALUE_NUMBER_INT) {
                       $L_parser.getShortValue()$L;
                     }""",
                 JsonTypes.jsonToken, prefix, suffix);
             case BINARY -> CodeBlock.of("""
-                    if (_token == $T.VALUE_STRING) {
+                    if (__token == $T.VALUE_STRING) {
                       $L_parser.getBinaryValue()$L;
                     }""",
                 JsonTypes.jsonToken, prefix, suffix);
             case UUID -> CodeBlock.of("""
-                    if (_token == $T.VALUE_STRING) {
-                      $L$T.fromString(_parser.getText())$L;
+                    if (__token == $T.VALUE_STRING) {
+                      $L$T.fromString(__parser.getText())$L;
                     }""",
                 JsonTypes.jsonToken, prefix, UUID.class, suffix);
         };
         method.add(code);
         if (jsonNullable) {
-            method.add(" else if (_token == $T.VALUE_NULL) {$>\nreturn $T.nullValue();$<\n}", JsonTypes.jsonToken, JsonTypes.jsonNullable);
+            method.add(" else if (__token == $T.VALUE_NULL) {$>\nreturn $T.nullValue();$<\n}", JsonTypes.jsonToken, JsonTypes.jsonNullable);
         } else if (nullable) {
-            method.add(" else if (_token == $T.VALUE_NULL) {$>\nreturn null;$<\n}", JsonTypes.jsonToken);
+            method.add(" else if (__token == $T.VALUE_NULL) {$>\nreturn null;$<\n}", JsonTypes.jsonToken);
         } else {
-            method.add(" else if (_token == $T.VALUE_NULL) {$>\nthrow _requiredFieldNull(_parser, $S);$<\n}", JsonTypes.jsonToken, "." + jsonName);
+            method.add(" else if (__token == $T.VALUE_NULL) {$>\nthrow __requiredFieldNull(__parser, $S);$<\n}", JsonTypes.jsonToken, "." + jsonName);
         }
-        method.add(" else {$>\nthrow _unexpectedToken(_parser, $S, $S);$<\n}", "." + jsonName, expectedPhrase(knownType));
+        method.add(" else {$>\nthrow __unexpectedToken(__parser, $S, $S);$<\n}", "." + jsonName, expectedPhrase(knownType));
         return method.build();
     }
 
@@ -460,16 +460,16 @@ public class JsonReaderGenerator {
     }
 
     private void assertTokenType(MethodSpec.Builder method, String expectedToken, String expectedPhrase) {
-        method.addCode("if (_token != $T.$L) $>\nthrow _unexpectedToken(_parser, $S, $S);$<\n",
+        method.addCode("if (__token != $T.$L) $>\nthrow __unexpectedToken(__parser, $S, $S);$<\n",
             JsonTypes.jsonToken, expectedToken, "", expectedPhrase
         );
     }
 
     private CodeBlock markReceived(JsonClassReaderMeta meta, int index) {
         if (meta.fields().size() > 32) {
-            return CodeBlock.of("_receivedFields.set($L);\n", index);
+            return CodeBlock.of("__receivedFields.set($L);\n", index);
         }
-        return CodeBlock.of("_receivedFields |= (1 << $L);\n", index);
+        return CodeBlock.of("__receivedFields |= (1 << $L);\n", index);
     }
 
     /**
@@ -480,65 +480,65 @@ public class JsonReaderGenerator {
     private void addErrorMethods(TypeSpec.Builder typeBuilder, JsonClassReaderMeta meta) {
         var typeName = meta.typeElement().getSimpleName().toString();
 
-        typeBuilder.addMethod(MethodSpec.methodBuilder("_jsonPath")
+        typeBuilder.addMethod(MethodSpec.methodBuilder("__jsonPath")
             .addModifiers(Modifier.PRIVATE, Modifier.STATIC)
-            .addParameter(JsonTypes.jsonParser, "_parser")
+            .addParameter(JsonTypes.jsonParser, "__parser")
             .returns(String.class)
-            .addStatement("var _p = _parser.streamReadContext().pathAsPointer().toString()")
-            .addStatement("return _p.isEmpty() ? $S : _p", "<root>")
+            .addStatement("var __p = __parser.streamReadContext().pathAsPointer().toString()")
+            .addStatement("return __p.isEmpty() ? $S : __p", "<root>")
             .build());
 
-        var actual = MethodSpec.methodBuilder("_actualValue")
+        var actual = MethodSpec.methodBuilder("__actualValue")
             .addModifiers(Modifier.PRIVATE, Modifier.STATIC)
-            .addParameter(JsonTypes.jsonParser, "_parser")
+            .addParameter(JsonTypes.jsonParser, "__parser")
             .returns(String.class);
-        actual.addStatement("var _t = _parser.currentToken()");
-        actual.beginControlFlow("if (_t == null)");
+        actual.addStatement("var __t = __parser.currentToken()");
+        actual.beginControlFlow("if (__t == null)");
         actual.addStatement("return $S", "nothing (end of input)");
         actual.endControlFlow();
-        actual.addStatement("var _v = _parser.getValueAsString()");
-        actual.beginControlFlow("if (_v != null && _v.length() > 128)");
-        actual.addStatement("_v = _v.substring(0, 128) + $S", "...(truncated)");
+        actual.addStatement("var __v = __parser.getValueAsString()");
+        actual.beginControlFlow("if (__v != null && __v.length() > 128)");
+        actual.addStatement("__v = __v.substring(0, 128) + $S", "...(truncated)");
         actual.endControlFlow();
-        actual.addCode("return switch (_t) {$>\n");
+        actual.addCode("return switch (__t) {$>\n");
         actual.addStatement("case VALUE_NULL -> $S", "null");
         actual.addStatement("case START_OBJECT -> $S", "an object");
         actual.addStatement("case START_ARRAY -> $S", "an array");
-        actual.addStatement("case VALUE_STRING -> $S + _v + $S", "a string \"", "\"");
-        actual.addStatement("case VALUE_NUMBER_INT -> $S + _v", "a number ");
-        actual.addStatement("case VALUE_NUMBER_FLOAT -> $S + _v", "a fractional number ");
-        actual.addStatement("case VALUE_TRUE, VALUE_FALSE -> $S + _v", "a boolean ");
-        actual.addStatement("default -> $S + _t", "token ");
+        actual.addStatement("case VALUE_STRING -> $S + __v + $S", "a string \"", "\"");
+        actual.addStatement("case VALUE_NUMBER_INT -> $S + __v", "a number ");
+        actual.addStatement("case VALUE_NUMBER_FLOAT -> $S + __v", "a fractional number ");
+        actual.addStatement("case VALUE_TRUE, VALUE_FALSE -> $S + __v", "a boolean ");
+        actual.addStatement("default -> $S + __t", "token ");
         actual.addCode("$<};\n");
         typeBuilder.addMethod(actual.build());
 
-        typeBuilder.addMethod(MethodSpec.methodBuilder("_unexpectedToken")
+        typeBuilder.addMethod(MethodSpec.methodBuilder("__unexpectedToken")
             .addModifiers(Modifier.PRIVATE, Modifier.STATIC)
-            .addParameter(JsonTypes.jsonParser, "_parser")
-            .addParameter(String.class, "_member")
-            .addParameter(String.class, "_expected")
+            .addParameter(JsonTypes.jsonParser, "__parser")
+            .addParameter(String.class, "__member")
+            .addParameter(String.class, "__expected")
             .returns(JsonTypes.jsonParseException)
-            .addStatement("return new $T(_parser, $S + _member + $S + _expected + $S + _actualValue(_parser) + $S + _jsonPath(_parser) + $S)",
+            .addStatement("return new $T(__parser, $S + __member + $S + __expected + $S + __actualValue(__parser) + $S + __jsonPath(__parser) + $S)",
                 JsonTypes.jsonParseException, "Failed to read json " + typeName, ": expected ", ", but got ", " (at ", ")")
             .build());
 
-        typeBuilder.addMethod(MethodSpec.methodBuilder("_missingRequiredFields")
+        typeBuilder.addMethod(MethodSpec.methodBuilder("__missingRequiredFields")
             .addModifiers(Modifier.PRIVATE, Modifier.STATIC)
-            .addParameter(JsonTypes.jsonParser, "_parser")
-            .addParameter(String.class, "_fields")
+            .addParameter(JsonTypes.jsonParser, "__parser")
+            .addParameter(String.class, "__fields")
             .returns(JsonTypes.jsonParseException)
-            .addStatement("return new $T(_parser, $S + _fields + $S + _jsonPath(_parser) + $S)",
+            .addStatement("return new $T(__parser, $S + __fields + $S + __jsonPath(__parser) + $S)",
                 JsonTypes.jsonParseException, "Failed to read json " + typeName + ": missing required field(s): ", " (at ", ")")
             .build());
 
         boolean anyRequired = meta.fields().stream().anyMatch(f -> !isNullable(f));
         if (anyRequired) {
-            typeBuilder.addMethod(MethodSpec.methodBuilder("_requiredFieldNull")
+            typeBuilder.addMethod(MethodSpec.methodBuilder("__requiredFieldNull")
                 .addModifiers(Modifier.PRIVATE, Modifier.STATIC)
-                .addParameter(JsonTypes.jsonParser, "_parser")
-                .addParameter(String.class, "_member")
+                .addParameter(JsonTypes.jsonParser, "__parser")
+                .addParameter(String.class, "__member")
                 .returns(JsonTypes.jsonParseException)
-                .addStatement("return new $T(_parser, $S + _member + $S + _jsonPath(_parser) + $S)",
+                .addStatement("return new $T(__parser, $S + __member + $S + __jsonPath(__parser) + $S)",
                     JsonTypes.jsonParseException, "Failed to read json " + typeName, ": required field must not be null (at ", ")")
                 .build());
         }

--- a/json/json-annotation-processor/src/main/java/io/koraframework/json/annotation/processor/reader/JsonReaderGenerator.java
+++ b/json/json-annotation-processor/src/main/java/io/koraframework/json/annotation/processor/reader/JsonReaderGenerator.java
@@ -18,7 +18,6 @@ import javax.lang.model.element.TypeParameterElement;
 import javax.lang.model.type.PrimitiveType;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Types;
-import java.util.Arrays;
 import java.util.BitSet;
 import java.util.UUID;
 
@@ -61,19 +60,20 @@ public class JsonReaderGenerator {
         this.addReaders(typeBuilder, meta);
         this.addFieldNames(typeBuilder, meta);
         this.addReadMethods(typeBuilder, meta);
+        this.addErrorMethods(typeBuilder, meta);
 
         var method = MethodSpec.methodBuilder("read")
             .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-            .addParameter(JsonTypes.jsonParser, "__parser")
+            .addParameter(JsonTypes.jsonParser, "_parser")
             .returns(TypeName.get(meta.typeElement().asType()).withoutAnnotations().annotated(CommonClassNames.nullableAnnotation));
-        method.addStatement("var __token = __parser.currentToken()");
-        method.addCode("if (__token == $T.VALUE_NULL) $>\nreturn null;$<\n", JsonTypes.jsonToken);
-        assertTokenType(method, "START_OBJECT");
+        method.addStatement("var _token = _parser.currentToken()");
+        method.addCode("if (_token == $T.VALUE_NULL) $>\nreturn null;$<\n", JsonTypes.jsonToken);
+        assertTokenType(method, "START_OBJECT", "an object '{...}'");
 
         if (meta.fields().size() <= 32) {
-            method.addStatement("var __receivedFields = new int[]{NULLABLE_FIELDS_RECEIVED}");
+            method.addStatement("int _receivedFields = NULLABLE_FIELDS_RECEIVED");
         } else {
-            method.addStatement("var __receivedFields = ($T) NULLABLE_FIELDS_RECEIVED.clone()", BitSet.class);
+            method.addStatement("var _receivedFields = ($T) NULLABLE_FIELDS_RECEIVED.clone()", BitSet.class);
         }
         method.addCode("\n");
 
@@ -81,60 +81,63 @@ public class JsonReaderGenerator {
         this.addFastPath(method, meta);
 
         if (meta.fields().isEmpty()) {
-            method.addStatement("__token = __parser.nextToken()");
+            method.addStatement("_token = _parser.nextToken()");
         } else {
-            method.addStatement("__token = __parser.currentToken()");
+            method.addStatement("_token = _parser.currentToken()");
         }
-        method.addCode("while (__token != $T.END_OBJECT) {$>\n", JsonTypes.jsonToken);
-        assertTokenType(method, "PROPERTY_NAME");
-        method.addStatement("var __fieldName = __parser.currentName()");
-        method.addCode("switch (__fieldName) {$>\n");
+        method.addCode("while (_token != $T.END_OBJECT) {$>\n", JsonTypes.jsonToken);
+        assertTokenType(method, "PROPERTY_NAME", "a field name");
+        method.addStatement("var _fieldName = _parser.currentName()");
+        method.addCode("switch (_fieldName) {$>\n");
         for (int i = 0, fieldsSize = meta.fields().size(); i < fieldsSize; i++) {
             var field = meta.fields().get(i);
             method.addCode("case $S -> {$>\n", field.jsonName());
-            method.addCode("$L = $L(__parser, __receivedFields);", field.parameter(), this.readerMethodName(field));
+            method.addCode("$L = $L(_parser);\n", field.parameter(), this.readerMethodName(field));
+            method.addCode(markReceived(meta, i));
             method.addCode("$<\n}\n");
         }
 
 
-        method.addCode("default -> {$>\n__parser.nextToken();\n__parser.skipChildren();$<\n}");
+        method.addCode("default -> {$>\n_parser.nextToken();\n_parser.skipChildren();$<\n}");
         method.addCode("$<\n}\n");
-        method.addCode("__token = __parser.nextToken();");
+        method.addCode("_token = _parser.nextToken();");
 
         method.addCode("$<\n}\n");
         var errorSwitch = CodeBlock.builder()
-            .add("switch (__i) {$>");
+            .add("switch (_i) {$>");
         for (int i = 0; i < meta.fields().size(); i++) {
             var field = meta.fields().get(i);
-            errorSwitch.add("\n    case $L -> $S;", i, "%s(%s)".formatted(field.parameter().getSimpleName(), field.jsonName()));
+            errorSwitch.add("\n    case $L -> $S;", i, field.jsonName());
         }
         errorSwitch.add("\n    default -> \"\";");
         errorSwitch.add("$<\n    }");
 
         if (meta.fields().size() > 32) {
             method.addCode("""
-                if (!__receivedFields.equals(ALL_FIELDS_RECEIVED)) {
-                  __receivedFields.flip(0, $L);
-                  var __error = new $T("Some of required json fields were not received:");
-                  for (int __i = __receivedFields.nextSetBit(0); __i >= 0; __i = __receivedFields.nextSetBit(__i+1)) {
-                    __error.append(" ").append($L);
+                if (!_receivedFields.equals(ALL_FIELDS_RECEIVED)) {
+                  _receivedFields.flip(0, $L);
+                  var _missing = new $T();
+                  for (int _i = _receivedFields.nextSetBit(0); _i >= 0; _i = _receivedFields.nextSetBit(_i+1)) {
+                    if (_missing.length() > 0) _missing.append(", ");
+                    _missing.append($L);
                   }
-                  throw new $T(__parser, __error.toString());
+                  throw _missingRequiredFields(_parser, _missing.toString());
                 }
-                """, meta.fields().size(), StringBuilder.class, errorSwitch.build(), JsonTypes.jsonParseException);
+                """, meta.fields().size(), StringBuilder.class, errorSwitch.build());
         } else {
             method.addCode("""
-                if (__receivedFields[0] != ALL_FIELDS_RECEIVED) {
-                  var _nonReceivedFields = (~__receivedFields[0]) & ALL_FIELDS_RECEIVED;
-                  var __error = new $T("Some of required json fields were not received:");
-                  for (int __i = 0; __i < $L; __i++) {
-                    if ((_nonReceivedFields & (1 << __i)) != 0) {
-                      __error.append(" ").append($L);
+                if (_receivedFields != ALL_FIELDS_RECEIVED) {
+                  var _nonReceivedFields = (~_receivedFields) & ALL_FIELDS_RECEIVED;
+                  var _missing = new $T();
+                  for (int _i = 0; _i < $L; _i++) {
+                    if ((_nonReceivedFields & (1 << _i)) != 0) {
+                      if (_missing.length() > 0) _missing.append(", ");
+                      _missing.append($L);
                     }
                   }
-                  throw new $T(__parser, __error.toString());
+                  throw _missingRequiredFields(_parser, _missing.toString());
                 }
-                """, StringBuilder.class, meta.fields().size(), errorSwitch.build(), JsonTypes.jsonParseException);
+                """, StringBuilder.class, meta.fields().size(), errorSwitch.build());
         }
 
         method.addCode("return new $T(", meta.typeElement());
@@ -197,15 +200,16 @@ public class JsonReaderGenerator {
     private void addFastPath(MethodSpec.Builder method, JsonClassReaderMeta meta) {
         for (int i = 0; i < meta.fields().size(); i++) {
             var field = meta.fields().get(i);
-            method.addCode("if (__parser.nextName($L)) {$>\n", jsonNameStaticName(field));
-            method.addCode("$L = $L(__parser, __receivedFields);\n", field.parameter(), readerMethodName(field));
+            method.addCode("if (_parser.nextName($L)) {$>\n", jsonNameStaticName(field));
+            method.addCode("$L = $L(_parser);\n", field.parameter(), readerMethodName(field));
+            method.addCode(markReceived(meta, i));
             if (i == meta.fields().size() - 1) {
                 method.addCode("""
-                    __token = __parser.nextToken();
-                    while (__token != JsonToken.END_OBJECT) {
-                        __parser.nextToken();
-                        __parser.skipChildren();
-                        __token = __parser.nextToken();
+                    _token = _parser.nextToken();
+                    while (_token != JsonToken.END_OBJECT) {
+                        _parser.nextToken();
+                        _parser.skipChildren();
+                        _token = _parser.nextToken();
                     }
                     """);
                 method.addCode("return new $T(", meta.typeMirror());
@@ -312,34 +316,23 @@ public class JsonReaderGenerator {
     private MethodSpec readParamMethod(int index, int size, FieldMeta field) {
         var method = MethodSpec.methodBuilder(this.readerMethodName(field))
             .addModifiers(Modifier.PRIVATE)
-            .addParameter(JsonTypes.jsonParser, "__parser")
-            .addParameter(size > 32 ? TypeName.get(BitSet.class) : ArrayTypeName.of(TypeName.INT), "__receivedFields")
+            .addParameter(JsonTypes.jsonParser, "_parser")
             .returns(field.typeName());
         if (field.reader() != null) {
-            method.addCode("var __token = __parser.nextToken();\n");
+            method.addCode("var _token = _parser.nextToken();\n");
             if (!isNullable(field)) {
                 method.addCode("""
-                    if (__token == $T.VALUE_NULL)
-                      throw new $T(__parser, $S);
-                    """, JsonTypes.jsonToken, JsonTypes.jsonParseException, "Expecting nonnull value for field %s, got VALUE_NULL token".formatted(field.jsonName()));
-                if (size > 32) {
-                    method.addCode("__receivedFields.set($L);\n", index);
-                } else {
-                    method.addCode("__receivedFields[0] = __receivedFields[0] | (1 << $L);\n", index);
-                }
+                    if (_token == $T.VALUE_NULL)
+                      throw _requiredFieldNull(_parser, $S);
+                    """, JsonTypes.jsonToken, "." + field.jsonName());
             }
-            method.addCode("return $L.read(__parser);\n", this.readerFieldName(field));
+            method.addCode("return $L.read(_parser);\n", this.readerFieldName(field));
             return method.build();
         }
-        method.addStatement("var __token = __parser.nextToken()");
+        method.addStatement("var _token = _parser.nextToken()");
         if (field.typeMeta() instanceof KnownTypeReaderMeta meta) {
             method.addModifiers(Modifier.STATIC);
             var block = CodeBlock.builder();
-            if (size > 32) {
-                block.add("__receivedFields.set($L);\n", index);
-            } else {
-                block.add("__receivedFields[0] = __receivedFields[0] | (1 << $L);\n", index);
-            }
 
             CodeBlock prefix = field.typeMeta().isJsonNullable()
                 ? CodeBlock.of("return $T.ofNullable(", JsonTypes.jsonNullable)
@@ -357,32 +350,27 @@ public class JsonReaderGenerator {
 
         if (field.typeMeta() != null && field.typeMeta().isJsonNullable()) {
             method.addCode("""
-                if (__token == $T.VALUE_NULL) {
+                if (_token == $T.VALUE_NULL) {
                   return $T.nullValue();
                 }
                 """, JsonTypes.jsonToken, JsonTypes.jsonNullable);
         } else if (isNullable(field)) {
             method.addCode("""
-                if (__token == $T.VALUE_NULL) {
+                if (_token == $T.VALUE_NULL) {
                   return null;
                 }
                 """, JsonTypes.jsonToken);
         } else {
             method.addCode("""
-                if (__token == $T.VALUE_NULL)
-                  throw new $T(__parser, $S);
-                """, JsonTypes.jsonToken, JsonTypes.jsonParseException, "Expecting nonnull value for field %s, got VALUE_NULL token".formatted(field.jsonName()));
-            if (size > 32) {
-                method.addCode("__receivedFields.set($L);\n", index);
-            } else {
-                method.addCode("__receivedFields[0] = __receivedFields[0] | (1 << $L);\n", index);
-            }
+                if (_token == $T.VALUE_NULL)
+                  throw _requiredFieldNull(_parser, $S);
+                """, JsonTypes.jsonToken, "." + field.jsonName());
         }
 
         if (field.typeMeta() != null && field.typeMeta().isJsonNullable()) {
-            method.addStatement("return $T.ofNullable($L.read(__parser))", JsonTypes.jsonNullable, readerFieldName(field));
+            method.addStatement("return $T.ofNullable($L.read(_parser))", JsonTypes.jsonNullable, readerFieldName(field));
         } else {
-            method.addStatement("return $L.read(__parser)", readerFieldName(field));
+            method.addStatement("return $L.read(_parser)", readerFieldName(field));
         }
         return method.build();
     }
@@ -395,86 +383,165 @@ public class JsonReaderGenerator {
         var method = CodeBlock.builder();
         var code = switch (knownType) {
             case STRING -> CodeBlock.of("""
-                    if (__token == $T.VALUE_STRING) {
-                      $L__parser.getText()$L;
+                    if (_token == $T.VALUE_STRING) {
+                      $L_parser.getText()$L;
                     }""",
                 JsonTypes.jsonToken, prefix, suffix);
             case BOOLEAN_OBJECT, BOOLEAN_PRIMITIVE -> CodeBlock.of("""
-                    if (__token == $T.VALUE_TRUE) {
+                    if (_token == $T.VALUE_TRUE) {
                       $Ltrue$L;
-                    } else if (__token == $T.VALUE_FALSE) {
+                    } else if (_token == $T.VALUE_FALSE) {
                       $Lfalse$L;
                     }""",
                 JsonTypes.jsonToken, prefix, suffix, JsonTypes.jsonToken, prefix, suffix);
             case INTEGER_OBJECT, INTEGER_PRIMITIVE -> CodeBlock.of("""
-                    if (__token == $T.VALUE_NUMBER_INT) {
-                      $L__parser.getIntValue()$L;
+                    if (_token == $T.VALUE_NUMBER_INT) {
+                      $L_parser.getIntValue()$L;
                     }""",
                 JsonTypes.jsonToken, prefix, suffix);
             case BIG_INTEGER -> CodeBlock.of("""
-                    if (__token == $T.VALUE_NUMBER_INT) {
-                      $L__parser.getBigIntegerValue()$L;
+                    if (_token == $T.VALUE_NUMBER_INT) {
+                      $L_parser.getBigIntegerValue()$L;
                     }""",
                 JsonTypes.jsonToken, prefix, suffix);
             case DOUBLE_OBJECT, DOUBLE_PRIMITIVE -> CodeBlock.of("""
-                    if (__token == $T.VALUE_NUMBER_FLOAT || __token == $T.VALUE_NUMBER_INT) {
-                      $L__parser.getDoubleValue()$L;
+                    if (_token == $T.VALUE_NUMBER_FLOAT || _token == $T.VALUE_NUMBER_INT) {
+                      $L_parser.getDoubleValue()$L;
                     }""",
                 JsonTypes.jsonToken, JsonTypes.jsonToken, prefix, suffix);
             case FLOAT_OBJECT, FLOAT_PRIMITIVE -> CodeBlock.of("""
-                    if (__token == $T.VALUE_NUMBER_FLOAT || __token == $T.VALUE_NUMBER_INT) {
-                      $L__parser.getFloatValue()$L;
+                    if (_token == $T.VALUE_NUMBER_FLOAT || _token == $T.VALUE_NUMBER_INT) {
+                      $L_parser.getFloatValue()$L;
                     }""",
                 JsonTypes.jsonToken, JsonTypes.jsonToken, prefix, suffix);
             case LONG_OBJECT, LONG_PRIMITIVE -> CodeBlock.of("""
-                    if (__token == $T.VALUE_NUMBER_INT) {
-                      $L__parser.getLongValue()$L;
+                    if (_token == $T.VALUE_NUMBER_INT) {
+                      $L_parser.getLongValue()$L;
                     }""",
                 JsonTypes.jsonToken, prefix, suffix);
             case SHORT_OBJECT, SHORT_PRIMITIVE -> CodeBlock.of("""
-                    if (__token == $T.VALUE_NUMBER_INT) {
-                      $L__parser.getShortValue()$L;
+                    if (_token == $T.VALUE_NUMBER_INT) {
+                      $L_parser.getShortValue()$L;
                     }""",
                 JsonTypes.jsonToken, prefix, suffix);
             case BINARY -> CodeBlock.of("""
-                    if (__token == $T.VALUE_STRING) {
-                      $L__parser.getBinaryValue()$L;
+                    if (_token == $T.VALUE_STRING) {
+                      $L_parser.getBinaryValue()$L;
                     }""",
                 JsonTypes.jsonToken, prefix, suffix);
             case UUID -> CodeBlock.of("""
-                    if (__token == $T.VALUE_STRING) {
-                      $L$T.fromString(__parser.getText())$L;
+                    if (_token == $T.VALUE_STRING) {
+                      $L$T.fromString(_parser.getText())$L;
                     }""",
                 JsonTypes.jsonToken, prefix, UUID.class, suffix);
         };
         method.add(code);
         if (jsonNullable) {
-            method.add(" else if (__token == $T.VALUE_NULL) {$>\nreturn $T.nullValue();$<\n}", JsonTypes.jsonToken, JsonTypes.jsonNullable);
+            method.add(" else if (_token == $T.VALUE_NULL) {$>\nreturn $T.nullValue();$<\n}", JsonTypes.jsonToken, JsonTypes.jsonNullable);
         } else if (nullable) {
-            method.add(" else if (__token == $T.VALUE_NULL) {$>\nreturn null;$<\n}", JsonTypes.jsonToken);
+            method.add(" else if (_token == $T.VALUE_NULL) {$>\nreturn null;$<\n}", JsonTypes.jsonToken);
+        } else {
+            method.add(" else if (_token == $T.VALUE_NULL) {$>\nthrow _requiredFieldNull(_parser, $S);$<\n}", JsonTypes.jsonToken, "." + jsonName);
         }
-        method.add(" else {$>\nthrow new $T(__parser, $S + __token);$<\n}", JsonTypes.jsonParseException, "Expecting %s token for field '%s', got ".formatted(Arrays.toString(expectedTokens(knownType, nullable)), jsonName));
+        method.add(" else {$>\nthrow _unexpectedToken(_parser, $S, $S);$<\n}", "." + jsonName, expectedPhrase(knownType));
         return method.build();
     }
 
-    private String[] expectedTokens(KnownType.KnownTypesEnum knownType, boolean nullable) {
-        var result = switch (knownType) {
-            case STRING, BINARY, UUID -> new String[]{"VALUE_STRING"};
-            case BOOLEAN_OBJECT, BOOLEAN_PRIMITIVE -> new String[]{"VALUE_TRUE", "VALUE_FALSE"};
-            case SHORT_OBJECT, INTEGER_OBJECT, LONG_OBJECT, BIG_INTEGER, INTEGER_PRIMITIVE, LONG_PRIMITIVE, SHORT_PRIMITIVE -> new String[]{"VALUE_NUMBER_INT"};
-            case DOUBLE_OBJECT, FLOAT_OBJECT, DOUBLE_PRIMITIVE, FLOAT_PRIMITIVE -> new String[]{"VALUE_NUMBER_FLOAT", "VALUE_NUMBER_INT"};
+    private String expectedPhrase(KnownType.KnownTypesEnum knownType) {
+        return switch (knownType) {
+            case STRING -> "a string";
+            case BINARY -> "a base64-encoded string";
+            case UUID -> "a UUID string";
+            case BOOLEAN_OBJECT, BOOLEAN_PRIMITIVE -> "a boolean";
+            case SHORT_OBJECT, SHORT_PRIMITIVE, INTEGER_OBJECT, INTEGER_PRIMITIVE,
+                 LONG_OBJECT, LONG_PRIMITIVE, BIG_INTEGER -> "an integer number";
+            case DOUBLE_OBJECT, DOUBLE_PRIMITIVE, FLOAT_OBJECT, FLOAT_PRIMITIVE -> "a number";
         };
-        if (nullable) {
-            result = Arrays.copyOf(result, result.length + 1);
-            result[result.length - 1] = "VALUE_NULL";
-        }
-        return result;
     }
 
-    private void assertTokenType(MethodSpec.Builder method, String expectedToken) {
-        method.addCode("if (__token != $T.$L) $>\nthrow new $T(__parser, $S + __token);$<\n",
-            JsonTypes.jsonToken, expectedToken, JsonTypes.jsonParseException, "Expecting %s token, got ".formatted(expectedToken)
+    private void assertTokenType(MethodSpec.Builder method, String expectedToken, String expectedPhrase) {
+        method.addCode("if (_token != $T.$L) $>\nthrow _unexpectedToken(_parser, $S, $S);$<\n",
+            JsonTypes.jsonToken, expectedToken, "", expectedPhrase
         );
+    }
+
+    private CodeBlock markReceived(JsonClassReaderMeta meta, int index) {
+        if (meta.fields().size() > 32) {
+            return CodeBlock.of("_receivedFields.set($L);\n", index);
+        }
+        return CodeBlock.of("_receivedFields |= (1 << $L);\n", index);
+    }
+
+    /**
+     * Generates the private helper methods each reader uses to build detailed, consistent parse-error
+     * messages (type + member + JSON path + humanized expected/actual value). Kept inside the mapper
+     * itself, not extracted to a shared runtime class.
+     */
+    private void addErrorMethods(TypeSpec.Builder typeBuilder, JsonClassReaderMeta meta) {
+        var typeName = meta.typeElement().getSimpleName().toString();
+
+        typeBuilder.addMethod(MethodSpec.methodBuilder("_jsonPath")
+            .addModifiers(Modifier.PRIVATE, Modifier.STATIC)
+            .addParameter(JsonTypes.jsonParser, "_parser")
+            .returns(String.class)
+            .addStatement("var _p = _parser.streamReadContext().pathAsPointer().toString()")
+            .addStatement("return _p.isEmpty() ? $S : _p", "<root>")
+            .build());
+
+        var actual = MethodSpec.methodBuilder("_actualValue")
+            .addModifiers(Modifier.PRIVATE, Modifier.STATIC)
+            .addParameter(JsonTypes.jsonParser, "_parser")
+            .returns(String.class);
+        actual.addStatement("var _t = _parser.currentToken()");
+        actual.beginControlFlow("if (_t == null)");
+        actual.addStatement("return $S", "nothing (end of input)");
+        actual.endControlFlow();
+        actual.addStatement("var _v = _parser.getValueAsString()");
+        actual.beginControlFlow("if (_v != null && _v.length() > 128)");
+        actual.addStatement("_v = _v.substring(0, 128) + $S", "...(truncated)");
+        actual.endControlFlow();
+        actual.addCode("return switch (_t) {$>\n");
+        actual.addStatement("case VALUE_NULL -> $S", "null");
+        actual.addStatement("case START_OBJECT -> $S", "an object");
+        actual.addStatement("case START_ARRAY -> $S", "an array");
+        actual.addStatement("case VALUE_STRING -> $S + _v + $S", "a string \"", "\"");
+        actual.addStatement("case VALUE_NUMBER_INT -> $S + _v", "a number ");
+        actual.addStatement("case VALUE_NUMBER_FLOAT -> $S + _v", "a fractional number ");
+        actual.addStatement("case VALUE_TRUE, VALUE_FALSE -> $S + _v", "a boolean ");
+        actual.addStatement("default -> $S + _t", "token ");
+        actual.addCode("$<};\n");
+        typeBuilder.addMethod(actual.build());
+
+        typeBuilder.addMethod(MethodSpec.methodBuilder("_unexpectedToken")
+            .addModifiers(Modifier.PRIVATE, Modifier.STATIC)
+            .addParameter(JsonTypes.jsonParser, "_parser")
+            .addParameter(String.class, "_member")
+            .addParameter(String.class, "_expected")
+            .returns(JsonTypes.jsonParseException)
+            .addStatement("return new $T(_parser, $S + _member + $S + _expected + $S + _actualValue(_parser) + $S + _jsonPath(_parser) + $S)",
+                JsonTypes.jsonParseException, "Failed to read json " + typeName, ": expected ", ", but got ", " (at ", ")")
+            .build());
+
+        typeBuilder.addMethod(MethodSpec.methodBuilder("_missingRequiredFields")
+            .addModifiers(Modifier.PRIVATE, Modifier.STATIC)
+            .addParameter(JsonTypes.jsonParser, "_parser")
+            .addParameter(String.class, "_fields")
+            .returns(JsonTypes.jsonParseException)
+            .addStatement("return new $T(_parser, $S + _fields + $S + _jsonPath(_parser) + $S)",
+                JsonTypes.jsonParseException, "Failed to read json " + typeName + ": missing required field(s): ", " (at ", ")")
+            .build());
+
+        boolean anyRequired = meta.fields().stream().anyMatch(f -> !isNullable(f));
+        if (anyRequired) {
+            typeBuilder.addMethod(MethodSpec.methodBuilder("_requiredFieldNull")
+                .addModifiers(Modifier.PRIVATE, Modifier.STATIC)
+                .addParameter(JsonTypes.jsonParser, "_parser")
+                .addParameter(String.class, "_member")
+                .returns(JsonTypes.jsonParseException)
+                .addStatement("return new $T(_parser, $S + _member + $S + _jsonPath(_parser) + $S)",
+                    JsonTypes.jsonParseException, "Failed to read json " + typeName, ": required field must not be null (at ", ")")
+                .build());
+        }
     }
 
     private String jsonNameStaticName(JsonClassReaderMeta.FieldMeta field) {

--- a/json/json-annotation-processor/src/main/java/io/koraframework/json/annotation/processor/reader/SealedInterfaceReaderGenerator.java
+++ b/json/json-annotation-processor/src/main/java/io/koraframework/json/annotation/processor/reader/SealedInterfaceReaderGenerator.java
@@ -46,27 +46,27 @@ public class SealedInterfaceReaderGenerator {
         var defaultDiscriminatorValue = discriminator == null ? null : discriminator.defaultValue();
         var method = MethodSpec.methodBuilder("read")
             .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-            .addParameter(JsonTypes.jsonParser, "_parser")
+            .addParameter(JsonTypes.jsonParser, "__parser")
             .returns(ClassName.get(jsonElement).annotated(CommonClassNames.nullableAnnotation))
             .addAnnotation(Override.class);
-        method.beginControlFlow("if (_parser.currentToken() == $T.VALUE_NULL)", JsonTypes.jsonToken)
+        method.beginControlFlow("if (__parser.currentToken() == $T.VALUE_NULL)", JsonTypes.jsonToken)
             .addStatement("return null")
             .endControlFlow();
-        method.addCode("var bufferingParser = new $T(_parser);\n", JsonTypes.bufferingJsonParser);
+        method.addCode("var bufferingParser = new $T(__parser);\n", JsonTypes.bufferingJsonParser);
         method.addCode("var discriminator = $T.readStringDiscriminator(bufferingParser, $S);\n", JsonTypes.discriminatorHelper, discriminatorField);
         var typeSimpleName = jsonElement.getSimpleName().toString();
         var allValues = permittedSubclasses.stream()
             .flatMap(e -> JsonUtils.discriminatorValue(e).stream())
             .toList();
         if (defaultDiscriminatorValue == null || defaultDiscriminatorValue.isEmpty()) {
-            method.addCode("if (discriminator == null) throw new $T(_parser, $S + _jsonPath(_parser) + $S);\n",
+            method.addCode("if (discriminator == null) throw new $T(__parser, $S + __jsonPath(__parser) + $S);\n",
                 JsonTypes.jsonParseException,
                 "Failed to read json " + typeSimpleName + ": missing required discriminator field \"" + discriminatorField + "\", expected one of " + allValues + " (at ",
                 ")");
         } else {
             method.addCode("if (discriminator == null) discriminator = $S;\n", defaultDiscriminatorValue);
         }
-        method.addCode("var bufferedParser = $T.createFlattened(false, bufferingParser.reset(), _parser);\n", JsonTypes.jsonParserSequence);
+        method.addCode("var bufferedParser = $T.createFlattened(false, bufferingParser.reset(), __parser);\n", JsonTypes.jsonParserSequence);
         method.addCode("bufferedParser.nextToken();\n");
         method.addCode("return switch(discriminator) {$>\n");
         for (var elem : permittedSubclasses) {
@@ -76,19 +76,19 @@ public class SealedInterfaceReaderGenerator {
                 method.addCode("case $S -> $L.read(bufferedParser);\n", discriminatorValue, readerName);
             }
         }
-        method.addCode("default -> throw new $T(_parser, $S + discriminator + $S + _jsonPath(_parser) + $S);$<\n};",
+        method.addCode("default -> throw new $T(__parser, $S + discriminator + $S + __jsonPath(__parser) + $S);$<\n};",
             JsonTypes.jsonParseException,
             "Failed to read json " + typeSimpleName + ": unknown discriminator value \"",
             "\" for field \"" + discriminatorField + "\", expected one of " + allValues + " (at ",
             ")");
         typeBuilder.addMethod(method.build());
 
-        typeBuilder.addMethod(MethodSpec.methodBuilder("_jsonPath")
+        typeBuilder.addMethod(MethodSpec.methodBuilder("__jsonPath")
             .addModifiers(Modifier.PRIVATE, Modifier.STATIC)
-            .addParameter(JsonTypes.jsonParser, "_parser")
+            .addParameter(JsonTypes.jsonParser, "__parser")
             .returns(String.class)
-            .addStatement("var _p = _parser.streamReadContext().pathAsPointer().toString()")
-            .addStatement("return _p.isEmpty() ? $S : _p", "<root>")
+            .addStatement("var __p = __parser.streamReadContext().pathAsPointer().toString()")
+            .addStatement("return __p.isEmpty() ? $S : __p", "<root>")
             .build());
 
         return typeBuilder.build();

--- a/json/json-annotation-processor/src/main/java/io/koraframework/json/annotation/processor/reader/SealedInterfaceReaderGenerator.java
+++ b/json/json-annotation-processor/src/main/java/io/koraframework/json/annotation/processor/reader/SealedInterfaceReaderGenerator.java
@@ -46,23 +46,27 @@ public class SealedInterfaceReaderGenerator {
         var defaultDiscriminatorValue = discriminator == null ? null : discriminator.defaultValue();
         var method = MethodSpec.methodBuilder("read")
             .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-            .addParameter(JsonTypes.jsonParser, "__parser")
+            .addParameter(JsonTypes.jsonParser, "_parser")
             .returns(ClassName.get(jsonElement).annotated(CommonClassNames.nullableAnnotation))
             .addAnnotation(Override.class);
-        method.beginControlFlow("if (__parser.currentToken() == $T.VALUE_NULL)", JsonTypes.jsonToken)
+        method.beginControlFlow("if (_parser.currentToken() == $T.VALUE_NULL)", JsonTypes.jsonToken)
             .addStatement("return null")
             .endControlFlow();
-        method.addCode("var bufferingParser = new $T(__parser);\n", JsonTypes.bufferingJsonParser);
+        method.addCode("var bufferingParser = new $T(_parser);\n", JsonTypes.bufferingJsonParser);
         method.addCode("var discriminator = $T.readStringDiscriminator(bufferingParser, $S);\n", JsonTypes.discriminatorHelper, discriminatorField);
+        var typeSimpleName = jsonElement.getSimpleName().toString();
+        var allValues = permittedSubclasses.stream()
+            .flatMap(e -> JsonUtils.discriminatorValue(e).stream())
+            .toList();
         if (defaultDiscriminatorValue == null || defaultDiscriminatorValue.isEmpty()) {
-            var allValues = permittedSubclasses.stream()
-                .flatMap(e -> JsonUtils.discriminatorValue(e).stream())
-                .toList();
-            method.addCode("if (discriminator == null) throw new $T(__parser, $S);\n", JsonTypes.jsonParseException, "Discriminator required, but not provided, expected one of: " + allValues);
+            method.addCode("if (discriminator == null) throw new $T(_parser, $S + _jsonPath(_parser) + $S);\n",
+                JsonTypes.jsonParseException,
+                "Failed to read json " + typeSimpleName + ": missing required discriminator field \"" + discriminatorField + "\", expected one of " + allValues + " (at ",
+                ")");
         } else {
             method.addCode("if (discriminator == null) discriminator = $S;\n", defaultDiscriminatorValue);
         }
-        method.addCode("var bufferedParser = $T.createFlattened(false, bufferingParser.reset(), __parser);\n", JsonTypes.jsonParserSequence);
+        method.addCode("var bufferedParser = $T.createFlattened(false, bufferingParser.reset(), _parser);\n", JsonTypes.jsonParserSequence);
         method.addCode("bufferedParser.nextToken();\n");
         method.addCode("return switch(discriminator) {$>\n");
         for (var elem : permittedSubclasses) {
@@ -72,8 +76,20 @@ public class SealedInterfaceReaderGenerator {
                 method.addCode("case $S -> $L.read(bufferedParser);\n", discriminatorValue, readerName);
             }
         }
-        method.addCode("default -> throw new $T(__parser, $S + discriminator + \"'\");$<\n};", JsonTypes.jsonParseException, "Unknown discriminator: '");
+        method.addCode("default -> throw new $T(_parser, $S + discriminator + $S + _jsonPath(_parser) + $S);$<\n};",
+            JsonTypes.jsonParseException,
+            "Failed to read json " + typeSimpleName + ": unknown discriminator value \"",
+            "\" for field \"" + discriminatorField + "\", expected one of " + allValues + " (at ",
+            ")");
         typeBuilder.addMethod(method.build());
+
+        typeBuilder.addMethod(MethodSpec.methodBuilder("_jsonPath")
+            .addModifiers(Modifier.PRIVATE, Modifier.STATIC)
+            .addParameter(JsonTypes.jsonParser, "_parser")
+            .returns(String.class)
+            .addStatement("var _p = _parser.streamReadContext().pathAsPointer().toString()")
+            .addStatement("return _p.isEmpty() ? $S : _p", "<root>")
+            .build());
 
         return typeBuilder.build();
     }

--- a/json/json-annotation-processor/src/test/java/io/koraframework/json/annotation/processor/JsonAnnotationProcessorTest.java
+++ b/json/json-annotation-processor/src/test/java/io/koraframework/json/annotation/processor/JsonAnnotationProcessorTest.java
@@ -283,7 +283,7 @@ class JsonAnnotationProcessorTest {
               "field2" : "field2"
             }"""))
             .isInstanceOf(StreamReadException.class)
-            .hasMessageStartingWith("Some of required json fields were not received: field1(field_1)");
+            .hasMessageStartingWith("Failed to read json DtoWithNullableFields: missing required field(s): field_1");
 
         assertThatThrownBy(() -> fromJson(reader, """
             {
@@ -292,7 +292,7 @@ class JsonAnnotationProcessorTest {
               "field4" : null
             }"""))
             .isInstanceOf(StreamReadException.class)
-            .hasMessageStartingWith("Expecting [VALUE_NUMBER_INT] token for field 'field4', got VALUE_NULL");
+            .hasMessageStartingWith("Failed to read json DtoWithNullableFields.field4: required field must not be null");
     }
 
     @Test

--- a/json/json-common/src/main/java/io/koraframework/json/common/JsonModule.java
+++ b/json/json-common/src/main/java/io/koraframework/json/common/JsonModule.java
@@ -10,6 +10,7 @@ import io.koraframework.json.common.writer.ListJsonWriter;
 import io.koraframework.json.common.writer.MapJsonWriter;
 import io.koraframework.json.common.writer.RawJsonWriter;
 import io.koraframework.json.common.writer.SetJsonWriter;
+import tools.jackson.core.JsonParser;
 import tools.jackson.core.StreamWriteFeature;
 import tools.jackson.core.exc.StreamReadException;
 import tools.jackson.core.json.JsonFactory;
@@ -90,7 +91,7 @@ public interface JsonModule {
         return parser -> switch (parser.currentToken()) {
             case VALUE_NULL -> null;
             case VALUE_NUMBER_INT -> parser.getShortValue();
-            default -> throw new StreamReadException(parser, "Expecting VALUE_NUMBER_INT token, got " + parser.currentToken());
+            default -> throw new StreamReadException(parser, "Failed to read json: expected an integer number, but got " + actualValue(parser) + " (at " + jsonPath(parser) + ")");
         };
     }
 
@@ -110,7 +111,7 @@ public interface JsonModule {
         return parser -> switch (parser.currentToken()) {
             case VALUE_NULL -> null;
             case VALUE_NUMBER_INT -> parser.getIntValue();
-            default -> throw new StreamReadException(parser, "Expecting VALUE_NUMBER_INT token, got " + parser.currentToken());
+            default -> throw new StreamReadException(parser, "Failed to read json: expected an integer number, but got " + actualValue(parser) + " (at " + jsonPath(parser) + ")");
         };
     }
 
@@ -130,7 +131,7 @@ public interface JsonModule {
         return parser -> switch (parser.currentToken()) {
             case VALUE_NULL -> null;
             case VALUE_NUMBER_INT -> parser.getLongValue();
-            default -> throw new StreamReadException(parser, "Expecting VALUE_NUMBER_INT token, got " + parser.currentToken());
+            default -> throw new StreamReadException(parser, "Failed to read json: expected an integer number, but got " + actualValue(parser) + " (at " + jsonPath(parser) + ")");
         };
     }
 
@@ -150,7 +151,7 @@ public interface JsonModule {
         return parser -> switch (parser.currentToken()) {
             case VALUE_NULL -> null;
             case VALUE_NUMBER_FLOAT, VALUE_NUMBER_INT -> parser.getDoubleValue();
-            default -> throw new StreamReadException(parser, "Expecting VALUE_NUMBER_FLOAT or VALUE_NUMBER_INT token, got " + parser.currentToken());
+            default -> throw new StreamReadException(parser, "Failed to read json: expected a number, but got " + actualValue(parser) + " (at " + jsonPath(parser) + ")");
         };
     }
 
@@ -170,7 +171,7 @@ public interface JsonModule {
         return parser -> switch (parser.currentToken()) {
             case VALUE_NULL -> null;
             case VALUE_NUMBER_FLOAT, VALUE_NUMBER_INT -> parser.getFloatValue();
-            default -> throw new StreamReadException(parser, "Expecting VALUE_NUMBER_FLOAT or VALUE_NUMBER_INT token, got " + parser.currentToken());
+            default -> throw new StreamReadException(parser, "Failed to read json: expected a number, but got " + actualValue(parser) + " (at " + jsonPath(parser) + ")");
         };
     }
 
@@ -190,7 +191,7 @@ public interface JsonModule {
         return parser -> switch (parser.currentToken()) {
             case VALUE_NULL -> null;
             case VALUE_STRING -> parser.getString();
-            default -> throw new StreamReadException(parser, "Expecting VALUE_STRING token, got " + parser.currentToken());
+            default -> throw new StreamReadException(parser, "Failed to read json: expected a string, but got " + actualValue(parser) + " (at " + jsonPath(parser) + ")");
         };
     }
 
@@ -211,7 +212,7 @@ public interface JsonModule {
             case VALUE_NULL -> null;
             case VALUE_TRUE -> true;
             case VALUE_FALSE -> false;
-            default -> throw new StreamReadException(parser, "Expecting VALUE_TRUE or VALUE_FALSE token, got " + parser.currentToken());
+            default -> throw new StreamReadException(parser, "Failed to read json: expected a boolean, but got " + actualValue(parser) + " (at " + jsonPath(parser) + ")");
         };
     }
 
@@ -231,7 +232,7 @@ public interface JsonModule {
         return parser -> switch (parser.currentToken()) {
             case VALUE_NULL -> null;
             case VALUE_NUMBER_FLOAT, VALUE_NUMBER_INT -> parser.getDecimalValue();
-            default -> throw new StreamReadException(parser, "Expecting VALUE_NUMBER_FLOAT or VALUE_NUMBER_INT token, got " + parser.currentToken());
+            default -> throw new StreamReadException(parser, "Failed to read json: expected a number, but got " + actualValue(parser) + " (at " + jsonPath(parser) + ")");
         };
     }
 
@@ -252,7 +253,7 @@ public interface JsonModule {
         return parser -> switch (parser.currentToken()) {
             case VALUE_NULL -> null;
             case VALUE_NUMBER_INT -> parser.getBigIntegerValue();
-            default -> throw new StreamReadException(parser, "Expecting VALUE_NUMBER_INT token, got " + parser.currentToken());
+            default -> throw new StreamReadException(parser, "Failed to read json: expected an integer number, but got " + actualValue(parser) + " (at " + jsonPath(parser) + ")");
         };
     }
 
@@ -297,7 +298,7 @@ public interface JsonModule {
         return parser -> switch (parser.currentToken()) {
             case VALUE_NULL -> null;
             case VALUE_STRING -> LocalDate.parse(parser.getValueAsString(), DateTimeFormatter.ISO_DATE);
-            default -> throw new StreamReadException(parser, "Expecting VALUE_STRING token, got " + parser.currentToken());
+            default -> throw new StreamReadException(parser, "Failed to read json: expected a string, but got " + actualValue(parser) + " (at " + jsonPath(parser) + ")");
         };
     }
 
@@ -322,7 +323,7 @@ public interface JsonModule {
         return parser -> switch (parser.currentToken()) {
             case VALUE_NULL -> null;
             case VALUE_STRING -> LocalTime.parse(parser.getValueAsString(), DateTimeFormatter.ISO_LOCAL_TIME);
-            default -> throw new StreamReadException(parser, "Expecting VALUE_STRING token, got " + parser.currentToken());
+            default -> throw new StreamReadException(parser, "Failed to read json: expected a string, but got " + actualValue(parser) + " (at " + jsonPath(parser) + ")");
         };
     }
 
@@ -347,7 +348,7 @@ public interface JsonModule {
         return parser -> switch (parser.currentToken()) {
             case VALUE_NULL -> null;
             case VALUE_STRING -> LocalDateTime.parse(parser.getValueAsString(), DateTimeFormatter.ISO_LOCAL_DATE_TIME);
-            default -> throw new StreamReadException(parser, "Expecting VALUE_STRING token, got " + parser.currentToken());
+            default -> throw new StreamReadException(parser, "Failed to read json: expected a string, but got " + actualValue(parser) + " (at " + jsonPath(parser) + ")");
         };
     }
 
@@ -372,7 +373,7 @@ public interface JsonModule {
         return parser -> switch (parser.currentToken()) {
             case VALUE_NULL -> null;
             case VALUE_STRING -> OffsetTime.parse(parser.getValueAsString(), DateTimeFormatter.ISO_OFFSET_TIME);
-            default -> throw new StreamReadException(parser, "Expecting VALUE_STRING token, got " + parser.currentToken());
+            default -> throw new StreamReadException(parser, "Failed to read json: expected a string, but got " + actualValue(parser) + " (at " + jsonPath(parser) + ")");
         };
     }
 
@@ -397,7 +398,7 @@ public interface JsonModule {
         return parser -> switch (parser.currentToken()) {
             case VALUE_NULL -> null;
             case VALUE_STRING -> OffsetDateTime.parse(parser.getValueAsString(), DateTimeFormatter.ISO_OFFSET_DATE_TIME);
-            default -> throw new StreamReadException(parser, "Expecting VALUE_STRING token, got " + parser.currentToken());
+            default -> throw new StreamReadException(parser, "Failed to read json: expected a string, but got " + actualValue(parser) + " (at " + jsonPath(parser) + ")");
         };
     }
 
@@ -422,7 +423,7 @@ public interface JsonModule {
         return parser -> switch (parser.currentToken()) {
             case VALUE_NULL -> null;
             case VALUE_STRING -> ZonedDateTime.parse(parser.getValueAsString(), DateTimeFormatter.ISO_ZONED_DATE_TIME);
-            default -> throw new StreamReadException(parser, "Expecting VALUE_STRING token, got " + parser.currentToken());
+            default -> throw new StreamReadException(parser, "Failed to read json: expected a string, but got " + actualValue(parser) + " (at " + jsonPath(parser) + ")");
         };
     }
 
@@ -442,7 +443,7 @@ public interface JsonModule {
         return parser -> switch (parser.currentToken()) {
             case VALUE_NULL -> null;
             case VALUE_STRING -> DateTimeFormatter.ISO_INSTANT.parse(parser.getValueAsString()).query(Instant::from);
-            default -> throw new StreamReadException(parser, "Expecting VALUE_STRING token, got " + parser.currentToken());
+            default -> throw new StreamReadException(parser, "Failed to read json: expected a string, but got " + actualValue(parser) + " (at " + jsonPath(parser) + ")");
         };
     }
 
@@ -462,7 +463,7 @@ public interface JsonModule {
         return parser -> switch (parser.currentToken()) {
             case VALUE_NULL -> null;
             case VALUE_STRING -> Year.parse(parser.getValueAsString(), KoraDateTimeFormatters.ISO_YEAR);
-            default -> throw new StreamReadException(parser, "Expecting VALUE_STRING token, got " + parser.currentToken());
+            default -> throw new StreamReadException(parser, "Failed to read json: expected a string, but got " + actualValue(parser) + " (at " + jsonPath(parser) + ")");
         };
     }
 
@@ -482,7 +483,7 @@ public interface JsonModule {
         return parser -> switch (parser.currentToken()) {
             case VALUE_NULL -> null;
             case VALUE_STRING -> YearMonth.parse(parser.getValueAsString(), KoraDateTimeFormatters.ISO_YEAR_MONTH);
-            default -> throw new StreamReadException(parser, "Expecting VALUE_STRING token, got " + parser.currentToken());
+            default -> throw new StreamReadException(parser, "Failed to read json: expected a string, but got " + actualValue(parser) + " (at " + jsonPath(parser) + ")");
         };
     }
 
@@ -502,7 +503,7 @@ public interface JsonModule {
         return parser -> switch (parser.currentToken()) {
             case VALUE_NULL -> null;
             case VALUE_STRING -> MonthDay.parse(parser.getValueAsString(), KoraDateTimeFormatters.ISO_MONTH_DAY);
-            default -> throw new StreamReadException(parser, "Expecting VALUE_STRING token, got " + parser.currentToken());
+            default -> throw new StreamReadException(parser, "Failed to read json: expected a string, but got " + actualValue(parser) + " (at " + jsonPath(parser) + ")");
         };
 
     }
@@ -533,7 +534,7 @@ public interface JsonModule {
                 yield Month.of(Integer.parseInt(valueAsString));
             }
             case VALUE_NUMBER_INT -> Month.of(parser.getValueAsInt());
-            default -> throw new StreamReadException(parser, "Expecting VALUE_STRING or VALUE_NUMBER_INT token, got " + parser.currentToken());
+            default -> throw new StreamReadException(parser, "Failed to read json: expected a string or integer number, but got " + actualValue(parser) + " (at " + jsonPath(parser) + ")");
         };
     }
 
@@ -563,7 +564,7 @@ public interface JsonModule {
                 yield DayOfWeek.of(Integer.parseInt(valueAsString));
             }
             case VALUE_NUMBER_INT -> DayOfWeek.of(parser.getValueAsInt());
-            default -> throw new StreamReadException(parser, "Expecting VALUE_STRING or VALUE_NUMBER_INT token, got " + parser.currentToken());
+            default -> throw new StreamReadException(parser, "Failed to read json: expected a string or integer number, but got " + actualValue(parser) + " (at " + jsonPath(parser) + ")");
         };
     }
 
@@ -583,7 +584,7 @@ public interface JsonModule {
         return parser -> switch (parser.currentToken()) {
             case VALUE_NULL -> null;
             case VALUE_STRING -> ZoneId.of(parser.getValueAsString());
-            default -> throw new StreamReadException(parser, "Expecting VALUE_STRING token, got " + parser.currentToken());
+            default -> throw new StreamReadException(parser, "Failed to read json: expected a string, but got " + actualValue(parser) + " (at " + jsonPath(parser) + ")");
         };
     }
 
@@ -603,7 +604,33 @@ public interface JsonModule {
         return parser -> switch (parser.currentToken()) {
             case VALUE_NULL -> null;
             case VALUE_STRING -> Duration.parse(parser.getValueAsString());
-            default -> throw new StreamReadException(parser, "Expecting VALUE_STRING token, got " + parser.currentToken());
+            default -> throw new StreamReadException(parser, "Failed to read json: expected a string, but got " + actualValue(parser) + " (at " + jsonPath(parser) + ")");
         };
+    }
+
+    private static String actualValue(JsonParser parser) {
+        var token = parser.currentToken();
+        if (token == null) {
+            return "nothing (end of input)";
+        }
+        var value = parser.getValueAsString();
+        if (value != null && value.length() > 128) {
+            value = value.substring(0, 128) + "...(truncated)";
+        }
+        return switch (token) {
+            case VALUE_NULL -> "null";
+            case START_OBJECT -> "an object";
+            case START_ARRAY -> "an array";
+            case VALUE_STRING -> "a string \"" + value + "\"";
+            case VALUE_NUMBER_INT -> "a number " + value;
+            case VALUE_NUMBER_FLOAT -> "a fractional number " + value;
+            case VALUE_TRUE, VALUE_FALSE -> "a boolean " + value;
+            default -> "token " + token;
+        };
+    }
+
+    private static String jsonPath(JsonParser parser) {
+        var pointer = parser.streamReadContext().pathAsPointer().toString();
+        return pointer.isEmpty() ? "<root>" : pointer;
     }
 }

--- a/json/json-common/src/main/java/io/koraframework/json/common/JsonReader.java
+++ b/json/json-common/src/main/java/io/koraframework/json/common/JsonReader.java
@@ -2,6 +2,7 @@ package io.koraframework.json.common;
 
 import org.jspecify.annotations.Nullable;
 import io.koraframework.common.annotation.Mapping;
+import tools.jackson.core.JacksonException;
 import tools.jackson.core.ObjectReadContext;
 
 import java.io.InputStream;
@@ -14,10 +15,10 @@ import java.io.InputStream;
 public interface JsonReader<T> extends Mapping.MappingFunction {
 
     @Nullable
-    T read(tools.jackson.core.JsonParser parser);
+    T read(tools.jackson.core.JsonParser parser) throws JacksonException;
 
     @Nullable
-    default T read(byte[] bytes) {
+    default T read(byte[] bytes) throws JacksonException {
         try (var parser = JsonModule.JSON_FACTORY.createParser(ObjectReadContext.empty(), bytes)) {
             parser.nextToken();
             return this.read(parser);
@@ -25,7 +26,7 @@ public interface JsonReader<T> extends Mapping.MappingFunction {
     }
 
     @Nullable
-    default T read(byte[] bytes, int offset, int length) {
+    default T read(byte[] bytes, int offset, int length) throws JacksonException {
         try (var parser = JsonModule.JSON_FACTORY.createParser(ObjectReadContext.empty(), bytes, offset, length)) {
             parser.nextToken();
             return this.read(parser);
@@ -33,7 +34,7 @@ public interface JsonReader<T> extends Mapping.MappingFunction {
     }
 
     @Nullable
-    default T read(String str) {
+    default T read(String str) throws JacksonException {
         try (var parser = JsonModule.JSON_FACTORY.createParser(ObjectReadContext.empty(), str)) {
             parser.nextToken();
             return this.read(parser);
@@ -41,7 +42,7 @@ public interface JsonReader<T> extends Mapping.MappingFunction {
     }
 
     @Nullable
-    default T read(InputStream is) {
+    default T read(InputStream is) throws JacksonException {
         try (var parser = JsonModule.JSON_FACTORY.createParser(ObjectReadContext.empty(), is)) {
             parser.nextToken();
             return this.read(parser);

--- a/json/json-common/src/main/java/io/koraframework/json/common/JsonWriter.java
+++ b/json/json-common/src/main/java/io/koraframework/json/common/JsonWriter.java
@@ -2,10 +2,7 @@ package io.koraframework.json.common;
 
 import io.koraframework.common.annotation.Mapping;
 import org.jspecify.annotations.Nullable;
-import tools.jackson.core.JsonEncoding;
-import tools.jackson.core.JsonGenerator;
-import tools.jackson.core.ObjectWriteContext;
-import tools.jackson.core.PrettyPrinter;
+import tools.jackson.core.*;
 import tools.jackson.core.io.SegmentedStringWriter;
 import tools.jackson.core.util.ByteArrayBuilder;
 import tools.jackson.core.util.DefaultPrettyPrinter;
@@ -21,9 +18,9 @@ public interface JsonWriter<T> extends Mapping.MappingFunction {
      * @param generator jackson generator that will be used for writing object to JSON
      * @param object    to serialize into JSON
      */
-    void write(JsonGenerator generator, @Nullable T object);
+    void write(JsonGenerator generator, @Nullable T object) throws JacksonException;
 
-    default byte[] toByteArray(@Nullable T value) {
+    default byte[] toByteArray(@Nullable T value) throws JacksonException {
         var bb = new ByteArrayBuilder(JsonModule.JSON_FACTORY._getBufferRecycler());
         try (var gen = JsonModule.JSON_FACTORY.createGenerator(ObjectWriteContext.empty(), bb, JsonEncoding.UTF8)) {
             this.write(gen, value);
@@ -34,15 +31,15 @@ public interface JsonWriter<T> extends Mapping.MappingFunction {
         }
     }
 
-    default String toString(@Nullable T value) {
+    default String toString(@Nullable T value) throws JacksonException {
         return toString(value, false);
     }
 
-    default String toPrettyString(@Nullable T value) {
+    default String toPrettyString(@Nullable T value) throws JacksonException {
         return toString(value, true);
     }
 
-    private String toString(@Nullable T value, boolean usePrettyPrinter) {
+    private String toString(@Nullable T value, boolean usePrettyPrinter) throws JacksonException {
         var ctx = usePrettyPrinter
             ? new ObjectWriteContext.Base() {
             @Override

--- a/json/json-common/src/main/java/io/koraframework/json/common/reader/EnumJsonReader.java
+++ b/json/json-common/src/main/java/io/koraframework/json/common/reader/EnumJsonReader.java
@@ -30,8 +30,13 @@ public final class EnumJsonReader<T extends Enum<T>, V> implements JsonReader<T>
         }
         var value = this.values.get(jsonValue);
         if (value == null) {
-            throw new StreamReadException(parser, "Expecting one of " + this.values.keySet() + ", got " + jsonValue);
+            throw new StreamReadException(parser, "Failed to read json enum: expected one of " + this.values.keySet() + ", but got \"" + jsonValue + "\" (at " + jsonPath(parser) + ")");
         }
         return value;
+    }
+
+    private static String jsonPath(JsonParser parser) {
+        var pointer = parser.streamReadContext().pathAsPointer().toString();
+        return pointer.isEmpty() ? "<root>" : pointer;
     }
 }

--- a/json/json-common/src/main/java/io/koraframework/json/common/reader/ListJsonReader.java
+++ b/json/json-common/src/main/java/io/koraframework/json/common/reader/ListJsonReader.java
@@ -22,7 +22,7 @@ public class ListJsonReader<T> implements JsonReader<List<T>> {
             return null;
         }
         if (token != JsonToken.START_ARRAY) {
-            throw new StreamReadException(parser, "Expecting START_ARRAY token, got " + token);
+            throw new StreamReadException(parser, "Failed to read json array: expected an array, but got " + actualValue(parser) + " (at " + jsonPath(parser) + ")");
         }
         token = parser.nextToken();
         if (token == JsonToken.END_ARRAY) {
@@ -37,5 +37,31 @@ public class ListJsonReader<T> implements JsonReader<List<T>> {
         }
 
         return result;
+    }
+
+    private static String actualValue(JsonParser parser) {
+        var token = parser.currentToken();
+        if (token == null) {
+            return "nothing (end of input)";
+        }
+        var value = parser.getValueAsString();
+        if (value != null && value.length() > 128) {
+            value = value.substring(0, 128) + "...(truncated)";
+        }
+        return switch (token) {
+            case VALUE_NULL -> "null";
+            case START_OBJECT -> "an object";
+            case START_ARRAY -> "an array";
+            case VALUE_STRING -> "a string \"" + value + "\"";
+            case VALUE_NUMBER_INT -> "a number " + value;
+            case VALUE_NUMBER_FLOAT -> "a fractional number " + value;
+            case VALUE_TRUE, VALUE_FALSE -> "a boolean " + value;
+            default -> "token " + token;
+        };
+    }
+
+    private static String jsonPath(JsonParser parser) {
+        var pointer = parser.streamReadContext().pathAsPointer().toString();
+        return pointer.isEmpty() ? "<root>" : pointer;
     }
 }

--- a/json/json-common/src/main/java/io/koraframework/json/common/reader/MapJsonReader.java
+++ b/json/json-common/src/main/java/io/koraframework/json/common/reader/MapJsonReader.java
@@ -22,7 +22,7 @@ public class MapJsonReader<T> implements JsonReader<Map<String, T>> {
             return null;
         }
         if (token != JsonToken.START_OBJECT) {
-            throw new StreamReadException(parser, "Expecting START_OBJECT token, got " + token);
+            throw new StreamReadException(parser, "Failed to read json object: expected an object, but got " + actualValue(parser) + " (at " + jsonPath(parser) + ")");
         }
         token = parser.nextToken();
         if (token == JsonToken.END_OBJECT) {
@@ -32,7 +32,7 @@ public class MapJsonReader<T> implements JsonReader<Map<String, T>> {
         Map<String, T> result = new LinkedHashMap<>();
         while (token != JsonToken.END_OBJECT) {
             if (token != JsonToken.PROPERTY_NAME) {
-                throw new StreamReadException(parser, "Expecting PROPERTY_NAME token, got " + token);
+                throw new StreamReadException(parser, "Failed to read json object: expected a field name, but got " + actualValue(parser) + " (at " + jsonPath(parser) + ")");
             }
             var fieldName = parser.currentName();
             token = parser.nextToken();
@@ -42,5 +42,31 @@ public class MapJsonReader<T> implements JsonReader<Map<String, T>> {
         }
 
         return result;
+    }
+
+    private static String actualValue(JsonParser parser) {
+        var token = parser.currentToken();
+        if (token == null) {
+            return "nothing (end of input)";
+        }
+        var value = parser.getValueAsString();
+        if (value != null && value.length() > 128) {
+            value = value.substring(0, 128) + "...(truncated)";
+        }
+        return switch (token) {
+            case VALUE_NULL -> "null";
+            case START_OBJECT -> "an object";
+            case START_ARRAY -> "an array";
+            case VALUE_STRING -> "a string \"" + value + "\"";
+            case VALUE_NUMBER_INT -> "a number " + value;
+            case VALUE_NUMBER_FLOAT -> "a fractional number " + value;
+            case VALUE_TRUE, VALUE_FALSE -> "a boolean " + value;
+            default -> "token " + token;
+        };
+    }
+
+    private static String jsonPath(JsonParser parser) {
+        var pointer = parser.streamReadContext().pathAsPointer().toString();
+        return pointer.isEmpty() ? "<root>" : pointer;
     }
 }

--- a/json/json-common/src/main/java/io/koraframework/json/common/reader/SetJsonReader.java
+++ b/json/json-common/src/main/java/io/koraframework/json/common/reader/SetJsonReader.java
@@ -22,7 +22,7 @@ public class SetJsonReader<T> implements JsonReader<Set<T>> {
             return null;
         }
         if (token != JsonToken.START_ARRAY) {
-            throw new StreamReadException(parser, "Expecting START_ARRAY token, got " + token);
+            throw new StreamReadException(parser, "Failed to read json array: expected an array, but got " + actualValue(parser) + " (at " + jsonPath(parser) + ")");
         }
         token = parser.nextToken();
         if (token == JsonToken.END_ARRAY) {
@@ -37,5 +37,31 @@ public class SetJsonReader<T> implements JsonReader<Set<T>> {
         }
 
         return result;
+    }
+
+    private static String actualValue(JsonParser parser) {
+        var token = parser.currentToken();
+        if (token == null) {
+            return "nothing (end of input)";
+        }
+        var value = parser.getValueAsString();
+        if (value != null && value.length() > 128) {
+            value = value.substring(0, 128) + "...(truncated)";
+        }
+        return switch (token) {
+            case VALUE_NULL -> "null";
+            case START_OBJECT -> "an object";
+            case START_ARRAY -> "an array";
+            case VALUE_STRING -> "a string \"" + value + "\"";
+            case VALUE_NUMBER_INT -> "a number " + value;
+            case VALUE_NUMBER_FLOAT -> "a fractional number " + value;
+            case VALUE_TRUE, VALUE_FALSE -> "a boolean " + value;
+            default -> "token " + token;
+        };
+    }
+
+    private static String jsonPath(JsonParser parser) {
+        var pointer = parser.streamReadContext().pathAsPointer().toString();
+        return pointer.isEmpty() ? "<root>" : pointer;
     }
 }

--- a/json/json-common/src/main/java/io/koraframework/json/common/reader/SortedSetJsonReader.java
+++ b/json/json-common/src/main/java/io/koraframework/json/common/reader/SortedSetJsonReader.java
@@ -23,7 +23,7 @@ public class SortedSetJsonReader<T extends Comparable<T>> implements JsonReader<
             return null;
         }
         if (token != JsonToken.START_ARRAY) {
-            throw new StreamReadException(parser, "Expecting START_ARRAY token, got " + token);
+            throw new StreamReadException(parser, "Failed to read json array: expected an array, but got " + actualValue(parser) + " (at " + jsonPath(parser) + ")");
         }
         token = parser.nextToken();
         if (token == JsonToken.END_ARRAY) {
@@ -37,5 +37,31 @@ public class SortedSetJsonReader<T extends Comparable<T>> implements JsonReader<
         }
 
         return result;
+    }
+
+    private static String actualValue(JsonParser parser) {
+        var token = parser.currentToken();
+        if (token == null) {
+            return "nothing (end of input)";
+        }
+        var value = parser.getValueAsString();
+        if (value != null && value.length() > 128) {
+            value = value.substring(0, 128) + "...(truncated)";
+        }
+        return switch (token) {
+            case VALUE_NULL -> "null";
+            case START_OBJECT -> "an object";
+            case START_ARRAY -> "an array";
+            case VALUE_STRING -> "a string \"" + value + "\"";
+            case VALUE_NUMBER_INT -> "a number " + value;
+            case VALUE_NUMBER_FLOAT -> "a fractional number " + value;
+            case VALUE_TRUE, VALUE_FALSE -> "a boolean " + value;
+            default -> "token " + token;
+        };
+    }
+
+    private static String jsonPath(JsonParser parser) {
+        var pointer = parser.streamReadContext().pathAsPointer().toString();
+        return pointer.isEmpty() ? "<root>" : pointer;
     }
 }

--- a/json/json-common/src/main/java/io/koraframework/json/common/util/DiscriminatorHelper.java
+++ b/json/json-common/src/main/java/io/koraframework/json/common/util/DiscriminatorHelper.java
@@ -1,6 +1,7 @@
 package io.koraframework.json.common.util;
 
 import org.jspecify.annotations.Nullable;
+import tools.jackson.core.JsonParser;
 import tools.jackson.core.JsonToken;
 import tools.jackson.core.exc.StreamReadException;
 import tools.jackson.core.io.SerializedString;
@@ -11,7 +12,7 @@ public class DiscriminatorHelper {
         var token = parser.currentToken();
         var name = new SerializedString(fieldName);
         if (token != JsonToken.START_OBJECT) {
-            throw new StreamReadException(parser, "Expected start of object for discriminator field " + name);
+            throw new StreamReadException(parser, "Failed to read json: expected an object to read discriminator field \"" + fieldName + "\", but got " + actualValue(parser) + " (at " + jsonPath(parser) + ")");
         }
         while (!parser.nextName(name)) {
             if (parser.currentToken() == JsonToken.END_OBJECT) {
@@ -20,8 +21,34 @@ public class DiscriminatorHelper {
             parser.skipChildren();
         }
         if (parser.nextToken() != JsonToken.VALUE_STRING) {
-            throw new StreamReadException(parser, "Expecting VALUE_STRING token, got " + parser.currentToken());
+            throw new StreamReadException(parser, "Failed to read json: expected a string discriminator value for field \"" + fieldName + "\", but got " + actualValue(parser) + " (at " + jsonPath(parser) + ")");
         }
         return parser.getValueAsString();
+    }
+
+    private static String actualValue(JsonParser parser) {
+        var token = parser.currentToken();
+        if (token == null) {
+            return "nothing (end of input)";
+        }
+        var value = parser.getValueAsString();
+        if (value != null && value.length() > 128) {
+            value = value.substring(0, 128) + "...(truncated)";
+        }
+        return switch (token) {
+            case VALUE_NULL -> "null";
+            case START_OBJECT -> "an object";
+            case START_ARRAY -> "an array";
+            case VALUE_STRING -> "a string \"" + value + "\"";
+            case VALUE_NUMBER_INT -> "a number " + value;
+            case VALUE_NUMBER_FLOAT -> "a fractional number " + value;
+            case VALUE_TRUE, VALUE_FALSE -> "a boolean " + value;
+            default -> "token " + token;
+        };
+    }
+
+    private static String jsonPath(JsonParser parser) {
+        var pointer = parser.streamReadContext().pathAsPointer().toString();
+        return pointer.isEmpty() ? "<root>" : pointer;
     }
 }

--- a/json/json-symbol-processor/src/main/kotlin/io/koraframework/json/ksp/reader/JsonReaderGenerator.kt
+++ b/json/json-symbol-processor/src/main/kotlin/io/koraframework/json/ksp/reader/JsonReaderGenerator.kt
@@ -45,21 +45,22 @@ class JsonReaderGenerator(val resolver: Resolver) {
         this.addReaders(typeBuilder, meta, typeParameterResolver)
         this.addFieldNames(typeBuilder, meta)
         this.addReadMethods(typeBuilder, meta)
+        this.addErrorMethods(typeBuilder, meta)
         val functionBody = CodeBlock.builder()
-        functionBody.addStatement("var __token = __parser.currentToken()")
-        functionBody.controlFlow("if (__token == %T.VALUE_NULL) ", JsonTypes.jsonToken) {
+        functionBody.addStatement("var _token = _parser.currentToken()")
+        functionBody.controlFlow("if (_token == %T.VALUE_NULL) ", JsonTypes.jsonToken) {
             if (JsonTypes.jsonNullable == declaration.toClassName()) {
                 addStatement("return %T.nullValue()", JsonTypes.jsonNullable)
             } else {
                 addStatement("return null")
             }
         }
-        assertTokenType(functionBody, "START_OBJECT")
+        assertTokenType(functionBody, "START_OBJECT", "an object '{...}'")
         functionBody.add("\n")
         if (meta.fields.size <= maxFields) {
-            functionBody.addStatement("val __receivedFields =  intArrayOf(NULLABLE_FIELDS_RECEIVED)")
+            functionBody.addStatement("var _receivedFields = NULLABLE_FIELDS_RECEIVED")
         } else {
-            functionBody.addStatement("val __receivedFields = NULLABLE_FIELDS_RECEIVED.clone() as %T", BitSet::class.java)
+            functionBody.addStatement("val _receivedFields = NULLABLE_FIELDS_RECEIVED.clone() as %T", BitSet::class.java)
         }
         functionBody.add("\n")
 
@@ -68,70 +69,75 @@ class JsonReaderGenerator(val resolver: Resolver) {
         this.addFastPath(functionBody, meta)
 
         if (meta.fields.isEmpty()) {
-            functionBody.addStatement("__token = __parser.nextToken()")
+            functionBody.addStatement("_token = _parser.nextToken()")
         } else {
-            functionBody.addStatement("__token = __parser.currentToken()")
+            functionBody.addStatement("_token = _parser.currentToken()")
         }
-        functionBody.controlFlow("while (__token != %T.END_OBJECT) ", JsonTypes.jsonToken) {
-            assertTokenType(functionBody, "PROPERTY_NAME")
-            functionBody.addStatement("val __fieldName = __parser.currentName()")
-            functionBody.controlFlow("when (__fieldName)") {
-                meta.fields.forEach { field ->
-                    functionBody.addStatement("%S -> %N = %N(__parser, __receivedFields)", field.jsonName, field.parameter.name!!.asString(), readerMethodName(field))
+        functionBody.controlFlow("while (_token != %T.END_OBJECT) ", JsonTypes.jsonToken) {
+            assertTokenType(functionBody, "PROPERTY_NAME", "a field name")
+            functionBody.addStatement("val _fieldName = _parser.currentName()")
+            functionBody.controlFlow("when (_fieldName)") {
+                meta.fields.forEachIndexed { i, field ->
+                    functionBody.controlFlow("%S ->", field.jsonName) {
+                        addStatement("%N = %N(_parser)", field.parameter.name!!.asString(), readerMethodName(field))
+                        add(markReceived(meta, i))
+                    }
                 }
                 functionBody.controlFlow("else -> ") {
-                    addStatement("__parser.nextToken()")
-                    addStatement("__parser.skipChildren()")
+                    addStatement("_parser.nextToken()")
+                    addStatement("_parser.skipChildren()")
                 }
             }
-            functionBody.addStatement("__token = __parser.nextToken()")
+            functionBody.addStatement("_token = _parser.nextToken()")
         }
 
         val errorSwitch = CodeBlock.builder()
-            .controlFlow("when (__i)") {
+            .controlFlow("when (_i)") {
                 for (i in 0 until meta.fields.size) {
                     val field = meta.fields[i]
-                    addStatement("%L -> %S", i, "${field.parameter.name!!.asString()}(${field.jsonName})")
+                    addStatement("%L -> %S", i, field.jsonName)
                 }
                 addStatement("else -> \"\"")
             }
         if (meta.fields.size > maxFields) {
-            functionBody.controlFlow("if (__receivedFields != ALL_FIELDS_RECEIVED)") {
-                addStatement(" __receivedFields.flip(0, %L)", meta.fields.size)
-                addStatement("val __error = %T(\"Some of required json fields were not received:\")", StringBuilder::class)
+            functionBody.controlFlow("if (_receivedFields != ALL_FIELDS_RECEIVED)") {
+                addStatement(" _receivedFields.flip(0, %L)", meta.fields.size)
+                addStatement("val _missing = %T()", StringBuilder::class)
 
-                addStatement("var __i = __receivedFields.nextSetBit(0)")
-                controlFlow("while (__i >= 0)") {
-                    add("__error.append(\" \").append(\n")
+                addStatement("var _i = _receivedFields.nextSetBit(0)")
+                controlFlow("while (_i >= 0)") {
+                    addStatement("if (_missing.isNotEmpty()) _missing.append(\", \")")
+                    add("_missing.append(\n")
                     indent()
                     add(errorSwitch.build())
                     unindent()
                     add(")\n")
-                    add("__i = __receivedFields.nextSetBit(__i + 1)\n")
+                    add("_i = _receivedFields.nextSetBit(_i + 1)\n")
                 }
-                addStatement("throw %T(__parser, __error.toString())", JsonTypes.jsonParseException)
+                addStatement("throw _missingRequiredFields(_parser, _missing.toString())")
             }
         } else {
-            functionBody.controlFlow("if (__receivedFields[0] != ALL_FIELDS_RECEIVED)") {
-                addStatement("val _nonReceivedFields = __receivedFields[0].inv() and ALL_FIELDS_RECEIVED")
-                addStatement("val __error = %T(\"Some of required json fields were not received:\")", StringBuilder::class)
-                controlFlow("(0..%L).forEach { __i ->", meta.fields.size) {
-                    controlFlow("if ((_nonReceivedFields and (1 shl __i)) != 0)") {
-                        add("__error.append(\" \").append(\n")
+            functionBody.controlFlow("if (_receivedFields != ALL_FIELDS_RECEIVED)") {
+                addStatement("val _nonReceivedFields = _receivedFields.inv() and ALL_FIELDS_RECEIVED")
+                addStatement("val _missing = %T()", StringBuilder::class)
+                controlFlow("(0..%L).forEach { _i ->", meta.fields.size) {
+                    controlFlow("if ((_nonReceivedFields and (1 shl _i)) != 0)") {
+                        addStatement("if (_missing.isNotEmpty()) _missing.append(\", \")")
+                        add("_missing.append(\n")
                         indent()
                         add(errorSwitch.build())
                         unindent()
                         add(")\n")
                     }
                 }
-                addStatement("throw %T(__parser, __error.toString())", JsonTypes.jsonParseException)
+                addStatement("throw _missingRequiredFields(_parser, _missing.toString())")
             }
         }
         generateReturnResult(meta, functionBody)
 
         typeBuilder.addFunction(
             FunSpec.builder("read")
-                .addParameter("__parser", JsonTypes.jsonParser)
+                .addParameter("_parser", JsonTypes.jsonParser)
                 .returns(typeName.copy(nullable = true))
                 .addModifiers(KModifier.OVERRIDE)
                 .addCode(functionBody.build())
@@ -173,13 +179,17 @@ class JsonReaderGenerator(val resolver: Resolver) {
         return field.parameter.name!!.asString() + "Reader"
     }
 
-    private fun assertTokenType(method: CodeBlock.Builder, expectedToken: String) {
-        method.controlFlow("if (__token != %T.%L)", JsonTypes.jsonToken, expectedToken) {
-            addStatement(
-                "throw %T(__parser, %P)",
-                JsonTypes.jsonParseException,
-                "Expecting $expectedToken token, got \$__token"
-            )
+    private fun assertTokenType(method: CodeBlock.Builder, expectedToken: String, expectedPhrase: String) {
+        method.controlFlow("if (_token != %T.%L)", JsonTypes.jsonToken, expectedToken) {
+            addStatement("throw _unexpectedToken(_parser, %S, %S)", "", expectedPhrase)
+        }
+    }
+
+    private fun markReceived(meta: JsonClassReaderMeta, index: Int): CodeBlock {
+        return if (meta.fields.size > maxFields) {
+            CodeBlock.of("_receivedFields.set(%L)\n", index)
+        } else {
+            CodeBlock.of("_receivedFields = _receivedFields or (1 shl %L)\n", index)
         }
     }
 
@@ -255,16 +265,17 @@ class JsonReaderGenerator(val resolver: Resolver) {
         functionBody.controlFlow("run") {
             for (i in meta.fields.indices) {
                 val field: JsonClassReaderMeta.FieldMeta = meta.fields[i]
-                addStatement("if (!__parser.nextName(%N)) return@run", jsonNameStaticName(field))
-                addStatement("%N = %N(__parser, __receivedFields)", field.parameter.name!!.asString(), readerMethodName(field))
+                addStatement("if (!_parser.nextName(%N)) return@run", jsonNameStaticName(field))
+                addStatement("%N = %N(_parser)", field.parameter.name!!.asString(), readerMethodName(field))
+                add(markReceived(meta, i))
                 functionBody.add("\n")
             }
 
-            functionBody.addStatement("__token = __parser.nextToken()")
-            functionBody.controlFlow("while (__token != %T.END_OBJECT)", JsonTypes.jsonToken) {
-                addStatement("__parser.nextToken()")
-                addStatement("__parser.skipChildren()")
-                addStatement("__token = __parser.nextToken()")
+            functionBody.addStatement("_token = _parser.nextToken()")
+            functionBody.controlFlow("while (_token != %T.END_OBJECT)", JsonTypes.jsonToken) {
+                addStatement("_parser.nextToken()")
+                addStatement("_parser.skipChildren()")
+                addStatement("_token = _parser.nextToken()")
             }
             generateReturnResult(meta, functionBody)
         }
@@ -299,90 +310,53 @@ class JsonReaderGenerator(val resolver: Resolver) {
     private fun readParamFunction(index: Int, size: Int, field: JsonClassReaderMeta.FieldMeta): FunSpec {
         val function = FunSpec.builder(readerMethodName(field))
             .addModifiers(KModifier.PRIVATE)
-            .addParameter("__parser", JsonTypes.jsonParser)
-            .addParameter("__receivedFields", if (size > maxFields) ClassName(BitSet::class.java.packageName, BitSet::class.simpleName!!) else INT_ARRAY)
+            .addParameter("_parser", JsonTypes.jsonParser)
             .returns(field.type)
 
         val functionBody = CodeBlock.builder()
         val isMarkedNullable = field.parameter.type.resolve().isMarkedNullable
 
         if (field.reader != null) {
-            functionBody.add("val __token = __parser.nextToken()\n")
-            if (field.typeMeta.isJsonNullable) {
-                functionBody.controlFlow("if (__token == %T.VALUE_NULL)", JsonTypes.jsonToken) {
-                    addStatement(
-                        "throw %T(\n__parser,\n%S\n)",
-                        JsonTypes.jsonParseException,
-                        "Expecting non nul value for field '${field.jsonName}', got VALUE_NULL token"
-                    )
-                }
-                if (size > maxFields) {
-                    functionBody.add("__receivedFields.set(%L)\n", index)
-                } else {
-                    functionBody.add("__receivedFields[0] = __receivedFields[0] or (1 shl %L)\n", index)
-                }
-            } else if (!isMarkedNullable) {
-                functionBody.controlFlow("if (__token == %T.VALUE_NULL)", JsonTypes.jsonToken) {
-                    addStatement(
-                        "throw %T(\n__parser,\n%S\n)",
-                        JsonTypes.jsonParseException,
-                        "Expecting non nul value for field '${field.jsonName}', got VALUE_NULL token"
-                    )
-                }
-                if (size > maxFields) {
-                    functionBody.add("__receivedFields.set(%L)\n", index)
-                } else {
-                    functionBody.add("__receivedFields[0] = __receivedFields[0] or (1 shl %L)\n", index)
+            functionBody.add("val _token = _parser.nextToken()\n")
+            if (field.typeMeta.isJsonNullable || !isMarkedNullable) {
+                functionBody.controlFlow("if (_token == %T.VALUE_NULL)", JsonTypes.jsonToken) {
+                    addStatement("throw _requiredFieldNull(_parser, %S)", ".${field.jsonName}")
                 }
             }
-            functionBody.add("return %L.read(__parser)\n", this.readerFieldName(field))
+            functionBody.add("return %L.read(_parser)\n", this.readerFieldName(field))
 
             return function.addCode(functionBody.build()).build()
         }
 
-        functionBody.addStatement("val __token = __parser.nextToken()\n")
+        functionBody.addStatement("val _token = _parser.nextToken()\n")
         if (field.typeMeta is ReaderFieldType.KnownTypeReaderMeta) {
-            if (size > maxFields) {
-                functionBody.add("__receivedFields.set(%L)\n", index)
-            } else {
-                functionBody.add("__receivedFields[0] = __receivedFields[0] or (1 shl %L)\n", index)
-            }
             functionBody.add(readKnownType(field.jsonName, field.typeMeta.knownType, isMarkedNullable, field.typeMeta.isJsonNullable))
 
             return function.addCode(functionBody.build()).build()
         }
 
         if (field.typeMeta.isJsonNullable) {
-            functionBody.controlFlow("if (__token == %T.VALUE_NULL)", JsonTypes.jsonToken) {
+            functionBody.controlFlow("if (_token == %T.VALUE_NULL)", JsonTypes.jsonToken) {
                 addStatement("return %T.nullValue()", JsonTypes.jsonNullable)
             }
         } else if (field.type.isNullable) {
-            functionBody.controlFlow("if (__token == %T.VALUE_NULL)", JsonTypes.jsonToken) {
+            functionBody.controlFlow("if (_token == %T.VALUE_NULL)", JsonTypes.jsonToken) {
                 addStatement("return null")
             }
         } else {
-            functionBody.controlFlow("if (__token == %T.VALUE_NULL)", JsonTypes.jsonToken) {
-                add("throw %T(", JsonTypes.jsonParseException)
-                addStatement("__parser,")
-                addStatement("%S", "Expecting non null value for field ${field.jsonName}, got VALUE_NULL token")
-                add(")")
-            }
-            if (size > maxFields) {
-                functionBody.addStatement("__receivedFields.set(%L)", index)
-            } else {
-                functionBody.addStatement("__receivedFields[0] = __receivedFields[0] or (1 shl %L)", index)
+            functionBody.controlFlow("if (_token == %T.VALUE_NULL)", JsonTypes.jsonToken) {
+                addStatement("throw _requiredFieldNull(_parser, %S)", ".${field.jsonName}")
             }
         }
 
         if (field.typeMeta.isJsonNullable) {
-            functionBody.addStatement("return %T.ofNullable(%L.read(__parser))", JsonTypes.jsonNullable, readerFieldName(field))
+            functionBody.addStatement("return %T.ofNullable(%L.read(_parser))", JsonTypes.jsonNullable, readerFieldName(field))
         } else {
             val exceptionBlock = if (isMarkedNullable) CodeBlock.of("") else CodeBlock.of(
-                " ?: throw %T(\n__parser, %S\n)",
-                JsonTypes.jsonParseException,
-                "Field ${field.jsonName} not marked as nullable but null was provided"
+                " ?: throw _requiredFieldNull(_parser, %S)",
+                ".${field.jsonName}"
             )
-            functionBody.addStatement("return %L.read(__parser)%L", readerFieldName(field), exceptionBlock)
+            functionBody.addStatement("return %L.read(_parser)%L", readerFieldName(field), exceptionBlock)
         }
         return function.addCode(functionBody.build()).build()
     }
@@ -390,23 +364,23 @@ class JsonReaderGenerator(val resolver: Resolver) {
     private fun readKnownType(jsonName: String, knownType: KnownTypesEnum, isNullable: Boolean, isJsonNullable: Boolean): CodeBlock {
         val method = CodeBlock.builder()
         when (knownType) {
-            KnownTypesEnum.STRING -> method.controlFlow("if (__token == %T.VALUE_STRING)", JsonTypes.jsonToken) {
+            KnownTypesEnum.STRING -> method.controlFlow("if (_token == %T.VALUE_STRING)", JsonTypes.jsonToken) {
                 if (isJsonNullable) {
-                    addStatement("return %T.ofNullable(__parser.text)", JsonTypes.jsonNullable)
+                    addStatement("return %T.ofNullable(_parser.text)", JsonTypes.jsonNullable)
                 } else {
-                    addStatement("return __parser.text")
+                    addStatement("return _parser.text")
                 }
             }
 
             KnownTypesEnum.BOOLEAN -> {
-                method.controlFlow("if (__token == %T.VALUE_TRUE)", JsonTypes.jsonToken) {
+                method.controlFlow("if (_token == %T.VALUE_TRUE)", JsonTypes.jsonToken) {
                     if (isJsonNullable) {
                         addStatement("return %T.of(true)", JsonTypes.jsonNullable)
                     } else {
                         addStatement("return true")
                     }
                 }
-                method.controlFlow("if (__token == %T.VALUE_FALSE)", JsonTypes.jsonToken) {
+                method.controlFlow("if (_token == %T.VALUE_FALSE)", JsonTypes.jsonToken) {
                     if (isJsonNullable) {
                         addStatement("return %T.of(false)", JsonTypes.jsonNullable)
                     } else {
@@ -415,115 +389,183 @@ class JsonReaderGenerator(val resolver: Resolver) {
                 }
             }
 
-            INTEGER -> method.controlFlow("if (__token == %T.VALUE_NUMBER_INT)", JsonTypes.jsonToken) {
+            INTEGER -> method.controlFlow("if (_token == %T.VALUE_NUMBER_INT)", JsonTypes.jsonToken) {
                 if (isJsonNullable) {
-                    addStatement("return %T.ofNullable(__parser.intValue)", JsonTypes.jsonNullable)
+                    addStatement("return %T.ofNullable(_parser.intValue)", JsonTypes.jsonNullable)
                 } else {
-                    addStatement("return __parser.intValue")
+                    addStatement("return _parser.intValue")
                 }
             }
 
-            BIG_INTEGER -> method.controlFlow("if (__token == %T.VALUE_NUMBER_INT)", JsonTypes.jsonToken) {
+            BIG_INTEGER -> method.controlFlow("if (_token == %T.VALUE_NUMBER_INT)", JsonTypes.jsonToken) {
                 if (isJsonNullable) {
-                    addStatement("return %T.ofNullable(__parser.bigIntegerValue)", JsonTypes.jsonNullable)
+                    addStatement("return %T.ofNullable(_parser.bigIntegerValue)", JsonTypes.jsonNullable)
                 } else {
-                    addStatement("return __parser.bigIntegerValue")
+                    addStatement("return _parser.bigIntegerValue")
                 }
             }
 
-            KnownTypesEnum.DOUBLE -> method.controlFlow("if (__token == %1T.VALUE_NUMBER_FLOAT || __token == %1T.VALUE_NUMBER_INT)", JsonTypes.jsonToken) {
+            KnownTypesEnum.DOUBLE -> method.controlFlow("if (_token == %1T.VALUE_NUMBER_FLOAT || _token == %1T.VALUE_NUMBER_INT)", JsonTypes.jsonToken) {
                 if (isJsonNullable) {
-                    addStatement("return %T.ofNullable(__parser.doubleValue)", JsonTypes.jsonNullable)
+                    addStatement("return %T.ofNullable(_parser.doubleValue)", JsonTypes.jsonNullable)
                 } else {
-                    addStatement("return __parser.doubleValue")
+                    addStatement("return _parser.doubleValue")
                 }
             }
 
-            KnownTypesEnum.FLOAT -> method.controlFlow("if (__token == %1T.VALUE_NUMBER_FLOAT || __token == %1T.VALUE_NUMBER_INT)", JsonTypes.jsonToken) {
+            KnownTypesEnum.FLOAT -> method.controlFlow("if (_token == %1T.VALUE_NUMBER_FLOAT || _token == %1T.VALUE_NUMBER_INT)", JsonTypes.jsonToken) {
                 if (isJsonNullable) {
-                    addStatement("return %T.ofNullable(__parser.floatValue)", JsonTypes.jsonNullable)
+                    addStatement("return %T.ofNullable(_parser.floatValue)", JsonTypes.jsonNullable)
                 } else {
-                    addStatement("return __parser.floatValue")
+                    addStatement("return _parser.floatValue")
                 }
             }
 
-            KnownTypesEnum.LONG -> method.controlFlow("if (__token == %T.VALUE_NUMBER_INT)", JsonTypes.jsonToken) {
+            KnownTypesEnum.LONG -> method.controlFlow("if (_token == %T.VALUE_NUMBER_INT)", JsonTypes.jsonToken) {
                 if (isJsonNullable) {
-                    addStatement("return %T.ofNullable(__parser.longValue)", JsonTypes.jsonNullable)
+                    addStatement("return %T.ofNullable(_parser.longValue)", JsonTypes.jsonNullable)
                 } else {
-                    addStatement("return __parser.longValue")
+                    addStatement("return _parser.longValue")
                 }
             }
 
-            KnownTypesEnum.SHORT -> method.controlFlow("if (__token == %T.VALUE_NUMBER_INT)", JsonTypes.jsonToken) {
+            KnownTypesEnum.SHORT -> method.controlFlow("if (_token == %T.VALUE_NUMBER_INT)", JsonTypes.jsonToken) {
                 if (isJsonNullable) {
-                    addStatement("return %T.ofNullable(__parser.shortValue)", JsonTypes.jsonNullable)
+                    addStatement("return %T.ofNullable(_parser.shortValue)", JsonTypes.jsonNullable)
                 } else {
-                    addStatement("return __parser.shortValue")
+                    addStatement("return _parser.shortValue")
                 }
             }
 
-            BINARY -> method.controlFlow("if (__token == %T.VALUE_STRING)", JsonTypes.jsonToken) {
+            BINARY -> method.controlFlow("if (_token == %T.VALUE_STRING)", JsonTypes.jsonToken) {
                 if (isJsonNullable) {
-                    addStatement("return %T.ofNullable(__parser.binaryValue)", JsonTypes.jsonNullable)
+                    addStatement("return %T.ofNullable(_parser.binaryValue)", JsonTypes.jsonNullable)
                 } else {
-                    addStatement("return __parser.binaryValue")
+                    addStatement("return _parser.binaryValue")
                 }
             }
 
-            KnownTypesEnum.UUID -> method.controlFlow("if (__token == %T.VALUE_STRING)", JsonTypes.jsonToken) {
+            KnownTypesEnum.UUID -> method.controlFlow("if (_token == %T.VALUE_STRING)", JsonTypes.jsonToken) {
                 if (isJsonNullable) {
-                    addStatement("return %T.ofNullable(%T.fromString(__parser.text))", JsonTypes.jsonNullable, java.util.UUID::class)
+                    addStatement("return %T.ofNullable(%T.fromString(_parser.text))", JsonTypes.jsonNullable, java.util.UUID::class)
                 } else {
-                    addStatement("return %T.fromString(__parser.text)", java.util.UUID::class)
+                    addStatement("return %T.fromString(_parser.text)", java.util.UUID::class)
                 }
             }
         }
 
         if (isJsonNullable) {
-            method.controlFlow("if (__token == %T.VALUE_NULL)", JsonTypes.jsonToken) {
+            method.controlFlow("if (_token == %T.VALUE_NULL)", JsonTypes.jsonToken) {
                 addStatement("return %T.nullValue()", JsonTypes.jsonNullable)
             }
         } else if (isNullable) {
-            method.controlFlow("if (__token == %T.VALUE_NULL)", JsonTypes.jsonToken) {
+            method.controlFlow("if (_token == %T.VALUE_NULL)", JsonTypes.jsonToken) {
                 addStatement("return null")
+            }
+        } else {
+            method.controlFlow("if (_token == %T.VALUE_NULL)", JsonTypes.jsonToken) {
+                addStatement("throw _requiredFieldNull(_parser, %S)", ".$jsonName")
             }
         }
 
-        val expectedTokenStr = expectedTokens(knownType, isNullable)
-            .contentToString()
-
         method.addStatement(
-            "throw %T(__parser, %S + __token)",
-            JsonTypes.jsonParseException,
-            "Expecting $expectedTokenStr token for field '$jsonName', got "
+            "throw _unexpectedToken(_parser, %S, %S)",
+            ".$jsonName",
+            expectedPhrase(knownType)
         )
         return method.build()
     }
 
-    private fun expectedTokens(knownType: KnownTypesEnum, nullable: Boolean): Array<String> {
-        var result = when (knownType) {
-            KnownTypesEnum.STRING, BINARY, KnownTypesEnum.UUID -> arrayOf(
-                "VALUE_STRING"
-            )
+    private fun expectedPhrase(knownType: KnownTypesEnum): String {
+        return when (knownType) {
+            KnownTypesEnum.STRING -> "a string"
+            BINARY -> "a base64-encoded string"
+            KnownTypesEnum.UUID -> "a UUID string"
+            KnownTypesEnum.BOOLEAN -> "a boolean"
+            KnownTypesEnum.SHORT, INTEGER, KnownTypesEnum.LONG, BIG_INTEGER -> "an integer number"
+            KnownTypesEnum.DOUBLE, KnownTypesEnum.FLOAT -> "a number"
+        }
+    }
 
-            KnownTypesEnum.BOOLEAN -> arrayOf(
-                "VALUE_TRUE",
-                "VALUE_FALSE"
-            )
+    /**
+     * Generates the private helper functions each reader uses to build detailed, consistent parse-error
+     * messages (type + member + JSON path + humanized expected/actual value). Kept inside the mapper
+     * itself, not extracted to a shared runtime class.
+     */
+    private fun addErrorMethods(typeBuilder: TypeSpec.Builder, meta: JsonClassReaderMeta) {
+        val typeName = meta.classDeclaration.simpleName.asString()
 
-            KnownTypesEnum.SHORT, INTEGER, KnownTypesEnum.LONG, BIG_INTEGER -> arrayOf(
-                "VALUE_NUMBER_INT"
-            )
+        typeBuilder.addFunction(
+            FunSpec.builder("_jsonPath")
+                .addModifiers(KModifier.PRIVATE)
+                .addParameter("_parser", JsonTypes.jsonParser)
+                .returns(String::class)
+                .addStatement("val _p = _parser.streamReadContext().pathAsPointer().toString()")
+                .addStatement("return if (_p.isEmpty()) %S else _p", "<root>")
+                .build()
+        )
 
-            KnownTypesEnum.DOUBLE, KnownTypesEnum.FLOAT -> arrayOf(
-                "VALUE_NUMBER_FLOAT", "VALUE_NUMBER_INT"
+        val actual = FunSpec.builder("_actualValue")
+            .addModifiers(KModifier.PRIVATE)
+            .addParameter("_parser", JsonTypes.jsonParser)
+            .returns(String::class)
+        actual.addStatement("val _t = _parser.currentToken() ?: return %S", "nothing (end of input)")
+        actual.addStatement("var _v = _parser.text")
+        actual.addStatement("if (_v != null && _v.length > 128) _v = _v.substring(0, 128) + %S", "...(truncated)")
+        actual.beginControlFlow("return when (_t)")
+        actual.addStatement("%T.VALUE_NULL -> %S", JsonTypes.jsonToken, "null")
+        actual.addStatement("%T.START_OBJECT -> %S", JsonTypes.jsonToken, "an object")
+        actual.addStatement("%T.START_ARRAY -> %S", JsonTypes.jsonToken, "an array")
+        actual.addStatement("%T.VALUE_STRING -> %S + _v + %S", JsonTypes.jsonToken, "a string \"", "\"")
+        actual.addStatement("%T.VALUE_NUMBER_INT -> %S + _v", JsonTypes.jsonToken, "a number ")
+        actual.addStatement("%T.VALUE_NUMBER_FLOAT -> %S + _v", JsonTypes.jsonToken, "a fractional number ")
+        actual.addStatement("%1T.VALUE_TRUE, %1T.VALUE_FALSE -> %2S + _v", JsonTypes.jsonToken, "a boolean ")
+        actual.addStatement("else -> %S + _t", "token ")
+        actual.endControlFlow()
+        typeBuilder.addFunction(actual.build())
+
+        typeBuilder.addFunction(
+            FunSpec.builder("_unexpectedToken")
+                .addModifiers(KModifier.PRIVATE)
+                .addParameter("_parser", JsonTypes.jsonParser)
+                .addParameter("_member", String::class)
+                .addParameter("_expected", String::class)
+                .returns(JsonTypes.jsonParseException)
+                .addStatement(
+                    "return %T(_parser, %S + _member + %S + _expected + %S + _actualValue(_parser) + %S + _jsonPath(_parser) + %S)",
+                    JsonTypes.jsonParseException, "Failed to read json $typeName", ": expected ", ", but got ", " (at ", ")"
+                )
+                .build()
+        )
+
+        typeBuilder.addFunction(
+            FunSpec.builder("_missingRequiredFields")
+                .addModifiers(KModifier.PRIVATE)
+                .addParameter("_parser", JsonTypes.jsonParser)
+                .addParameter("_fields", String::class)
+                .returns(JsonTypes.jsonParseException)
+                .addStatement(
+                    "return %T(_parser, %S + _fields + %S + _jsonPath(_parser) + %S)",
+                    JsonTypes.jsonParseException, "Failed to read json $typeName: missing required field(s): ", " (at ", ")"
+                )
+                .build()
+        )
+
+        val anyRequired = meta.fields.any { !(it.parameter.type.resolve().isMarkedNullable || it.typeMeta.isJsonNullable) }
+        if (anyRequired) {
+            typeBuilder.addFunction(
+                FunSpec.builder("_requiredFieldNull")
+                    .addModifiers(KModifier.PRIVATE)
+                    .addParameter("_parser", JsonTypes.jsonParser)
+                    .addParameter("_member", String::class)
+                    .returns(JsonTypes.jsonParseException)
+                    .addStatement(
+                        "return %T(_parser, %S + _member + %S + _jsonPath(_parser) + %S)",
+                        JsonTypes.jsonParseException, "Failed to read json $typeName", ": required field must not be null (at ", ")"
+                    )
+                    .build()
             )
         }
-        if (nullable) {
-            result = result.plus("VALUE_NULL")
-        }
-        return result
     }
 
     private fun readerMethodName(field: JsonClassReaderMeta.FieldMeta): String {

--- a/json/json-symbol-processor/src/main/kotlin/io/koraframework/json/ksp/reader/JsonReaderGenerator.kt
+++ b/json/json-symbol-processor/src/main/kotlin/io/koraframework/json/ksp/reader/JsonReaderGenerator.kt
@@ -47,8 +47,8 @@ class JsonReaderGenerator(val resolver: Resolver) {
         this.addReadMethods(typeBuilder, meta)
         this.addErrorMethods(typeBuilder, meta)
         val functionBody = CodeBlock.builder()
-        functionBody.addStatement("var _token = _parser.currentToken()")
-        functionBody.controlFlow("if (_token == %T.VALUE_NULL) ", JsonTypes.jsonToken) {
+        functionBody.addStatement("var __token = __parser.currentToken()")
+        functionBody.controlFlow("if (__token == %T.VALUE_NULL) ", JsonTypes.jsonToken) {
             if (JsonTypes.jsonNullable == declaration.toClassName()) {
                 addStatement("return %T.nullValue()", JsonTypes.jsonNullable)
             } else {
@@ -58,9 +58,9 @@ class JsonReaderGenerator(val resolver: Resolver) {
         assertTokenType(functionBody, "START_OBJECT", "an object '{...}'")
         functionBody.add("\n")
         if (meta.fields.size <= maxFields) {
-            functionBody.addStatement("var _receivedFields = NULLABLE_FIELDS_RECEIVED")
+            functionBody.addStatement("var __receivedFields = NULLABLE_FIELDS_RECEIVED")
         } else {
-            functionBody.addStatement("val _receivedFields = NULLABLE_FIELDS_RECEIVED.clone() as %T", BitSet::class.java)
+            functionBody.addStatement("val __receivedFields = NULLABLE_FIELDS_RECEIVED.clone() as %T", BitSet::class.java)
         }
         functionBody.add("\n")
 
@@ -69,30 +69,30 @@ class JsonReaderGenerator(val resolver: Resolver) {
         this.addFastPath(functionBody, meta)
 
         if (meta.fields.isEmpty()) {
-            functionBody.addStatement("_token = _parser.nextToken()")
+            functionBody.addStatement("__token = __parser.nextToken()")
         } else {
-            functionBody.addStatement("_token = _parser.currentToken()")
+            functionBody.addStatement("__token = __parser.currentToken()")
         }
-        functionBody.controlFlow("while (_token != %T.END_OBJECT) ", JsonTypes.jsonToken) {
+        functionBody.controlFlow("while (__token != %T.END_OBJECT) ", JsonTypes.jsonToken) {
             assertTokenType(functionBody, "PROPERTY_NAME", "a field name")
-            functionBody.addStatement("val _fieldName = _parser.currentName()")
-            functionBody.controlFlow("when (_fieldName)") {
+            functionBody.addStatement("val __fieldName = __parser.currentName()")
+            functionBody.controlFlow("when (__fieldName)") {
                 meta.fields.forEachIndexed { i, field ->
                     functionBody.controlFlow("%S ->", field.jsonName) {
-                        addStatement("%N = %N(_parser)", field.parameter.name!!.asString(), readerMethodName(field))
+                        addStatement("%N = %N(__parser)", field.parameter.name!!.asString(), readerMethodName(field))
                         add(markReceived(meta, i))
                     }
                 }
                 functionBody.controlFlow("else -> ") {
-                    addStatement("_parser.nextToken()")
-                    addStatement("_parser.skipChildren()")
+                    addStatement("__parser.nextToken()")
+                    addStatement("__parser.skipChildren()")
                 }
             }
-            functionBody.addStatement("_token = _parser.nextToken()")
+            functionBody.addStatement("__token = __parser.nextToken()")
         }
 
         val errorSwitch = CodeBlock.builder()
-            .controlFlow("when (_i)") {
+            .controlFlow("when (__i)") {
                 for (i in 0 until meta.fields.size) {
                     val field = meta.fields[i]
                     addStatement("%L -> %S", i, field.jsonName)
@@ -100,44 +100,44 @@ class JsonReaderGenerator(val resolver: Resolver) {
                 addStatement("else -> \"\"")
             }
         if (meta.fields.size > maxFields) {
-            functionBody.controlFlow("if (_receivedFields != ALL_FIELDS_RECEIVED)") {
-                addStatement(" _receivedFields.flip(0, %L)", meta.fields.size)
-                addStatement("val _missing = %T()", StringBuilder::class)
+            functionBody.controlFlow("if (__receivedFields != ALL_FIELDS_RECEIVED)") {
+                addStatement(" __receivedFields.flip(0, %L)", meta.fields.size)
+                addStatement("val __missing = %T()", StringBuilder::class)
 
-                addStatement("var _i = _receivedFields.nextSetBit(0)")
-                controlFlow("while (_i >= 0)") {
-                    addStatement("if (_missing.isNotEmpty()) _missing.append(\", \")")
-                    add("_missing.append(\n")
+                addStatement("var __i = __receivedFields.nextSetBit(0)")
+                controlFlow("while (__i >= 0)") {
+                    addStatement("if (__missing.isNotEmpty()) __missing.append(\", \")")
+                    add("__missing.append(\n")
                     indent()
                     add(errorSwitch.build())
                     unindent()
                     add(")\n")
-                    add("_i = _receivedFields.nextSetBit(_i + 1)\n")
+                    add("__i = __receivedFields.nextSetBit(__i + 1)\n")
                 }
-                addStatement("throw _missingRequiredFields(_parser, _missing.toString())")
+                addStatement("throw __missingRequiredFields(__parser, __missing.toString())")
             }
         } else {
-            functionBody.controlFlow("if (_receivedFields != ALL_FIELDS_RECEIVED)") {
-                addStatement("val _nonReceivedFields = _receivedFields.inv() and ALL_FIELDS_RECEIVED")
-                addStatement("val _missing = %T()", StringBuilder::class)
-                controlFlow("(0..%L).forEach { _i ->", meta.fields.size) {
-                    controlFlow("if ((_nonReceivedFields and (1 shl _i)) != 0)") {
-                        addStatement("if (_missing.isNotEmpty()) _missing.append(\", \")")
-                        add("_missing.append(\n")
+            functionBody.controlFlow("if (__receivedFields != ALL_FIELDS_RECEIVED)") {
+                addStatement("val _nonReceivedFields = __receivedFields.inv() and ALL_FIELDS_RECEIVED")
+                addStatement("val __missing = %T()", StringBuilder::class)
+                controlFlow("(0..%L).forEach { __i ->", meta.fields.size) {
+                    controlFlow("if ((_nonReceivedFields and (1 shl __i)) != 0)") {
+                        addStatement("if (__missing.isNotEmpty()) __missing.append(\", \")")
+                        add("__missing.append(\n")
                         indent()
                         add(errorSwitch.build())
                         unindent()
                         add(")\n")
                     }
                 }
-                addStatement("throw _missingRequiredFields(_parser, _missing.toString())")
+                addStatement("throw __missingRequiredFields(__parser, __missing.toString())")
             }
         }
         generateReturnResult(meta, functionBody)
 
         typeBuilder.addFunction(
             FunSpec.builder("read")
-                .addParameter("_parser", JsonTypes.jsonParser)
+                .addParameter("__parser", JsonTypes.jsonParser)
                 .returns(typeName.copy(nullable = true))
                 .addModifiers(KModifier.OVERRIDE)
                 .addCode(functionBody.build())
@@ -180,16 +180,16 @@ class JsonReaderGenerator(val resolver: Resolver) {
     }
 
     private fun assertTokenType(method: CodeBlock.Builder, expectedToken: String, expectedPhrase: String) {
-        method.controlFlow("if (_token != %T.%L)", JsonTypes.jsonToken, expectedToken) {
-            addStatement("throw _unexpectedToken(_parser, %S, %S)", "", expectedPhrase)
+        method.controlFlow("if (__token != %T.%L)", JsonTypes.jsonToken, expectedToken) {
+            addStatement("throw __unexpectedToken(__parser, %S, %S)", "", expectedPhrase)
         }
     }
 
     private fun markReceived(meta: JsonClassReaderMeta, index: Int): CodeBlock {
         return if (meta.fields.size > maxFields) {
-            CodeBlock.of("_receivedFields.set(%L)\n", index)
+            CodeBlock.of("__receivedFields.set(%L)\n", index)
         } else {
-            CodeBlock.of("_receivedFields = _receivedFields or (1 shl %L)\n", index)
+            CodeBlock.of("__receivedFields = __receivedFields or (1 shl %L)\n", index)
         }
     }
 
@@ -265,17 +265,17 @@ class JsonReaderGenerator(val resolver: Resolver) {
         functionBody.controlFlow("run") {
             for (i in meta.fields.indices) {
                 val field: JsonClassReaderMeta.FieldMeta = meta.fields[i]
-                addStatement("if (!_parser.nextName(%N)) return@run", jsonNameStaticName(field))
-                addStatement("%N = %N(_parser)", field.parameter.name!!.asString(), readerMethodName(field))
+                addStatement("if (!__parser.nextName(%N)) return@run", jsonNameStaticName(field))
+                addStatement("%N = %N(__parser)", field.parameter.name!!.asString(), readerMethodName(field))
                 add(markReceived(meta, i))
                 functionBody.add("\n")
             }
 
-            functionBody.addStatement("_token = _parser.nextToken()")
-            functionBody.controlFlow("while (_token != %T.END_OBJECT)", JsonTypes.jsonToken) {
-                addStatement("_parser.nextToken()")
-                addStatement("_parser.skipChildren()")
-                addStatement("_token = _parser.nextToken()")
+            functionBody.addStatement("__token = __parser.nextToken()")
+            functionBody.controlFlow("while (__token != %T.END_OBJECT)", JsonTypes.jsonToken) {
+                addStatement("__parser.nextToken()")
+                addStatement("__parser.skipChildren()")
+                addStatement("__token = __parser.nextToken()")
             }
             generateReturnResult(meta, functionBody)
         }
@@ -310,25 +310,25 @@ class JsonReaderGenerator(val resolver: Resolver) {
     private fun readParamFunction(index: Int, size: Int, field: JsonClassReaderMeta.FieldMeta): FunSpec {
         val function = FunSpec.builder(readerMethodName(field))
             .addModifiers(KModifier.PRIVATE)
-            .addParameter("_parser", JsonTypes.jsonParser)
+            .addParameter("__parser", JsonTypes.jsonParser)
             .returns(field.type)
 
         val functionBody = CodeBlock.builder()
         val isMarkedNullable = field.parameter.type.resolve().isMarkedNullable
 
         if (field.reader != null) {
-            functionBody.add("val _token = _parser.nextToken()\n")
+            functionBody.add("val __token = __parser.nextToken()\n")
             if (field.typeMeta.isJsonNullable || !isMarkedNullable) {
-                functionBody.controlFlow("if (_token == %T.VALUE_NULL)", JsonTypes.jsonToken) {
-                    addStatement("throw _requiredFieldNull(_parser, %S)", ".${field.jsonName}")
+                functionBody.controlFlow("if (__token == %T.VALUE_NULL)", JsonTypes.jsonToken) {
+                    addStatement("throw __requiredFieldNull(__parser, %S)", ".${field.jsonName}")
                 }
             }
-            functionBody.add("return %L.read(_parser)\n", this.readerFieldName(field))
+            functionBody.add("return %L.read(__parser)\n", this.readerFieldName(field))
 
             return function.addCode(functionBody.build()).build()
         }
 
-        functionBody.addStatement("val _token = _parser.nextToken()\n")
+        functionBody.addStatement("val __token = __parser.nextToken()\n")
         if (field.typeMeta is ReaderFieldType.KnownTypeReaderMeta) {
             functionBody.add(readKnownType(field.jsonName, field.typeMeta.knownType, isMarkedNullable, field.typeMeta.isJsonNullable))
 
@@ -336,27 +336,27 @@ class JsonReaderGenerator(val resolver: Resolver) {
         }
 
         if (field.typeMeta.isJsonNullable) {
-            functionBody.controlFlow("if (_token == %T.VALUE_NULL)", JsonTypes.jsonToken) {
+            functionBody.controlFlow("if (__token == %T.VALUE_NULL)", JsonTypes.jsonToken) {
                 addStatement("return %T.nullValue()", JsonTypes.jsonNullable)
             }
         } else if (field.type.isNullable) {
-            functionBody.controlFlow("if (_token == %T.VALUE_NULL)", JsonTypes.jsonToken) {
+            functionBody.controlFlow("if (__token == %T.VALUE_NULL)", JsonTypes.jsonToken) {
                 addStatement("return null")
             }
         } else {
-            functionBody.controlFlow("if (_token == %T.VALUE_NULL)", JsonTypes.jsonToken) {
-                addStatement("throw _requiredFieldNull(_parser, %S)", ".${field.jsonName}")
+            functionBody.controlFlow("if (__token == %T.VALUE_NULL)", JsonTypes.jsonToken) {
+                addStatement("throw __requiredFieldNull(__parser, %S)", ".${field.jsonName}")
             }
         }
 
         if (field.typeMeta.isJsonNullable) {
-            functionBody.addStatement("return %T.ofNullable(%L.read(_parser))", JsonTypes.jsonNullable, readerFieldName(field))
+            functionBody.addStatement("return %T.ofNullable(%L.read(__parser))", JsonTypes.jsonNullable, readerFieldName(field))
         } else {
             val exceptionBlock = if (isMarkedNullable) CodeBlock.of("") else CodeBlock.of(
-                " ?: throw _requiredFieldNull(_parser, %S)",
+                " ?: throw __requiredFieldNull(__parser, %S)",
                 ".${field.jsonName}"
             )
-            functionBody.addStatement("return %L.read(_parser)%L", readerFieldName(field), exceptionBlock)
+            functionBody.addStatement("return %L.read(__parser)%L", readerFieldName(field), exceptionBlock)
         }
         return function.addCode(functionBody.build()).build()
     }
@@ -364,23 +364,23 @@ class JsonReaderGenerator(val resolver: Resolver) {
     private fun readKnownType(jsonName: String, knownType: KnownTypesEnum, isNullable: Boolean, isJsonNullable: Boolean): CodeBlock {
         val method = CodeBlock.builder()
         when (knownType) {
-            KnownTypesEnum.STRING -> method.controlFlow("if (_token == %T.VALUE_STRING)", JsonTypes.jsonToken) {
+            KnownTypesEnum.STRING -> method.controlFlow("if (__token == %T.VALUE_STRING)", JsonTypes.jsonToken) {
                 if (isJsonNullable) {
-                    addStatement("return %T.ofNullable(_parser.text)", JsonTypes.jsonNullable)
+                    addStatement("return %T.ofNullable(__parser.text)", JsonTypes.jsonNullable)
                 } else {
-                    addStatement("return _parser.text")
+                    addStatement("return __parser.text")
                 }
             }
 
             KnownTypesEnum.BOOLEAN -> {
-                method.controlFlow("if (_token == %T.VALUE_TRUE)", JsonTypes.jsonToken) {
+                method.controlFlow("if (__token == %T.VALUE_TRUE)", JsonTypes.jsonToken) {
                     if (isJsonNullable) {
                         addStatement("return %T.of(true)", JsonTypes.jsonNullable)
                     } else {
                         addStatement("return true")
                     }
                 }
-                method.controlFlow("if (_token == %T.VALUE_FALSE)", JsonTypes.jsonToken) {
+                method.controlFlow("if (__token == %T.VALUE_FALSE)", JsonTypes.jsonToken) {
                     if (isJsonNullable) {
                         addStatement("return %T.of(false)", JsonTypes.jsonNullable)
                     } else {
@@ -389,87 +389,87 @@ class JsonReaderGenerator(val resolver: Resolver) {
                 }
             }
 
-            INTEGER -> method.controlFlow("if (_token == %T.VALUE_NUMBER_INT)", JsonTypes.jsonToken) {
+            INTEGER -> method.controlFlow("if (__token == %T.VALUE_NUMBER_INT)", JsonTypes.jsonToken) {
                 if (isJsonNullable) {
-                    addStatement("return %T.ofNullable(_parser.intValue)", JsonTypes.jsonNullable)
+                    addStatement("return %T.ofNullable(__parser.intValue)", JsonTypes.jsonNullable)
                 } else {
-                    addStatement("return _parser.intValue")
+                    addStatement("return __parser.intValue")
                 }
             }
 
-            BIG_INTEGER -> method.controlFlow("if (_token == %T.VALUE_NUMBER_INT)", JsonTypes.jsonToken) {
+            BIG_INTEGER -> method.controlFlow("if (__token == %T.VALUE_NUMBER_INT)", JsonTypes.jsonToken) {
                 if (isJsonNullable) {
-                    addStatement("return %T.ofNullable(_parser.bigIntegerValue)", JsonTypes.jsonNullable)
+                    addStatement("return %T.ofNullable(__parser.bigIntegerValue)", JsonTypes.jsonNullable)
                 } else {
-                    addStatement("return _parser.bigIntegerValue")
+                    addStatement("return __parser.bigIntegerValue")
                 }
             }
 
-            KnownTypesEnum.DOUBLE -> method.controlFlow("if (_token == %1T.VALUE_NUMBER_FLOAT || _token == %1T.VALUE_NUMBER_INT)", JsonTypes.jsonToken) {
+            KnownTypesEnum.DOUBLE -> method.controlFlow("if (__token == %1T.VALUE_NUMBER_FLOAT || __token == %1T.VALUE_NUMBER_INT)", JsonTypes.jsonToken) {
                 if (isJsonNullable) {
-                    addStatement("return %T.ofNullable(_parser.doubleValue)", JsonTypes.jsonNullable)
+                    addStatement("return %T.ofNullable(__parser.doubleValue)", JsonTypes.jsonNullable)
                 } else {
-                    addStatement("return _parser.doubleValue")
+                    addStatement("return __parser.doubleValue")
                 }
             }
 
-            KnownTypesEnum.FLOAT -> method.controlFlow("if (_token == %1T.VALUE_NUMBER_FLOAT || _token == %1T.VALUE_NUMBER_INT)", JsonTypes.jsonToken) {
+            KnownTypesEnum.FLOAT -> method.controlFlow("if (__token == %1T.VALUE_NUMBER_FLOAT || __token == %1T.VALUE_NUMBER_INT)", JsonTypes.jsonToken) {
                 if (isJsonNullable) {
-                    addStatement("return %T.ofNullable(_parser.floatValue)", JsonTypes.jsonNullable)
+                    addStatement("return %T.ofNullable(__parser.floatValue)", JsonTypes.jsonNullable)
                 } else {
-                    addStatement("return _parser.floatValue")
+                    addStatement("return __parser.floatValue")
                 }
             }
 
-            KnownTypesEnum.LONG -> method.controlFlow("if (_token == %T.VALUE_NUMBER_INT)", JsonTypes.jsonToken) {
+            KnownTypesEnum.LONG -> method.controlFlow("if (__token == %T.VALUE_NUMBER_INT)", JsonTypes.jsonToken) {
                 if (isJsonNullable) {
-                    addStatement("return %T.ofNullable(_parser.longValue)", JsonTypes.jsonNullable)
+                    addStatement("return %T.ofNullable(__parser.longValue)", JsonTypes.jsonNullable)
                 } else {
-                    addStatement("return _parser.longValue")
+                    addStatement("return __parser.longValue")
                 }
             }
 
-            KnownTypesEnum.SHORT -> method.controlFlow("if (_token == %T.VALUE_NUMBER_INT)", JsonTypes.jsonToken) {
+            KnownTypesEnum.SHORT -> method.controlFlow("if (__token == %T.VALUE_NUMBER_INT)", JsonTypes.jsonToken) {
                 if (isJsonNullable) {
-                    addStatement("return %T.ofNullable(_parser.shortValue)", JsonTypes.jsonNullable)
+                    addStatement("return %T.ofNullable(__parser.shortValue)", JsonTypes.jsonNullable)
                 } else {
-                    addStatement("return _parser.shortValue")
+                    addStatement("return __parser.shortValue")
                 }
             }
 
-            BINARY -> method.controlFlow("if (_token == %T.VALUE_STRING)", JsonTypes.jsonToken) {
+            BINARY -> method.controlFlow("if (__token == %T.VALUE_STRING)", JsonTypes.jsonToken) {
                 if (isJsonNullable) {
-                    addStatement("return %T.ofNullable(_parser.binaryValue)", JsonTypes.jsonNullable)
+                    addStatement("return %T.ofNullable(__parser.binaryValue)", JsonTypes.jsonNullable)
                 } else {
-                    addStatement("return _parser.binaryValue")
+                    addStatement("return __parser.binaryValue")
                 }
             }
 
-            KnownTypesEnum.UUID -> method.controlFlow("if (_token == %T.VALUE_STRING)", JsonTypes.jsonToken) {
+            KnownTypesEnum.UUID -> method.controlFlow("if (__token == %T.VALUE_STRING)", JsonTypes.jsonToken) {
                 if (isJsonNullable) {
-                    addStatement("return %T.ofNullable(%T.fromString(_parser.text))", JsonTypes.jsonNullable, java.util.UUID::class)
+                    addStatement("return %T.ofNullable(%T.fromString(__parser.text))", JsonTypes.jsonNullable, java.util.UUID::class)
                 } else {
-                    addStatement("return %T.fromString(_parser.text)", java.util.UUID::class)
+                    addStatement("return %T.fromString(__parser.text)", java.util.UUID::class)
                 }
             }
         }
 
         if (isJsonNullable) {
-            method.controlFlow("if (_token == %T.VALUE_NULL)", JsonTypes.jsonToken) {
+            method.controlFlow("if (__token == %T.VALUE_NULL)", JsonTypes.jsonToken) {
                 addStatement("return %T.nullValue()", JsonTypes.jsonNullable)
             }
         } else if (isNullable) {
-            method.controlFlow("if (_token == %T.VALUE_NULL)", JsonTypes.jsonToken) {
+            method.controlFlow("if (__token == %T.VALUE_NULL)", JsonTypes.jsonToken) {
                 addStatement("return null")
             }
         } else {
-            method.controlFlow("if (_token == %T.VALUE_NULL)", JsonTypes.jsonToken) {
-                addStatement("throw _requiredFieldNull(_parser, %S)", ".$jsonName")
+            method.controlFlow("if (__token == %T.VALUE_NULL)", JsonTypes.jsonToken) {
+                addStatement("throw __requiredFieldNull(__parser, %S)", ".$jsonName")
             }
         }
 
         method.addStatement(
-            "throw _unexpectedToken(_parser, %S, %S)",
+            "throw __unexpectedToken(__parser, %S, %S)",
             ".$jsonName",
             expectedPhrase(knownType)
         )
@@ -496,56 +496,56 @@ class JsonReaderGenerator(val resolver: Resolver) {
         val typeName = meta.classDeclaration.simpleName.asString()
 
         typeBuilder.addFunction(
-            FunSpec.builder("_jsonPath")
+            FunSpec.builder("__jsonPath")
                 .addModifiers(KModifier.PRIVATE)
-                .addParameter("_parser", JsonTypes.jsonParser)
+                .addParameter("__parser", JsonTypes.jsonParser)
                 .returns(String::class)
-                .addStatement("val _p = _parser.streamReadContext().pathAsPointer().toString()")
-                .addStatement("return if (_p.isEmpty()) %S else _p", "<root>")
+                .addStatement("val __p = __parser.streamReadContext().pathAsPointer().toString()")
+                .addStatement("return if (__p.isEmpty()) %S else __p", "<root>")
                 .build()
         )
 
-        val actual = FunSpec.builder("_actualValue")
+        val actual = FunSpec.builder("__actualValue")
             .addModifiers(KModifier.PRIVATE)
-            .addParameter("_parser", JsonTypes.jsonParser)
+            .addParameter("__parser", JsonTypes.jsonParser)
             .returns(String::class)
-        actual.addStatement("val _t = _parser.currentToken() ?: return %S", "nothing (end of input)")
-        actual.addStatement("var _v = _parser.text")
-        actual.addStatement("if (_v != null && _v.length > 128) _v = _v.substring(0, 128) + %S", "...(truncated)")
-        actual.beginControlFlow("return when (_t)")
+        actual.addStatement("val __t = __parser.currentToken() ?: return %S", "nothing (end of input)")
+        actual.addStatement("var __v = __parser.text")
+        actual.addStatement("if (__v != null && __v.length > 128) __v = __v.substring(0, 128) + %S", "...(truncated)")
+        actual.beginControlFlow("return when (__t)")
         actual.addStatement("%T.VALUE_NULL -> %S", JsonTypes.jsonToken, "null")
         actual.addStatement("%T.START_OBJECT -> %S", JsonTypes.jsonToken, "an object")
         actual.addStatement("%T.START_ARRAY -> %S", JsonTypes.jsonToken, "an array")
-        actual.addStatement("%T.VALUE_STRING -> %S + _v + %S", JsonTypes.jsonToken, "a string \"", "\"")
-        actual.addStatement("%T.VALUE_NUMBER_INT -> %S + _v", JsonTypes.jsonToken, "a number ")
-        actual.addStatement("%T.VALUE_NUMBER_FLOAT -> %S + _v", JsonTypes.jsonToken, "a fractional number ")
-        actual.addStatement("%1T.VALUE_TRUE, %1T.VALUE_FALSE -> %2S + _v", JsonTypes.jsonToken, "a boolean ")
-        actual.addStatement("else -> %S + _t", "token ")
+        actual.addStatement("%T.VALUE_STRING -> %S + __v + %S", JsonTypes.jsonToken, "a string \"", "\"")
+        actual.addStatement("%T.VALUE_NUMBER_INT -> %S + __v", JsonTypes.jsonToken, "a number ")
+        actual.addStatement("%T.VALUE_NUMBER_FLOAT -> %S + __v", JsonTypes.jsonToken, "a fractional number ")
+        actual.addStatement("%1T.VALUE_TRUE, %1T.VALUE_FALSE -> %2S + __v", JsonTypes.jsonToken, "a boolean ")
+        actual.addStatement("else -> %S + __t", "token ")
         actual.endControlFlow()
         typeBuilder.addFunction(actual.build())
 
         typeBuilder.addFunction(
-            FunSpec.builder("_unexpectedToken")
+            FunSpec.builder("__unexpectedToken")
                 .addModifiers(KModifier.PRIVATE)
-                .addParameter("_parser", JsonTypes.jsonParser)
-                .addParameter("_member", String::class)
-                .addParameter("_expected", String::class)
+                .addParameter("__parser", JsonTypes.jsonParser)
+                .addParameter("__member", String::class)
+                .addParameter("__expected", String::class)
                 .returns(JsonTypes.jsonParseException)
                 .addStatement(
-                    "return %T(_parser, %S + _member + %S + _expected + %S + _actualValue(_parser) + %S + _jsonPath(_parser) + %S)",
+                    "return %T(__parser, %S + __member + %S + __expected + %S + __actualValue(__parser) + %S + __jsonPath(__parser) + %S)",
                     JsonTypes.jsonParseException, "Failed to read json $typeName", ": expected ", ", but got ", " (at ", ")"
                 )
                 .build()
         )
 
         typeBuilder.addFunction(
-            FunSpec.builder("_missingRequiredFields")
+            FunSpec.builder("__missingRequiredFields")
                 .addModifiers(KModifier.PRIVATE)
-                .addParameter("_parser", JsonTypes.jsonParser)
-                .addParameter("_fields", String::class)
+                .addParameter("__parser", JsonTypes.jsonParser)
+                .addParameter("__fields", String::class)
                 .returns(JsonTypes.jsonParseException)
                 .addStatement(
-                    "return %T(_parser, %S + _fields + %S + _jsonPath(_parser) + %S)",
+                    "return %T(__parser, %S + __fields + %S + __jsonPath(__parser) + %S)",
                     JsonTypes.jsonParseException, "Failed to read json $typeName: missing required field(s): ", " (at ", ")"
                 )
                 .build()
@@ -554,13 +554,13 @@ class JsonReaderGenerator(val resolver: Resolver) {
         val anyRequired = meta.fields.any { !(it.parameter.type.resolve().isMarkedNullable || it.typeMeta.isJsonNullable) }
         if (anyRequired) {
             typeBuilder.addFunction(
-                FunSpec.builder("_requiredFieldNull")
+                FunSpec.builder("__requiredFieldNull")
                     .addModifiers(KModifier.PRIVATE)
-                    .addParameter("_parser", JsonTypes.jsonParser)
-                    .addParameter("_member", String::class)
+                    .addParameter("__parser", JsonTypes.jsonParser)
+                    .addParameter("__member", String::class)
                     .returns(JsonTypes.jsonParseException)
                     .addStatement(
-                        "return %T(_parser, %S + _member + %S + _jsonPath(_parser) + %S)",
+                        "return %T(__parser, %S + __member + %S + __jsonPath(__parser) + %S)",
                         JsonTypes.jsonParseException, "Failed to read json $typeName", ": required field must not be null (at ", ")"
                     )
                     .build()

--- a/json/json-symbol-processor/src/main/kotlin/io/koraframework/json/ksp/reader/SealedInterfaceReaderGenerator.kt
+++ b/json/json-symbol-processor/src/main/kotlin/io/koraframework/json/ksp/reader/SealedInterfaceReaderGenerator.kt
@@ -58,21 +58,27 @@ class SealedInterfaceReaderGenerator {
         val discriminatorField = discriminator.field
         val function = FunSpec.builder("read")
             .addModifiers(KModifier.PUBLIC, KModifier.OVERRIDE)
-            .addParameter("__parser", JsonTypes.jsonParser)
+            .addParameter("_parser", JsonTypes.jsonParser)
             .returns(typeName.copy(nullable = true))
-        function.controlFlow("if (__parser.currentToken() == %T.VALUE_NULL)", JsonTypes.jsonToken) {
+        function.controlFlow("if (_parser.currentToken() == %T.VALUE_NULL)", JsonTypes.jsonToken) {
             addStatement("return null")
         }
-        function.addCode("val bufferingParser = %T(__parser)\n", JsonTypes.bufferingJsonParser)
+        function.addCode("val bufferingParser = %T(_parser)\n", JsonTypes.bufferingJsonParser)
 
+        val typeSimpleName = jsonClassDeclaration.simpleName.asString()
+        val allValues = subclasses.flatMap { elem -> elem.discriminatorValues() }.toList()
         if (discriminator.defaultValue.isNullOrEmpty()) {
-            val allValues = subclasses.flatMap { elem -> elem.discriminatorValues() }.toList()
             function.addCode("val discriminator = %T.readStringDiscriminator(bufferingParser, %S)\n", JsonTypes.discriminatorHelper, discriminatorField);
-            function.addCode("if (discriminator == null) throw %T(__parser, %S)\n", JsonTypes.jsonParseException, "Discriminator required, but not provided, expected one of: $allValues")
+            function.addCode(
+                "if (discriminator == null) throw %T(_parser, %S + _jsonPath(_parser) + %S)\n",
+                JsonTypes.jsonParseException,
+                "Failed to read json $typeSimpleName: missing required discriminator field \"$discriminatorField\", expected one of $allValues (at ",
+                ")"
+            )
         } else {
             function.addCode("val discriminator = %T.readStringDiscriminator(bufferingParser, %S) ?: %S\n", JsonTypes.discriminatorHelper, discriminatorField, discriminator.defaultValue);
         }
-        function.addCode("val bufferedParser = %T.createFlattened(false, bufferingParser.reset(), __parser)\n", JsonTypes.jsonParserSequence)
+        function.addCode("val bufferedParser = %T.createFlattened(false, bufferingParser.reset(), _parser)\n", JsonTypes.jsonParserSequence)
         function.addCode("bufferedParser.nextToken()\n")
         function.beginControlFlow("return when(discriminator) {")
         subclasses.forEach { elem ->
@@ -86,9 +92,25 @@ class SealedInterfaceReaderGenerator {
                 )
             }
         }
-        function.addCode("else -> throw %T(__parser, %S)", JsonTypes.jsonParseException, "Unknown discriminator")
+        function.addCode(
+            "else -> throw %T(_parser, %S + discriminator + %S + _jsonPath(_parser) + %S)",
+            JsonTypes.jsonParseException,
+            "Failed to read json $typeSimpleName: unknown discriminator value \"",
+            "\" for field \"$discriminatorField\", expected one of $allValues (at ",
+            ")"
+        )
         function.endControlFlow()
         typeBuilder.addFunction(function.build())
+
+        typeBuilder.addFunction(
+            FunSpec.builder("_jsonPath")
+                .addModifiers(KModifier.PRIVATE)
+                .addParameter("_parser", JsonTypes.jsonParser)
+                .returns(String::class)
+                .addStatement("val _p = _parser.streamReadContext().pathAsPointer().toString()")
+                .addStatement("return if (_p.isEmpty()) %S else _p", "<root>")
+                .build()
+        )
         return typeBuilder.build()
     }
 

--- a/json/json-symbol-processor/src/main/kotlin/io/koraframework/json/ksp/reader/SealedInterfaceReaderGenerator.kt
+++ b/json/json-symbol-processor/src/main/kotlin/io/koraframework/json/ksp/reader/SealedInterfaceReaderGenerator.kt
@@ -58,19 +58,19 @@ class SealedInterfaceReaderGenerator {
         val discriminatorField = discriminator.field
         val function = FunSpec.builder("read")
             .addModifiers(KModifier.PUBLIC, KModifier.OVERRIDE)
-            .addParameter("_parser", JsonTypes.jsonParser)
+            .addParameter("__parser", JsonTypes.jsonParser)
             .returns(typeName.copy(nullable = true))
-        function.controlFlow("if (_parser.currentToken() == %T.VALUE_NULL)", JsonTypes.jsonToken) {
+        function.controlFlow("if (__parser.currentToken() == %T.VALUE_NULL)", JsonTypes.jsonToken) {
             addStatement("return null")
         }
-        function.addCode("val bufferingParser = %T(_parser)\n", JsonTypes.bufferingJsonParser)
+        function.addCode("val bufferingParser = %T(__parser)\n", JsonTypes.bufferingJsonParser)
 
         val typeSimpleName = jsonClassDeclaration.simpleName.asString()
         val allValues = subclasses.flatMap { elem -> elem.discriminatorValues() }.toList()
         if (discriminator.defaultValue.isNullOrEmpty()) {
             function.addCode("val discriminator = %T.readStringDiscriminator(bufferingParser, %S)\n", JsonTypes.discriminatorHelper, discriminatorField);
             function.addCode(
-                "if (discriminator == null) throw %T(_parser, %S + _jsonPath(_parser) + %S)\n",
+                "if (discriminator == null) throw %T(__parser, %S + __jsonPath(__parser) + %S)\n",
                 JsonTypes.jsonParseException,
                 "Failed to read json $typeSimpleName: missing required discriminator field \"$discriminatorField\", expected one of $allValues (at ",
                 ")"
@@ -78,7 +78,7 @@ class SealedInterfaceReaderGenerator {
         } else {
             function.addCode("val discriminator = %T.readStringDiscriminator(bufferingParser, %S) ?: %S\n", JsonTypes.discriminatorHelper, discriminatorField, discriminator.defaultValue);
         }
-        function.addCode("val bufferedParser = %T.createFlattened(false, bufferingParser.reset(), _parser)\n", JsonTypes.jsonParserSequence)
+        function.addCode("val bufferedParser = %T.createFlattened(false, bufferingParser.reset(), __parser)\n", JsonTypes.jsonParserSequence)
         function.addCode("bufferedParser.nextToken()\n")
         function.beginControlFlow("return when(discriminator) {")
         subclasses.forEach { elem ->
@@ -93,7 +93,7 @@ class SealedInterfaceReaderGenerator {
             }
         }
         function.addCode(
-            "else -> throw %T(_parser, %S + discriminator + %S + _jsonPath(_parser) + %S)",
+            "else -> throw %T(__parser, %S + discriminator + %S + __jsonPath(__parser) + %S)",
             JsonTypes.jsonParseException,
             "Failed to read json $typeSimpleName: unknown discriminator value \"",
             "\" for field \"$discriminatorField\", expected one of $allValues (at ",
@@ -103,12 +103,12 @@ class SealedInterfaceReaderGenerator {
         typeBuilder.addFunction(function.build())
 
         typeBuilder.addFunction(
-            FunSpec.builder("_jsonPath")
+            FunSpec.builder("__jsonPath")
                 .addModifiers(KModifier.PRIVATE)
-                .addParameter("_parser", JsonTypes.jsonParser)
+                .addParameter("__parser", JsonTypes.jsonParser)
                 .returns(String::class)
-                .addStatement("val _p = _parser.streamReadContext().pathAsPointer().toString()")
-                .addStatement("return if (_p.isEmpty()) %S else _p", "<root>")
+                .addStatement("val __p = __parser.streamReadContext().pathAsPointer().toString()")
+                .addStatement("return if (__p.isEmpty()) %S else __p", "<root>")
                 .build()
         )
         return typeBuilder.build()

--- a/json/json-symbol-processor/src/test/kotlin/io/koraframework/json/ksp/JsonAnnotationProcessorTest.kt
+++ b/json/json-symbol-processor/src/test/kotlin/io/koraframework/json/ksp/JsonAnnotationProcessorTest.kt
@@ -240,7 +240,7 @@ internal class JsonAnnotationProcessorTest {
             )
         }
 
-        assertThat(ex.message).startsWith("Some of required json fields were not received: field2(renamedField2) field3(field3)")
+        assertThat(ex.message).startsWith("Failed to read json DtoOnlyReader: missing required field(s): renamedField2, field3")
     }
 
     @Test
@@ -344,7 +344,7 @@ internal class JsonAnnotationProcessorTest {
             )
         }
             .isInstanceOf(StreamReadException::class.java)
-            .hasMessageStartingWith("Some of required json fields were not received: field1(field_1)")
+            .hasMessageStartingWith("Failed to read json DtoWithNullableFields: missing required field(s): field_1")
         Assertions.assertThatThrownBy {
             fromJson(
                 reader, """
@@ -356,7 +356,7 @@ internal class JsonAnnotationProcessorTest {
             )
         }
             .isInstanceOf(StreamReadException::class.java)
-            .hasMessageStartingWith("Expecting [VALUE_NUMBER_INT] token for field 'field4', got VALUE_NULL")
+            .hasMessageStartingWith("Failed to read json DtoWithNullableFields.field4: required field must not be null")
     }
 
     @Test
@@ -389,7 +389,7 @@ internal class JsonAnnotationProcessorTest {
             )
         }
             .isInstanceOf(StreamReadException::class.java)
-            .hasMessageStartingWith("Expecting [VALUE_STRING] token for field 'field1', got VALUE_NULL")
+            .hasMessageStartingWith("Failed to read json KotlinDataClassDtoWithNonPrimaryConstructor.field1: required field must not be null")
     }
 
     @Test


### PR DESCRIPTION
Improved(json): rework generated and runtime JSON reader parse-error messages into a detailed, consistent format, and drop per-read allocation.

- Improved(json): every message carries the JSON path via the parser stream-read context, distinguishing cases such as /inner/field1 from /field2/0/field1 that previously produced identical text.
- Improved(json): a missing required field, a required field explicitly set to null, and a wrong-type value now produce separate, purpose-specific messages; expected/actual are humanized (a string, an integer number, an object) and long values are truncated.
- Improved(json): sealed-hierarchy discriminator errors now name the discriminator field, list the allowed values, and report the offending value for both missing and unknown discriminators.
- Improved(json): runtime readers (Enum, List, Set, SortedSet, Map, DiscriminatorHelper, and the built-in JsonModule scalar and java.time codecs) were aligned to the same message format.
- Improved(json): removed the per-read int[] received-field allocation for readers with up to 32 fields by tracking received bits in a primitive int and marking them at the call sites.
- Fixed(json): unified the Java and KSP wording, resolving the previous nonnull / non nul / non null inconsistency.