### PR TITLE
Fixed(http-client): wrap response body decoding failures

### DIFF
--- a/http/http-client-annotation-processor/src/main/java/io/koraframework/http/client/annotation/processor/ClientClassGenerator.java
+++ b/http/http-client-annotation-processor/src/main/java/io/koraframework/http/client/annotation/processor/ClientClassGenerator.java
@@ -460,13 +460,18 @@ public class ClientClassGenerator {
         var b = CodeBlock.builder();
         if (methodData.responseMapper != null && methodData.responseMapper.mapperClass() != null && methodData.codeMappers().isEmpty()) {
             var responseMapperName = methodData.element.getSimpleName() + "ResponseMapper";
-            if (resultType.getKind() != TypeKind.VOID) {
-                b.add("return ");
-            }
             var ref = findMapperField(builder, responseMapperName).modifiers().contains(Modifier.STATIC)
                 ? CodeBlock.of("$T", implClassName(methodData.element))
                 : CodeBlock.of("this");
-            b.addStatement("$L.$N.apply(_response)", ref, responseMapperName);
+            b.beginControlFlow("try");
+            if (resultType.getKind() != TypeKind.VOID) {
+                b.addStatement("return $L.$N.apply(_response)", ref, responseMapperName);
+            } else {
+                b.addStatement("$L.$N.apply(_response)", ref, responseMapperName);
+            }
+            b.nextControlFlow("catch ($T _e)", Exception.class);
+            b.addStatement("throw new $T(_e)", httpClientDecoderException);
+            b.endControlFlow();
         } else if (methodData.codeMappers().isEmpty()) {
             b.addStatement("var _code = _response.code()");
             if (!isEitherResponse(resultType)) {
@@ -481,7 +486,11 @@ public class ClientClassGenerator {
                 var ref = findMapperField(builder, responseMapperName).modifiers().contains(Modifier.STATIC)
                     ? CodeBlock.of("$T", implClassName(methodData.element))
                     : CodeBlock.of("this");
+                b.beginControlFlow("try");
                 b.addStatement("return $L.$N.apply(_response)", ref, responseMapperName);
+                b.nextControlFlow("catch ($T _e)", Exception.class);
+                b.addStatement("throw new $T(_e)", httpClientDecoderException);
+                b.endControlFlow();
             }
             if (!isEitherResponse(resultType)) {
                 b.nextControlFlow("else");
@@ -493,6 +502,7 @@ public class ClientClassGenerator {
             if (resultType.getKind() != TypeKind.VOID) {
                 b.add("return ");
             }
+            var isVoid = resultType.getKind() == TypeKind.VOID;
             b.add("switch (_code) {\n");
             ResponseCodeMapperData defaultMapper = null;
             for (var codeMapper : methodData.codeMappers()) {
@@ -504,7 +514,7 @@ public class ClientClassGenerator {
                         ? CodeBlock.of("$T", implClassName(methodData.element))
                         : CodeBlock.of("this");
                     if (isMapperAssignable(methodData.element.getReturnType(), codeMapper.type, codeMapper.mapper)) {
-                        b.add("  case $L -> $L.$L.apply(_response);\n", codeMapper.code(), ref, responseMapperName);
+                        addResponseMapperCase(b, "case " + codeMapper.code(), CodeBlock.of("$L.$L.apply(_response)", ref, responseMapperName), isVoid);
                     } else {
                         b.add("  case $L -> throw $L.$L.apply(_response);\n", codeMapper.code(), ref, responseMapperName);
                     }
@@ -520,7 +530,7 @@ public class ClientClassGenerator {
                     ? CodeBlock.of("$T", implClassName(methodData.element))
                     : CodeBlock.of("this");
                 if (isMapperAssignable(methodData.element.getReturnType(), defaultMapper.type, defaultMapper.mapper)) {
-                    b.add("  default -> $L.$L.apply(_response);\n", ref, responseMapperName);
+                    addResponseMapperCase(b, "default", CodeBlock.of("$L.$L.apply(_response)", ref, responseMapperName), isVoid);
                 } else {
                     b.add("  default -> throw $L.$L.apply(_response);\n", ref, responseMapperName);
                 }
@@ -528,6 +538,20 @@ public class ClientClassGenerator {
             b.add("};\n");
         }
         return b.build();
+    }
+
+    private void addResponseMapperCase(CodeBlock.Builder b, String label, CodeBlock applyExpr, boolean isVoid) {
+        b.add("  $L -> {\n", label);
+        b.add("    try {\n");
+        if (isVoid) {
+            b.add("      $L;\n", applyExpr);
+        } else {
+            b.add("      yield $L;\n", applyExpr);
+        }
+        b.add("    } catch ($T _e) {\n", Exception.class);
+        b.add("      throw new $T(_e);\n", httpClientDecoderException);
+        b.add("    }\n");
+        b.add("  }\n");
     }
 
     private MethodSpec buildConstructor(TypeSpec.Builder tb, TypeElement element, List<MethodData> methods) {

--- a/http/http-client-annotation-processor/src/main/java/io/koraframework/http/client/annotation/processor/HttpClientClassNames.java
+++ b/http/http-client-annotation-processor/src/main/java/io/koraframework/http/client/annotation/processor/HttpClientClassNames.java
@@ -22,6 +22,7 @@ public class HttpClientClassNames {
 
     public static final ClassName httpClientException = ClassName.get("io.koraframework.http.client.common.exception", "HttpClientException");
     public static final ClassName httpClientEncoderException = ClassName.get("io.koraframework.http.client.common.exception", "HttpClientEncoderException");
+    public static final ClassName httpClientDecoderException = ClassName.get("io.koraframework.http.client.common.exception", "HttpClientDecoderException");
     public static final ClassName httpClientResponseException = ClassName.get("io.koraframework.http.client.common.exception", "HttpClientResponseException");
     public static final ClassName httpClientUnknownException = ClassName.get("io.koraframework.http.client.common.exception", "HttpClientUnknownException");
 

--- a/http/http-client-annotation-processor/src/test/java/io/koraframework/http/client/annotation/processor/BlockingApiTest.java
+++ b/http/http-client-annotation-processor/src/test/java/io/koraframework/http/client/annotation/processor/BlockingApiTest.java
@@ -3,6 +3,7 @@ package io.koraframework.http.client.annotation.processor;
 import io.koraframework.common.annotation.Component;
 import io.koraframework.common.annotation.Tag;
 import io.koraframework.common.Either;
+import io.koraframework.http.client.common.exception.HttpClientDecoderException;
 import io.koraframework.http.client.common.exception.HttpClientEncoderException;
 import io.koraframework.http.client.common.exception.HttpClientException;
 import io.koraframework.http.client.common.exception.HttpClientResponseException;
@@ -469,6 +470,50 @@ public class BlockingApiTest extends AbstractHttpClientTest {
         onRequest("POST", "http://test-url:8080/test", rs -> rs.withCode(200));
         assertThatThrownBy(() -> client.invoke("request", "test-value")).isInstanceOf(HttpClientEncoderException.class);
         verify(mockMapper).apply(eq("test-value"));
+    }
+
+    @Test
+    public void testBlockingResponseBodyDecoderException() throws Exception {
+        var mockMapper = Mockito.mock(HttpClientResponseMapper.class);
+        var client = compileClient(List.of(mockMapper), """
+            @HttpClient
+            public interface TestClient {
+              @HttpRoute(method = "GET", path = "/test")
+              String request();
+            }
+            """);
+
+        when(mockMapper.apply(any())).thenReturn("test-value");
+        onRequest("GET", "http://test-url:8080/test", rs -> rs.withCode(200));
+        assertThat(client.<String>invoke("request")).isEqualTo("test-value");
+
+        reset(httpClient, mockMapper);
+        when(mockMapper.apply(any())).thenThrow(RuntimeException.class);
+        onRequest("GET", "http://test-url:8080/test", rs -> rs.withCode(200));
+        assertThatThrownBy(() -> client.invoke("request")).isInstanceOf(HttpClientDecoderException.class);
+
+        reset(httpClient, mockMapper);
+        when(mockMapper.apply(any())).thenThrow(IOException.class);
+        onRequest("GET", "http://test-url:8080/test", rs -> rs.withCode(200));
+        assertThatThrownBy(() -> client.invoke("request")).isInstanceOf(HttpClientDecoderException.class);
+    }
+
+    @Test
+    public void testBlockingCodeMapperDecoderException() throws Exception {
+        var mockMapper = Mockito.mock(HttpClientResponseMapper.class);
+        var client = compileClient(List.of(mockMapper), """
+            @HttpClient
+            public interface TestClient {
+              @ResponseCodeMapper(code = 201)
+              @HttpRoute(method = "GET", path = "/test")
+              String request();
+            }
+            """);
+
+        reset(httpClient, mockMapper);
+        when(mockMapper.apply(any())).thenThrow(RuntimeException.class);
+        onRequest("GET", "http://test-url:8080/test", rs -> rs.withCode(201));
+        assertThatThrownBy(() -> client.invoke("request")).isInstanceOf(HttpClientDecoderException.class);
     }
 
     @Test

--- a/http/http-client-symbol-processor/src/main/kotlin/io/koraframework/http/client/symbol/processor/ClientClassGenerator.kt
+++ b/http/http-client-symbol-processor/src/main/kotlin/io/koraframework/http/client/symbol/processor/ClientClassGenerator.kt
@@ -13,6 +13,7 @@ import com.squareup.kotlinpoet.ksp.toTypeParameterResolver
 import io.koraframework.http.client.symbol.processor.HttpClientClassNames.httpBody
 import io.koraframework.http.client.symbol.processor.HttpClientClassNames.httpClient
 import io.koraframework.http.client.symbol.processor.HttpClientClassNames.httpClientAnnotation
+import io.koraframework.http.client.symbol.processor.HttpClientClassNames.httpClientDecoderException
 import io.koraframework.http.client.symbol.processor.HttpClientClassNames.httpClientEncoderException
 import io.koraframework.http.client.symbol.processor.HttpClientClassNames.httpClientEncoderUtils
 import io.koraframework.http.client.symbol.processor.HttpClientClassNames.httpClientException
@@ -554,11 +555,8 @@ class ClientClassGenerator(private val resolver: Resolver) {
         val isNullableResult = method.returnType?.resolveToUnderlying()?.isMarkedNullable == true
         if (methodData.responseMapper?.mapper != null) {
             val responseMapperName = method.simpleName.asString() + "ResponseMapper"
-            if (isNullableResult) {
-                b.add("return %N.apply(_response)", responseMapperName)
-            } else {
-                b.add("return %N.apply(_response)!!", responseMapperName)
-            }
+            b.add("return ")
+            b.decodeTry(if (isNullableResult) "%N.apply(_response)" else "%N.apply(_response)!!", responseMapperName)
         } else if (methodData.codeMappers.isEmpty()) {
             b.addStatement("val _code = _response.code()")
             val mapWithoutStatusCheck = methodData.returnType.isEitherResponse()
@@ -569,11 +567,8 @@ class ClientClassGenerator(private val resolver: Resolver) {
                 b.add("return\n")
             } else {
                 val responseMapperName = method.simpleName.asString() + "ResponseMapper"
-                if (isNullableResult) {
-                    b.addStatement("return %N.apply(_response)", responseMapperName)
-                } else {
-                    b.addStatement("return %N.apply(_response)!!", responseMapperName)
-                }
+                b.add("return ")
+                b.decodeTry(if (isNullableResult) "%N.apply(_response)" else "%N.apply(_response)!!", responseMapperName)
             }
             if (!mapWithoutStatusCheck) {
                 b.nextControlFlow("else")
@@ -590,30 +585,25 @@ class ClientClassGenerator(private val resolver: Resolver) {
                     } else {
                         val responseMapperName = method.simpleName.asString() + codeMapper.code.toString() + "ResponseMapper"
                         if (codeMapper.assignable) {
-                            if (isNullableResult) {
-                                add("%L -> %L.apply(_response)", codeMapper.code, responseMapperName)
-                            } else {
-                                add("%L -> %L.apply(_response)!!", codeMapper.code, responseMapperName)
-                            }
+                            add("%L -> ", codeMapper.code)
+                            decodeTry(if (isNullableResult) "%L.apply(_response)" else "%L.apply(_response)!!", responseMapperName)
                         } else {
                             add("%L -> throw %L.apply(_response)!!", codeMapper.code, responseMapperName)
+                            b.add("\n")
                         }
-                        b.add("\n")
                     }
                 }
                 if (defaultMapper == null) {
                     add("else -> throw %T.fromResponse(_response)", httpClientResponseException)
                 } else {
+                    val responseMapperName = method.simpleName.asString() + "DefaultResponseMapper"
                     if (defaultMapper.assignable) {
-                        if (isNullableResult) {
-                            add("else -> %L.apply(_response)", method.simpleName.asString() + "DefaultResponseMapper")
-                        } else {
-                            add("else -> %L.apply(_response)!!", method.simpleName.asString() + "DefaultResponseMapper")
-                        }
+                        add("else -> ")
+                        decodeTry(if (isNullableResult) "%L.apply(_response)" else "%L.apply(_response)!!", responseMapperName)
                     } else {
-                        add("else -> throw %L.apply(_response)!!", method.simpleName.asString() + "DefaultResponseMapper")
+                        add("else -> throw %L.apply(_response)!!", responseMapperName)
+                        b.add("\n")
                     }
-                    b.add("\n")
                 }
             }
         }
@@ -635,6 +625,15 @@ class ClientClassGenerator(private val resolver: Resolver) {
         return m.addCode(b.build()).build()
     }
 
+    private fun CodeBlock.Builder.decodeTry(applyStatement: String, vararg args: Any) {
+        controlFlow("try") {
+            addStatement(applyStatement, *args)
+            nextControlFlow("catch (_e: %T)", httpClientException)
+            addStatement("throw _e")
+            nextControlFlow("catch (_e: Exception)")
+            addStatement("throw %T(_e)", httpClientDecoderException)
+        }
+    }
 
     private fun parseRouteParts(httpPath: String, parameters: List<Parameter>): List<RoutePart> {
         var parts = listOf(RoutePart(null, httpPath))

--- a/http/http-client-symbol-processor/src/main/kotlin/io/koraframework/http/client/symbol/processor/HttpClientClassNames.kt
+++ b/http/http-client-symbol-processor/src/main/kotlin/io/koraframework/http/client/symbol/processor/HttpClientClassNames.kt
@@ -23,6 +23,7 @@ object HttpClientClassNames {
     val responseCodeMappers = responseCodeMapper.nestedClass("ResponseCodeMappers")
     val httpClientException = ClassName("io.koraframework.http.client.common.exception", "HttpClientException")
     val httpClientEncoderException = ClassName("io.koraframework.http.client.common.exception", "HttpClientEncoderException")
+    val httpClientDecoderException = ClassName("io.koraframework.http.client.common.exception", "HttpClientDecoderException")
     val httpClientResponseException = ClassName("io.koraframework.http.client.common.exception", "HttpClientResponseException")
     val httpClientUnknownException = ClassName("io.koraframework.http.client.common.exception", "HttpClientUnknownException")
 

--- a/http/http-client-symbol-processor/src/test/kotlin/io/koraframework/http/client/symbol/processor/BlockingApiTest.kt
+++ b/http/http-client-symbol-processor/src/test/kotlin/io/koraframework/http/client/symbol/processor/BlockingApiTest.kt
@@ -3,6 +3,7 @@ package io.koraframework.http.client.symbol.processor
 import io.koraframework.common.annotation.Component
 import io.koraframework.common.Either
 import io.koraframework.common.annotation.Tag
+import io.koraframework.http.client.common.exception.HttpClientDecoderException
 import io.koraframework.http.client.common.exception.HttpClientEncoderException
 import io.koraframework.http.client.common.exception.HttpClientResponseException
 import io.koraframework.http.client.common.request.HttpClientRequestMapper
@@ -533,6 +534,30 @@ class BlockingApiTest : AbstractHttpClientTest() {
         onRequest("POST", "http://test-url:8080/test") { rs -> rs.withCode(200) }
         Assertions.assertThatThrownBy { client.invoke<Unit>("request", "test-value") }.isInstanceOf(HttpClientEncoderException::class.java)
         Mockito.verify(mapper).apply(ArgumentMatchers.eq("test-value"))
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    fun testBlockingResponseBodyDecoderException() {
+        val mapper = Mockito.mock(HttpClientResponseMapper::class.java) as HttpClientResponseMapper<String>
+        val client = compile(
+            listOf(mapper), """
+            @HttpClient
+            interface TestClient {
+              @HttpRoute(method = "GET", path = "/test")
+              fun request(): String
+            }
+            """.trimIndent()
+        )
+
+        whenever(mapper.apply(ArgumentMatchers.any())).thenReturn("test-value")
+        onRequest("GET", "http://test-url:8080/test") { rs -> rs.withCode(200) }
+        Assertions.assertThat(client.invoke<String>("request")).isEqualTo("test-value")
+
+        reset(httpClient, mapper)
+        whenever(mapper.apply(ArgumentMatchers.any())).thenAnswer { throw RuntimeException() }
+        onRequest("GET", "http://test-url:8080/test") { rs -> rs.withCode(200) }
+        Assertions.assertThatThrownBy { client.invoke<String>("request") }.isInstanceOf(HttpClientDecoderException::class.java)
     }
 
     @Test


### PR DESCRIPTION
Fixed(http-client): wrap response body decoding failures in generated blocking clients in HttpClientDecoderException.

Generated Java and Kotlin blocking HTTP clients now wrap every response mapper apply call in HttpClientDecoderException, matching the existing HttpClientEncoderException handling on the request side. Previously a failing decoder was rethrown as-is or wrapped in HttpClientUnknownException, so callers could not reliably distinguish response decoding errors.

This restores symmetry between request encoding and response decoding error handling and gives clients a stable exception type to catch for malformed responses.