### PR TITLE
Refactored(kafka): assign strategy consumer now accepts multiple topics via config

### DIFF
--- a/kafka/kafka-annotation-processor/src/main/java/io/koraframework/kafka/annotation/processor/consumer/KafkaConsumerContainerGenerator.java
+++ b/kafka/kafka-annotation-processor/src/main/java/io/koraframework/kafka/annotation/processor/consumer/KafkaConsumerContainerGenerator.java
@@ -78,10 +78,7 @@ public class KafkaConsumerContainerGenerator {
             methodBuilder.addCode("var wrappedHandler = $T.wrapHandlerRecords($L, handler, config.allowEmptyRecords());\n", handlerWrapper, consumerParameter.isEmpty());
         }
         methodBuilder.addCode("if (config.driverProperties().getProperty($T.GROUP_ID_CONFIG) == null) {$>\n", commonClientConfigs);
-        methodBuilder.beginControlFlow("if (config.topics() == null || config.topics().size() != 1)"); // todo allow list?
-        methodBuilder.addStatement("throw new java.lang.IllegalArgumentException($S + config.topics())", "@KafkaListener require to specify 1 topic to subscribe when groupId is null, but received: ");
-        methodBuilder.endControlFlow();
-        methodBuilder.addCode("return new $T<>($S, $S, config, config.topics().get(0), keyDeserializer, valueDeserializer, telemetry, wrappedHandler);",
+        methodBuilder.addCode("return new $T<>($S, $S, config, keyDeserializer, valueDeserializer, telemetry, wrappedHandler);",
              kafkaAssignConsumerContainer, configPath, consumerName);
         methodBuilder.addCode("$<\n} else {$>\n");
         methodBuilder.addCode("return new $T<>($S, $S, config, keyDeserializer, valueDeserializer, wrappedHandler, telemetry, rebalanceListener);",

--- a/kafka/kafka-symbol-processor/src/main/kotlin/io/koraframework/kafka/symbol/processor/consumer/KafkaContainerGenerator.kt
+++ b/kafka/kafka-symbol-processor/src/main/kotlin/io/koraframework/kafka/symbol/processor/consumer/KafkaContainerGenerator.kt
@@ -47,10 +47,7 @@ class KafkaContainerGenerator {
             funBuilder.addStatement("val wrappedHandler = %T.wrapHandlerRecords(%L, handler, config.allowEmptyRecords())", KafkaClassNames.handlerWrapper, consumerParameter == null)
         }
         funBuilder.controlFlow("if (config.driverProperties().getProperty(%T.GROUP_ID_CONFIG) == null)", KafkaClassNames.commonClientConfigs) {
-            addStatement("val topics = config.topics()")
-            addStatement("require(topics != null)")
-            addStatement("require(topics.size == 1)")
-            addStatement("return %T(%S, %S, config, topics[0], keyDeserializer, valueDeserializer, telemetry, wrappedHandler)",
+            addStatement("return %T(%S, %S, config, keyDeserializer, valueDeserializer, telemetry, wrappedHandler)",
                 KafkaClassNames.kafkaAssignConsumerContainer, configPath, consumerName)
             nextControlFlow("else")
             addStatement("return %T(%S, %S, config, keyDeserializer, valueDeserializer, wrappedHandler, telemetry, rebalanceListener)",

--- a/kafka/kafka/src/main/java/io/koraframework/kafka/common/consumer/containers/KafkaAssignConsumerContainer.java
+++ b/kafka/kafka/src/main/java/io/koraframework/kafka/common/consumer/containers/KafkaAssignConsumerContainer.java
@@ -51,23 +51,29 @@ public final class KafkaAssignConsumerContainer<K, V> implements GeneratedListen
     private final Set<Consumer<K, V>> consumers = Collections.synchronizedSet(Collections.newSetFromMap(new IdentityHashMap<>()));
 
     private final AtomicReference<List<TopicPartition>> partitions = new AtomicReference<>(new ArrayList<>());
-    private final ArrayList<Long> offsets = new ArrayList<>();
-    private final String topic;
+    private final Map<TopicPartition, Long> offsets = new HashMap<>();
+    private final List<String> topics;
     private final KafkaConsumerTelemetry telemetry;
 
     public KafkaAssignConsumerContainer(String listenerConfig,
                                         String listenerImpl,
                                         KafkaListenerConfig config,
-                                        String topic,
                                         Deserializer<K> keyDeserializer,
                                         Deserializer<V> valueDeserializer,
                                         KafkaConsumerTelemetry telemetry,
                                         BaseKafkaRecordsHandler<K, V> handler) {
+        if (config.topicsPattern() != null) {
+            throw new IllegalArgumentException("@KafkaListener with assign strategy (when group.id is null) does not support topicsPattern, please specify topics instead");
+        }
+        var topics = config.topics();
+        if (topics == null || topics.isEmpty()) {
+            throw new IllegalArgumentException("@KafkaListener with assign strategy (when group.id is null) requires at least one topic to subscribe, but received: " + topics);
+        }
         this.handler = Objects.requireNonNull(handler);
         this.backoffTimeout = new AtomicLong(config.backoffTimeout().toMillis());
         this.keyDeserializer = Objects.requireNonNull(keyDeserializer);
         this.valueDeserializer = Objects.requireNonNull(valueDeserializer);
-        this.topic = Objects.requireNonNull(topic);
+        this.topics = List.copyOf(topics);
         this.threads = config.threads();
         this.config = config;
         this.refreshInterval = config.partitionRefreshInterval().toMillis();
@@ -115,9 +121,8 @@ public final class KafkaAssignConsumerContainer<K, V> implements GeneratedListen
                         .addKeyValue("listenerName", this.listenerConfig)
                         .log("{} assigned {} partitions: {}", listenerLogName, partitions.size(), partitions);
                     synchronized (this.offsets) {
-                        this.offsets.ensureCapacity(partitions.size());
                         for (var partition : partitions) {
-                            var offset = this.offsets.get(partition.partition());
+                            var offset = this.offsets.get(partition);
                             if (offset == null) { // new partition
                                 if (config.offset().right() != null) {
                                     var resetTo = Objects.requireNonNull(config.offset().right());
@@ -200,7 +205,7 @@ public final class KafkaAssignConsumerContainer<K, V> implements GeneratedListen
                         var partitionRecords = records.records(partition);
                         var lastRecord = partitionRecords.getLast();
                         synchronized (this.offsets) {
-                            this.offsets.set(partition.partition(), lastRecord.offset());
+                            this.offsets.put(partition, lastRecord.offset());
                             this.refreshLag(consumer);
                         }
                     }
@@ -242,7 +247,7 @@ public final class KafkaAssignConsumerContainer<K, V> implements GeneratedListen
         for (var entry : consumer.endOffsets(this.partitions.get()).entrySet()) {
             var p = entry.getKey();
             var latestOffset = entry.getValue();
-            var currentOffset = this.offsets.get(p.partition());
+            var currentOffset = this.offsets.get(p);
             if (currentOffset != null) {
                 // add -1 cause
                 // In the default read_uncommitted isolation level endOffsets() returns, the end offset is the high watermark
@@ -266,20 +271,19 @@ public final class KafkaAssignConsumerContainer<K, V> implements GeneratedListen
         if (lastUpdateTime.compareAndSet(updateTime, currentTime)) {
             // we have to create new consumer to ignore metadata cache
             try (var consumer = new KafkaConsumer<>(this.config.driverProperties(), new ByteArrayDeserializer(), new ByteArrayDeserializer())) {
-                var newPartitions = consumer.partitionsFor(this.topic);
+                var newPartitions = new ArrayList<TopicPartition>();
+                for (var topic : this.topics) {
+                    for (var partitionInfo : consumer.partitionsFor(topic)) {
+                        newPartitions.add(new TopicPartition(partitionInfo.topic(), partitionInfo.partition()));
+                    }
+                }
                 if (newPartitions.size() == partitions.size()) {
                     return false;
                 }
-                this.partitions.set(newPartitions.stream().map(p -> new TopicPartition(p.topic(), p.partition())).toList());
+                this.partitions.set(List.copyOf(newPartitions));
                 synchronized (this.offsets) {
-                    for (int i = this.offsets.size(); i < newPartitions.size(); i++) {
-                        this.offsets.add(null);
-                    }
-                    if (oldPartitions.isEmpty()) {
-                        var p = newPartitions.stream().skip(this.offsets.size()).map(i -> new TopicPartition(i.topic(), i.partition())).toList();
-                        for (var entry : consumer.endOffsets(p).entrySet()) {
-                            this.offsets.set(entry.getKey().partition(), entry.getValue());
-                        }
+                    for (var partition : newPartitions) {
+                        this.offsets.putIfAbsent(partition, null);
                     }
                 }
                 return true;
@@ -321,40 +325,38 @@ public final class KafkaAssignConsumerContainer<K, V> implements GeneratedListen
     public void init() {
         var threads = this.threads;
         if (threads > 0) {
-            if (this.topic != null) {
-                logger.atDebug()
-                    .addKeyValue("listenerName", this.listenerConfig)
-                    .log("KafkaListener starting in assign mode...", listenerConfig);
-                final long started = TimeUtils.started();
+            logger.atDebug()
+                .addKeyValue("listenerName", this.listenerConfig)
+                .log("KafkaListener starting in assign mode...");
+            final long started = TimeUtils.started();
 
-                executorService = Executors.newFixedThreadPool(threads, new NamedThreadFactory(listenerConfig));
-                CountDownLatch initLatch = new CountDownLatch(config.threads());
+            executorService = Executors.newFixedThreadPool(threads, new NamedThreadFactory(listenerConfig));
+            CountDownLatch initLatch = new CountDownLatch(config.threads());
 
-                for (int i = 0; i < threads; i++) {
-                    var number = i;
-                    executorService.execute(() -> {
-                        // infinite try to init in cycle, will go into infinite pool loop if init success
-                        while (isActive.get()) {
-                            var consumer = initializeConsumer();
-                            if (consumer != null) {
-                                var listenerName = (threads == 1)
-                                    ? "KafkaListener '" + this.listenerConfig + "'"
-                                    : "KafkaListener-" + number + " '" + this.listenerConfig + "'";
-                                launchPollLoop(consumer, listenerName, number, started, initLatch::countDown);
-                            }
+            for (int i = 0; i < threads; i++) {
+                var number = i;
+                executorService.execute(() -> {
+                    // infinite try to init in cycle, will go into infinite pool loop if init success
+                    while (isActive.get()) {
+                        var consumer = initializeConsumer();
+                        if (consumer != null) {
+                            var listenerName = (threads == 1)
+                                ? "KafkaListener '" + this.listenerConfig + "'"
+                                : "KafkaListener-" + number + " '" + this.listenerConfig + "'";
+                            launchPollLoop(consumer, listenerName, number, started, initLatch::countDown);
                         }
-                    });
-                }
-
-                if (config.initializationFailTimeout() != null) {
-                    try {
-                        if (!initLatch.await(config.initializationFailTimeout().toMillis(), TimeUnit.MILLISECONDS)) {
-                            throw new RuntimeException("KafkaListener '{}' failed to start, due to timeout in {}ms".formatted(
-                                listenerConfig, TimeUtils.durationForLogging(config.initializationFailTimeout())));
-                        }
-                    } catch (InterruptedException e) {
-                        // ignore
                     }
+                });
+            }
+
+            if (config.initializationFailTimeout() != null) {
+                try {
+                    if (!initLatch.await(config.initializationFailTimeout().toMillis(), TimeUnit.MILLISECONDS)) {
+                        throw new RuntimeException("KafkaListener '{}' failed to start, due to timeout in {}ms".formatted(
+                            listenerConfig, TimeUtils.durationForLogging(config.initializationFailTimeout())));
+                    }
+                } catch (InterruptedException e) {
+                    // ignore
                 }
             }
         }

--- a/kafka/kafka/src/test/java/io/koraframework/kafka/common/containers/KafkaAssignConsumerContainerTest.java
+++ b/kafka/kafka/src/test/java/io/koraframework/kafka/common/containers/KafkaAssignConsumerContainerTest.java
@@ -68,7 +68,7 @@ class KafkaAssignConsumerContainerTest {
         );
         var deque = new ConcurrentLinkedDeque<>();
         var telemetry = Mockito.mock(KafkaConsumerTelemetry.class);
-        var container = new KafkaAssignConsumerContainer<>("test", "test", config, params.topic("test-topic"), new StringDeserializer(), new IntegerDeserializer(), telemetry, (observation, records, consumer, commitAllowed) -> {
+        var container = new KafkaAssignConsumerContainer<>("test", "test", config, new StringDeserializer(), new IntegerDeserializer(), telemetry, (observation, records, consumer, commitAllowed) -> {
             for (var record : records) {
                 try {
                     deque.offer(record);


### PR DESCRIPTION
Refactored(kafka): assign strategy consumer now accepts multiple topics via config

Refactored KafkaAssignConsumerContainer, used when group.id is not set, to source its topic list from KafkaListenerConfig.topics() instead of a single topic argument, so it subscribes to all configured topics via assign like the subscribe strategy already does for group.id-based listeners. Constructing the container now fails fast with topicsPattern, since assign mode has no rebalance protocol to resolve pattern matches. This is a breaking change to the container constructor and generated listener code.

- Breaking: KafkaAssignConsumerContainer constructor no longer takes a topic argument; it validates config.topics() is non-empty and config.topicsPattern() is null instead.
- Refactored(kafka): partition and offset tracking switched from partition-index lists to a TopicPartition-keyed map, since partition numbers can collide across topics once multiple topics are assigned.

Assign-mode listeners were previously limited to a single topic due to a not-yet-implemented multi-topic path in the generator; this brings assign in line with subscribe mode's topic handling and removes that limitation.