### PR TITLE
Added(openapi): support status-code range responses (4XX, 5XX) for Java and Kotlin clients and servers

### DIFF
--- a/openapi/openapi-generator/build.gradle
+++ b/openapi/openapi-generator/build.gradle
@@ -80,6 +80,8 @@ sourceSets {
             addOpenapiDir("petstoreV3_nullable_enable_json_nullable")
             addOpenapiDir("petstoreV3_request_parameters")
             addOpenapiDir("petstoreV3_responses")
+            addOpenapiDir("petstoreV3_response_ranges")
+            addOpenapiDir("petstoreV3_response_ranges_no_default")
             addOpenapiDir("petstoreV3_requests")
             addOpenapiDir("petstoreV3_same_response_model")
             addOpenapiDir("petstoreV3_bare_object")

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/AbstractGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/AbstractGenerator.java
@@ -80,6 +80,7 @@ public abstract class AbstractGenerator<C, R> {
 
         public static final ClassName httpClientResponse = ClassName.get("io.koraframework.http.client.common.response", "HttpClientResponse");
         public static final ClassName httpClientResponseMapper = ClassName.get("io.koraframework.http.client.common.response", "HttpClientResponseMapper");
+        public static final ClassName httpClientResponseException = ClassName.get("io.koraframework.http.client.common.exception", "HttpClientResponseException");
         public static final ClassName stringParameterConverter = ClassName.get("io.koraframework.http.client.common.request", "HttpClientParameterWriter");
         public static final ClassName enumStringParameterConverter = ClassName.get("io.koraframework.http.client.common.request.mapper", "EnumHttpClientParameterWriter");
 
@@ -144,6 +145,31 @@ public abstract class AbstractGenerator<C, R> {
 
     protected static String capitalize(String s) {
         return StringUtils.capitalize(s);
+    }
+
+    /**
+     * OpenAPI allows an operation to declare a response for a whole status-code range: {@code 1XX},
+     * {@code 2XX}, {@code 3XX}, {@code 4XX} or {@code 5XX} (see the OpenAPI 3 "Responses Object").
+     * These are not exact codes, so they cannot be emitted where an {@code int} status is required
+     * and cannot be registered directly on a {@code @ResponseCodeMapper(code = ...)}.
+     */
+    public static boolean isRangeCode(CodegenResponse response) {
+        return !response.isDefault && response.code != null && response.code.matches("[1-5]XX");
+    }
+
+    /** Inclusive lower bound of a range code, e.g. {@code "4XX"} -> {@code 400}. */
+    public static int rangeCodeLowerBound(String code) {
+        return (code.charAt(0) - '0') * 100;
+    }
+
+    /** Exclusive upper bound of a range code, e.g. {@code "4XX"} -> {@code 500}. */
+    public static int rangeCodeUpperBound(String code) {
+        return rangeCodeLowerBound(code) + 100;
+    }
+
+    /** Whether a range response or an OpenAPI {@code default} response carries a runtime-supplied status code. */
+    public static boolean hasDynamicStatusCode(CodegenResponse response) {
+        return response.isDefault || isRangeCode(response);
     }
 
     protected static String toVarName(String s) {

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ApiResponseGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ApiResponseGenerator.java
@@ -53,7 +53,7 @@ public class ApiResponseGenerator extends AbstractJavaGenerator<OperationsMap> {
         }
         var c = MethodSpec.constructorBuilder()
             .addModifiers(Modifier.PUBLIC);
-        if (response.isDefault) {
+        if (hasDynamicStatusCode(response)) {
             c.addParameter(TypeName.INT, "statusCode");
         }
         if (response.dataType != null) {
@@ -64,12 +64,12 @@ public class ApiResponseGenerator extends AbstractJavaGenerator<OperationsMap> {
             c.addParameter(ClassName.get(String.class), header.nameInCamelCase);
         }
 
-        if (sharedResponse != null && sharedResponse.statusCodeMethod != null && (!response.isDefault || !"statusCode".equals(sharedResponse.statusCodeMethod))) {
+        if (sharedResponse != null && sharedResponse.statusCodeMethod != null && (!hasDynamicStatusCode(response) || !"statusCode".equals(sharedResponse.statusCodeMethod))) {
             var method = MethodSpec.methodBuilder(sharedResponse.statusCodeMethod)
                 .addAnnotation(Override.class)
                 .addModifiers(Modifier.PUBLIC)
                 .returns(TypeName.INT);
-            if (response.isDefault) {
+            if (hasDynamicStatusCode(response)) {
                 method.addStatement("return this.statusCode");
             } else {
                 method.addStatement("return $L", response.code);

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientApiGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientApiGenerator.java
@@ -273,10 +273,33 @@ public class ClientApiGenerator extends AbstractJavaGenerator<OperationsMap> {
                 .addMember("value", "$T.class", ClassName.bestGuess(clientMapping.type()))
                 .build());
         } else {
+            var op = StringUtils.capitalize(operation.operationId);
+            var mappersClass = ctx.get("classname") + "ClientResponseMappers";
             for (var response : operation.responses) {
+                // Exact codes are registered directly. Ranges (4XX, 5XX, ...) and the OpenAPI `default`
+                // response cannot be an int `code`, so they are funneled through a single aggregate
+                // DEFAULT mapper registered below.
+                if (hasDynamicStatusCode(response)) {
+                    continue;
+                }
                 b.addAnnotation(AnnotationSpec.builder(Classes.responseCodeMapper)
-                    .addMember("code", "$L", response.isDefault ? "-1" : response.code)
-                    .addMember("mapper", "$T.class", ClassName.get(apiPackage, ctx.get("classname") + "ClientResponseMappers", StringUtils.capitalize(operation.operationId) + response.code + "ApiResponseMapper"))
+                    .addMember("code", "$L", response.code)
+                    .addMember("mapper", "$T.class", ClassName.get(apiPackage, mappersClass, op + response.code + "ApiResponseMapper"))
+                    .build()
+                );
+            }
+            var hasRanges = operation.responses.stream().anyMatch(io.koraframework.openapi.generator.AbstractGenerator::isRangeCode);
+            var defaultResponse = operation.responses.stream().filter(r -> r.isDefault).findFirst().orElse(null);
+            if (hasRanges) {
+                b.addAnnotation(AnnotationSpec.builder(Classes.responseCodeMapper)
+                    .addMember("code", "$T.DEFAULT", Classes.responseCodeMapper)
+                    .addMember("mapper", "$T.class", ClassName.get(apiPackage, mappersClass, op + "DefaultCodeApiResponseMapper"))
+                    .build()
+                );
+            } else if (defaultResponse != null) {
+                b.addAnnotation(AnnotationSpec.builder(Classes.responseCodeMapper)
+                    .addMember("code", "$T.DEFAULT", Classes.responseCodeMapper)
+                    .addMember("mapper", "$T.class", ClassName.get(apiPackage, mappersClass, op + defaultResponse.code + "ApiResponseMapper"))
                     .build()
                 );
             }

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientResponseMapperGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientResponseMapperGenerator.java
@@ -7,6 +7,9 @@ import org.openapitools.codegen.model.OperationsMap;
 
 import javax.lang.model.element.Modifier;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
 
 import static io.koraframework.openapi.generator.KoraCodegen.isContentJson;
 
@@ -21,9 +24,76 @@ public class ClientResponseMapperGenerator extends AbstractJavaGenerator<Operati
             for (var response : operation.responses) {
                 b.addType(responseMapper(ctx, className, operation, response));
             }
+            var ranges = operation.responses.stream()
+                .filter(io.koraframework.openapi.generator.AbstractGenerator::isRangeCode)
+                .sorted(Comparator.comparingInt(r -> rangeCodeLowerBound(r.code)))
+                .toList();
+            if (!ranges.isEmpty()) {
+                var defaultResponse = operation.responses.stream()
+                    .filter(r -> r.isDefault)
+                    .findFirst()
+                    .orElse(null);
+                b.addType(defaultCodeMapper(ctx, className, operation, ranges, defaultResponse));
+            }
         }
 
         return JavaFile.builder(apiPackage, b.build()).build();
+    }
+
+    /**
+     * Builds the aggregate mapper registered as {@code @ResponseCodeMapper(code = DEFAULT, ...)} whenever
+     * an operation declares status-code ranges ({@code 4XX}, {@code 5XX}, ...). Exact codes are still
+     * registered directly; every other code reaches this mapper, which dispatches on the actual status
+     * to the matching per-range mapper, falling back to the OpenAPI {@code default} response mapper or,
+     * if none was declared, throwing like the runtime does for unmatched codes.
+     */
+    private TypeSpec defaultCodeMapper(OperationsMap ctx, ClassName mappers, CodegenOperation operation, List<CodegenResponse> ranges, CodegenResponse defaultResponse) {
+        var op = capitalize(operation.operationId);
+        var responseType = ClassName.get(apiPackage, ctx.get("classname") + "Responses", op + "ApiResponse");
+        var className = mappers.nestedClass(op + "DefaultCodeApiResponseMapper");
+        var b = TypeSpec.classBuilder(className)
+            .addAnnotation(generated())
+            .addAnnotation(Classes.defaultComponent)
+            .addAnnotation(Classes.component)
+            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+            .addSuperinterface(ParameterizedTypeName.get(Classes.httpClientResponseMapper, responseType));
+
+        record Delegate(String field, ClassName type) {}
+        var delegates = new ArrayList<Delegate>();
+        for (var range : ranges) {
+            delegates.add(new Delegate("mapper" + range.code, mappers.nestedClass(op + range.code + "ApiResponseMapper")));
+        }
+        if (defaultResponse != null) {
+            delegates.add(new Delegate("mapperDefault", mappers.nestedClass(op + defaultResponse.code + "ApiResponseMapper")));
+        }
+
+        var constructor = MethodSpec.constructorBuilder().addModifiers(Modifier.PUBLIC);
+        for (var delegate : delegates) {
+            b.addField(delegate.type(), delegate.field(), Modifier.PRIVATE, Modifier.FINAL);
+            constructor.addParameter(delegate.type(), delegate.field());
+            constructor.addStatement("this.$N = $N", delegate.field(), delegate.field());
+        }
+        b.addMethod(constructor.build());
+
+        var apply = MethodSpec.methodBuilder("apply")
+            .addModifiers(Modifier.PUBLIC)
+            .addAnnotation(Override.class)
+            .returns(responseType)
+            .addParameter(Classes.httpClientResponse, "response")
+            .addException(IOException.class)
+            .addStatement("var code = response.code()");
+        for (var range : ranges) {
+            apply.beginControlFlow("if (code >= $L && code < $L)", rangeCodeLowerBound(range.code), rangeCodeUpperBound(range.code))
+                .addStatement("return this.$N.apply(response)", "mapper" + range.code)
+                .endControlFlow();
+        }
+        if (defaultResponse != null) {
+            apply.addStatement("return this.mapperDefault.apply(response)");
+        } else {
+            apply.addStatement("throw $T.fromResponse(response)", Classes.httpClientResponseException);
+        }
+        b.addMethod(apply.build());
+        return b.build();
     }
 
     private TypeSpec responseMapper(OperationsMap ctx, ClassName mappers, CodegenOperation operation, CodegenResponse response) {
@@ -73,7 +143,7 @@ public class ClientResponseMapperGenerator extends AbstractJavaGenerator<Operati
             ? responseType
             : responseType.nestedClass(capitalize(operation.operationId) + (response.isDefault ? "Default" : response.code) + "ApiResponse");
         var newArgs = CodeBlock.builder();
-        if (response.isDefault) {
+        if (hasDynamicStatusCode(response)) {
             newArgs.add("response.code()");
         }
         if (response.dataType != null) {

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ServerResponseMapperGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ServerResponseMapperGenerator.java
@@ -90,7 +90,7 @@ public class ServerResponseMapperGenerator extends AbstractJavaGenerator<Operati
                 }
             }
         }
-        var responseCode = rs.isDefault
+        var responseCode = hasDynamicStatusCode(rs)
             ? CodeBlock.of("$N.statusCode()", rsName)
             : CodeBlock.of(rs.code);
         if (rs.isBinary) {

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ApiResponseGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ApiResponseGenerator.kt
@@ -44,7 +44,7 @@ class ApiResponseGenerator : AbstractKotlinGenerator<OperationsMap>() {
             t.addSuperinterface(sharedResponse?.className ?: name.enclosingClassName()!!)
         }
         val c = FunSpec.constructorBuilder()
-        if (response.isDefault) {
+        if (hasDynamicStatusCode(response)) {
             c.addParameter("statusCode", INT)
             val statusCodeProperty = PropertySpec.builder("statusCode", INT)
                 .initializer("statusCode")
@@ -71,12 +71,12 @@ class ApiResponseGenerator : AbstractKotlinGenerator<OperationsMap>() {
             c.addParameter(header.name, type)
             t.addProperty(PropertySpec.builder(header.name, type).initializer(header.name).build())
         }
-        if (sharedResponse?.statusCodeProperty != null && (!response.isDefault || sharedResponse.statusCodeProperty != "statusCode")) {
+        if (sharedResponse?.statusCodeProperty != null && (!hasDynamicStatusCode(response) || sharedResponse.statusCodeProperty != "statusCode")) {
             val property = PropertySpec.builder(sharedResponse.statusCodeProperty, INT)
                 .addModifiers(KModifier.OVERRIDE)
                 .getter(
                     FunSpec.getterBuilder()
-                        .addStatement("return %L", if (response.isDefault) "statusCode" else response.code)
+                        .addStatement("return %L", if (hasDynamicStatusCode(response)) "statusCode" else response.code)
                         .build()
                 )
                 .build()

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ClientApiGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ClientApiGenerator.kt
@@ -38,14 +38,39 @@ class ClientApiGenerator() : AbstractKotlinGenerator<OperationsMap>() {
                     .build()
             )
         } else {
+            val op = StringUtils.capitalize(operation.operationId)
+            val mappersClass = ctx.get("classname").toString() + "ClientResponseMappers"
             for (response in operation.responses) {
+                // Exact codes are registered directly. Ranges (4XX, 5XX, ...) and the OpenAPI `default`
+                // response cannot be an int `code`, so they are funneled through a single aggregate
+                // DEFAULT mapper registered below.
+                if (hasDynamicStatusCode(response)) {
+                    continue
+                }
                 b.addAnnotation(
                     AnnotationSpec.builder(Classes.responseCodeMapper.asKt())
-                        .addMember("code = %L", if (response.isDefault) "-1" else response.code)
+                        .addMember("code = %L", response.code)
                         .addMember(
                             "mapper = %T::class",
-                            ClassName(apiPackage, ctx.get("classname").toString() + "ClientResponseMappers", (StringUtils.capitalize(operation.operationId) + response.code) + "ApiResponseMapper")
+                            ClassName(apiPackage, mappersClass, op + response.code + "ApiResponseMapper")
                         )
+                        .build()
+                )
+            }
+            val hasRanges = operation.responses.any { isRangeCode(it) }
+            val defaultResponse = operation.responses.firstOrNull { it.isDefault }
+            if (hasRanges) {
+                b.addAnnotation(
+                    AnnotationSpec.builder(Classes.responseCodeMapper.asKt())
+                        .addMember("code = %T.DEFAULT", Classes.responseCodeMapper.asKt())
+                        .addMember("mapper = %T::class", ClassName(apiPackage, mappersClass, op + "DefaultCodeApiResponseMapper"))
+                        .build()
+                )
+            } else if (defaultResponse != null) {
+                b.addAnnotation(
+                    AnnotationSpec.builder(Classes.responseCodeMapper.asKt())
+                        .addMember("code = %T.DEFAULT", Classes.responseCodeMapper.asKt())
+                        .addMember("mapper = %T::class", ClassName(apiPackage, mappersClass, op + defaultResponse.code + "ApiResponseMapper"))
                         .build()
                 )
             }

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ClientResponseMapperGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ClientResponseMapperGenerator.kt
@@ -16,9 +16,69 @@ class ClientResponseMapperGenerator : AbstractKotlinGenerator<OperationsMap>() {
             for (response in operation.responses) {
                 b.addType(responseMapper(ctx, className, operation, response))
             }
+            val ranges = operation.responses
+                .filter { isRangeCode(it) }
+                .sortedBy { rangeCodeLowerBound(it.code) }
+            if (ranges.isNotEmpty()) {
+                val defaultResponse = operation.responses.firstOrNull { it.isDefault }
+                b.addType(defaultCodeMapper(ctx, className, operation, ranges, defaultResponse))
+            }
         }
 
         return FileSpec.get(apiPackage, b.build())
+    }
+
+    /**
+     * Builds the aggregate mapper registered as `@ResponseCodeMapper(code = DEFAULT, ...)` whenever an
+     * operation declares status-code ranges (`4XX`, `5XX`, ...). Exact codes are still registered
+     * directly; every other code reaches this mapper, which dispatches on the actual status to the
+     * matching per-range mapper, falling back to the OpenAPI `default` response mapper or, if none was
+     * declared, throwing like the runtime does for unmatched codes.
+     */
+    private fun defaultCodeMapper(ctx: OperationsMap, mappers: ClassName, operation: CodegenOperation, ranges: List<CodegenResponse>, defaultResponse: CodegenResponse?): TypeSpec {
+        val op = capitalize(operation.operationId)
+        val responseType = ClassName(apiPackage, ctx["classname"].toString() + "Responses", op + "ApiResponse")
+        val className = mappers.nestedClass(op + "DefaultCodeApiResponseMapper")
+        val b = TypeSpec.classBuilder(className)
+            .addAnnotation(generated())
+            .addAnnotation(Classes.defaultComponent.asKt())
+            .addAnnotation(Classes.component.asKt())
+            .addModifiers(KModifier.OPEN)
+            .addSuperinterface(Classes.httpClientResponseMapper.asKt().parameterizedBy(responseType))
+
+        data class Delegate(val field: String, val type: ClassName)
+        val delegates = mutableListOf<Delegate>()
+        for (range in ranges) {
+            delegates.add(Delegate("mapper" + range.code, mappers.nestedClass(op + range.code + "ApiResponseMapper")))
+        }
+        if (defaultResponse != null) {
+            delegates.add(Delegate("mapperDefault", mappers.nestedClass(op + defaultResponse.code + "ApiResponseMapper")))
+        }
+
+        val constructor = FunSpec.constructorBuilder()
+        for (delegate in delegates) {
+            constructor.addParameter(delegate.field, delegate.type)
+            b.addProperty(PropertySpec.builder(delegate.field, delegate.type).initializer(delegate.field).addModifiers(KModifier.PRIVATE).build())
+        }
+        b.primaryConstructor(constructor.build())
+
+        val apply = FunSpec.builder("apply")
+            .addModifiers(KModifier.OVERRIDE)
+            .returns(responseType)
+            .addParameter("response", Classes.httpClientResponse.asKt())
+            .addStatement("val code = response.code()")
+        for (range in ranges) {
+            apply.beginControlFlow("if (code >= %L && code < %L)", rangeCodeLowerBound(range.code), rangeCodeUpperBound(range.code))
+            apply.addStatement("return this.%N.apply(response)", "mapper" + range.code)
+            apply.endControlFlow()
+        }
+        if (defaultResponse != null) {
+            apply.addStatement("return this.mapperDefault.apply(response)")
+        } else {
+            apply.addStatement("throw %T.fromResponse(response)", Classes.httpClientResponseException.asKt())
+        }
+        b.addFunction(apply.build())
+        return b.build()
     }
 
     private fun responseMapper(ctx: OperationsMap, mappers: ClassName, operation: CodegenOperation, response: CodegenResponse): TypeSpec {
@@ -62,7 +122,7 @@ class ClientResponseMapperGenerator : AbstractKotlinGenerator<OperationsMap>() {
         else
             responseType.nestedClass(capitalize(operation.operationId) + (if (response.isDefault) "Default" else response.code) + "ApiResponse")
         val newArgs = CodeBlock.builder()
-        if (response.isDefault) {
+        if (hasDynamicStatusCode(response)) {
             newArgs.add("response.code()")
         }
         if (response.dataType != null) {

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ServerResponseMappersGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ServerResponseMappersGenerator.kt
@@ -84,7 +84,7 @@ class ServerResponseMappersGenerator : AbstractKotlinGenerator<OperationsMap>() 
                 }
             }
         }
-        val responseCode = if (rs.isDefault)
+        val responseCode = if (hasDynamicStatusCode(rs))
             CodeBlock.of("rs.statusCode")
         else
             CodeBlock.of(rs.code)

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/BaseOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/BaseOpenapiTest.java
@@ -131,6 +131,8 @@ public abstract class BaseOpenapiTest {
             "/example/petstoreV3_same_response_model.yaml",
             "/example/petstoreV3_bare_object.yaml",
             "/example/petstoreV3_responses.yaml",
+            "/example/petstoreV3_response_ranges.yaml",
+            "/example/petstoreV3_response_ranges_no_default.yaml",
             "/example/petstoreV3_requests.yaml",
             "/example/petstoreV3_types.yaml",
             "/example/petstoreV3_validation.yaml",

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/ResponseRangeCodeKotlinTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/ResponseRangeCodeKotlinTest.java
@@ -1,0 +1,109 @@
+package io.koraframework.openapi.generator;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Kotlin counterpart of {@link ResponseRangeCodeTest}: OpenAPI status-code ranges ({@code 4XX},
+ * {@code 5XX}, ...) are lowered the same way for the Kotlin generators — exact codes register
+ * directly, ranges and {@code default} funnel through one aggregate {@code DEFAULT} mapper that
+ * dispatches on the real status code, and range response data classes carry a runtime
+ * {@code statusCode}. Each test inspects the generated Kotlin and compiles the whole output.
+ */
+public class ResponseRangeCodeKotlinTest extends BaseKotlinOpenapiTest {
+
+    private static final String SPEC = "/example/petstoreV3_response_ranges.yaml";
+    private static final String SPEC_NO_DEFAULT = "/example/petstoreV3_response_ranges_no_default.yaml";
+
+    @Test
+    void clientLowersRangeCodesToAnAggregateDefaultMapper() throws Exception {
+        var files = generate("petstoreV3_response_ranges_kt_client", "kotlin-client",
+            getClass().getResource(SPEC).toExternalForm(), new SwaggerParams.Options());
+
+        var responses = read(files, "DefaultApiResponses.kt");
+        var api = read(files, "DefaultApi.kt");
+        var mappers = read(files, "DefaultApiClientResponseMappers.kt");
+
+        // Range data classes carry a runtime status code instead of emitting an invalid `return 4XX`.
+        assertFalse(responses.contains("return 4XX"), responses);
+        assertFalse(responses.contains("return 5XX"), responses);
+        assertTrue(responses.contains("class ListPets4XXApiResponse("), responses);
+        assertTrue(responses.contains("class ListPets5XXApiResponse("), responses);
+        assertTrue(responses.contains("override val statusCode: Int"), responses);
+
+        // Exact code registered directly; a single DEFAULT registration points at the aggregate mapper.
+        assertTrue(api.contains("code = 200"), api);
+        assertFalse(api.contains("code = 4XX"), api);
+        assertFalse(api.contains("code = 5XX"), api);
+        assertTrue(api.contains("code = ResponseCodeMapper.DEFAULT"), api);
+        assertTrue(api.contains("ListPetsDefaultCodeApiResponseMapper::class"), api);
+        assertEquals(1, countOccurrences(api, "code = ResponseCodeMapper.DEFAULT"), api);
+        assertFalse(api.contains("code = -1"), api);
+
+        // The aggregate mapper dispatches on the real status code and falls back to the `default` mapper.
+        assertTrue(mappers.contains("class ListPetsDefaultCodeApiResponseMapper"), mappers);
+        assertTrue(mappers.contains("if (code >= 400 && code < 500)"), mappers);
+        assertTrue(mappers.contains("if (code >= 500 && code < 600)"), mappers);
+        assertTrue(mappers.contains("return this.mapperDefault.apply(response)"), mappers);
+        assertFalse(mappers.contains("fromResponse"), mappers);
+
+        process("petstoreV3_response_ranges_kt_client_compile", "kotlin-client",
+            getClass().getResource(SPEC).toExternalForm(), new SwaggerParams.Options());
+    }
+
+    @Test
+    void aggregateMapperThrowsWhenNoDefaultResponseIsDeclared() throws Exception {
+        var files = generate("petstoreV3_response_ranges_kt_no_default_client", "kotlin-client",
+            getClass().getResource(SPEC_NO_DEFAULT).toExternalForm(), new SwaggerParams.Options());
+
+        var api = read(files, "DefaultApi.kt");
+        var mappers = read(files, "DefaultApiClientResponseMappers.kt");
+
+        assertTrue(api.contains("code = 200"), api);
+        assertTrue(api.contains("code = 404"), api);
+        assertTrue(api.contains("ListPetsDefaultCodeApiResponseMapper::class"), api);
+
+        assertTrue(mappers.contains("if (code >= 400 && code < 500)"), mappers);
+        assertTrue(mappers.contains("if (code >= 500 && code < 600)"), mappers);
+        assertTrue(mappers.contains("throw HttpClientResponseException.fromResponse(response)"), mappers);
+        assertFalse(mappers.contains("mapperDefault"), mappers);
+
+        process("petstoreV3_response_ranges_kt_no_default_compile", "kotlin-client",
+            getClass().getResource(SPEC_NO_DEFAULT).toExternalForm(), new SwaggerParams.Options());
+    }
+
+    @Test
+    void serverBuildsRangeResponsesFromRuntimeStatusCode() throws Exception {
+        var files = generate("petstoreV3_response_ranges_kt_server", "kotlin-server",
+            getClass().getResource(SPEC).toExternalForm(), new SwaggerParams.Options());
+
+        var mappers = read(files, "DefaultApiServerResponseMappers.kt");
+
+        assertFalse(mappers.contains("HttpResponseEntity.of(4XX,"), mappers);
+        assertFalse(mappers.contains("HttpResponseEntity.of(5XX,"), mappers);
+        assertTrue(mappers.contains("HttpResponseEntity.of(rs.statusCode,"), mappers);
+
+        process("petstoreV3_response_ranges_kt_server_compile", "kotlin-server",
+            getClass().getResource(SPEC).toExternalForm(), new SwaggerParams.Options());
+    }
+
+    private static int countOccurrences(String haystack, String needle) {
+        int count = 0;
+        for (int i = haystack.indexOf(needle); i >= 0; i = haystack.indexOf(needle, i + needle.length())) {
+            count++;
+        }
+        return count;
+    }
+
+    private static String read(java.util.List<File> files, String fileName) throws Exception {
+        return Files.readString(files.stream()
+            .map(File::toPath)
+            .filter(path -> path.getFileName().toString().equals(fileName))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError(fileName + " was not generated")));
+    }
+}

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/ResponseRangeCodeTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/ResponseRangeCodeTest.java
@@ -1,0 +1,127 @@
+package io.koraframework.openapi.generator;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * OpenAPI lets an operation declare responses for status-code ranges ({@code 1XX}, {@code 2XX},
+ * {@code 3XX}, {@code 4XX}, {@code 5XX}) in addition to exact codes and {@code default}
+ * (see the OpenAPI 3 "Responses Object" spec).
+ *
+ * <p>Ranges are not exact codes, so they cannot be emitted where an {@code int} status is required
+ * ({@code @ResponseCodeMapper.code()}, {@code HttpResponseEntity.of(code, ...)}, the record's
+ * {@code statusCode()}). The generator therefore lowers them as follows:
+ *
+ * <ul>
+ *   <li><b>Client</b>: exact codes are registered directly with {@code @ResponseCodeMapper(code = N)};
+ *   ranges and the OpenAPI {@code default} response funnel through a single aggregate mapper
+ *   registered as {@code @ResponseCodeMapper(code = DEFAULT)} that dispatches on the real status code
+ *   to the per-range mappers, falling back to the {@code default} mapper or throwing when none exists.</li>
+ *   <li><b>Server</b>: range response records carry a runtime {@code int statusCode} (like {@code default}),
+ *   and the response entity is built from {@code statusCode()} rather than the range token.</li>
+ * </ul>
+ *
+ * <p>Each test both inspects the generated sources ({@link #generate}) and compiles the whole output
+ * ({@link #process}) so a regression that reintroduces an invalid {@code int} literal fails the build.
+ */
+public class ResponseRangeCodeTest extends BaseJavaOpenapiTest {
+
+    private static final String SPEC = "/example/petstoreV3_response_ranges.yaml";
+    private static final String SPEC_NO_DEFAULT = "/example/petstoreV3_response_ranges_no_default.yaml";
+
+    @Test
+    void clientLowersRangeCodesToAnAggregateDefaultMapper() throws Exception {
+        var files = generate("petstoreV3_response_ranges_client", "java-client",
+            getClass().getResource(SPEC).toExternalForm(), new SwaggerParams.Options());
+
+        var responses = read(files, "DefaultApiResponses.java");
+        var api = read(files, "DefaultApi.java");
+        var mappers = read(files, "DefaultApiClientResponseMappers.java");
+
+        // Range records no longer emit an invalid `return 4XX;` — they carry a runtime status code.
+        assertFalse(responses.contains("return 4XX"), responses);
+        assertFalse(responses.contains("return 5XX"), responses);
+        assertTrue(responses.contains("record ListPets4XXApiResponse(int statusCode,"), responses);
+        assertTrue(responses.contains("record ListPets5XXApiResponse(int statusCode,"), responses);
+
+        // Exact code is registered directly; ranges/default are NOT registered as their own code.
+        assertTrue(api.contains("code = 200"), api);
+        assertFalse(api.contains("code = 4XX"), api);
+        assertFalse(api.contains("code = 5XX"), api);
+        // Exactly one DEFAULT registration, pointing at the aggregate mapper.
+        assertTrue(api.contains("code = ResponseCodeMapper.DEFAULT"), api);
+        assertTrue(api.contains("ListPetsDefaultCodeApiResponseMapper.class"), api);
+        assertEquals(1, countOccurrences(api, "code = ResponseCodeMapper.DEFAULT"), api);
+        assertFalse(api.contains("code = -1"), api);
+
+        // The aggregate mapper dispatches on the real status code and falls back to the `default` mapper.
+        assertTrue(mappers.contains("class ListPetsDefaultCodeApiResponseMapper"), mappers);
+        assertTrue(mappers.contains("if (code >= 400 && code < 500)"), mappers);
+        assertTrue(mappers.contains("if (code >= 500 && code < 600)"), mappers);
+        assertTrue(mappers.contains("return this.mapperDefault.apply(response)"), mappers);
+        assertFalse(mappers.contains("fromResponse"), mappers);
+
+        // And the whole thing compiles.
+        process("petstoreV3_response_ranges_client_compile", "java-client",
+            getClass().getResource(SPEC).toExternalForm(), new SwaggerParams.Options());
+    }
+
+    @Test
+    void aggregateMapperThrowsWhenNoDefaultResponseIsDeclared() throws Exception {
+        var files = generate("petstoreV3_response_ranges_no_default_client", "java-client",
+            getClass().getResource(SPEC_NO_DEFAULT).toExternalForm(), new SwaggerParams.Options());
+
+        var api = read(files, "DefaultApi.java");
+        var mappers = read(files, "DefaultApiClientResponseMappers.java");
+
+        // Both exact codes are registered directly; the aggregate covers the two ranges.
+        assertTrue(api.contains("code = 200"), api);
+        assertTrue(api.contains("code = 404"), api);
+        assertTrue(api.contains("ListPetsDefaultCodeApiResponseMapper.class"), api);
+
+        assertTrue(mappers.contains("if (code >= 400 && code < 500)"), mappers);
+        assertTrue(mappers.contains("if (code >= 500 && code < 600)"), mappers);
+        // No `default` response, so an unmatched code throws like the runtime does.
+        assertTrue(mappers.contains("throw HttpClientResponseException.fromResponse(response)"), mappers);
+        assertFalse(mappers.contains("mapperDefault"), mappers);
+
+        process("petstoreV3_response_ranges_no_default_compile", "java-client",
+            getClass().getResource(SPEC_NO_DEFAULT).toExternalForm(), new SwaggerParams.Options());
+    }
+
+    @Test
+    void serverBuildsRangeResponsesFromRuntimeStatusCode() throws Exception {
+        var files = generate("petstoreV3_response_ranges_server", "java-server",
+            getClass().getResource(SPEC).toExternalForm(), new SwaggerParams.Options());
+
+        var mappers = read(files, "DefaultApiServerResponseMappers.java");
+
+        // The response entity is built from the record's runtime status code, not the range token.
+        assertFalse(mappers.contains("HttpResponseEntity.of(4XX,"), mappers);
+        assertFalse(mappers.contains("HttpResponseEntity.of(5XX,"), mappers);
+        assertTrue(mappers.contains("HttpResponseEntity.of(rs.statusCode(),"), mappers);
+
+        process("petstoreV3_response_ranges_server_compile", "java-server",
+            getClass().getResource(SPEC).toExternalForm(), new SwaggerParams.Options());
+    }
+
+    private static int countOccurrences(String haystack, String needle) {
+        int count = 0;
+        for (int i = haystack.indexOf(needle); i >= 0; i = haystack.indexOf(needle, i + needle.length())) {
+            count++;
+        }
+        return count;
+    }
+
+    private static String read(java.util.List<File> files, String fileName) throws Exception {
+        return Files.readString(files.stream()
+            .map(File::toPath)
+            .filter(path -> path.getFileName().toString().equals(fileName))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError(fileName + " was not generated")));
+    }
+}

--- a/openapi/openapi-generator/src/test/resources/example/petstoreV3_response_ranges.yaml
+++ b/openapi/openapi-generator/src/test/resources/example/petstoreV3_response_ranges.yaml
@@ -1,0 +1,61 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore Response Ranges
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        '4XX':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '5XX':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/openapi/openapi-generator/src/test/resources/example/petstoreV3_response_ranges_no_default.yaml
+++ b/openapi/openapi-generator/src/test/resources/example/petstoreV3_response_ranges_no_default.yaml
@@ -1,0 +1,61 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore Response Ranges Without Default
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '4XX':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '5XX':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string


### PR DESCRIPTION
## EN

### Description

Added support for OpenAPI status-code range responses (`1XX`–`5XX`) in the generator. An operation may declare responses for ranges alongside exact codes and `default`, but the generator previously copied the raw range token (for example `4XX`) into positions requiring an `int`, producing Java and Kotlin sources that did not compile. Range responses now carry a runtime status code and are dispatched by the actual response code, so range declarations generate and compile correctly for clients and servers in both languages.

### Intention & Motivation

Added range support because range responses are a valid and common part of real OpenAPI specifications, and silently emitting non-compiling code forced users to hand-edit generated sources or restructure their specs.

---

## RU

### Описание

Добавлена поддержка ответов с диапазонами статус-кодов OpenAPI (`1XX`–`5XX`) в генераторе. Операция может объявлять ответы для диапазонов наряду с точными кодами и `default`, однако ранее генератор подставлял исходный токен диапазона (например `4XX`) в места, требующие `int`, из-за чего сгенерированные исходники на Java и Kotlin не компилировались. Теперь ответы для диапазонов несут статус-код времени выполнения и выбираются по фактическому коду ответа, поэтому объявления диапазонов корректно генерируются и компилируются для клиентов и серверов на обоих языках.

### Намерение и мотивация

Поддержка диапазонов добавлена потому, что такие ответы являются допустимой и распространённой частью реальных спецификаций OpenAPI, а тихая генерация некомпилируемого кода вынуждала пользователей вручную править сгенерированные исходники или перестраивать спецификацию.

---

## Changelog

- Added generation of client operations that register exact codes directly with `@ResponseCodeMapper(code = N)`, while ranges and the OpenAPI `default` response funnel through a single aggregate mapper registered as `@ResponseCodeMapper(code = ResponseCodeMapper.DEFAULT)` that dispatches on the real status code to the matching per-range mapper, falling back to the `default` response mapper or throwing `HttpClientResponseException` when no `default` is declared.
- Added server range response records that carry a runtime `statusCode`, with the response entity built from it instead of the range token.
- Improved generated `DEFAULT` registrations to emit `ResponseCodeMapper.DEFAULT` instead of the literal `-1`.

---

## Design

OpenAPI allows a response key to be an exact code, a range bucket (`1XX`–`5XX`), or `default`. A range has no single concrete status, so it cannot be written where an `int` is required (`@ResponseCodeMapper.code()`, `HttpResponseEntity.of(code, ...)`, a response record's `statusCode()`), and it cannot be matched by the existing exact-or-default runtime. The change lowers ranges entirely within the generator, leaving the `ResponseCodeMapper` runtime and annotation processor untouched.

On the client, exact codes are still registered directly. Ranges and `default` are not registered on their own code; instead the generator emits one aggregate `<Op>DefaultCodeApiResponseMapper` registered as the `DEFAULT`. Every code not matched by an exact `@ResponseCodeMapper` reaches this aggregate, which dispatches on the real status code, applying range precedence (exact wins, then range, then `default`). The aggregate injects the per-range and `default` mappers by their concrete generated types, so dependency resolution stays unambiguous even though they all implement the same `HttpClientResponseMapper` interface.

```java
@ResponseCodeMapper(code = 200, mapper = DefaultApiClientResponseMappers.ListPets200ApiResponseMapper.class)
@ResponseCodeMapper(code = ResponseCodeMapper.DEFAULT, mapper = DefaultApiClientResponseMappers.ListPetsDefaultCodeApiResponseMapper.class)
ListPetsApiResponse listPets();

public ListPetsApiResponse apply(HttpClientResponse response) throws IOException {
    var code = response.code();
    if (code >= 400 && code < 500) return this.mapper4XX.apply(response);
    if (code >= 500 && code < 600) return this.mapper5XX.apply(response);
    return this.mapperDefault.apply(response); // or: throw HttpClientResponseException.fromResponse(response)
}
```

Range and default response records both carry an int statusCode supplied at runtime (response.code() on the client), which removes the invalid return 4XX and gives the server a concrete status to emit. On the server no matching is needed — the delegate returns a specific range record and the mapper writes HttpResponseEntity.of(rs.statusCode(), ...). When a spec declares ranges but no default, an unmatched code throws HttpClientResponseException.fromResponse(response), preserving the runtime's existing unmatched-code behavior. The Java and Kotlin generators produce equivalent structures.