### PR TITLE
Fixed(kafka): KSP listener with Headers + deserialization exception argument (Backport of #845)

### DIFF
--- a/kafka/kafka-annotation-processor/src/test/java/io/koraframework/kafka/annotation/processor/consumer/KafkaListenerKeyAndValueTest.java
+++ b/kafka/kafka-annotation-processor/src/test/java/io/koraframework/kafka/annotation/processor/consumer/KafkaListenerKeyAndValueTest.java
@@ -202,6 +202,30 @@ public class KafkaListenerKeyAndValueTest extends AbstractKafkaListenerAnnotatio
     }
 
     @Test
+    public void testProcessValueAndHeaders() {
+        var handler = compile("""
+            public class KafkaListenerClass {
+                @KafkaListener("test.config.path")
+                public void process(String value, Headers headers) {
+                }
+            }
+            """)
+            .handler(byte[].class, String.class);
+
+        handler.handle(record("test".getBytes(), "test-value"), i -> {
+            i.assertValue(0, "test-value");
+            i.assertHeadersIsEmpty(1);
+        });
+
+        handler.handle(errorKey("test-value"), i -> {
+            i.assertValue(0, "test-value");
+            i.assertHeadersIsEmpty(1);
+        });
+
+        handler.handle(errorValue(), RecordValueDeserializationException.class);
+    }
+
+    @Test
     public void testProcessKeyAndValueAndHeaders() {
         var handler = compile("""
             public class KafkaListenerClass {

--- a/kafka/kafka-symbol-processor/src/main/kotlin/io/koraframework/kafka/symbol/processor/consumer/KafkaHandlerGenerator.kt
+++ b/kafka/kafka-symbol-processor/src/main/kotlin/io/koraframework/kafka/symbol/processor/consumer/KafkaHandlerGenerator.kt
@@ -210,6 +210,9 @@ class KafkaHandlerGenerator(private val kspLogger: KSPLogger) {
                 addStatement("var key: %T? = null", keyType)
             }
             addStatement("var value: %T? = null", valueType)
+            if (headerParameter != null) {
+                addStatement("val headers = record.headers()")
+            }
             if (catchesKeyException || catchesValueException) {
                 beginControlFlow("try")
             }
@@ -219,9 +222,6 @@ class KafkaHandlerGenerator(private val kspLogger: KSPLogger) {
                 addStatement("record.key()")
             }
             addStatement("value = record.value()")
-            if (headerParameter != null) {
-                addStatement("val headers = record.headers()")
-            }
             if (catchesKeyException) {
                 nextControlFlow("catch (e: %T)", recordKeyDeserializationException)
                 addStatement("keyException = e")

--- a/kafka/kafka-symbol-processor/src/test/kotlin/io/koraframework/kafka/symbol/processor/consumer/KafkaListenerKeyAndValueTest.kt
+++ b/kafka/kafka-symbol-processor/src/test/kotlin/io/koraframework/kafka/symbol/processor/consumer/KafkaListenerKeyAndValueTest.kt
@@ -168,7 +168,77 @@ class KafkaListenerKeyAndValueTest : AbstractKafkaListenerAnnotationProcessorTes
                 fun process(consumer: Consumer<*,*>, value: String?, exception: Exception?) {
                 }
             }
-            
+
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun testProcessKeyValueAndException() {
+        compile(
+            """
+            class KafkaListenerClass {
+                @KafkaListener("test.config.path")
+                fun process(key: String?, value: String?, exception: Exception?) {
+                }
+            }
+
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun testProcessValueAndHeaders() {
+        compile(
+            """
+            class KafkaListenerClass {
+                @KafkaListener("test.config.path")
+                fun process(value: String, headers: Headers) {
+                }
+            }
+
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun testProcessKeyAndValueAndHeaders() {
+        compile(
+            """
+            class KafkaListenerClass {
+                @KafkaListener("test.config.path")
+                fun process(key: String, value: String, headers: Headers) {
+                }
+            }
+
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun testProcessKeyValueHeaderAndException() {
+        compile(
+            """
+            class KafkaListenerClass {
+                @KafkaListener("test.config.path")
+                fun process(key: String?, value: String?, headers: Headers, exception: Exception?) {
+                }
+            }
+
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun testProcessKeyValueHeadersAndConsumer() {
+        compile(
+            """
+            class KafkaListenerClass {
+                @KafkaListener("test.config.path")
+                fun process(consumer: Consumer<*,*>, key: String?, value: String?, headers: Headers, exception: Exception?) {
+                }
+            }
+
             """.trimIndent()
         )
     }


### PR DESCRIPTION
Fixed(kafka): KSP listener with Headers + deserialization exception argument (Backport of #845)

Backport of #845 (branch 1.0, commit 95c01fc0a87da0af1e5eda5830aa871c5c68d129)

Fixed the KSP KafkaListener generator emitting `val headers = record.headers()` inside the try block used for key/value deserialization while referencing it in the outer handler call, producing uncompilable code (unresolved reference: headers) for signatures like (key, value, Headers, Exception). Moved the headers declaration ahead of the try block since headers() never throws a deserialization exception.

- Added KSP consumer tests for the previously untested key/value/Headers signatures and a value+Headers parity case for the Java annotation processor.

The generator bug is present on master unchanged, so the fix ports as-is onto the io.koraframework KafkaHandlerGenerator; only package paths differ from the 1.0 source.