### PR TITLE
Fixed(openapi-generator): multipart form mapping and parsing (Backport of #830, #843, #848)

### DIFF
--- a/http/http-server-common/src/main/java/io/koraframework/http/server/common/request/mapper/HttpServerParameterReaderModule.java
+++ b/http/http-server-common/src/main/java/io/koraframework/http/server/common/request/mapper/HttpServerParameterReaderModule.java
@@ -50,7 +50,15 @@ public interface HttpServerParameterReaderModule {
 
     @DefaultComponent
     default HttpServerParameterReader<Boolean> booleanHttpServerParameterReader() {
-        return HttpServerParameterReader.of(Boolean::parseBoolean, "Parameter has incorrect value '%s' for 'Boolean' type"::formatted);
+        return HttpServerParameterReader.of(HttpServerParameterReaderModule::parseBooleanStrict, "Parameter has incorrect value '%s' for 'Boolean' type"::formatted);
+    }
+
+    private static boolean parseBooleanStrict(String value) {
+        return switch (value) {
+            case "true" -> true;
+            case "false" -> false;
+            default -> throw new IllegalArgumentException("Invalid boolean value: " + value);
+        };
     }
 
     @DefaultComponent

--- a/http/http-server-common/src/test/java/io/koraframework/http/server/common/request/mapper/HttpServerParameterReaderModuleTest.java
+++ b/http/http-server-common/src/test/java/io/koraframework/http/server/common/request/mapper/HttpServerParameterReaderModuleTest.java
@@ -1,0 +1,34 @@
+package io.koraframework.http.server.common.request.mapper;
+
+import io.koraframework.http.server.common.request.HttpServerParameterReader;
+import io.koraframework.http.server.common.response.HttpServerResponseException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class HttpServerParameterReaderModuleTest {
+
+    private final HttpServerParameterReaderModule module = new HttpServerParameterReaderModule() {};
+
+    @Test
+    void booleanReaderParsesTrueAndFalse() {
+        HttpServerParameterReader<Boolean> reader = module.booleanHttpServerParameterReader();
+
+        assertThat(reader.read("true")).isTrue();
+        assertThat(reader.read("false")).isFalse();
+    }
+
+    @Test
+    void booleanReaderRejectsInvalidValueInsteadOfSilentlyReturningFalse() {
+        HttpServerParameterReader<Boolean> reader = module.booleanHttpServerParameterReader();
+
+        // Boolean.parseBoolean would silently return false here; strict parsing must reject it with a 400
+        assertThatThrownBy(() -> reader.read("yes"))
+            .isInstanceOf(HttpServerResponseException.class);
+        assertThatThrownBy(() -> reader.read("1"))
+            .isInstanceOf(HttpServerResponseException.class);
+        assertThatThrownBy(() -> reader.read("TRUE"))
+            .isInstanceOf(HttpServerResponseException.class);
+    }
+}

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientRequestMapperGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ClientRequestMapperGenerator.java
@@ -89,8 +89,10 @@ public class ClientRequestMapperGenerator extends AbstractJavaGenerator<Operatio
             .addModifiers(Modifier.PUBLIC)
             .addAnnotation(Override.class);
         for (var p : operation.formParams) {
-            if (requiresMapper(p)) {
-                var mapperType = ParameterizedTypeName.get(Classes.stringParameterConverter, asType(p));
+            if (needsConverter(p)) {
+                // an array is written element by element, so its converter is over the element type
+                var valueType = isConvertibleArray(p) ? elementType(p) : asType(p);
+                var mapperType = ParameterizedTypeName.get(Classes.stringParameterConverter, valueType.box());
                 constructor.addParameter(mapperType, p.paramName + "Converter")
                     .addStatement("this.$N = $N", p.paramName + "Converter", p.paramName + "Converter");
                 b.addField(mapperType, p.paramName + "Converter", Modifier.PRIVATE, Modifier.FINAL);
@@ -108,19 +110,38 @@ public class ClientRequestMapperGenerator extends AbstractJavaGenerator<Operatio
         if (urlEncodedForm) {
             apply.addStatement("var b = new $T()", URL_ENCODED_WRITER);
             for (var formParam : operation.formParams) {
-                apply.beginControlFlow("if (value.$N() != null)", formParam.paramName);
-                if (requiresMapper(formParam)) {
+                // a required primitive record component is never null, so guarding it would not compile
+                var nullChecked = !isRequiredPrimitive(formParam);
+                if (nullChecked) {
+                    apply.beginControlFlow("if (value.$N() != null)", formParam.paramName);
+                }
+                if (isConvertibleArray(formParam)) {
+                    // multiple values are sent as repeated same-named fields, one per element
+                    apply.beginControlFlow("for (var item : value.$N())", formParam.paramName);
+                    if (elementType(formParam).equals(ClassName.get(String.class))) {
+                        apply.addStatement("b.add($S, item)", formParam.baseName);
+                    } else {
+                        apply.addStatement("b.add($S, $N.convert(item))", formParam.baseName, formParam.paramName + "Converter");
+                    }
+                    apply.endControlFlow();
+                } else if (requiresMapper(formParam)) {
                     apply.addStatement("b.add($S, $N.convert(value.$N()))", formParam.baseName, formParam.paramName + "Converter", formParam.paramName);
                 } else {
                     apply.addStatement("b.add($S, $T.toString(value.$N()))", formParam.baseName, ClassName.get(Objects.class), formParam.paramName);
                 }
-                apply.endControlFlow();
+                if (nullChecked) {
+                    apply.endControlFlow();
+                }
             }
             apply.addStatement("return b.write()");
         } else if (multipartForm) {
             apply.addStatement("var l = new $T<$T>()", ClassName.get(ArrayList.class), Classes.formPart);
             for (var formParam : operation.formParams) {
-                apply.beginControlFlow("if (value.$N() != null)", formParam.paramName);
+                // a required primitive record component is never null, so guarding it would not compile
+                var nullChecked = !isRequiredPrimitive(formParam);
+                if (nullChecked) {
+                    apply.beginControlFlow("if (value.$N() != null)", formParam.paramName);
+                }
                 if (formParam.isFile) {
                     if (formParam.isArray) {
                         apply.addStatement("l.addAll(value.$N())", formParam.paramName);
@@ -133,12 +154,23 @@ public class ClientRequestMapperGenerator extends AbstractJavaGenerator<Operatio
                         .endControlFlow();
                 } else if (isByteArrayType(formParam)) {
                     apply.addStatement("l.add($T.data($S, $T.getEncoder().encodeToString(value.$N())))", Classes.formMultipart, formParam.baseName, ClassName.get(Base64.class), formParam.paramName);
+                } else if (isConvertibleArray(formParam)) {
+                    // multiple values are sent as repeated same-named parts, one per element
+                    apply.beginControlFlow("for (var item : value.$N())", formParam.paramName);
+                    if (elementType(formParam).equals(ClassName.get(String.class))) {
+                        apply.addStatement("l.add($T.data($S, item))", Classes.formMultipart, formParam.baseName);
+                    } else {
+                        apply.addStatement("l.add($T.data($S, $N.convert(item)))", Classes.formMultipart, formParam.baseName, formParam.paramName + "Converter");
+                    }
+                    apply.endControlFlow();
                 } else if (requiresMapper(formParam)) {
                     apply.addStatement("l.add($T.data($S, $N.convert(value.$N())))", Classes.formMultipart, formParam.baseName, formParam.paramName + "Converter", formParam.paramName);
                 } else {
                     apply.addStatement("l.add($T.data($S, $T.toString(value.$N())))", Classes.formMultipart, formParam.baseName, ClassName.get(Objects.class), formParam.paramName);
                 }
-                apply.endControlFlow();
+                if (nullChecked) {
+                    apply.endControlFlow();
+                }
             }
             apply.addStatement("return $T.write(l)", Classes.multipartWriter);
         } else {
@@ -146,6 +178,28 @@ public class ClientRequestMapperGenerator extends AbstractJavaGenerator<Operatio
         }
 
         return b.addMethod(constructor.build()).addMethod(apply.build()).build();
+    }
+
+    // a non-file, non-byte array whose elements are written as repeated same-named form fields
+    private boolean isConvertibleArray(CodegenParameter p) {
+        return Boolean.TRUE.equals(p.isArray) && !p.isFile && !isByteArrayArrayType(p);
+    }
+
+    private TypeName elementType(CodegenParameter p) {
+        return ((ParameterizedTypeName) asType(p)).typeArguments().getFirst();
+    }
+
+    private boolean needsConverter(CodegenParameter p) {
+        if (isConvertibleArray(p)) {
+            // string elements are written directly; every other element type goes through a converter
+            return !elementType(p).equals(ClassName.get(String.class));
+        }
+        return requiresMapper(p);
+    }
+
+    private boolean isRequiredPrimitive(CodegenParameter p) {
+        // buildFormParamsRecord boxes optional components but keeps required primitives unboxed
+        return p.required && !p.isFile && !p.isArray && asType(p).isPrimitive();
     }
 
     private boolean isByteArrayType(CodegenParameter p) {

--- a/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ServerRequestMapperGenerator.java
+++ b/openapi/openapi-generator/src/main/java/io/koraframework/openapi/generator/javagen/ServerRequestMapperGenerator.java
@@ -93,6 +93,11 @@ public class ServerRequestMapperGenerator extends AbstractJavaGenerator<Operatio
         return b.build();
     }
 
+    // a non-file, non-byte array collected element by element into a list
+    private boolean isConvertibleArray(CodegenParameter p) {
+        return Boolean.TRUE.equals(p.isArray) && !p.isFile && !isByteArrayArrayType(p);
+    }
+
     private boolean isByteArrayType(CodegenParameter p) {
         return "byte[]".equals(p.dataType) || "ByteArray".equals(p.dataType);
     }
@@ -123,12 +128,17 @@ public class ServerRequestMapperGenerator extends AbstractJavaGenerator<Operatio
             } else if (isByteArrayArrayType(formParam)) {
                 b.addStatement("var $N = new $T<byte[]>()", formParam.paramName, ClassName.get(java.util.ArrayList.class));
                 continue;
+            } else if (formParam.isArray) {
+                var elementType = ((ParameterizedTypeName) asType(formParam)).typeArguments().getFirst();
+                b.addStatement("var $N = new $T<$T>()", formParam.paramName, ClassName.get(java.util.ArrayList.class), elementType);
+                continue;
             }
             var type = asType(formParam);
             if (formParam.isFile) {
                 type = Classes.formPart;
             }
-            b.addStatement("var $N = ($T) null", formParam.paramName, type);
+            // box primitive types so the nullable local can hold null before the part is read
+            b.addStatement("var $N = ($T) null", formParam.paramName, type.box());
         }
         b.addStatement("var _parts = $T.read(rq)", MULTIPART_READER);
         b.beginControlFlow("for (var _part : _parts) switch(_part.name())");
@@ -143,11 +153,19 @@ public class ServerRequestMapperGenerator extends AbstractJavaGenerator<Operatio
                 b.addStatement("$N.add($T.getDecoder().decode(_part.content()))", formParam.paramName, ClassName.get(Base64.class));
             } else if (isByteArrayType(formParam)) {
                 b.addStatement("$N = $T.getDecoder().decode(_part.content())", formParam.paramName, ClassName.get(Base64.class));
+            } else if (formParam.isArray) {
+                var elementType = ((ParameterizedTypeName) type).typeArguments().getFirst();
+                if (elementType.equals(ClassName.get(String.class))) {
+                    b.addStatement("$N.add(new $T(_part.content(), $T.UTF_8))", formParam.paramName, String.class, StandardCharsets.class);
+                } else {
+                    var converterName = formParam.paramName + "Converter";
+                    b.addStatement("$N.add($N.read(new $T(_part.content(), $T.UTF_8)))", formParam.paramName, converterName, String.class, StandardCharsets.class);
+                }
             } else if (type.equals(ClassName.get(String.class))) {
                 b.addStatement("$N = new $T(_part.content(), $T.UTF_8)", formParam.paramName, String.class, StandardCharsets.class);
             } else {
                 var converterName = formParam.paramName + "Converter";
-                b.addStatement("$N = $T.read(new $T(_part.content(), $T.UTF_8))", formParam.paramName, converterName, String.class, StandardCharsets.class);
+                b.addStatement("$N = $N.read(new $T(_part.content(), $T.UTF_8))", formParam.paramName, converterName, String.class, StandardCharsets.class);
             }
             b.endControlFlow();
         }
@@ -155,9 +173,7 @@ public class ServerRequestMapperGenerator extends AbstractJavaGenerator<Operatio
         b.endControlFlow();
         for (var formParam : op.formParams) {
             if (formParam.required) {
-                if (formParam.isFile && formParam.isArray) {
-                    b.beginControlFlow("if ($N.isEmpty())", formParam.paramName);
-                } else if (isByteArrayArrayType(formParam)) {
+                if (formParam.isArray) {
                     b.beginControlFlow("if ($N.isEmpty())", formParam.paramName);
                 } else {
                     b.beginControlFlow("if ($N == null)", formParam.paramName);
@@ -173,8 +189,12 @@ public class ServerRequestMapperGenerator extends AbstractJavaGenerator<Operatio
             if (i > 0) {
                 b.add(", ");
             }
-            b.add(formParam.paramName);
-
+            if (!formParam.required && isConvertibleArray(formParam)) {
+                // an absent optional array yields null rather than an empty collection
+                b.add("$N.isEmpty() ? null : $N", formParam.paramName, formParam.paramName);
+            } else {
+                b.add(formParam.paramName);
+            }
         }
         b.add(");\n");
         return b.build();

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/AbstractKotlinGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/AbstractKotlinGenerator.kt
@@ -425,8 +425,8 @@ abstract class AbstractKotlinGenerator<C : Any> : AbstractGenerator<C, FileSpec>
         com.palantir.javapoet.TypeName.SHORT.box() -> SHORT
         com.palantir.javapoet.TypeName.BYTE.box() -> BYTE
         com.palantir.javapoet.TypeName.DOUBLE.box() -> DOUBLE
-        com.palantir.javapoet.TypeName.FLOAT.box() -> BOOLEAN
-        com.palantir.javapoet.TypeName.BOOLEAN.box() -> FLOAT
+        com.palantir.javapoet.TypeName.FLOAT.box() -> FLOAT
+        com.palantir.javapoet.TypeName.BOOLEAN.box() -> BOOLEAN
         else -> ClassName(packageName(), simpleNames())
     }
 

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ClientRequestMapperGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ClientRequestMapperGenerator.kt
@@ -78,8 +78,10 @@ class ClientRequestMapperGenerator : AbstractKotlinGenerator<OperationsMap>() {
             .addParameter("value", formParamClassName)
             .addModifiers(KModifier.OVERRIDE)
         for (p in operation.formParams) {
-            if (requiresMapper(p)) {
-                val mapperType = Classes.stringParameterConverter.asKt().parameterizedBy(asType(p).asKt())
+            if (needsConverter(p)) {
+                // an array is written element by element, so its converter is over the element type
+                val valueType = if (isConvertibleArray(p)) elementType(p) else asType(p).asKt()
+                val mapperType = Classes.stringParameterConverter.asKt().parameterizedBy(valueType)
                 val mapperName = p.paramName + "Converter"
                 constructor.addParameter(mapperName, mapperType)
                 b.addProperty(PropertySpec.builder(mapperName, mapperType).initializer(mapperName).build())
@@ -102,7 +104,16 @@ class ClientRequestMapperGenerator : AbstractKotlinGenerator<OperationsMap>() {
                 } else {
                     apply.beginControlFlow("value.%N?.let", formParam.paramName)
                 }
-                if (requiresMapper(formParam)) {
+                if (isConvertibleArray(formParam)) {
+                    // multiple values are sent as repeated same-named fields, one per element
+                    apply.beginControlFlow("for (item in it)")
+                    if (elementType(formParam) == String::class.asClassName()) {
+                        apply.addStatement("b.add(%S, item)", formParam.baseName)
+                    } else {
+                        apply.addStatement("b.add(%S, %N.convert(item))", formParam.baseName, formParam.paramName + "Converter")
+                    }
+                    apply.endControlFlow()
+                } else if (requiresMapper(formParam)) {
                     apply.addStatement("b.add(%S, %N.convert(it))", formParam.baseName, formParam.paramName + "Converter")
                 } else {
                     apply.addStatement("b.add(%S, it.toString())", formParam.baseName)
@@ -130,6 +141,15 @@ class ClientRequestMapperGenerator : AbstractKotlinGenerator<OperationsMap>() {
                         .endControlFlow()
                 } else if (isByteArrayType(formParam)) {
                     apply.addStatement("l.add(%T.data(%S, %T.getEncoder().encodeToString(it)))", Classes.formMultipart.asKt(), formParam.baseName, base64)
+                } else if (isConvertibleArray(formParam)) {
+                    // multiple values are sent as repeated same-named parts, one per element
+                    apply.beginControlFlow("for (item in it)")
+                    if (elementType(formParam) == String::class.asClassName()) {
+                        apply.addStatement("l.add(%T.data(%S, item))", Classes.formMultipart.asKt(), formParam.baseName)
+                    } else {
+                        apply.addStatement("l.add(%T.data(%S, %N.convert(item)))", Classes.formMultipart.asKt(), formParam.baseName, formParam.paramName + "Converter")
+                    }
+                    apply.endControlFlow()
                 } else if (requiresMapper(formParam)) {
                     apply.addStatement("l.add(%T.data(%S, %N.convert(it)))", Classes.formMultipart.asKt(), formParam.baseName, formParam.paramName + "Converter")
                 } else {
@@ -163,6 +183,16 @@ class ClientRequestMapperGenerator : AbstractKotlinGenerator<OperationsMap>() {
         }
         return !p.isPrimitiveType
     }
+
+    // a non-file, non-byte array whose elements are written as repeated same-named form fields
+    private fun isConvertibleArray(p: CodegenParameter): Boolean =
+        p.isArray == true && !p.isFile && !isByteArrayArrayType(p)
+
+    private fun elementType(p: CodegenParameter): TypeName =
+        (asType(p).asKt() as ParameterizedTypeName).typeArguments.single()
+
+    private fun needsConverter(p: CodegenParameter): Boolean =
+        if (isConvertibleArray(p)) elementType(p) != String::class.asClassName() else requiresMapper(p)
 
     private fun ambiguousFormContentTypeError(operation: CodegenOperation): String {
         return """

--- a/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ServerRequestMappersGenerator.kt
+++ b/openapi/openapi-generator/src/main/kotlin/io/koraframework/openapi/generator/kotlingen/ServerRequestMappersGenerator.kt
@@ -20,6 +20,10 @@ class ServerRequestMappersGenerator : AbstractKotlinGenerator<OperationsMap>() {
     private fun isByteArrayType(p: CodegenParameter): Boolean =
         p.dataType == "byte[]" || p.dataType == "ByteArray"
 
+    // a non-file, non-byte array collected element by element into a list
+    private fun isConvertibleArray(p: CodegenParameter): Boolean =
+        p.isArray == true && !p.isFile && !isByteArrayArrayType(p)
+
     private fun isByteArrayArrayType(p: CodegenParameter): Boolean =
         p.isArray == true && (p.baseType == "byte[]" || p.baseType == "ByteArray"
             || p.dataType?.contains("byte[]") == true || p.dataType?.contains("ByteArray") == true)
@@ -114,6 +118,10 @@ class ServerRequestMappersGenerator : AbstractKotlinGenerator<OperationsMap>() {
             } else if (isByteArrayArrayType(formParam)) {
                 b.addStatement("val %N = mutableListOf<ByteArray>()", formParam.paramName)
                 continue
+            } else if (formParam.isArray) {
+                val elementType = (asType(formParam).asKt() as ParameterizedTypeName).typeArguments.single()
+                b.addStatement("val %N = mutableListOf<%T>()", formParam.paramName, elementType)
+                continue
             }
             var type = asType(formParam).asKt()
             if (formParam.isFile) {
@@ -134,11 +142,19 @@ class ServerRequestMappersGenerator : AbstractKotlinGenerator<OperationsMap>() {
                 b.addStatement("%N.add(%T.getDecoder().decode(_part.content()))", formParam.paramName, base64)
             } else if (isByteArrayType(formParam)) {
                 b.addStatement("%N = %T.getDecoder().decode(_part.content())", formParam.paramName, base64)
+            } else if (formParam.isArray) {
+                val elementType = (type as ParameterizedTypeName).typeArguments.single()
+                if (elementType == String::class.asClassName()) {
+                    b.addStatement("%N.add(%T(_part.content(), %T.UTF_8))", formParam.paramName, String::class.asClassName(), StandardCharsets::class.asClassName())
+                } else {
+                    val converterName = formParam.paramName + "Converter"
+                    b.addStatement("%N.add(%N.read(%T(_part.content(), %T.UTF_8)))", formParam.paramName, converterName, String::class.asClassName(), StandardCharsets::class.asClassName())
+                }
             } else if (type == String::class.asClassName()) {
                 b.addStatement("%N = %T(_part.content(), %T.UTF_8)", formParam.paramName, String::class.asClassName(), StandardCharsets::class.asClassName())
             } else {
                 val converterName = formParam.paramName + "Converter"
-                b.addStatement("%N = %T.read(%T(_part.content(), %T.UTF_8))", formParam.paramName, converterName, String::class.asClassName(), StandardCharsets::class.asClassName())
+                b.addStatement("%N = %N.read(%T(_part.content(), %T.UTF_8))", formParam.paramName, converterName, String::class.asClassName(), StandardCharsets::class.asClassName())
             }
             b.endControlFlow()
         }
@@ -146,9 +162,7 @@ class ServerRequestMappersGenerator : AbstractKotlinGenerator<OperationsMap>() {
         b.endControlFlow()
         for (formParam in op.formParams) {
             if (formParam.required) {
-                if (formParam.isFile && formParam.isArray) {
-                    b.beginControlFlow("if (%N.isEmpty())", formParam.paramName)
-                } else if (isByteArrayArrayType(formParam)) {
+                if (formParam.isArray) {
                     b.beginControlFlow("if (%N.isEmpty())", formParam.paramName)
                 } else {
                     b.beginControlFlow("if (%N == null)", formParam.paramName)
@@ -164,7 +178,12 @@ class ServerRequestMappersGenerator : AbstractKotlinGenerator<OperationsMap>() {
             if (i > 0) {
                 b.add(", ")
             }
-            b.add(formParam.paramName)
+            if (!formParam.required && isConvertibleArray(formParam)) {
+                // an absent optional array yields null rather than an empty collection
+                b.add("%N.ifEmpty { null }", formParam.paramName)
+            } else {
+                b.add(formParam.paramName)
+            }
         }
         b.add(")\n")
         return b.build()

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientJavaOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientJavaOpenapiTest.java
@@ -43,6 +43,50 @@ public class HttpClientJavaOpenapiTest extends BaseJavaOpenapiTest {
     }
 
     @Test
+    void multipartFormWritesArraysAsRepeatedParts() throws Exception {
+        var files = generate(
+            "petstoreV3_form_multipart_client_types",
+            "java-client",
+            getClass().getResource("/example/petstoreV3_form.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+        );
+
+        var content = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("DefaultApiClientRequestMappers.java"))
+            .findFirst()
+            .orElseThrow());
+
+        // a string array is written as one part per element, using the raw element, no converter
+        var stringArray = nestedClass(content, "FormMultipartFormDataWithStringArrayPatchFormParamRequestMapper");
+        assertFalse(stringArray.contains("tagsConverter"));
+        assertTrue(stringArray.contains("for (var item : value.tags())"));
+        assertTrue(stringArray.contains("l.add(FormMultipart.data(\"tags\", item))"));
+
+        // an int array is written one part per element through an element-typed writer
+        var intArray = nestedClass(content, "FormMultipartFormDataWithIntArrayPatchFormParamRequestMapper");
+        assertTrue(intArray.contains("HttpClientParameterWriter<Integer> countsConverter"));
+        assertTrue(intArray.contains("for (var item : value.counts())"));
+        assertTrue(intArray.contains("l.add(FormMultipart.data(\"counts\", countsConverter.convert(item)))"));
+
+        // an enum array likewise writes one part per element
+        var enumArray = nestedClass(content, "FormMultipartFormDataWithEnumArrayPatchFormParamRequestMapper");
+        assertTrue(enumArray.contains("HttpClientParameterWriter<CurrencyType> typesConverter"));
+        assertTrue(enumArray.contains("for (var item : value.types())"));
+        assertTrue(enumArray.contains("l.add(FormMultipart.data(\"types\", typesConverter.convert(item)))"));
+
+        // the whole-list single-part form must be gone
+        assertFalse(content.contains("countsConverter.convert(value.counts())"));
+    }
+
+    private static String nestedClass(String content, String name) {
+        var start = content.indexOf("class " + name);
+        assertTrue(start > 0, () -> name + " was not generated");
+        var end = content.indexOf("class ", start + 1);
+        return end < 0 ? content.substring(start) : content.substring(start, end);
+    }
+
+    @Test
     void clientConfigIsUsedAsSingleConfigPath() throws Exception {
         var files = generate(
             "petstoreV3_single_config",

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientKotlinOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpClientKotlinOpenapiTest.java
@@ -21,6 +21,38 @@ public class HttpClientKotlinOpenapiTest extends BaseKotlinOpenapiTest {
     }
 
     @Test
+    void multipartFormWritesArraysAsRepeatedParts() throws Exception {
+        var files = generate(
+            "petstoreV3_form_multipart_client_types",
+            "kotlin-client",
+            getClass().getResource("/example/petstoreV3_form.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+        );
+
+        var content = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("DefaultApiClientRequestMappers.kt"))
+            .findFirst()
+            .orElseThrow());
+
+        // an int array is written one part per element through an element-typed writer
+        var intArray = nestedClass(content, "FormMultipartFormDataWithIntArrayPatchFormParamRequestMapper");
+        assertTrue(intArray.contains("countsConverter: HttpClientParameterWriter<Int>"));
+        assertTrue(intArray.contains("for (item in it)"));
+        assertTrue(intArray.contains("l.add(FormMultipart.data(\"counts\", countsConverter.convert(item)))"));
+
+        // the whole-list single-part form must be gone
+        assertFalse(content.contains("countsConverter.convert(value.counts)"));
+    }
+
+    private static String nestedClass(String content, String name) {
+        var start = content.indexOf("class " + name);
+        assertTrue(start > 0, () -> name + " was not generated");
+        var end = content.indexOf("class ", start + 1);
+        return end < 0 ? content.substring(start) : content.substring(start, end);
+    }
+
+    @Test
     void clientConfigIsUsedAsSingleConfigPath() throws Exception {
         var files = generate(
             "petstoreV3_single_config",

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpServerJavaOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpServerJavaOpenapiTest.java
@@ -38,6 +38,62 @@ public class HttpServerJavaOpenapiTest extends BaseJavaOpenapiTest {
         assertTrue(urlEncoded.contains("HttpServerParameterReader<Boolean> providedConverter"));
     }
 
+    @Test
+    void multipartFormMapsEnumModelPrimitiveAndArrayParams() throws Exception {
+        var files = generate(
+            "petstoreV3_form_multipart_types",
+            "java-server",
+            getClass().getResource("/example/petstoreV3_form.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+        );
+
+        var content = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("DefaultApiServerRequestMappers.java"))
+            .findFirst()
+            .orElseThrow());
+
+        // a single enum part is read through its converter, not passed through as a raw String
+        var enumMapper = nestedClass(content, "FormMultipartFormDataWithEnumPatchFormParamRequestMapper");
+        assertTrue(enumMapper.contains("HttpServerParameterReader<CurrencyType> typeConverter"));
+        assertTrue(enumMapper.contains("type = typeConverter.read(new String(_part.content(), StandardCharsets.UTF_8))"));
+
+        // a single model part is read through its converter as well
+        var modelMapper = nestedClass(content, "FormMultipartFormDataWithModelPatchFormParamRequestMapper");
+        assertTrue(modelMapper.contains("HttpServerParameterReader<Info> infoConverter"));
+        assertTrue(modelMapper.contains("info = infoConverter.read(new String(_part.content(), StandardCharsets.UTF_8))"));
+
+        // single primitive parts declare a boxed nullable local so it can be null before the part is read
+        var primitiveMapper = nestedClass(content, "FormMultipartFormDataWithPrimitivesPatchFormParamRequestMapper");
+        assertTrue(primitiveMapper.contains("var active = (Boolean) null"));
+        assertTrue(primitiveMapper.contains("var count = (Integer) null"));
+        assertTrue(primitiveMapper.contains("active = activeConverter.read(new String(_part.content(), StandardCharsets.UTF_8))"));
+
+        // an array of strings collects every part directly, no converter and required checked via isEmpty()
+        var stringArray = nestedClass(content, "FormMultipartFormDataWithStringArrayPatchFormParamRequestMapper");
+        assertFalse(stringArray.contains("tagsConverter"));
+        assertTrue(stringArray.contains("var tags = new ArrayList<String>()"));
+        assertTrue(stringArray.contains("tags.add(new String(_part.content(), StandardCharsets.UTF_8))"));
+        assertTrue(stringArray.contains("if (tags.isEmpty())"));
+
+        // an array of primitives collects converted elements
+        var intArray = nestedClass(content, "FormMultipartFormDataWithIntArrayPatchFormParamRequestMapper");
+        assertTrue(intArray.contains("HttpServerParameterReader<Integer> countsConverter"));
+        assertTrue(intArray.contains("var counts = new ArrayList<Integer>()"));
+        assertTrue(intArray.contains("counts.add(countsConverter.read(new String(_part.content(), StandardCharsets.UTF_8)))"));
+        assertTrue(intArray.contains("if (counts.isEmpty())"));
+
+        // an array of enums collects converted elements
+        var enumArray = nestedClass(content, "FormMultipartFormDataWithEnumArrayPatchFormParamRequestMapper");
+        assertTrue(enumArray.contains("HttpServerParameterReader<CurrencyType> typesConverter"));
+        assertTrue(enumArray.contains("var types = new ArrayList<CurrencyType>()"));
+        assertTrue(enumArray.contains("types.add(typesConverter.read(new String(_part.content(), StandardCharsets.UTF_8)))"));
+
+        // an absent optional array yields null, not an empty list
+        var optionalArray = nestedClass(content, "FormMultipartFormDataWithOptionalArrayPatchFormParamRequestMapper");
+        assertTrue(optionalArray.contains("labels.isEmpty() ? null : labels"));
+    }
+
     private static String nestedClass(String content, String name) {
         var start = content.indexOf("class " + name);
         assertTrue(start > 0, () -> name + " was not generated");

--- a/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpServerKotlinOpenapiTest.java
+++ b/openapi/openapi-generator/src/test/java/io/koraframework/openapi/generator/HttpServerKotlinOpenapiTest.java
@@ -46,6 +46,45 @@ public class HttpServerKotlinOpenapiTest extends BaseKotlinOpenapiTest {
         return end < 0 ? content.substring(start) : content.substring(start, end);
     }
 
+    @Test
+    void multipartFormMapsEnumPrimitiveAndArrayParams() throws Exception {
+        var files = generate(
+            "petstoreV3_form_multipart_types",
+            "kotlin-server",
+            getClass().getResource("/example/petstoreV3_form.yaml").toExternalForm(),
+            new SwaggerParams.Options()
+        );
+
+        var content = Files.readString(files.stream()
+            .map(java.io.File::toPath)
+            .filter(path -> path.getFileName().toString().equals("DefaultApiServerRequestMappers.kt"))
+            .findFirst()
+            .orElseThrow());
+
+        // a single enum part is read through its converter
+        var enumMapper = nestedClass(content, "FormMultipartFormDataWithEnumPatchFormParamRequestMapper");
+        assertTrue(enumMapper.contains("typeConverter: HttpServerParameterReader<CurrencyType>"));
+        assertTrue(enumMapper.contains("= typeConverter.read(String(_part.content(), StandardCharsets.UTF_8))"));
+
+        // an array of strings collects parts directly and checks presence via isEmpty()
+        var stringArray = nestedClass(content, "FormMultipartFormDataWithStringArrayPatchFormParamRequestMapper");
+        assertFalse(stringArray.contains("tagsConverter"));
+        assertTrue(stringArray.contains("val tags = mutableListOf<String>()"));
+        assertTrue(stringArray.contains(".add(String(_part.content(), StandardCharsets.UTF_8))"));
+        assertTrue(stringArray.contains(".isEmpty()"));
+
+        // an array of enums collects converted elements
+        var enumArray = nestedClass(content, "FormMultipartFormDataWithEnumArrayPatchFormParamRequestMapper");
+        assertTrue(enumArray.contains("typesConverter: HttpServerParameterReader<CurrencyType>"));
+        assertTrue(enumArray.contains("val types = mutableListOf<CurrencyType>()"));
+
+        // a boolean array must map to Boolean (not Float, which the asKt mapping used to swap)
+        var boolArray = nestedClass(content, "FormMultipartFormDataWithBoolArrayPatchFormParamRequestMapper");
+        assertTrue(boolArray.contains("flagsConverter: HttpServerParameterReader<Boolean>"));
+        assertTrue(boolArray.contains("val flags = mutableListOf<Boolean>()"));
+        assertFalse(boolArray.contains("HttpServerParameterReader<Float>"));
+    }
+
     @ParameterizedTest
     @MethodSource("generateParams")
     void test(SwaggerParams params) throws Exception {

--- a/openapi/openapi-generator/src/test/resources/example/petstoreV3_form.yaml
+++ b/openapi/openapi-generator/src/test/resources/example/petstoreV3_form.yaml
@@ -97,6 +97,183 @@ paths:
         '200':
           description: Updated
 
+  /form-multipart-form-data-with-enum:
+    patch:
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - account
+                - type
+              properties:
+                account:
+                  type: string
+                type:
+                  $ref: '#/components/schemas/CurrencyType'
+      responses:
+        '200':
+          description: Updated
+
+  /form-multipart-form-data-with-model:
+    patch:
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - name
+                - info
+              properties:
+                name:
+                  type: string
+                info:
+                  $ref: '#/components/schemas/Info'
+      responses:
+        '200':
+          description: Updated
+
+  /form-multipart-form-data-with-primitives:
+    patch:
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - active
+                - count
+              properties:
+                active:
+                  type: boolean
+                count:
+                  type: integer
+                  format: int32
+                rating:
+                  type: number
+                  format: double
+      responses:
+        '200':
+          description: Updated
+
+  /form-multipart-form-data-with-string-array:
+    patch:
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - tags
+              properties:
+                tags:
+                  type: array
+                  items:
+                    type: string
+      responses:
+        '200':
+          description: Updated
+
+  /form-multipart-form-data-with-int-array:
+    patch:
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - counts
+              properties:
+                counts:
+                  type: array
+                  items:
+                    type: integer
+                    format: int32
+      responses:
+        '200':
+          description: Updated
+
+  /form-multipart-form-data-with-bool-array:
+    patch:
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - flags
+              properties:
+                flags:
+                  type: array
+                  items:
+                    type: boolean
+      responses:
+        '200':
+          description: Updated
+
+  /form-multipart-form-data-with-enum-array:
+    patch:
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - types
+              properties:
+                types:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/CurrencyType'
+      responses:
+        '200':
+          description: Updated
+
+  /form-multipart-form-data-with-model-array:
+    patch:
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - infos
+              properties:
+                infos:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/Info'
+      responses:
+        '200':
+          description: Updated
+
+  /form-multipart-form-data-with-optional-array:
+    patch:
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                labels:
+                  type: array
+                  items:
+                    type: string
+      responses:
+        '200':
+          description: Updated
+
   /form-image:
     patch:
       requestBody:


### PR DESCRIPTION
Fixed(openapi-generator): multipart form enum/model/primitive/array mapping and strict boolean form parsing (Backport of #830, #843, #848)

Backport of #830 (branch 1.0, commit b0721a8ce4d49e2db15c7e985df59367a24a3b5a)
Backport of #843 (branch 1.0, commit 1fab9c883297a9b7911bcf1b1f4273a28a7e2319)
Backport of #848 (branch 1.0, commit 1e897f372c8b24a1c383533a27983a574833069a)

Fixed multipart/form-data server request mappers to handle enum, model, primitive and array form parameters, and made boolean form parsing strict. Previously the multipart mapper only handled files, byte arrays, single strings and single converter-backed values; arrays of strings/primitives/enums/models produced uncompilable code, single enum/model parts crashed generation, and single primitive parts declared an uncompilable primitive-typed nullable local. Boolean form values were parsed leniently and silently accepted invalid input as false.

- Multipart arrays (string/primitive/enum/model) now initialize a list, collect each part (strings directly, everything else through the element `HttpServerParameterReader`), and check required presence via `isEmpty()`.
- Single enum/model/primitive multipart parts are read through their converter; primitive locals are boxed so they can hold null before the part is read.
- The client Java request mapper no longer emits a null-guard around required primitive record components (which are never null and would not compile).
- `HttpServerParameterReaderModule.booleanHttpServerParameterReader` now parses strictly (`true`/`false` only) and rejects other values with a 400, matching the integer/long/float/double readers; this covers every boolean parameter, forms included.
- Fixed a swapped boxed-type mapping in `AbstractKotlinGenerator` (`Boolean`/`Float`) that surfaced once boxed primitives flow through generic reader/list types.
- Added multipart enum/model/primitive/array fixtures to `petstoreV3_form.yaml`, generated-output assertions for the Java and Kotlin server mappers, and a unit test for the strict boolean reader.

These were mustache-template fixes on 1.0; on 2.0 the templates are gone, so the intent was reimplemented on the JavaPoet/KotlinPoet generators (`ServerRequestMapperGenerator`, `ServerRequestMappersGenerator`, `ClientRequestMapperGenerator`). 2.0 already routes every non-string form value through `HttpServerParameterReader` components, so #830's "enum form import missing" is handled by the converter mechanism and #848's strict-parsing fix belongs in the shared boolean reader rather than inline in each mapper. Generating the new fixtures also exposed and fixed latent 2.0 crashes in single enum/model/primitive multipart handling and the Kotlin boxed-type mapping.