### PR TITLE
Fixed(openapi-generator): client writes multipart form arrays as repeated same-named parts

### DIFF
--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaClientRequestMappers.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaClientRequestMappers.mustache
@@ -80,13 +80,17 @@ public interface {{classname}}ClientRequestMappers {
           l.add(ru.tinkoff.kora.http.common.form.FormMultipart.data(
           "{{baseName}}",
             java.util.Base64.getEncoder().encodeToString(value.{{paramName}}())
-          ));{{/vendorExtensions.isByteArray}}{{^vendorExtensions.isByteArray}}
-          var buf = java.nio.charset.StandardCharsets.UTF_8.encode(java.util.Objects.toString(value.{{paramName}}()));
-          var part = ru.tinkoff.kora.http.common.form.FormMultipart.data(
+          ));{{/vendorExtensions.isByteArray}}{{^vendorExtensions.isByteArray}}{{#isArray}}
+          for (var item : value.{{paramName}}()) {
+              l.add(ru.tinkoff.kora.http.common.form.FormMultipart.data(
+              "{{baseName}}",
+                {{#vendorExtensions.requiresMapper}}{{paramName}}Converter.convert(item){{/vendorExtensions.requiresMapper}}{{^vendorExtensions.requiresMapper}}{{#vendorExtensions.isPrimitive}}java.util.Objects.toString(item){{/vendorExtensions.isPrimitive}}{{^vendorExtensions.isPrimitive}}item{{/vendorExtensions.isPrimitive}}{{/vendorExtensions.requiresMapper}}
+              ));
+          }{{/isArray}}{{^isArray}}
+          l.add(ru.tinkoff.kora.http.common.form.FormMultipart.data(
           "{{baseName}}",
-            java.util.Objects.toString(value.{{paramName}}())
-          );
-          l.add(part);{{/vendorExtensions.isByteArray}}{{/vendorExtensions.isByteArrayArray}}
+            {{#vendorExtensions.requiresMapper}}{{paramName}}Converter.convert(value.{{paramName}}()){{/vendorExtensions.requiresMapper}}{{^vendorExtensions.requiresMapper}}java.util.Objects.toString(value.{{paramName}}()){{/vendorExtensions.requiresMapper}}
+          ));{{/isArray}}{{/vendorExtensions.isByteArray}}{{/vendorExtensions.isByteArrayArray}}
       }{{/isFile}}{{/formParams}}
       return MultipartWriter.write(l);{{/vendorExtensions.multipartForm}}
     }

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinClientRequestMappers.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinClientRequestMappers.mustache
@@ -51,7 +51,9 @@ interface {{classname}}ClientRequestMappers {
       if (value.{{paramName}} != null) {
         {{#vendorExtensions.isByteArrayArray}}for (item in value.{{paramName}}) {
           l += ru.tinkoff.kora.http.common.form.FormMultipart.data("{{baseName}}", java.util.Base64.getEncoder().encodeToString(item))
-        }{{/vendorExtensions.isByteArrayArray}}{{^vendorExtensions.isByteArrayArray}}{{#vendorExtensions.isByteArray}}l += ru.tinkoff.kora.http.common.form.FormMultipart.data("{{baseName}}", java.util.Base64.getEncoder().encodeToString(value.{{paramName}})){{/vendorExtensions.isByteArray}}{{^vendorExtensions.isByteArray}}l += ru.tinkoff.kora.http.common.form.FormMultipart.data("{{baseName}}", "${value.{{paramName}}}"){{/vendorExtensions.isByteArray}}{{/vendorExtensions.isByteArrayArray}}
+        }{{/vendorExtensions.isByteArrayArray}}{{^vendorExtensions.isByteArrayArray}}{{#vendorExtensions.isByteArray}}l += ru.tinkoff.kora.http.common.form.FormMultipart.data("{{baseName}}", java.util.Base64.getEncoder().encodeToString(value.{{paramName}})){{/vendorExtensions.isByteArray}}{{^vendorExtensions.isByteArray}}{{#isArray}}for (item in value.{{paramName}}) {
+          l += ru.tinkoff.kora.http.common.form.FormMultipart.data("{{baseName}}", {{#vendorExtensions.requiresMapper}}{{paramName}}Converter.convert(item){{/vendorExtensions.requiresMapper}}{{^vendorExtensions.requiresMapper}}{{#vendorExtensions.isPrimitive}}"$item"{{/vendorExtensions.isPrimitive}}{{^vendorExtensions.isPrimitive}}item{{/vendorExtensions.isPrimitive}}{{/vendorExtensions.requiresMapper}})
+        }{{/isArray}}{{^isArray}}l += ru.tinkoff.kora.http.common.form.FormMultipart.data("{{baseName}}", {{#vendorExtensions.requiresMapper}}{{paramName}}Converter.convert(value.{{paramName}}){{/vendorExtensions.requiresMapper}}{{^vendorExtensions.requiresMapper}}"${value.{{paramName}}}"{{/vendorExtensions.requiresMapper}}){{/isArray}}{{/vendorExtensions.isByteArray}}{{/vendorExtensions.isByteArrayArray}}
       }{{/isFile}}
       {{/formParams}}
       return MultipartWriter.write(l) {{/vendorExtensions.multipartForm}}


### PR DESCRIPTION
Fixed(openapi-generator): client writes multipart form arrays as repeated same-named parts

The generated HTTP client serialized a non-file, non-byte multipart form array (arrays of strings, primitives, enums or models) as a single part whose body was the whole list's `toString()` (e.g. "[1, 2, 3]"). That does not round-trip with the server, which reads a form array as repeated same-named parts (RFC 7578 / HTML form convention), and it was inconsistent with how the client already wrote file and byte-array parts. For arrays of enums/models the element `StringParameterConverter` was even declared on the mapper but never used.

The client now emits one part per element for multipart form arrays, using the element converter for enum/model elements, `Objects.toString` for primitive elements, and the raw value for string elements — mirroring the server request mapper. Single non-file, non-byte multipart parts now also go through their converter when one is required (previously enum/model singles were written via `toString()` while their converter went unused). Removed a dead intermediate buffer variable.

This fixes only the multipart client path, which works end-to-end with the server after the multipart array server fix. The url-encoded client array path is left unchanged: url-encoded form arrays are not yet supported on the server side either, so fixing the client alone would be untestable and misleading; that is a separate, larger change.