### PR TITLE
Fixed(database): mapping empty embedded

### DIFF
--- a/database/database-annotation-processor/src/main/java/io/koraframework/database/annotation/processor/DbEntityReadHelper.java
+++ b/database/database-annotation-processor/src/main/java/io/koraframework/database/annotation/processor/DbEntityReadHelper.java
@@ -51,9 +51,10 @@ public class DbEntityReadHelper {
             var mapper = mapping.getMapping(this.fieldMapperName);
             var fieldName = entityField.variableName();
             var mapperFieldName = "_" + fieldName + "Mapper";
-            var fieldData = new FieldData(entityField.type(), mapperFieldName, entityField.columnName(), fieldName, entityField.isNullable());
+            var isNullable = entityField.isNullable() || entityField.entityField() instanceof DbEntity.EmbeddedCollectionEntityField;
+            var fieldData = new FieldData(entityField.type(), mapperFieldName, entityField.columnName(), fieldName, isNullable);
             var mapperTypeParameter = TypeName.get(entityField.type()).box();
-            var type = entityField.isNullable() ? TypeName.get(fieldData.type()).box() : TypeName.get(fieldData.type());
+            var type = isNullable ? TypeName.get(fieldData.type()).box() : TypeName.get(fieldData.type());
             if (mapper != null) {
                 var mapperType = mapper.mapperClass() != null
                     ? TypeName.get(mapper.mapperClass())

--- a/database/database-annotation-processor/src/test/java/io/koraframework/database/common/annotation/processor/jdbc/JdbcExtensionTest.java
+++ b/database/database-annotation-processor/src/test/java/io/koraframework/database/common/annotation/processor/jdbc/JdbcExtensionTest.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.function.Predicate;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class JdbcExtensionTest extends AbstractAnnotationProcessorTest {
 
@@ -44,7 +45,7 @@ public class JdbcExtensionTest extends AbstractAnnotationProcessorTest {
             """
             import io.koraframework.database.common.annotation.*;
             @Table("orders")
-            record Order(@Id String id, @Column("user_id") String userId, String number) {}
+            record Order(@Id long id, @Column("user_id") String userId, @org.jspecify.annotations.Nullable String number) {}
             """,
             """
             import io.koraframework.database.common.annotation.*;
@@ -57,25 +58,110 @@ public class JdbcExtensionTest extends AbstractAnnotationProcessorTest {
         compileResult.assertSuccess();
         var mapper = (JdbcResultSetMapper<?>) compileResult.loadClass("$UserOrdersView_ListJdbcResultSetMapper").getConstructor().newInstance();
         var rs = Mockito.mock(ResultSet.class);
-        Mockito.when(rs.next()).thenReturn(true, true, false);
+        Mockito.when(rs.next()).thenReturn(true, true, true, false);
         Mockito.when(rs.findColumn("u_id")).thenReturn(1);
         Mockito.when(rs.findColumn("u_name")).thenReturn(2);
         Mockito.when(rs.findColumn("o_id")).thenReturn(3);
         Mockito.when(rs.findColumn("o_user_id")).thenReturn(4);
         Mockito.when(rs.findColumn("o_number")).thenReturn(5);
-        Mockito.when(rs.getString(1)).thenReturn("u1", "u1");
-        Mockito.when(rs.getString(2)).thenReturn("User 1", "User 1");
-        Mockito.when(rs.getString(3)).thenReturn("o1", "o2");
-        Mockito.when(rs.getString(4)).thenReturn("u1", "u1");
-        Mockito.when(rs.getString(5)).thenReturn("n1", "n2");
-        Mockito.when(rs.wasNull()).thenReturn(false, false, false, false, false, false, false, false, false, false);
+        Mockito.when(rs.getString(1)).thenReturn("u1", "u2", "u2");
+        Mockito.when(rs.getString(2)).thenReturn("User 1", "User 2", "User 2");
+        Mockito.when(rs.getLong(3)).thenReturn(0L, 1L, 2L);
+        Mockito.when(rs.getString(4)).thenReturn(null, "u2", "u2");
+        Mockito.when(rs.getString(5)).thenReturn(null, null, "n2");
+        Mockito.when(rs.wasNull()).thenReturn(
+            false, false, true, true, true,
+            false, false, false, false, true,
+            false, false, false, false, false
+        );
+
+        var result = (List<?>) mapper.apply(rs);
+
+        assertThat(result).hasSize(2);
+        var orders = result.get(0).getClass().getMethod("orders");
+        orders.setAccessible(true);
+        assertThat((List<?>) orders.invoke(result.get(0))).isEmpty();
+        var secondOrders = (List<?>) orders.invoke(result.get(1));
+        assertThat(secondOrders).hasSize(2);
+        var number = secondOrders.get(0).getClass().getMethod("number");
+        number.setAccessible(true);
+        assertThat(number.invoke(secondOrders.get(0))).isNull();
+        assertThat(number.invoke(secondOrders.get(1))).isEqualTo("n2");
+    }
+
+    @Test
+    public void testOneToManyListResultSetMapperRejectsPartiallyNullChild() throws Exception {
+        compile(List.of(new JdbcEntityAnnotationProcessor()),
+            """
+            import io.koraframework.database.common.annotation.*;
+            @Table("users")
+            record User(@Id String id, String name) {}
+            """,
+            """
+            import io.koraframework.database.common.annotation.*;
+            @Table("orders")
+            record Order(@Id long id, @Column("user_id") String userId, String number) {}
+            """,
+            """
+            import io.koraframework.database.common.annotation.*;
+            import io.koraframework.database.jdbc.annotation.EntityJdbc;
+            @EntityJdbc
+            record UserOrdersView(@Embedded("u_") User user, @Embedded("o_") java.util.List<Order> orders) {}
+            """
+        );
+
+        compileResult.assertSuccess();
+        var mapper = (JdbcResultSetMapper<?>) compileResult.loadClass("$UserOrdersView_ListJdbcResultSetMapper").getConstructor().newInstance();
+        var rs = Mockito.mock(ResultSet.class);
+        Mockito.when(rs.next()).thenReturn(true, false);
+        Mockito.when(rs.findColumn("u_id")).thenReturn(1);
+        Mockito.when(rs.findColumn("u_name")).thenReturn(2);
+        Mockito.when(rs.findColumn("o_id")).thenReturn(3);
+        Mockito.when(rs.findColumn("o_user_id")).thenReturn(4);
+        Mockito.when(rs.findColumn("o_number")).thenReturn(5);
+        Mockito.when(rs.getString(1)).thenReturn("u1");
+        Mockito.when(rs.getString(2)).thenReturn("User 1");
+        Mockito.when(rs.getLong(3)).thenReturn(1L);
+        Mockito.when(rs.getString(5)).thenReturn("n1");
+        Mockito.when(rs.wasNull()).thenReturn(false, false, false, true, false);
+
+        assertThatThrownBy(() -> mapper.apply(rs))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage("Field userId is not nullable, but column o_user_id is null");
+    }
+
+    @Test
+    public void testOneToManyListResultSetMapperHandlesEmptySingleBoxedFieldChild() throws Exception {
+        compile(List.of(new JdbcEntityAnnotationProcessor()),
+            """
+            import io.koraframework.database.common.annotation.*;
+            @Table("children")
+            record Child(@Id Long id) {}
+            """,
+            """
+            import io.koraframework.database.common.annotation.*;
+            import io.koraframework.database.jdbc.annotation.EntityJdbc;
+            @EntityJdbc
+            record ParentChildren(@Id String id, @Embedded("c_") java.util.List<Child> children) {}
+            """
+        );
+
+        compileResult.assertSuccess();
+        var mapper = (JdbcResultSetMapper<?>) compileResult.loadClass("$ParentChildren_ListJdbcResultSetMapper").getConstructor().newInstance();
+        var rs = Mockito.mock(ResultSet.class);
+        Mockito.when(rs.next()).thenReturn(true, false);
+        Mockito.when(rs.findColumn("id")).thenReturn(1);
+        Mockito.when(rs.findColumn("c_id")).thenReturn(2);
+        Mockito.when(rs.getString(1)).thenReturn("p1");
+        Mockito.when(rs.getLong(2)).thenReturn(0L);
+        Mockito.when(rs.wasNull()).thenReturn(false, true);
 
         var result = (List<?>) mapper.apply(rs);
 
         assertThat(result).hasSize(1);
-        var orders = result.get(0).getClass().getMethod("orders");
-        orders.setAccessible(true);
-        assertThat((List<?>) orders.invoke(result.get(0))).hasSize(2);
+        var children = result.get(0).getClass().getMethod("children");
+        children.setAccessible(true);
+        assertThat((List<?>) children.invoke(result.get(0))).isEmpty();
     }
 
     @Test

--- a/database/database-symbol-processor/src/main/kotlin/io/koraframework/database/symbol/processor/DbEntityReader.kt
+++ b/database/database-symbol-processor/src/main/kotlin/io/koraframework/database/symbol/processor/DbEntityReader.kt
@@ -30,7 +30,13 @@ class DbEntityReader(
             val mapper = entityField.mapping.getMapping(this.fieldMapperName)
             val fieldName = entityField.variableName
             val mapperFieldName = "\$${fieldName}Mapper"
-            val fieldData = FieldData(entityField.type, mapperFieldName, entityField.columnName, fieldName, entityField.isNullable)
+            val fieldData = FieldData(
+                entityField.type,
+                mapperFieldName,
+                entityField.columnName,
+                fieldName,
+                entityField.isNullable || entityField.entityField is DbEntity.EmbeddedCollectionEntityField
+            )
             val mapperTypeParameter = entityField.type.toTypeName().copy(false)
             val fieldType = mapperTypeParameter.copy(true)
             if (mapper != null) {

--- a/database/database-symbol-processor/src/test/kotlin/io/koraframework/database/symbol/processor/jdbc/JdbcMapperTests.kt
+++ b/database/database-symbol-processor/src/test/kotlin/io/koraframework/database/symbol/processor/jdbc/JdbcMapperTests.kt
@@ -3,6 +3,7 @@ package io.koraframework.database.symbol.processor.jdbc
 import io.koraframework.database.jdbc.mapper.result.JdbcResultSetMapper
 import io.koraframework.database.jdbc.mapper.result.JdbcRowMapper
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.*
 import java.sql.ResultSet
@@ -21,31 +22,105 @@ class JdbcMapperTests : AbstractJdbcRepositoryTest() {
             data class User(@field:Id val id: String, val name: String)
 
             @Table("orders")
-            data class Order(@field:Id val id: String, @field:Column("user_id") val userId: String, val number: String)
+            data class Order(@field:Id val id: Long, @field:Column("user_id") val userId: String, val number: String?)
             """.trimIndent()
         )
         compileResult.assertSuccess()
 
         val mapper = newGenerated("\$UserOrdersView_ListJdbcResultSetMapper").invoke() as JdbcResultSetMapper<*>
         val rs = mock<ResultSet>()
-        whenever(rs.next()).thenReturn(true, true, false)
+        whenever(rs.next()).thenReturn(true, true, true, false)
         whenever(rs.findColumn("u_id")).thenReturn(1)
         whenever(rs.findColumn("u_name")).thenReturn(2)
         whenever(rs.findColumn("o_id")).thenReturn(3)
         whenever(rs.findColumn("o_user_id")).thenReturn(4)
         whenever(rs.findColumn("o_number")).thenReturn(5)
-        whenever(rs.getString(1)).thenReturn("u1", "u1")
-        whenever(rs.getString(2)).thenReturn("User 1", "User 1")
-        whenever(rs.getString(3)).thenReturn("o1", "o2")
-        whenever(rs.getString(4)).thenReturn("u1", "u1")
-        whenever(rs.getString(5)).thenReturn("n1", "n2")
-        whenever(rs.wasNull()).thenReturn(false, false, false, false, false, false, false, false, false, false)
+        whenever(rs.getString(1)).thenReturn("u1", "u2", "u2")
+        whenever(rs.getString(2)).thenReturn("User 1", "User 2", "User 2")
+        whenever(rs.getLong(3)).thenReturn(0L, 1L, 2L)
+        whenever(rs.getString(4)).thenReturn(null, "u2", "u2")
+        whenever(rs.getString(5)).thenReturn(null, null, "n2")
+        whenever(rs.wasNull()).thenReturn(
+            false, false, true, true, true,
+            false, false, false, false, true,
+            false, false, false, false, false
+        )
+
+        val result = mapper.apply(rs) as List<*>
+
+        assertThat(result).hasSize(2)
+        val orders = result[0]!!.javaClass.getMethod("getOrders").invoke(result[0]) as List<*>
+        assertThat(orders).isEmpty()
+        val secondOrders = result[1]!!.javaClass.getMethod("getOrders").invoke(result[1]) as List<*>
+        assertThat(secondOrders).hasSize(2)
+        assertThat(secondOrders[0]!!.javaClass.getMethod("getNumber").invoke(secondOrders[0])).isNull()
+        assertThat(secondOrders[1]!!.javaClass.getMethod("getNumber").invoke(secondOrders[1])).isEqualTo("n2")
+    }
+
+    @Test
+    fun testOneToManyListResultSetMapperRejectsPartiallyNullChild() {
+        compile0(
+            listOf(JdbcEntitySymbolProcessorProvider()),
+            """
+            @EntityJdbc
+            data class UserOrdersView(@field:Embedded("u_") val user: User, @field:Embedded("o_") val orders: List<Order>)
+
+            @Table("users")
+            data class User(@field:Id val id: String, val name: String)
+
+            @Table("orders")
+            data class Order(@field:Id val id: Long, @field:Column("user_id") val userId: String, val number: String)
+            """.trimIndent()
+        )
+        compileResult.assertSuccess()
+
+        val mapper = newGenerated("\$UserOrdersView_ListJdbcResultSetMapper").invoke() as JdbcResultSetMapper<*>
+        val rs = mock<ResultSet>()
+        whenever(rs.next()).thenReturn(true, false)
+        whenever(rs.findColumn("u_id")).thenReturn(1)
+        whenever(rs.findColumn("u_name")).thenReturn(2)
+        whenever(rs.findColumn("o_id")).thenReturn(3)
+        whenever(rs.findColumn("o_user_id")).thenReturn(4)
+        whenever(rs.findColumn("o_number")).thenReturn(5)
+        whenever(rs.getString(1)).thenReturn("u1")
+        whenever(rs.getString(2)).thenReturn("User 1")
+        whenever(rs.getLong(3)).thenReturn(1L)
+        whenever(rs.getString(5)).thenReturn("n1")
+        whenever(rs.wasNull()).thenReturn(false, false, false, true, false)
+
+        assertThatThrownBy { mapper.apply(rs) }
+            .isInstanceOf(NullPointerException::class.java)
+            .hasMessage("Field userId is not nullable, but column o_user_id is null")
+    }
+
+    @Test
+    fun testOneToManyListResultSetMapperHandlesEmptySingleFieldChild() {
+        compile0(
+            listOf(JdbcEntitySymbolProcessorProvider()),
+            """
+            @EntityJdbc
+            data class ParentChildren(@field:Id val id: String, @field:Embedded("c_") val children: List<Child>)
+
+            @Table("children")
+            data class Child(@field:Id val id: Long)
+            """.trimIndent()
+        )
+        compileResult.assertSuccess()
+
+        val mapper = newGenerated("\$ParentChildren_ListJdbcResultSetMapper").invoke() as JdbcResultSetMapper<*>
+        val rs = mock<ResultSet>()
+        whenever(rs.next()).thenReturn(true, false)
+        whenever(rs.findColumn("id")).thenReturn(1)
+        whenever(rs.findColumn("c_id")).thenReturn(2)
+        whenever(rs.getString(1)).thenReturn("p1")
+        whenever(rs.getLong(2)).thenReturn(0L)
+        whenever(rs.wasNull()).thenReturn(false, true)
 
         val result = mapper.apply(rs) as List<*>
 
         assertThat(result).hasSize(1)
-        val orders = result[0]!!.javaClass.getMethod("getOrders").invoke(result[0]) as List<*>
-        assertThat(orders).hasSize(2)
+        val children = result[0]!!.javaClass.getMethod("getChildren").invoke(result[0]) as List<*>
+        assertThat(children).isEmpty()
     }
 
     @Test


### PR DESCRIPTION
Fixed JDBC embedded collection mapping for empty LEFT JOIN rows by reading child columns as nullable before validating field constraints. Primitive IDs remain supported, while partially null children still fail.