### PR TITLE
Fixed(application-graph): GraphCondition.and returns Matched when all conditions matched

### DIFF
--- a/core/application-graph/src/main/java/io/koraframework/application/graph/GraphCondition.java
+++ b/core/application-graph/src/main/java/io/koraframework/application/graph/GraphCondition.java
@@ -42,7 +42,7 @@ public interface GraphCondition {
                 for (var matched : matchedReasons) {
                     sb.append(matched.reason().indent(2));
                 }
-                return new ConditionResult.Failed(sb.toString());
+                return new ConditionResult.Matched(sb.toString());
             } else {
                 var sb = new StringBuilder("Some of required conditions were failed:\n");
                 for (var failedReason : failedReasons) {

--- a/core/application-graph/src/test/java/io/koraframework/application/graph/GraphTest.java
+++ b/core/application-graph/src/test/java/io/koraframework/application/graph/GraphTest.java
@@ -536,6 +536,51 @@ class GraphTest {
                 """);
     }
 
+    @Test
+    void andConditionMatchesWhenEveryConditionMatched() {
+        var condition = GraphCondition.and(
+            new NodeConditionImpl(GraphCondition.ConditionResult.matched("first matched")),
+            new NodeConditionImpl(GraphCondition.ConditionResult.matched("second matched"))
+        );
+
+        assertThat(condition.eval()).isInstanceOf(GraphCondition.ConditionResult.Matched.class);
+    }
+
+    @Test
+    void andConditionFailsWhenSomeConditionFailed() {
+        var condition = GraphCondition.and(
+            new NodeConditionImpl(GraphCondition.ConditionResult.matched("first matched")),
+            new NodeConditionImpl(GraphCondition.ConditionResult.failed("second failed"))
+        );
+
+        var result = condition.eval();
+
+        assertThat(result).isInstanceOf(GraphCondition.ConditionResult.Failed.class);
+        assertThat(((GraphCondition.ConditionResult.Failed) result).reason()).contains("second failed");
+    }
+
+    @Test
+    void componentWithOwnAndInheritedConditionIsCreatedWhenBothMatched() throws Exception {
+        var draw = new ApplicationGraphDraw(GraphTest.class);
+        var ownCondition = draw.addNode(GraphCondition.class, null, null, List.of(), List.of(), List.of(), g -> new NodeConditionImpl(GraphCondition.ConditionResult.matched("own matched")));
+        var parentCondition = draw.addNode(GraphCondition.class, null, null, List.of(), List.of(), List.of(), g -> new NodeConditionImpl(GraphCondition.ConditionResult.matched("parent matched")));
+        var inner = draw.addNode(
+            String.class,
+            null,
+            g -> GraphCondition.and(g.condition(parentCondition), g.condition(ownCondition)).eval(),
+            List.of(ownCondition, parentCondition),
+            List.of(ownCondition, parentCondition),
+            List.of(),
+            g -> "inner"
+        );
+        var outer = draw.addNode(String.class, null, g -> g.condition(parentCondition).eval(), List.of(inner), List.of(inner), List.of(), g -> g.get(inner) + "-outer");
+
+        var graph = draw.init();
+
+        assertThat(graph.get(outer)).isEqualTo("inner-outer");
+        graph.release();
+    }
+
 
     /**
      * <pre>


### PR DESCRIPTION
Closes #856

В `GraphCondition.and(...)` ветка «ни одно условие не провалилось» собирала сообщение `All of required conditions were matched` и возвращала его как `ConditionResult.Failed`. То есть `and(...)` не мог сматчиться никогда.

Ветка достижима из сгенерированного кода: `GraphFileGenerator` вставляет `GraphCondition.and(parentCondition, ownCondition)`, когда у компонента есть и собственный `@Conditional`, и условие, унаследованное от условного потребителя. Такой компонент не создавался даже при обоих совпавших условиях, причём с самопротиворечивым сообщением:

```text
Graph node value was not initialized because condition failed:
All of required conditions were matched:
```

Тесты в `GraphTest`: `and(...)` на совпавших и на провалившихся условиях, плюс граф с компонентом, у которого своё и унаследованное условие. Оба первых падают на текущем `master`.

---

**EN:** `GraphCondition.and()` returned `ConditionResult.Failed` in the branch where every condition matched, so a component having both its own `@Conditional` and a condition inherited from a conditional consumer could never be created.
